### PR TITLE
ORC-54: Evolve schemas based on field name rather than index

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -82,6 +82,12 @@ public enum OrcConf {
       "If ORC reader encounters corrupt data, this value will be used to\n" +
           "determine whether to skip the corrupt data or throw exception.\n" +
           "The default behavior is to throw exception."),
+  TOLERATE_MISSING_SCHEMA("orc.tolerate.missing.schema",
+      "hive.exec.orc.tolerate.missing.schema",
+      true,
+      "Writers earlier than HIVE-4243 may have inaccurate schema metadata.\n"
+          + "This setting will enable best effort schema evolution rather\n"
+          + "than rejecting mismatched schemas"),
   MEMORY_POOL("orc.memory.pool", "hive.exec.orc.memory.pool", 0.5,
       "Maximum fraction of heap that can be used by ORC file writers"),
   DICTIONARY_KEY_SIZE_THRESHOLD("orc.dictionary.key.threshold",

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -150,6 +150,7 @@ public interface Reader {
     private Boolean skipCorruptRecords = null;
     private TypeDescription schema = null;
     private DataReader dataReader = null;
+    private Boolean tolerateMissingSchema = false;
 
     /**
      * Set the list of columns to read.
@@ -218,6 +219,18 @@ public interface Reader {
       return this;
     }
 
+    /**
+     * Set whether to make a best effort to tolerate schema evolution for files
+     * which do not have an embedded schema because they were written with a'
+     * pre-HIVE-4243 writer.
+     * @param value the new tolerance flag
+     * @return this
+     */
+    public Options tolerateMissingSchema(boolean value) {
+      this.tolerateMissingSchema = value;
+      return this;
+    }
+
     public boolean[] getInclude() {
       return include;
     }
@@ -273,6 +286,7 @@ public interface Reader {
       result.useZeroCopy = useZeroCopy;
       result.skipCorruptRecords = skipCorruptRecords;
       result.dataReader = dataReader == null ? null : dataReader.clone();
+      result.tolerateMissingSchema = tolerateMissingSchema;
       return result;
     }
 
@@ -316,6 +330,10 @@ public interface Reader {
       }
       buffer.append("}");
       return buffer.toString();
+    }
+
+    public boolean getTolerateMissingSchema() {
+      return tolerateMissingSchema;
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/BitFieldReader.java
+++ b/java/core/src/java/org/apache/orc/impl/BitFieldReader.java
@@ -34,7 +34,7 @@ public class BitFieldReader {
   private final int mask;
 
   public BitFieldReader(InStream input,
-      int bitSize) throws IOException {
+      int bitSize) {
     this.input = new RunLengthByteReader(input);
     this.bitSize = bitSize;
     mask = (1 << bitSize) - 1;

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -2734,8 +2734,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     }
   }
 
-  public static boolean canConvert(TypeDescription fileType, TypeDescription readerType)
-    throws IOException {
+  public static boolean canConvert(TypeDescription fileType, TypeDescription readerType) {
 
     Category readerTypeCategory = readerType.getCategory();
 

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -572,7 +572,14 @@ public class ReaderImpl implements Reader {
     boolean[] include = options.getInclude();
     // if included columns is null, then include all columns
     if (include == null) {
-      include = new boolean[types.size()];
+      int size;
+      TypeDescription readSchema = options.getSchema();
+      if (readSchema != null){
+        size = readSchema.getMaximumId() + 1;
+      } else {
+        size = types.size();
+      }
+      include = new boolean[size];
       Arrays.fill(include, true);
       options.include(include);
     }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
@@ -35,7 +35,7 @@ public class RunLengthByteReader {
   private int used = 0;
   private boolean repeat = false;
 
-  public RunLengthByteReader(InStream input) throws IOException {
+  public RunLengthByteReader(InStream input) {
     this.input = input;
   }
 

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -18,25 +18,33 @@
 
 package org.apache.orc.impl;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.orc.TypeDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Take the file types and the (optional) configuration column names/types and see if there
- * has been schema evolution.
+ * Infer and track the evolution between the schema as stored in the file and the schema that has been requested by the
+ * reader.
  */
 public class SchemaEvolution {
+
+  public static class IllegalEvolutionException extends RuntimeException {
+    public IllegalEvolutionException(String msg) {
+      super(msg);
+    }
+  }
+
   private final Map<Integer, TypeDescription> readerToFile;
   private final boolean[] included;
   private final TypeDescription readerSchema;
   private static final Logger LOG = LoggerFactory.getLogger(SchemaEvolution.class);
+  private static final Pattern missingMetadataPattern = Pattern.compile("_col\\d+");
 
   public SchemaEvolution(TypeDescription readerSchema, boolean[] included) {
     this.included = included;
@@ -45,8 +53,9 @@ public class SchemaEvolution {
   }
 
   public SchemaEvolution(TypeDescription fileSchema,
-                         TypeDescription readerSchema,
-                         boolean[] included) throws IOException {
+      TypeDescription readerSchema,
+      boolean allowMissingMetadata,
+      boolean[] included) {
     readerToFile = new HashMap<>(readerSchema.getMaximumId() + 1);
     this.included = included;
     if (checkAcidSchema(fileSchema)) {
@@ -54,7 +63,55 @@ public class SchemaEvolution {
     } else {
       this.readerSchema = readerSchema;
     }
-    buildMapping(fileSchema, this.readerSchema);
+
+    boolean useFieldNames;
+    if (!hasColumnNames(fileSchema)){
+      if (!allowMissingMetadata && !fileSchema.equals(readerSchema)){
+        throw new RuntimeException("Found that schema metadata is missing from file. This is likely caused by a writer earlier than HIVE-4243. Will not try to reconcile schemas");
+      } else {
+        LOG.warn("Found that schema metadata is missing from file. This is likely caused by a writer earlier than HIVE-4243. Will try to reconcile schemas based on index");
+        useFieldNames = false;
+      }
+    } else {
+      useFieldNames = true;
+    }
+    buildMapping(fileSchema, this.readerSchema, useFieldNames);
+  }
+
+  // Return true iff all fields have names like _col[0-9]+
+  private boolean hasColumnNames(TypeDescription fileSchema) {
+    switch (fileSchema.getCategory()) {
+    case STRUCT:
+      for (String fieldName : fileSchema.getFieldNames()) {
+        if (!missingMetadataPattern.matcher(fieldName).matches()) {
+          return true;
+        }
+      }
+      for (TypeDescription child : fileSchema.getChildren()) {
+        if (hasColumnNames(child)) {
+          return true;
+        }
+      }
+      return false;
+
+    case MAP:
+      return hasColumnNames(fileSchema.getChildren().get(0))
+          || hasColumnNames(fileSchema.getChildren().get(1));
+
+    case UNION:
+      for (TypeDescription child : fileSchema.getChildren()) {
+        if (hasColumnNames(child)) {
+          return true;
+        }
+      }
+      return false;
+
+    case LIST:
+      return hasColumnNames(fileSchema.getChildren().get(0));
+
+    default:
+      return false;
+    }
   }
 
   public TypeDescription getReaderSchema() {
@@ -75,8 +132,8 @@ public class SchemaEvolution {
     return result;
   }
 
-  void buildMapping(TypeDescription fileType,
-                    TypeDescription readerType) throws IOException {
+  private void buildMapping(TypeDescription fileType,
+      TypeDescription readerType, boolean useFieldNames) {
     // if the column isn't included, don't map it
     if (included != null && !included[readerType.getId()]) {
       return;
@@ -85,55 +142,78 @@ public class SchemaEvolution {
     // check the easy case first
     if (fileType.getCategory() == readerType.getCategory()) {
       switch (readerType.getCategory()) {
-        case BOOLEAN:
-        case BYTE:
-        case SHORT:
-        case INT:
-        case LONG:
-        case DOUBLE:
-        case FLOAT:
-        case STRING:
-        case TIMESTAMP:
-        case BINARY:
-        case DATE:
-          // these are always a match
-          break;
-        case CHAR:
-        case VARCHAR:
-          // HIVE-13648: Look at ORC data type conversion edge cases (CHAR, VARCHAR, DECIMAL)
-          isOk = fileType.getMaxLength() == readerType.getMaxLength();
-          break;
-        case DECIMAL:
-          // HIVE-13648: Look at ORC data type conversion edge cases (CHAR, VARCHAR, DECIMAL)
-          // TODO we don't enforce scale and precision checks, but probably should
-          break;
-        case UNION:
-        case MAP:
-        case LIST: {
-          // these must be an exact match
-          List<TypeDescription> fileChildren = fileType.getChildren();
-          List<TypeDescription> readerChildren = readerType.getChildren();
-          if (fileChildren.size() == readerChildren.size()) {
-            for(int i=0; i < fileChildren.size(); ++i) {
-              buildMapping(fileChildren.get(i), readerChildren.get(i));
+      case BOOLEAN:
+      case BYTE:
+      case SHORT:
+      case INT:
+      case LONG:
+      case DOUBLE:
+      case FLOAT:
+      case STRING:
+      case TIMESTAMP:
+      case BINARY:
+      case DATE:
+        // these are always a match
+        break;
+      case CHAR:
+      case VARCHAR:
+        // HIVE-13648: Look at ORC data type conversion edge cases (CHAR, VARCHAR, DECIMAL)
+        isOk = fileType.getMaxLength() == readerType.getMaxLength();
+        break;
+      case DECIMAL:
+        // HIVE-13648: Look at ORC data type conversion edge cases (CHAR, VARCHAR, DECIMAL)
+        // TODO we don't enforce scale and precision checks, but probably should
+        break;
+      case UNION:
+      case MAP:
+      case LIST: {
+        // these must be an exact match
+        List<TypeDescription> fileChildren = fileType.getChildren();
+        List<TypeDescription> readerChildren = readerType.getChildren();
+        if (fileChildren.size() == readerChildren.size()) {
+          for (int i = 0; i < fileChildren.size(); ++i) {
+            buildMapping(fileChildren.get(i), readerChildren.get(i), useFieldNames);
+          }
+        } else {
+          isOk = false;
+        }
+        break;
+      }
+      case STRUCT: {
+        List<TypeDescription> readerChildren = readerType.getChildren();
+        List<String> readerFieldNames = readerType.getFieldNames();
+
+        List<String> fileFieldNames = fileType.getFieldNames();
+        List<TypeDescription> fileChildren =
+            fileType.getChildren();
+
+        if (useFieldNames) {
+          Map<String, TypeDescription> fileTypesIdx = new HashMap<>();
+          for (int i = 0; i < fileFieldNames.size(); i++) {
+            fileTypesIdx.put(fileFieldNames.get(i), fileChildren.get(i));
+          }
+
+          for (int i = 0; i < readerFieldNames.size(); i++) {
+            String readerFieldName = readerFieldNames.get(i);
+            TypeDescription readerField = readerChildren.get(i);
+
+            TypeDescription fileField = fileTypesIdx.get(readerFieldName);
+            if (fileField == null) {
+              continue;
             }
-          } else {
-            isOk = false;
+
+            buildMapping(fileField, readerField, true);
           }
-          break;
-        }
-        case STRUCT: {
-          // allow either side to have fewer fields than the other
-          List<TypeDescription> fileChildren = fileType.getChildren();
-          List<TypeDescription> readerChildren = readerType.getChildren();
+        } else {
           int jointSize = Math.min(fileChildren.size(), readerChildren.size());
-          for(int i=0; i < jointSize; ++i) {
-            buildMapping(fileChildren.get(i), readerChildren.get(i));
+          for (int i = 0; i < jointSize; ++i) {
+            buildMapping(fileChildren.get(i), readerChildren.get(i), false);
           }
-          break;
         }
-        default:
-          throw new IllegalArgumentException("Unknown type " + readerType);
+        break;
+      }
+      default:
+        throw new IllegalArgumentException("Unknown type " + readerType);
       }
     } else {
       /*
@@ -145,7 +225,7 @@ public class SchemaEvolution {
     if (isOk) {
       readerToFile.put(readerType.getId(), fileType);
     } else {
-      throw new IOException(
+      throw new IllegalEvolutionException(
           String.format(
               "ORC does not support type conversion from file type %s (%d) to reader type %s (%d)",
               fileType.toString(), fileType.getId(),
@@ -178,7 +258,9 @@ public class SchemaEvolution {
     return result;
   }
 
-  public static final List<String> acidEventFieldNames= new ArrayList<String>();
+  public static final List<String> acidEventFieldNames =
+      new ArrayList<String>();
+
   static {
     acidEventFieldNames.add("operation");
     acidEventFieldNames.add("originalTransaction");

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -201,6 +201,10 @@ public class TreeReaderFactory {
     public BitFieldReader getPresent() {
       return present;
     }
+
+    public void collectRequiredColumns(boolean[] writerColumns){
+      writerColumns[columnId] = true;
+    };
   }
 
   public static class NullTreeReader extends TreeReader {
@@ -235,6 +239,11 @@ public class TreeReaderFactory {
       vector.noNulls = false;
       vector.isNull[0] = true;
       vector.isRepeating = true;
+    }
+
+    @Override
+    public void collectRequiredColumns(boolean[] writerColumns) {
+      // PASS
     }
   }
 
@@ -1778,6 +1787,14 @@ public class TreeReaderFactory {
         }
       }
     }
+
+    @Override
+    public void collectRequiredColumns(boolean[] writerColumns){
+      super.collectRequiredColumns(writerColumns);
+      for (TreeReader field : fields){
+        field.collectRequiredColumns(writerColumns);
+      }
+    }
   }
 
   public static class UnionTreeReader extends TreeReader {
@@ -1853,6 +1870,14 @@ public class TreeReaderFactory {
       }
       for (int i = 0; i < counts.length; ++i) {
         fields[i].skipRows(counts[i]);
+      }
+    }
+
+    @Override
+    public void collectRequiredColumns(boolean[] writerColumns) {
+      super.collectRequiredColumns(writerColumns);
+      for (TreeReader field : fields){
+        field.collectRequiredColumns(writerColumns);
       }
     }
   }
@@ -1933,6 +1958,12 @@ public class TreeReaderFactory {
         childSkip += lengths.next();
       }
       elementReader.skipRows(childSkip);
+    }
+
+    @Override
+    public void collectRequiredColumns(boolean[] writerColumns) {
+      super.collectRequiredColumns(writerColumns);
+      elementReader.collectRequiredColumns(writerColumns);
     }
   }
 
@@ -2020,6 +2051,13 @@ public class TreeReaderFactory {
       }
       keyReader.skipRows(childSkip);
       valueReader.skipRows(childSkip);
+    }
+
+    @Override
+    public void collectRequiredColumns(boolean[] writerColumns) {
+      super.collectRequiredColumns(writerColumns);
+      keyReader.collectRequiredColumns(writerColumns);
+      valueReader.collectRequiredColumns(writerColumns);
     }
   }
 

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -1,0 +1,400 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.orc.impl;
+
+import org.apache.orc.TypeDescription;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertSame;
+
+public class TestSchemaEvolution {
+
+  private boolean[] includeAll(TypeDescription readerType) {
+    int numColumns = readerType.getMaximumId() + 1;
+    boolean[] result = new boolean[numColumns];
+    Arrays.fill(result, true);
+    return result;
+  }
+
+  @Test
+  public void testAddFieldToEnd() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,b:string,c:double>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // b -> b
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(2);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testAddFieldBeforeEnd() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,c:double,b:string>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+
+    // b -> b
+    reader = readerType.getChildren().get(2);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testRemoveLastField() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string,c:double>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // b -> b
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testRemoveFieldBeforeEnd() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string,c:double>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,c:double>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c -> b
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(2);
+    assertSame(original, mapped);
+
+  }
+
+  @Test
+  public void testRemoveAndAddField() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,c:double>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testReorderFields() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<b:string,a:int>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // b -> b
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+
+    // a -> a
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testAddFieldEndOfStruct() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:struct<b:int>,c:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:struct<b:int,d:double>,c:string>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    TypeDescription readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    TypeDescription originalChild = original.getChildren().get(0);
+    assertSame(originalChild, mapped);
+
+    // a.d -> null
+    readerChild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerChild);
+    originalChild = null;
+    assertSame(originalChild, mapped);
+
+    // c -> c
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testAddFieldBeforeEndOfStruct() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:struct<b:int>,c:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:struct<d:double,b:int>,c:string>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    TypeDescription readerChild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerChild);
+    TypeDescription originalChild = original.getChildren().get(0);
+    assertSame(originalChild, mapped);
+
+    // a.d -> null
+    readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    originalChild = null;
+    assertSame(originalChild, mapped);
+
+    // c -> c
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  /**
+   * Two structs can be equal but in different locations. They can converge to this.
+   */
+  @Test
+  public void testAddSimilarField() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:struct<b:int>>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:struct<b:int>,c:struct<b:int>>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    TypeDescription readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    TypeDescription originalChild = original.getChildren().get(0);
+    assertSame(originalChild, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+
+    // c.b -> null
+    readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  /**
+   * Two structs can be equal but in different locations. They can converge to this.
+   */
+  @Test
+  public void testConvergentEvolution() {
+    TypeDescription fileType = TypeDescription
+        .fromString("struct<a:struct<a:int,b:string>,c:struct<a:int>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<a:struct<a:int,b:string>,c:struct<a:int,b:string>>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // c -> c
+    TypeDescription reader = readerType.getChildren().get(1);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+
+    // c.a -> c.a
+    TypeDescription readerchild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c.b -> null
+    readerchild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerchild);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testMapEvolution() {
+    TypeDescription fileType =
+        TypeDescription
+            .fromString("struct<a:map<struct<a:int>,struct<a:int>>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<a:map<struct<a:int,b:string>,struct<a:int,c:string>>>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.key -> a.key
+    TypeDescription readerchild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.value -> a.value
+    readerchild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerchild);
+    original = fileType.getChildren().get(0).getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testListEvolution() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:array<struct<b:int>>>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:array<struct<b:int,c:string>>>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.element -> a.element
+    TypeDescription readerchild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    readerchild = reader.getChildren().get(0).getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.c -> null
+    readerchild = reader.getChildren().get(0).getChildren().get(1);
+    mapped = transition.getFileType(readerchild);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test(expected = SchemaEvolution.IllegalEvolutionException.class)
+  public void testIncompatibleTypes() {
+    TypeDescription fileType = TypeDescription.fromString("struct<a:int>");
+    TypeDescription readerType = TypeDescription.fromString("struct<a:date>");
+    boolean[] included = includeAll(readerType);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, false, included);
+  }
+}

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
@@ -113,7 +113,8 @@ public class OrcInputFormat<V extends WritableComparable>
     Reader.Options options = new Reader.Options()
         .range(start, length)
         .useZeroCopy(OrcConf.USE_ZEROCOPY.getBoolean(conf))
-        .skipCorruptRecords(OrcConf.SKIP_CORRUPT_DATA.getBoolean(conf));
+        .skipCorruptRecords(OrcConf.SKIP_CORRUPT_DATA.getBoolean(conf))
+        .tolerateMissingSchema(OrcConf.TOLERATE_MISSING_SCHEMA.getBoolean(conf));
     if (schema != null) {
       options.schema(schema);
     } else {

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -1,0 +1,331 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.mapred;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.*;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.orc.*;
+import org.apache.orc.TypeDescription.Category;
+import org.apache.orc.impl.SchemaEvolution;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test the behavior of ORC's schema evolution
+ */
+public class TestOrcFileEvolution {
+
+  // These utility methods are just to make writing tests easier. The values
+  // created here will not feed directly to the ORC writers, but are converted
+  // within checkEvolution().
+  private List<Object> struct(Object... fields) {
+    return list(fields);
+  }
+
+  private List<Object> list(Object... elements) {
+    return Arrays.asList(elements);
+  }
+
+  private Map<Object, Object> map(Object... kvs) {
+    if (kvs.length != 2) {
+      throw new IllegalArgumentException(
+          "Map must be provided an even number of arguments");
+    }
+
+    Map<Object, Object> result = new HashMap<>();
+    for (int i = 0; i < kvs.length; i += 2) {
+      result.put(kvs[i], kvs[i + 1]);
+    }
+    return result;
+  }
+
+  Path workDir = new Path(System.getProperty("test.tmp.dir",
+      "target" + File.separator + "test" + File.separator + "tmp"));
+
+  Configuration conf;
+  FileSystem fs;
+  Path testFilePath;
+
+  @Rule
+  public TestName testCaseName = new TestName();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void openFileSystem() throws Exception {
+    conf = new Configuration();
+    fs = FileSystem.getLocal(conf);
+    testFilePath = new Path(workDir, "TestOrcFile." +
+        testCaseName.getMethodName() + ".orc");
+    fs.delete(testFilePath, false);
+  }
+
+  @Test
+  public void testAddFieldToEnd() {
+    checkEvolution("struct<a:int,b:string>", "struct<a:int,b:string,c:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null));
+  }
+
+  @Test
+  public void testAddFieldBeforeEnd() {
+    checkEvolution("struct<a:int,b:string>", "struct<a:int,c:double,b:string>",
+        struct(1, "foo"),
+        struct(1, null, "foo"));
+  }
+
+  @Test
+  public void testRemoveLastField() {
+    checkEvolution("struct<a:int,b:string,c:double>", "struct<a:int,b:string>",
+        struct(1, "foo", 3.14),
+        struct(1, "foo"));
+  }
+
+  @Test
+  public void testRemoveFieldBeforeEnd() {
+    checkEvolution("struct<a:int,b:string,c:double>", "struct<a:int,c:double>",
+        struct(1, "foo", 3.14),
+        struct(1, 3.14));
+  }
+
+  @Test
+  public void testRemoveAndAddField() {
+    checkEvolution("struct<a:int,b:string>", "struct<a:int,c:double>",
+        struct(1, "foo"), struct(1, null));
+  }
+
+  @Test
+  public void testReorderFields() {
+    checkEvolution("struct<a:int,b:string>", "struct<b:string,a:int>",
+        struct(1, "foo"), struct("foo", 1));
+  }
+
+  @Test
+  public void testAddFieldEndOfStruct() {
+    checkEvolution("struct<a:struct<b:int>,c:string>",
+        "struct<a:struct<b:int,d:double>,c:string>",
+        struct(struct(2), "foo"), struct(struct(2, null), "foo"));
+  }
+
+  @Test
+  public void testAddFieldBeforeEndOfStruct() {
+    checkEvolution("struct<a:struct<b:int>,c:string>",
+        "struct<a:struct<d:double,b:int>,c:string>",
+        struct(struct(2), "foo"), struct(struct(null, 2), "foo"));
+  }
+
+  @Test
+  public void testAddSimilarField() {
+    checkEvolution("struct<a:struct<b:int>>",
+        "struct<a:struct<b:int>,c:struct<b:int>>", struct(struct(2)),
+        struct(struct(2), null));
+  }
+
+  @Test
+  public void testConvergentEvolution() {
+    checkEvolution("struct<a:struct<a:int,b:string>,c:struct<a:int>>",
+        "struct<a:struct<a:int,b:string>,c:struct<a:int,b:string>>",
+        struct(struct(2, "foo"), struct(3)),
+        struct(struct(2, "foo"), struct(3, null)));
+  }
+
+  @Test
+  public void testMapKeyEvolution() {
+    checkEvolution("struct<a:map<struct<a:int>,int>>",
+        "struct<a:map<struct<a:int,b:string>,int>>",
+        struct(map(struct(1), 2)),
+        struct(map(struct(1, null), 2)));
+  }
+
+  @Test
+  public void testMapValueEvolution() {
+    checkEvolution("struct<a:map<int,struct<a:int>>>",
+        "struct<a:map<int,struct<a:int,b:string>>>",
+        struct(map(2, struct(1))),
+        struct(map(2, struct(1, null))));
+  }
+
+  @Test
+  public void testListEvolution() {
+    checkEvolution("struct<a:array<struct<b:int>>>",
+        "struct<a:array<struct<b:int,c:string>>>",
+        struct(list(struct(1), struct(2))),
+        struct(list(struct(1, null), struct(2, null))));
+  }
+
+  @Test
+  public void testPreHive4243CheckEqual() {
+    // Expect success on equal schemas
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<_col0:int,_col1:string>",
+        struct(1, "foo"),
+        struct(1, "foo", null), false);
+  }
+
+  @Test
+  public void testPreHive4243Check() {
+    // Expect exception on strict compatibility check
+    thrown.expectMessage("HIVE-4243");
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<_col0:int,_col1:string,_col2:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null), false);
+  }
+
+  @Test
+  public void testPreHive4243AddColumn() {
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<_col0:int,_col1:string,_col2:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null), true);
+  }
+
+  @Test
+  public void testPreHive4243AddColumnMiddle() {
+    // Expect exception on type mismatch
+    thrown.expect(SchemaEvolution.IllegalEvolutionException.class);
+    checkEvolution("struct<_col0:int,_col1:double>",
+        "struct<_col0:int,_col1:date,_col2:double>",
+        struct(1, 1.0),
+        null, true);
+  }
+
+  @Test
+  public void testPreHive4243AddColumnWithFix() {
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<a:int,b:string,c:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null), true);
+  }
+
+  @Test
+  public void testPreHive4243AddColumnMiddleWithFix() {
+    // Expect exception on type mismatch
+    thrown.expect(SchemaEvolution.IllegalEvolutionException.class);
+    checkEvolution("struct<_col0:int,_col1:double>",
+        "struct<a:int,b:date,c:double>",
+        struct(1, 1.0),
+        null, true);
+  }
+
+  private void checkEvolution(String writerType, String readerType,
+      Object inputRow, Object expectedOutput) {
+    checkEvolution(writerType, readerType,
+        inputRow, expectedOutput,
+        (boolean) OrcConf.TOLERATE_MISSING_SCHEMA.getDefaultValue());
+  }
+
+  private void checkEvolution(String writerType, String readerType,
+      Object inputRow, Object expectedOutput, boolean tolerateSchema) {
+    TypeDescription readTypeDescr = TypeDescription.fromString(readerType);
+    TypeDescription writerTypeDescr = TypeDescription.fromString(writerType);
+
+    OrcStruct inputStruct = assembleStruct(writerTypeDescr, inputRow);
+    OrcStruct expectedStruct = assembleStruct(readTypeDescr, expectedOutput);
+    try {
+      Writer writer = OrcFile.createWriter(testFilePath,
+          OrcFile.writerOptions(conf).setSchema(writerTypeDescr)
+              .stripeSize(100000).bufferSize(10000)
+              .version(OrcFile.Version.CURRENT));
+
+      OrcMapredRecordWriter<OrcStruct> recordWriter =
+          new OrcMapredRecordWriter<OrcStruct>(writer);
+      recordWriter.write(NullWritable.get(), inputStruct);
+      recordWriter.close(mock(Reporter.class));
+      Reader reader = OrcFile.createReader(testFilePath,
+          OrcFile.readerOptions(conf).filesystem(fs));
+      OrcMapredRecordReader<OrcStruct> recordReader =
+          new OrcMapredRecordReader<>(reader,
+              new Reader.Options().schema(readTypeDescr)
+                  .tolerateMissingSchema(tolerateSchema));
+      OrcStruct result = recordReader.createValue();
+      recordReader.next(recordReader.createKey(), result);
+      assertEquals(expectedStruct, result);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private OrcStruct assembleStruct(TypeDescription type, Object row) {
+    Preconditions.checkArgument(
+        type.getCategory() == Category.STRUCT, "Top level type must be STRUCT");
+
+    return (OrcStruct) assembleRecord(type, row);
+  }
+
+  private WritableComparable assembleRecord(TypeDescription type, Object row) {
+    if (row == null) {
+      return null;
+    }
+    switch (type.getCategory()) {
+    case STRUCT:
+      OrcStruct structResult = new OrcStruct(type);
+      for (int i = 0; i < structResult.getNumFields(); i++) {
+        List<TypeDescription> childTypes = type.getChildren();
+        structResult.setFieldValue(i,
+            assembleRecord(childTypes.get(i), ((List<Object>) row).get(i)));
+      }
+      return structResult;
+    case LIST:
+      OrcList<WritableComparable> listResult = new OrcList<>(type);
+      TypeDescription elemType = type.getChildren().get(0);
+      List<Object> elems = (List<Object>) row;
+      for (int i = 0; i < elems.size(); i++) {
+        listResult.add(assembleRecord(elemType, elems.get(i)));
+      }
+      return listResult;
+    case MAP:
+      OrcMap<WritableComparable, WritableComparable> mapResult =
+          new OrcMap<>(type);
+      TypeDescription keyType = type.getChildren().get(0);
+      TypeDescription valueType = type.getChildren().get(1);
+      for (Map.Entry<Object, Object> entry : ((Map<Object, Object>) row)
+          .entrySet()) {
+        mapResult.put(assembleRecord(keyType, entry.getKey()),
+            assembleRecord(valueType, entry.getValue()));
+      }
+      return mapResult;
+    case INT:
+      return new IntWritable((Integer) row);
+    case DOUBLE:
+      return new DoubleWritable((Double) row);
+    case STRING:
+      return new Text((String) row);
+    default:
+      throw new UnsupportedOperationException(String
+          .format("Not expecting to have a field of type %s in unit tests",
+              type.getCategory()));
+    }
+  }
+}


### PR DESCRIPTION
Change evolution to compare column names when building mapping.

Misc notes:
- I've added a setting orc.tolerate.missing.schema to allow working with data before HIVE-4243 was fixed. This is important for anyone who has older data, though it limits the evolutions that can be supported
- A lot of changes in RecordReaderImpl to make the reader column vs writer column difference explicit
- SARG tests are passing, but there's no test coverage for SARG + evolution. Will work on that.
- Removed some unneeded checked exceptions.