### PR TITLE
ORC-56. Extend cmake system to build, test, and package java also.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,20 +89,28 @@ elseif (MSVC)
 
   set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /NODEFAULTLIB:msvcrtd.lib")
 endif ()
-  
+
 enable_testing()
 
 set (EXAMPLE_DIRECTORY ${CMAKE_SOURCE_DIR}/examples)
 
 add_subdirectory(c++)
 add_subdirectory(tools)
+add_subdirectory(java)
 
 # Add another target called test-out that prints the results on failure
 if (CMAKE_CONFIGURATION_TYPES)
-  add_custom_target (test-out COMMAND ${CMAKE_CTEST_COMMAND}
-    --force-new-ctest-process --output-on-failure
-    --build-config "$<CONFIGURATION>")
+  add_custom_target (test-out
+    COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process
+      --output-on-failure --build-config "$<CONFIGURATION>"
+  )
 else (CMAKE_CONFIGURATION_TYPES)
-  add_custom_target (test-out COMMAND ${CMAKE_CTEST_COMMAND}
-    --force-new-ctest-process --output-on-failure)
+  add_custom_target (test-out
+    COMMAND ${CMAKE_CTEST_COMMAND} --force-new-ctest-process
+      --output-on-failure
+  )
 endif (CMAKE_CONFIGURATION_TYPES)
+
+install(
+  FILES LICENSE NOTICE
+  DESTINATION .)

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -116,11 +116,9 @@ include_directories (
   )
 
 add_custom_command(OUTPUT orc_proto.pb.h orc_proto.pb.cc
-   COMMAND mkdir -p "${CMAKE_BINARY_DIR}/orc-java" &&
-     ${PROTOBUF_EXECUTABLE}
+   COMMAND ${PROTOBUF_EXECUTABLE}
         -I ${CMAKE_SOURCE_DIR}/proto
         --cpp_out="${CMAKE_CURRENT_BINARY_DIR}"
-        --java_out="${CMAKE_BINARY_DIR}/orc-java"
         "${CMAKE_SOURCE_DIR}/proto/orc_proto.proto"
 )
 

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS} ${WARN_FLAGS}")
 
