### PR TITLE
ORC-9. Create a vector type for timestamp columns

### DIFF
--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -294,6 +294,24 @@ namespace orc {
     friend class DecimalHive11ColumnReader;
   };
 
+  /**
+   * A column vector batch for storing timestamp values.
+   * The timestamps are stored split into the time_t value (seconds since
+   * 1 Jan 1970 00:00:00) and the nanoseconds within the time_t value.
+   */
+  struct TimestampVectorBatch: public ColumnVectorBatch {
+    TimestampVectorBatch(uint64_t capacity, MemoryPool& pool);
+    virtual ~TimestampVectorBatch();
+    std::string toString() const;
+    void resize(uint64_t capacity);
+
+    // the number of seconds past 1 Jan 1970 00:00 UTC (aka time_t)
+    DataBuffer<int64_t> data;
+
+    // the nanoseconds of each value
+    DataBuffer<int64_t> nanoseconds;
+  };
+
 }
 
 #endif

--- a/c++/src/ColumnReader.hh
+++ b/c++/src/ColumnReader.hh
@@ -63,6 +63,13 @@ namespace orc {
      * Get the memory pool for this reader.
      */
     virtual MemoryPool& getMemoryPool() const = 0;
+
+    /**
+     * Get the number of seconds between the ORC epoch and Unix epoch.
+     * ORC epoch is 1 Jan 2015 00:00:00 local.
+     * Unix epoch is 1 Jan 1970 00:00:00 UTC.
+     */
+    virtual int64_t getEpochOffset() const = 0;
   };
 
   /**

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -996,6 +996,8 @@ namespace orc {
   }
 
   int64_t getEpochOffset() {
+    // Build the literal for the ORC epoch
+    // 2015 Jan 1 00:00:00
     struct tm epoch;
     epoch.tm_sec = 0;
     epoch.tm_min = 0;

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -303,4 +303,32 @@ namespace orc {
   std::string Decimal::toString() const {
     return value.toDecimalString(scale);
   }
+
+  TimestampVectorBatch::TimestampVectorBatch(uint64_t capacity,
+                                             MemoryPool& pool
+                                             ): ColumnVectorBatch(capacity,
+                                                                  pool),
+                                                data(pool, capacity),
+                                                nanoseconds(pool, capacity) {
+    // PASS
+  }
+
+  TimestampVectorBatch::~TimestampVectorBatch() {
+    // PASS
+  }
+
+  std::string TimestampVectorBatch::toString() const {
+    std::ostringstream buffer;
+    buffer << "Timestamp vector <" << numElements << " of " << capacity << ">";
+    return buffer.str();
+  }
+
+  void TimestampVectorBatch::resize(uint64_t cap) {
+    if (capacity < cap) {
+      ColumnVectorBatch::resize(cap);
+      data.resize(cap);
+      nanoseconds.resize(cap);
+    }
+  }
+
 }

--- a/c++/test/TestColumnPrinter.cc
+++ b/c++/test/TestColumnPrinter.cc
@@ -128,21 +128,33 @@ namespace orc {
     std::string line;
     std::unique_ptr<Type> type = createPrimitiveType(TIMESTAMP);
     std::unique_ptr<ColumnPrinter> printer = createColumnPrinter(line, *type);
-    LongVectorBatch batch(1024, *getDefaultPool());
+    TimestampVectorBatch batch(1024, *getDefaultPool());
     batch.numElements = 12;
     batch.hasNulls = false;
-    batch.data[0]  = 1420070400000000000;
-    batch.data[1]  =  963270000000000000;
-    batch.data[2]  = 1426168859000000000;
-    batch.data[3]  = 1426168859000000001;
-    batch.data[4]  = 1426168859000000010;
-    batch.data[5]  = 1426168859000000100;
-    batch.data[6]  = 1426168859000001000;
-    batch.data[7]  = 1426168859000010000;
-    batch.data[8]  = 1426168859000100000;
-    batch.data[9]  = 1426168859001000000;
-    batch.data[10] = 1426168859010000000;
-    batch.data[11] = 1426168859100000000;
+    batch.data[0]  = 1420099200;
+    batch.data[1]  =  963298800;
+    batch.data[2]  = 1426197659;
+    batch.data[3]  = 1426197659;
+    batch.data[4]  = 1426197659;
+    batch.data[5]  = 1426197659;
+    batch.data[6]  = 1426197659;
+    batch.data[7]  = 1426197659;
+    batch.data[8]  = 1426197659;
+    batch.data[9]  = 1426197659;
+    batch.data[10] = 1426197659;
+    batch.data[11] = 1426197659;
+    batch.nanoseconds[0]  = 0;
+    batch.nanoseconds[1]  = 0;
+    batch.nanoseconds[2]  = 0;
+    batch.nanoseconds[3]  = 1;
+    batch.nanoseconds[4]  = 10;
+    batch.nanoseconds[5]  = 100;
+    batch.nanoseconds[6]  = 1000;
+    batch.nanoseconds[7]  = 10000;
+    batch.nanoseconds[8]  = 100000;
+    batch.nanoseconds[9]  = 1000000;
+    batch.nanoseconds[10] = 10000000;
+    batch.nanoseconds[11] = 100000000;
     const char *expected[] = {"\"2015-01-01 00:00:00.0\"",
                               "\"2000-07-11 00:00:00.0\"",
                               "\"2015-03-12 15:00:59.0\"",


### PR DESCRIPTION
Create a vector type for timestamp columns that separates out the seconds from the nanoseconds.