### PR TITLE
ORC-32. Fix warnings under MacOS.

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1070,8 +1070,9 @@ namespace orc {
         columnId != included.end(); ++columnId) {
       if (*columnId == 0) {
         selectType(*(schema.get()));
-      } else if (*columnId <= static_cast<int64_t>(schema->getSubtypeCount())) {
-        selectType(schema->getSubtype(*columnId-1));
+      } else if (*columnId <=
+                 static_cast<int64_t>(schema->getSubtypeCount())) {
+        selectType(schema->getSubtype(static_cast<uint64_t>(*columnId-1)));
       }
     }
     if (included.size() > 0) {
@@ -1080,8 +1081,8 @@ namespace orc {
   }
 
   void ReaderImpl::selectType(const Type& type) {
-    if (!selectedColumns[type.getColumnId()]) {
-      selectedColumns[type.getColumnId()] = true;
+    if (!selectedColumns[static_cast<size_t>(type.getColumnId())]) {
+      selectedColumns[static_cast<size_t>(type.getColumnId())] = true;
       for (uint64_t i=0; i < type.getSubtypeCount(); i++) {
         selectType(type.getSubtype(i));
       }

--- a/c++/src/wrap/coded-stream-wrapper.h
+++ b/c++/src/wrap/coded-stream-wrapper.h
@@ -21,6 +21,7 @@ DIAGNOSTIC_PUSH
 
 #ifdef __clang__
   DIAGNOSTIC_IGNORE("-Wshorten-64-to-32")
+  DIAGNOSTIC_IGNORE("-Wreserved-id-macro")
 #endif
 
 DIAGNOSTIC_IGNORE("-Wconversion")


### PR DESCRIPTION
This patch fixes a couple of MacOS warnings.