### PR TITLE
ORC-92 add support for nested column id selection

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -503,9 +503,17 @@ namespace orc {
      * all columns are read. This option clears any previous setting of
      * the selected columns.
      * @param include a list of fields to read
+     * @param isColumnIdIncluded whether ids in include are ColumnId
      * @return this
      */
-    ReaderOptions& include(const std::list<uint64_t>& include);
+    ReaderOptions& include(const std::list<uint64_t>& include, 
+        bool isColumnIdIncluded = false);
+
+    /**
+     * Tell whether column ids are stored in include
+     * @return bool, true for column id
+     */
+    bool isColumnIdIncluded();
 
     /**
      * For files that have structs as the top-level object, select the fields

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -35,6 +35,7 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#include <set>
 
 namespace orc {
 
@@ -80,6 +81,7 @@ namespace orc {
     bool setIndexes;
     bool setNames;
     std::list<uint64_t> includedColumnIndexes;
+    bool isColumnIdIncluded;
     std::list<std::string> includedColumnNames;
     uint64_t dataStart;
     uint64_t dataLength;
@@ -93,6 +95,7 @@ namespace orc {
     ReaderOptionsPrivate() {
       setIndexes = false;
       setNames = false;
+      isColumnIdIncluded = false;
       dataStart = 0;
       dataLength = std::numeric_limits<uint64_t>::max();
       tailLocation = std::numeric_limits<uint64_t>::max();
@@ -133,12 +136,18 @@ namespace orc {
     // PASS
   }
 
-  ReaderOptions& ReaderOptions::include(const std::list<uint64_t>& include) {
+  ReaderOptions& ReaderOptions::include(const std::list<uint64_t>& include,
+          bool isColumnIdIncluded) {
     privateBits->setIndexes = true;
     privateBits->includedColumnIndexes.assign(include.begin(), include.end());
     privateBits->setNames = false;
     privateBits->includedColumnNames.clear();
+    privateBits->isColumnIdIncluded = isColumnIdIncluded;
     return *this;
+  }
+
+  bool ReaderOptions::isColumnIdIncluded() {
+    return privateBits->isColumnIdIncluded;
   }
 
   ReaderOptions& ReaderOptions::include
@@ -1115,7 +1124,10 @@ namespace orc {
     void checkOrcVersion();
     void selectType(const Type& type);
     void readMetadata() const;
-    void updateSelected(const std::list<uint64_t>& fieldIds);
+    void updateSelected(const std::list<uint64_t>& Ids);
+    void updateSelectedFieldId(const std::list<uint64_t>& fieldIds);
+    void updateSelectedColumnId(const std::list<uint64_t>& columnIds);
+    bool updateSelectedByIdHelper(const Type* type, std::set<uint64_t>& columnIds);
     void updateSelected(const std::list<std::string>& fieldNames);
 
   public:
@@ -2209,7 +2221,15 @@ namespace orc {
     }
   }
 
-  void ReaderImpl::updateSelected(const std::list<uint64_t>& fieldIds) {
+  void ReaderImpl::updateSelected(const std::list<uint64_t>& ids) {
+    if (options.isColumnIdIncluded()) {
+      updateSelectedColumnId(ids);
+    } else {
+      updateSelectedFieldId(ids);
+    }
+  }
+
+  void ReaderImpl::updateSelectedFieldId(const std::list<uint64_t>& fieldIds) {
     uint64_t childCount = schema->getSubtypeCount();
     for(std::list<uint64_t>::const_iterator i = fieldIds.begin();
         i != fieldIds.end(); ++i) {
@@ -2224,6 +2244,48 @@ namespace orc {
           c <= child.getMaximumColumnId(); ++c){
         selectedColumns[c] = true;
       }
+    }
+  }
+
+  void ReaderImpl::updateSelectedColumnId(const std::list<uint64_t>& columnIds) {
+    std::set<uint64_t> idSet(columnIds.begin(), columnIds.end());
+    updateSelectedByIdHelper(schema.get(), idSet);
+    if (!idSet.empty()) {
+      std::set<uint64_t>::const_iterator begIter = idSet.begin();
+      std::set<uint64_t>::const_iterator endIter = idSet.end();
+      std::stringstream buffer;
+      buffer << "Invalid column selected: ";
+      while (begIter != endIter) {
+        buffer << *begIter << " "; 
+        ++begIter;
+      }
+      buffer << "out of " << selectedColumns.size();
+      throw ParseError(buffer.str());
+    }
+  }
+
+  bool ReaderImpl::updateSelectedByIdHelper(const Type* type, std::set<uint64_t>& idSet) {
+    uint64_t columnId = type->getColumnId();
+    std::set<uint64_t>::const_iterator found = idSet.find(columnId);
+    if (found != idSet.end()) {
+      for (size_t c = columnId;
+          c <= type->getMaximumColumnId(); ++c) {
+        selectedColumns[c] = true;
+        idSet.erase(c);
+      }
+      return true;
+    }
+    if (0 == type->getSubtypeCount()) {
+      // primitive type, not found in idSet
+      return false;
+    } else {
+      // mark column as selected if any of his subtype is selected.
+      bool subtypeSelected = selectedColumns[columnId];
+      for (size_t i = 0; i < type->getSubtypeCount(); ++i) {
+        subtypeSelected |= updateSelectedByIdHelper(type->getSubtype(i), idSet);
+      }
+      selectedColumns[columnId] = subtypeSelected;
+      return subtypeSelected;
     }
   }
 

--- a/tools/test/TestMatch.cc
+++ b/tools/test/TestMatch.cc
@@ -1035,6 +1035,35 @@ TEST(TestMatch, selectColumns) {
         << "\"887336a7\", \"value\": {\"int1\": -941468492, \"string1\": "
         << "\"887336a7\"}}]}";
     EXPECT_EQ(expectedMap.str(), line);
+
+    // Map column #12
+    // two subtypes with column id:
+    // map<string(20),struct(21)<int1(22):int,string1(23):string>
+    cols.clear();
+    cols.push_back(20);
+    cols.push_back(22);
+    cols.push_back(23);
+    opts.include(cols, true);
+    reader = orc::createReader(orc::readLocalFile(filename), opts);
+    c = reader->getSelectedColumns();
+    for (unsigned int i=1; i < c.size(); i++) {
+      if (i>=19 && i<=23)
+        EXPECT_TRUE(c[i]);
+      else
+        EXPECT_TRUE(!c[i]);
+    }
+    batch = reader->createRowBatch(1);
+    line.clear();
+    printer = createColumnPrinter(line, &reader->getSelectedType());
+    reader->next(*batch);
+    printer->reset(*batch);
+    printer->printRow(0);
+    std::ostringstream expectedMapWithColumnId;
+    expectedMapWithColumnId << "{\"map\": [{\"key\": \"ba419d35-x\", \"value\": {\"int1\":"
+        << " -1598014431, \"string1\": \"ba419d35-x\"}}, {\"key\": "
+        << "\"887336a7\", \"value\": {\"int1\": -941468492, \"string1\": "
+        << "\"887336a7\"}}]}";
+    EXPECT_EQ(expectedMapWithColumnId.str(), line);
 }
 
 TEST(TestMatch, memoryUse) {


### PR DESCRIPTION
Currently, orc c++ ReaderOptions only supports first level's id selection. It is suitable for a flat data structure such as "struct\<int1:int, d1:double, t1:timestamp, d2:double\>". The column id is: 0(root type), 1(int1), 2(d1), 3(t1), 4(d2). We can choose any combinations of 1,2,3,4.

But if orc file's schema has different levels of nested types, the include function in ReaderOptions may not  work properly. If the schema is “struct\<int1:int, s1: struct\<d1:double, t1:timestamp, d2:doulbe\>\>".

We can only select combination of 1(int1), 2(s1). Selecting other column id will get an exception thrown.

In this patch, nested column id is supported. We can selected any column, if one column is selected, its path to the root will also be selected in order to create the reader.