### PR TITLE
add support for nested column id selection, not only first level's id

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <set>
 
 namespace orc {
 
@@ -1112,6 +1113,7 @@ namespace orc {
     void selectType(const Type& type);
     void readMetadata() const;
     void updateSelected(const std::list<uint64_t>& fieldIds);
+    bool updateSelectedByIdHelper(const Type* type, std::set<uint64_t>& fieldIds);
     void updateSelected(const std::list<std::string>& fieldNames);
 
   public:
@@ -2206,20 +2208,44 @@ namespace orc {
   }
 
   void ReaderImpl::updateSelected(const std::list<uint64_t>& fieldIds) {
-    uint64_t childCount = schema->getSubtypeCount();
-    for(std::list<uint64_t>::const_iterator i = fieldIds.begin();
-        i != fieldIds.end(); ++i) {
-      if (*i >= childCount) {
-        std::stringstream buffer;
-        buffer << "Invalid column selected " << *i << " out of "
-               << childCount;
-        throw ParseError(buffer.str());
+    std::set<uint64_t> idSet(fieldIds.begin(), fieldIds.end());
+    updateSelectedByIdHelper(schema.get(), idSet);
+    if (!idSet.empty()) {
+      std::set<uint64_t>::const_iterator begIter = idSet.begin();
+      std::set<uint64_t>::const_iterator endIter = idSet.end();
+      std::stringstream buffer;
+      buffer << "Invalid column selected: ";
+      while (begIter != endIter) {
+        buffer << *begIter << " "; 
+        ++begIter;
       }
-      const Type& child = *schema->getSubtype(*i);
-      for(size_t c = child.getColumnId();
-          c <= child.getMaximumColumnId(); ++c){
+      buffer << "out of " << selectedColumns.size();
+      throw ParseError(buffer.str());
+    }
+  }
+
+  bool ReaderImpl::updateSelectedByIdHelper(const Type* type, std::set<uint64_t>& idSet) {
+    uint64_t columnId = type->getColumnId();
+    std::set<uint64_t>::const_iterator found = idSet.find(columnId);
+    if (found != idSet.end()) {
+      for (size_t c = columnId;
+          c <= type->getMaximumColumnId(); ++c) {
         selectedColumns[c] = true;
+        idSet.erase(c);
       }
+      return true;
+    }
+    if (0 == type->getSubtypeCount()) {
+      // primitive type, not found in idSet
+      return false;
+    } else {
+      // mark column as selected if any of his subtype is selected.
+      bool subtypeSelected = selectedColumns[columnId];
+      for (size_t i = 0; i < type->getSubtypeCount(); ++i) {
+        subtypeSelected |= updateSelectedByIdHelper(type->getSubtype(i), idSet);
+      }
+      selectedColumns[columnId] = subtypeSelected;
+      return subtypeSelected;
     }
   }
 


### PR DESCRIPTION
Currently, orc c++ ReaderOptions only supports first level's id selection. It is suitable for a flat data structure such as "struct\<int1:int, d1:double, t1:timestamp, d2:double\>". The column id is: 0(root type), 1(int1), 2(d1), 3(t1), 4(d2). We can choose any combinations of 1,2,3,4.

But if orc file's schema has different levels of nested types, the include function in ReaderOptions may not  work properly. If the schema is “struct\<int1:int, s1: struct\<d1:double, t1:timestamp, d2:doulbe\>\>".

We can only select combination of 1(int1), 2(s1). Selecting other column id will get an exception thrown.

In this patch, nested column id is supported. We can selected any column, if one column is selected, its path to the root will also be selected in order to create the reader.