-add_executable (test-orc
+add_executable (orc-test
   TestByteRle.cc
   TestColumnPrinter.cc
   TestColumnReader.cc
@@ -34,7 +34,7 @@ add_executable (test-orc
   TestType.cc
 )
 
-target_link_libraries (test-orc
+target_link_libraries (orc-test
   orc
   ${PROTOBUF_LIBRARIES}
   ${GMOCK_LIBRARIES}
@@ -51,5 +51,5 @@ target_link_libraries (create-test-files
   ${PROTOBUF_LIBRARIES}
 )
 
-add_test (test-orc test-orc)
+add_test (NAME orc-test COMMAND orc-test)
 

--- a/docker/centos6/Dockerfile
+++ b/docker/centos6/Dockerfile
@@ -29,12 +29,19 @@ RUN yum install -y \
   gcc-c++ \
   gettext-devel \
   git \
+  java-1.7.0-openjdk \
+  java-1.7.0-openjdk-devel \
   make \
   openssl-devel \
+  tar \
+  wget \
+  which \
   zlib-devel
 
-ENV TZ=America/Los_Angeles
 WORKDIR /root
+RUN wget http://apache.mesi.com.ar/maven/maven-3/3.3.9/binaries/apache-maven-3.3.9-bin.tar.gz -O maven.tgz
+RUN tar xzf maven.tgz
+RUN ln -s /root/apache-maven-3.3.9/bin/mvn /usr/bin/mvn
 
 CMD git clone https://github.com/apache/orc.git -b master && \
   mkdir orc/build && \

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -29,8 +29,12 @@ RUN yum install -y \
   gcc-c++ \
   gettext-devel \
   git \
+  java-1.7.0-openjdk \
+  java-1.7.0-openjdk-devel \
   make \
+  maven \
   openssl-devel \
+  which \
   zlib-devel
 
 ENV TZ=America/Los_Angeles

--- a/docker/debian7/Dockerfile
+++ b/docker/debian7/Dockerfile
@@ -26,9 +26,10 @@ RUN apt-get install -y \
   gcc \
   g++ \
   git \
-  make
+  make \
+  maven \
+  openjdk-7-jdk
 
-ENV TZ=America/Los_Angeles
 WORKDIR /root
 
 CMD git clone https://github.com/apache/orc.git -b master && \

--- a/docker/debian8/Dockerfile
+++ b/docker/debian8/Dockerfile
@@ -14,30 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ORC compile for CentOS 5
+# ORC compile for Debian 8
 #
 
-FROM centos:5
+FROM debian:8
 MAINTAINER Owen O'Malley <owen@hortonworks.com>
 
-RUN yum check-update || true
-RUN yum install -y \
+RUN apt-get update
+RUN apt-get install -y \
   cmake \
-  curl-devel \
-  expat-devel \
   gcc \
-  gcc-c++ \
-  gettext-devel \
+  g++ \
+  git \
   make \
-  openssl-devel \
-  wget \
-  zlib-devel
+  maven \
+  openjdk-7-jdk
 
-ENV TZ=America/Los_Angeles
 WORKDIR /root
-RUN wget https://github.com/git/git/archive/v2.7.0.tar.gz -O git.tgz
-RUN tar xzf git.tgz
-RUN cd git-2.7.0 && make prefix=/usr all install
 
 CMD git clone https://github.com/apache/orc.git -b master && \
   mkdir orc/build && \

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -20,7 +20,7 @@ URL=https://github.com/$GITHUB_USER/orc.git
 BRANCH=$2
 
 start=`date`
-for os in centos5 centos6 centos7 debian6 debian7 ubuntu12 ubuntu14; do
+for os in centos6 centos7 debian7 debian8 ubuntu12 ubuntu14 ubuntu16; do
   echo "Testing $os"
   ( cd $os && docker build -t "orc-$os" . )
   docker run "orc-$os" /bin/bash -c "git clone $URL -b $BRANCH && mkdir orc/build && cd orc/build && cmake .. && make package test-out" || exit 1

--- a/docker/ubuntu12/Dockerfile
+++ b/docker/ubuntu12/Dockerfile
@@ -26,9 +26,10 @@ RUN apt-get install -y \
   gcc \
   g++ \
   git \
-  make
+  make \
+  maven \
+  openjdk-7-jdk
 
-ENV TZ=America/Los_Angeles
 WORKDIR /root
 
 CMD git clone https://github.com/apache/orc.git -b master && \

--- a/docker/ubuntu14/Dockerfile
+++ b/docker/ubuntu14/Dockerfile
@@ -26,9 +26,10 @@ RUN apt-get install -y \
   gcc \
   g++ \
   git \
-  make
+  make \
+  maven \
+  openjdk-7-jdk
 
-ENV TZ=America/Los_Angeles
 WORKDIR /root
 
 CMD git clone https://github.com/apache/orc.git -b master && \

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -14,21 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ORC compile for Debian 6
+# ORC compile for Ubuntu 16
 #
 
-FROM debian:6
+FROM ubuntu:16.04
 MAINTAINER Owen O'Malley <owen@hortonworks.com>
 
 RUN apt-get update
 RUN apt-get install -y \
   cmake \
+  default-jdk \
   gcc \
   g++ \
   git \
-  make
+  make \
+  maven
 
-ENV TZ=America/Los_Angeles
 WORKDIR /root
 
 CMD git clone https://github.com/apache/orc.git -b master && \

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -1,0 +1,39 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# set the version in the POM file to match the CMake version string
+execute_process(COMMAND mvn versions:set -DnewVersion=${ORC_VERSION}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(ORC_JARS
+  ${CMAKE_CURRENT_BINARY_DIR}/storage-api/hive-storage-api-2.0.2-pre-orc.jar
+  ${CMAKE_CURRENT_BINARY_DIR}/core/orc-core-${ORC_VERSION}.jar
+  ${CMAKE_CURRENT_BINARY_DIR}/mapreduce/orc-mapreduce-${ORC_VERSION}.jar
+)
+
+add_custom_command(
+   OUTPUT ${ORC_JARS}
+   COMMAND mvn -Pcmake -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} -DskipTests package
+   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+   COMMENT "Build the java directory"
+   VERBATIM)
+
+add_custom_target(java_build ALL DEPENDS ${ORC_JARS})
+
+add_test(
+  NAME java-test
+  COMMAND mvn -Pcmake -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+install(
+  FILES ${ORC_JARS}
+  DESTINATION share)

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.orc</groupId>
     <artifactId>orc</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -136,7 +136,7 @@
             </goals>
             <configuration>
               <sources>
-                <source>target/generated-sources</source>
+                <source>${project.build.directory}/generated-sources</source>
               </sources>
             </configuration>
           </execution>
@@ -176,4 +176,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>cmake</id>
+      <build>
+        <directory>${build.dir}/core</directory>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>org.apache.orc</groupId>
     <artifactId>orc</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
-      <version>1.1.0-SNAPSHOT</version>
+      <version>1.1.0</version>
     </dependency>
 
     <!-- inter-project -->
@@ -140,4 +140,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>cmake</id>
+      <build>
+        <directory>${build.dir}/mapreduce</directory>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -21,7 +21,7 @@
   </parent>
   <groupId>org.apache.orc</groupId>
   <artifactId>orc</artifactId>
-  <version>1.1.0-SNAPSHOT</version>
+  <version>1.1.0</version>
   <packaging>pom</packaging>
 
   <name>ORC</name>
@@ -98,6 +98,15 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>cmake</id>
+      <build>
+        <directory>${build.dir}</directory>
+      </build>
+    </profile>
+  </profiles>
 
   <dependencies>
     <!-- global dependencies -->

--- a/java/storage-api/pom.xml
+++ b/java/storage-api/pom.xml
@@ -75,4 +75,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>cmake</id>
+      <build>
+        <directory>${build.dir}/storage-api</directory>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
This patch:
  * extends the cmake build to build, test, and package the java
  * causes cmake to set the java version to the one in the cmake file
  * adds a cmake profile to the pom files so that they can build into the cmake target directory
  * removes the end-of-life centos5 and debian6 from the docker test scripts
  * adds the new debian8, and ubuntu 16.04 docker scripts
  * renames the test-orc executable to orc-test
  * adds jdk and maven to each of the Docker scripts
  * removes the setting of TZ from the Docker scripts
  * adds the LICENSE and NOTICE file to the tar balls.