### PR TITLE
Fixed ORC-21: Add dynamic memory usage estimation.

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -718,7 +718,7 @@ namespace orc {
     * all stripes are considered).
      * @return upper bound on memory use
      */
-    virtual uint64_t memoryUse(int stripeIx=-1) = 0;
+    virtual uint64_t getMemoryUse(int stripeIx=-1) = 0;
   };
 }
 

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -709,6 +709,16 @@ namespace orc {
      * @return a string of bytes with the file tail
      */
     virtual std::string getSerializedFileTail() const = 0;
+
+    /**
+     * Estimate an upper bound on heap memory allocation by the Reader
+     * based on the information in the file footer.
+     * The bound is less tight if only few columns are read or compression is used.
+     * @param stripeIx index of the stripe to be read (if not specified,
+    * all stripes are considered).
+     * @return upper bound on memory use
+     */
+    virtual uint64_t memoryUse(int stripeIx=-1) = 0;
   };
 }
 

--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -143,7 +143,12 @@ namespace orc {
     /**
      * Heap memory used by the batch.
      */
-    virtual int64_t memoryUse();
+    virtual uint64_t getMemoryUsage();
+
+    /**
+     * Check whether the batch length varies depending on data.
+     */
+    virtual bool hasVariableLength();
 
   private:
     ColumnVectorBatch(const ColumnVectorBatch&);
@@ -157,7 +162,7 @@ namespace orc {
     DataBuffer<int64_t> data;
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
   };
 
   struct DoubleVectorBatch: public ColumnVectorBatch {
@@ -165,7 +170,7 @@ namespace orc {
     virtual ~DoubleVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
 
     DataBuffer<double> data;
   };
@@ -175,7 +180,7 @@ namespace orc {
     virtual ~StringVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
 
     // pointers to the start of each string
     DataBuffer<char*> data;
@@ -188,7 +193,8 @@ namespace orc {
     virtual ~StructVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
+    bool hasVariableLength();
 
     std::vector<ColumnVectorBatch*> fields;
   };
@@ -198,7 +204,8 @@ namespace orc {
     virtual ~ListVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
+    bool hasVariableLength();
 
     /**
      * The offset of the first element of each list.
@@ -215,7 +222,8 @@ namespace orc {
     virtual ~MapVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
+    bool hasVariableLength();
 
     /**
      * The offset of the first element of each list.
@@ -234,7 +242,8 @@ namespace orc {
     virtual ~UnionVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
+    bool hasVariableLength();
 
     /**
      * For each value, which element of children has the value.
@@ -264,7 +273,7 @@ namespace orc {
     virtual ~Decimal64VectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
 
     // total number of digits
     int32_t precision;
@@ -288,7 +297,7 @@ namespace orc {
     virtual ~Decimal128VectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
 
     // total number of digits
     int32_t precision;
@@ -318,7 +327,7 @@ namespace orc {
     virtual ~TimestampVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
-    int64_t memoryUse();
+    uint64_t getMemoryUsage();
 
     // the number of seconds past 1 Jan 1970 00:00 UTC (aka time_t)
     DataBuffer<int64_t> data;

--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -140,6 +140,11 @@ namespace orc {
      */
     virtual void resize(uint64_t capacity);
 
+    /**
+     * Heap memory used by the batch.
+     */
+    virtual int64_t memoryUse();
+
   private:
     ColumnVectorBatch(const ColumnVectorBatch&);
     ColumnVectorBatch& operator=(const ColumnVectorBatch&);
@@ -152,6 +157,7 @@ namespace orc {
     DataBuffer<int64_t> data;
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
   };
 
   struct DoubleVectorBatch: public ColumnVectorBatch {
@@ -159,6 +165,7 @@ namespace orc {
     virtual ~DoubleVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     DataBuffer<double> data;
   };
@@ -168,6 +175,7 @@ namespace orc {
     virtual ~StringVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     // pointers to the start of each string
     DataBuffer<char*> data;
@@ -180,6 +188,7 @@ namespace orc {
     virtual ~StructVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     std::vector<ColumnVectorBatch*> fields;
   };
@@ -189,6 +198,7 @@ namespace orc {
     virtual ~ListVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     /**
      * The offset of the first element of each list.
@@ -205,6 +215,7 @@ namespace orc {
     virtual ~MapVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     /**
      * The offset of the first element of each list.
@@ -223,6 +234,7 @@ namespace orc {
     virtual ~UnionVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     /**
      * For each value, which element of children has the value.
@@ -252,6 +264,7 @@ namespace orc {
     virtual ~Decimal64VectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     // total number of digits
     int32_t precision;
@@ -275,6 +288,7 @@ namespace orc {
     virtual ~Decimal128VectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     // total number of digits
     int32_t precision;
@@ -304,6 +318,7 @@ namespace orc {
     virtual ~TimestampVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    int64_t memoryUse();
 
     // the number of seconds past 1 Jan 1970 00:00 UTC (aka time_t)
     DataBuffer<int64_t> data;

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1414,7 +1414,7 @@ namespace orc {
     bool hasStringColumn = false;
     uint64_t nSelectedStreams = 0;
     for (int i=0; !hasStringColumn && i < footer->types_size(); i++) {
-      if (selectedColumns[i]) {
+      if (selectedColumns[static_cast<size_t>(i)]) {
         const proto::Type& type = footer->types(i);
         nSelectedStreams += maxStreamsForType(type) ;
         switch (static_cast<int64_t>(type.kind())) {
@@ -1457,7 +1457,7 @@ namespace orc {
     uint64_t decompressorMemory = 0;
     if (compression != CompressionKind_NONE) {
       for (int i=0; i < footer->types_size(); i++) {
-        if (selectedColumns[i]) {
+        if (selectedColumns[static_cast<size_t>(i)]) {
           const proto::Type& type = footer->types(i);
           decompressorMemory += maxStreamsForType(type) * blockSize;
         }

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -48,6 +48,10 @@ namespace orc {
     }
   }
 
+  int64_t ColumnVectorBatch::memoryUse() {
+    return static_cast<int64_t>(notNull.capacity() * sizeof(char));
+  }
+
   LongVectorBatch::LongVectorBatch(uint64_t capacity, MemoryPool& pool
                      ): ColumnVectorBatch(capacity, pool),
                         data(pool, capacity) {
@@ -71,6 +75,11 @@ namespace orc {
     }
   }
 
+  int64_t LongVectorBatch::memoryUse() {
+    return ColumnVectorBatch::memoryUse() +
+        static_cast<int64_t>(data.capacity() * sizeof(int64_t));
+  }
+
   DoubleVectorBatch::DoubleVectorBatch(uint64_t capacity, MemoryPool& pool
                    ): ColumnVectorBatch(capacity, pool),
                       data(pool, capacity) {
@@ -92,6 +101,11 @@ namespace orc {
       ColumnVectorBatch::resize(cap);
       data.resize(cap);
     }
+  }
+
+  int64_t DoubleVectorBatch::memoryUse() {
+    return ColumnVectorBatch::memoryUse()
+          + static_cast<int64_t>(data.capacity() * sizeof(double));
   }
 
   StringVectorBatch::StringVectorBatch(uint64_t capacity, MemoryPool& pool
@@ -119,6 +133,12 @@ namespace orc {
     }
   }
 
+  int64_t StringVectorBatch::memoryUse() {
+    return ColumnVectorBatch::memoryUse()
+          + static_cast<int64_t>(data.capacity() * sizeof(char*)
+          + length.capacity() * sizeof(int64_t));
+  }
+
   StructVectorBatch::StructVectorBatch(uint64_t cap, MemoryPool& pool
                                         ): ColumnVectorBatch(cap, pool) {
     // PASS
@@ -142,9 +162,19 @@ namespace orc {
     return buffer.str();
   }
 
-
   void StructVectorBatch::resize(uint64_t cap) {
     ColumnVectorBatch::resize(cap);
+  }
+
+  int64_t StructVectorBatch::memoryUse() {
+    int64_t memory = ColumnVectorBatch::memoryUse();
+    for (unsigned int i=0; i < fields.size(); i++) {
+      int64_t mem = fields[i]->memoryUse();
+      if (mem < 0)
+        return -1;
+      memory += mem;
+    }
+    return memory;
   }
 
   ListVectorBatch::ListVectorBatch(uint64_t cap, MemoryPool& pool
@@ -171,6 +201,10 @@ namespace orc {
     }
   }
 
+  int64_t ListVectorBatch::memoryUse() {
+    return -1;
+  }
+
   MapVectorBatch::MapVectorBatch(uint64_t cap, MemoryPool& pool
                  ): ColumnVectorBatch(cap, pool),
                     offsets(pool, cap+1) {
@@ -194,6 +228,10 @@ namespace orc {
       ColumnVectorBatch::resize(cap);
       offsets.resize(cap + 1);
     }
+  }
+
+  int64_t MapVectorBatch::memoryUse() {
+    return -1;
   }
 
   UnionVectorBatch::UnionVectorBatch(uint64_t cap, MemoryPool& pool
@@ -230,6 +268,19 @@ namespace orc {
     }
   }
 
+  int64_t UnionVectorBatch::memoryUse() {
+    int64_t memory = ColumnVectorBatch::memoryUse()
+                 + static_cast<int64_t>(tags.capacity() * sizeof(unsigned char)
+                 + offsets.capacity() * sizeof(uint64_t));
+    for(size_t i=0; i < children.size(); ++i) {
+     int64_t mem = children[i]->memoryUse();
+      if (mem < 0)
+        return -1;
+      memory += mem;
+    }
+    return memory;
+  }
+
   Decimal64VectorBatch::Decimal64VectorBatch(uint64_t cap, MemoryPool& pool
                  ): ColumnVectorBatch(cap, pool),
                     precision(0),
@@ -258,6 +309,12 @@ namespace orc {
     }
   }
 
+  int64_t Decimal64VectorBatch::memoryUse() {
+    return ColumnVectorBatch::memoryUse()
+          + static_cast<int64_t>(
+              (values.capacity() + readScales.capacity()) * sizeof(int64_t));
+  }
+
   Decimal128VectorBatch::Decimal128VectorBatch(uint64_t cap, MemoryPool& pool
                ): ColumnVectorBatch(cap, pool),
                   precision(0),
@@ -284,6 +341,12 @@ namespace orc {
       values.resize(cap);
       readScales.resize(cap);
     }
+  }
+
+  int64_t Decimal128VectorBatch::memoryUse() {
+    return ColumnVectorBatch::memoryUse()
+          + static_cast<int64_t>(values.capacity() * sizeof(Int128)
+          + readScales.capacity() * sizeof(int64_t));
   }
 
   Decimal::Decimal(const Int128& _value,
@@ -335,4 +398,9 @@ namespace orc {
     }
   }
 
+  int64_t TimestampVectorBatch::memoryUse() {
+    return ColumnVectorBatch::memoryUse()
+          + static_cast<int64_t>(
+              (data.capacity() + nanoseconds.capacity()) * sizeof(int64_t));
+  }
 }

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -249,7 +249,7 @@ namespace orc {
   uint64_t MapVectorBatch::getMemoryUsage() {
     return ColumnVectorBatch::getMemoryUsage()
            + static_cast<uint64_t>(offsets.capacity() * sizeof(int64_t))
-           + keys->getMemoryUsage();
+           + keys->getMemoryUsage()
            + elements->getMemoryUsage();
   }
 

--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -55,10 +55,20 @@ target_link_libraries (file-statistics
   orc
   ${PROTOBUF_LIBRARIES}
   ) 
+  
+add_executable (file-memory
+  FileMemory.cc
+  )
+
+target_link_libraries (file-memory
+  orc
+  ${PROTOBUF_LIBRARIES}
+  )   
 
 install(TARGETS
    file-contents
    file-metadata
    file-scan
    file-statistics
+   file-memory
    DESTINATION bin)

--- a/tools/src/FileMemory.cc
+++ b/tools/src/FileMemory.cc
@@ -111,14 +111,14 @@ int main(int argc, char* argv[]) {
 
   std::unique_ptr<orc::ColumnVectorBatch> batch =
       reader->createRowBatch(batchSize);
-  uint64_t readerMemory = reader->memoryUse();
-  int64_t batchMemory = batch->memoryUse();
+  uint64_t readerMemory = reader->getMemoryUse();
+  uint64_t batchMemory = batch->getMemoryUsage();
   while (reader->next(*batch)) {}
   uint64_t actualMemory =
       static_cast<TestMemoryPool*>(pool.get())->getMaxMemory();
   std::cout << "Reader memory estimate: " << readerMemory
             << "\nBatch memory estimate:  " ;
-  if (batchMemory == -1) {
+  if (batch->hasVariableLength()) {
     std::cout << "Cannot estimate because reading ARRAY or MAP columns";
   } else {
     std::cout << batchMemory

--- a/tools/src/FileMemory.cc
+++ b/tools/src/FileMemory.cc
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "orc/ColumnPrinter.hh"
+#include "Exceptions.hh"
+
+#include <string>
+#include <memory>
+#include <iostream>
+#include <map>
+#include <exception>
+
+class TestMemoryPool: public orc::MemoryPool {
+private:
+  std::map<char*, uint64_t> blocks;
+  uint64_t totalMemory;
+  uint64_t maxMemory;
+
+public:
+  char* malloc(uint64_t size) override {
+    char* p = static_cast<char*>(std::malloc(size));
+    blocks[p] = size ;
+    totalMemory += size;
+    if (maxMemory < totalMemory) {
+      maxMemory = totalMemory;
+    }
+    return p;
+  }
+
+  void free(char* p) override {
+    std::free(p);
+    totalMemory -= blocks[p] ;
+    blocks.erase(p);
+  }
+
+  uint64_t getMaxMemory() {
+    return maxMemory ;
+  }
+
+  TestMemoryPool(): totalMemory(0), maxMemory(0) {}
+  ~TestMemoryPool();
+};
+
+TestMemoryPool::~TestMemoryPool() {}
+
+int main(int argc, char* argv[]) {
+  if (argc < 2) {
+    std::cout << "Usage: file-memory [--columns=column1,column2,...] "
+        << "[--batch=rows_in_batch] <filename> \n";
+    return 1;
+  }
+
+  const std::string COLUMNS_PREFIX = "--columns=";
+  const std::string BATCH_PREFIX = "--batch=";
+  char* filename = ORC_NULLPTR;
+
+  // Default parameters
+  std::list<int64_t> cols;
+  uint32_t batchSize = 1000;
+
+  // Read command-line options
+  char *param, *value;
+  for (int i = 1; i < argc; i++) {
+    if ( (param = std::strstr(argv[i], COLUMNS_PREFIX.c_str())) ) {
+      value = std::strtok(param+COLUMNS_PREFIX.length(), "," );
+      while (value) {
+        cols.push_back(std::atoi(value));
+        value = std::strtok(nullptr, "," );
+      }
+    } else if ( (param=strstr(argv[i], BATCH_PREFIX.c_str())) ) {
+      batchSize = static_cast<uint32_t>(std::atoi(param+BATCH_PREFIX.length()));
+    } else {
+      filename = argv[i];
+    }
+  }
+
+  if (filename == ORC_NULLPTR) {
+    std::cout << "Error: Filename not provided.\n";
+    return 1;
+  }
+
+  orc::ReaderOptions opts;
+  if (cols.size() > 0) {
+    opts.include(cols);
+  }
+  std::unique_ptr<orc::MemoryPool> pool(new TestMemoryPool());
+  opts.setMemoryPool(*(pool.get()));
+
+  std::unique_ptr<orc::Reader> reader;
+  try{
+    reader = orc::createReader(orc::readLocalFile(std::string(filename)), opts);
+  } catch (orc::ParseError e) {
+    std::cout << "Error reading file " << filename << "! " << e.what() << "\n";
+    return -1;
+  }
+
+  std::unique_ptr<orc::ColumnVectorBatch> batch =
+      reader->createRowBatch(batchSize);
+  uint64_t readerMemory = reader->memoryUse();
+  int64_t batchMemory = batch->memoryUse();
+  while (reader->next(*batch)) {}
+  uint64_t actualMemory =
+      static_cast<TestMemoryPool*>(pool.get())->getMaxMemory();
+  std::cout << "Reader memory estimate: " << readerMemory
+            << "\nBatch memory estimate:  " ;
+  if (batchMemory == -1) {
+    std::cout << "Cannot estimate because reading ARRAY or MAP columns";
+  } else {
+    std::cout << batchMemory
+              << "\nTotal memory estimate:  " << readerMemory + batchMemory;
+  }
+  std::cout << "\nActual max memory used: " << actualMemory << "\n";
+
+  return 0;
+}

--- a/tools/test/TestReader.cc
+++ b/tools/test/TestReader.cc
@@ -977,6 +977,81 @@ TEST(Reader, selectColumns) {
     }
 }
 
+TEST(Reader, memoryUse) {
+  std::ostringstream filename;
+  filename << exampleDirectory << "/TestOrcFile.testSeek.orc";
+  std::unique_ptr<orc::Reader> reader;
+  std::unique_ptr<orc::ColumnVectorBatch> batch;
+  orc::ReaderOptions opts;
+  std::list<int64_t> cols;
+
+  // Int column
+  cols.push_back(2);
+  opts.include(cols);
+  reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
+  EXPECT_EQ(483517, reader->memoryUse());
+  batch = reader->createRowBatch(1);
+  EXPECT_EQ(10, batch->memoryUse());
+  batch = reader->createRowBatch(1000);
+  EXPECT_EQ(10000, batch->memoryUse());
+
+  // Binary column
+  cols.clear();
+  cols.push_back(8);
+  opts.include(cols);
+  reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
+  EXPECT_EQ(835906, reader->memoryUse());
+  batch = reader->createRowBatch(1);
+  EXPECT_EQ(18, batch->memoryUse());
+
+  // String column
+  cols.clear();
+  cols.push_back(9);
+  opts.include(cols);
+  reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
+  EXPECT_EQ(901442, reader->memoryUse());
+  batch = reader->createRowBatch(1);
+  EXPECT_EQ(18, batch->memoryUse());
+
+  // Struct column (with list subcolumn)
+  cols.clear();
+  cols.push_back(10);
+  opts.include(cols);
+  reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
+  EXPECT_EQ(1294658, reader->memoryUse());
+  batch = reader->createRowBatch(1);
+  EXPECT_EQ(-1, batch->memoryUse());
+  batch = reader->createRowBatch(1000);
+  EXPECT_EQ(-1, batch->memoryUse());
+
+  // List column
+   cols.clear();
+   cols.push_back(11);
+   opts.include(cols);
+   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
+   EXPECT_EQ(1229122, reader->memoryUse());
+   batch = reader->createRowBatch(1);
+   EXPECT_EQ(-1, batch->memoryUse());
+
+  // Map column
+  cols.clear();
+  cols.push_back(12);
+  opts.include(cols);
+  reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
+  EXPECT_EQ(1491266, reader->memoryUse());
+  batch = reader->createRowBatch(1);
+  EXPECT_EQ(-1, batch->memoryUse());
+
+  // All columns
+  cols.clear();
+  cols.push_back(0);
+  opts.include(cols);
+  reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
+  EXPECT_EQ(4112706, reader->memoryUse());
+  batch = reader->createRowBatch(1);
+  EXPECT_EQ(-1, batch->memoryUse());
+}
+
   std::map<std::string, std::string> makeMetadata() {
     std::map<std::string, std::string> result;
     result["my.meta"] = "\x01\x02\x03\x04\x05\x06\x07\xff\xfe\x7f\x80";

--- a/tools/test/TestReader.cc
+++ b/tools/test/TestReader.cc
@@ -989,67 +989,72 @@ TEST(Reader, memoryUse) {
   cols.push_back(2);
   opts.include(cols);
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
-  EXPECT_EQ(483517, reader->memoryUse());
+  EXPECT_EQ(483517, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(10, batch->memoryUse());
+  EXPECT_EQ(10, batch->getMemoryUsage());
   batch = reader->createRowBatch(1000);
-  EXPECT_EQ(10000, batch->memoryUse());
+  EXPECT_EQ(10000, batch->getMemoryUsage());
+  EXPECT_FALSE(batch->hasVariableLength());
 
   // Binary column
   cols.clear();
   cols.push_back(8);
   opts.include(cols);
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
-  EXPECT_EQ(835906, reader->memoryUse());
+  EXPECT_EQ(835906, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(18, batch->memoryUse());
+  EXPECT_EQ(18, batch->getMemoryUsage());
+  EXPECT_FALSE(batch->hasVariableLength());
 
   // String column
   cols.clear();
   cols.push_back(9);
   opts.include(cols);
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
-  EXPECT_EQ(901442, reader->memoryUse());
+  EXPECT_EQ(901442, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(18, batch->memoryUse());
+  EXPECT_EQ(18, batch->getMemoryUsage());
+  EXPECT_FALSE(batch->hasVariableLength());
 
-  // Struct column (with list subcolumn)
+  // Struct column (with a List subcolumn)
   cols.clear();
   cols.push_back(10);
   opts.include(cols);
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
-  EXPECT_EQ(1294658, reader->memoryUse());
+  EXPECT_EQ(1294658, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(-1, batch->memoryUse());
-  batch = reader->createRowBatch(1000);
-  EXPECT_EQ(-1, batch->memoryUse());
+  EXPECT_EQ(46, batch->getMemoryUsage());
+  EXPECT_TRUE(batch->hasVariableLength());
 
   // List column
    cols.clear();
    cols.push_back(11);
    opts.include(cols);
    reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
-   EXPECT_EQ(1229122, reader->memoryUse());
+   EXPECT_EQ(1229122, reader->getMemoryUse());
    batch = reader->createRowBatch(1);
-   EXPECT_EQ(-1, batch->memoryUse());
+   EXPECT_EQ(45, batch->getMemoryUsage());
+   EXPECT_TRUE(batch->hasVariableLength());
 
   // Map column
   cols.clear();
   cols.push_back(12);
   opts.include(cols);
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
-  EXPECT_EQ(1491266, reader->memoryUse());
+  EXPECT_EQ(1491266, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(-1, batch->memoryUse());
+  EXPECT_EQ(35, batch->getMemoryUsage());
+  EXPECT_TRUE(batch->hasVariableLength());
 
   // All columns
   cols.clear();
   cols.push_back(0);
   opts.include(cols);
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
-  EXPECT_EQ(4112706, reader->memoryUse());
+  EXPECT_EQ(4112706, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(-1, batch->memoryUse());
+  EXPECT_EQ(221, batch->getMemoryUsage());
+  EXPECT_TRUE(batch->hasVariableLength());
 }
 
   std::map<std::string, std::string> makeMetadata() {

--- a/tools/test/TestReader.cc
+++ b/tools/test/TestReader.cc
@@ -1043,7 +1043,7 @@ TEST(Reader, memoryUse) {
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
   EXPECT_EQ(1491266, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(35, batch->getMemoryUsage());
+  EXPECT_EQ(62, batch->getMemoryUsage());
   EXPECT_TRUE(batch->hasVariableLength());
 
   // All columns
@@ -1053,7 +1053,7 @@ TEST(Reader, memoryUse) {
   reader = orc::createReader(orc::readLocalFile(filename.str()), opts);
   EXPECT_EQ(4112706, reader->getMemoryUse());
   batch = reader->createRowBatch(1);
-  EXPECT_EQ(221, batch->getMemoryUsage());
+  EXPECT_EQ(248, batch->getMemoryUsage());
   EXPECT_TRUE(batch->hasVariableLength());
 }
 


### PR DESCRIPTION
An upper bound on memory requirements is provided by two components:
* Reader::memoryUse() returns an upper bound on its memory needs. It depends on the file and columns read.
* ColumnBatch::memoryUse() returns an upper bound on its memory needs. It depends on the file, columns, and number of rows read.

The new utility FileMemory.cc compares estimated and actual memory usage.