### PR TITLE
ORC-54: Evolve schemas based on field name rather than index

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -82,6 +82,12 @@ public enum OrcConf {
       "If ORC reader encounters corrupt data, this value will be used to\n" +
           "determine whether to skip the corrupt data or throw exception.\n" +
           "The default behavior is to throw exception."),
+  TOLERATE_MISSING_SCHEMA("orc.tolerate.missing.schema",
+      "hive.exec.orc.tolerate.missing.schema",
+      true,
+      "Writers earlier than HIVE-4243 may have inaccurate schema metadata.\n"
+          + "This setting will enable best effort schema evolution rather\n"
+          + "than rejecting mismatched schemas"),
   MEMORY_POOL("orc.memory.pool", "hive.exec.orc.memory.pool", 0.5,
       "Maximum fraction of heap that can be used by ORC file writers"),
   DICTIONARY_KEY_SIZE_THRESHOLD("orc.dictionary.key.threshold",

--- a/java/core/src/java/org/apache/orc/impl/BitFieldReader.java
+++ b/java/core/src/java/org/apache/orc/impl/BitFieldReader.java
@@ -34,7 +34,7 @@ public class BitFieldReader {
   private final int mask;
 
   public BitFieldReader(InStream input,
-      int bitSize) throws IOException {
+                        int bitSize) {
     this.input = new RunLengthByteReader(input);
     this.bitSize = bitSize;
     mask = (1 << bitSize) - 1;

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -568,8 +568,13 @@ public class ReaderImpl implements Reader {
   }
 
   @Override
+  public Options options() {
+    return new Options(conf);
+  }
+
+  @Override
   public RecordReader rows() throws IOException {
-    return rows(new Options());
+    return rows(options());
   }
 
   @Override
@@ -579,7 +584,11 @@ public class ReaderImpl implements Reader {
     // if included columns is null, then include all columns
     if (include == null) {
       options = options.clone();
-      include = new boolean[types.size()];
+      TypeDescription readSchema = options.getSchema();
+      if (readSchema == null) {
+        readSchema = schema;
+      }
+      include = new boolean[readSchema.getMaximumId() + 1];
       Arrays.fill(include, true);
       options.include(include);
     }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -863,7 +863,7 @@ public class RecordReaderImpl implements RecordReader {
   }
 
   private boolean isFullRead() {
-    for (Boolean isColumnPresent : writerIncluded){
+    for (boolean isColumnPresent : writerIncluded){
       if (!isColumnPresent){
         return false;
       }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
@@ -35,7 +35,7 @@ public class RunLengthByteReader {
   private int used = 0;
   private boolean repeat = false;
 
-  public RunLengthByteReader(InStream input) throws IOException {
+  public RunLengthByteReader(InStream input) {
     this.input = input;
   }
 

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -264,6 +264,17 @@ public class SchemaEvolution {
     return false;
   }
 
+  /**
+   * Build the mapping from the file type to the reader type. For pre-HIVE-4243
+   * ORC files, the top level structure is matched using position within the
+   * row. Otherwise, structs fields are matched by name.
+   * @param fileType the type in the file
+   * @param readerType the type in the reader
+   * @param positionalLevels the number of structure levels that must be
+   *                         mapped by position rather than field name. Pre
+   *                         HIVE-4243 files have either 1 or 2 levels matched
+   *                         positionally depending on whether they are ACID.
+   */
   void buildConversion(TypeDescription fileType,
                        TypeDescription readerType,
                        int positionalLevels) {

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
@@ -170,7 +170,7 @@ public class TestOrcTimezone1 {
     boolean[] include = new boolean[schema.getMaximumId() + 1];
     include[schema.getChildren().get(col).getId()] = true;
     RecordReader rows = reader.rows
-        (new Reader.Options().include(include));
+        (reader.options().include(include));
     assertEquals(true, rows.nextBatch(batch));
     assertEquals(Timestamp.valueOf("2000-03-12 15:00:00"),
         ts.asScratchTimestamp(0));

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -1199,9 +1199,9 @@ public class TestVectorOrcFile {
 
     // read the contents and make sure they match
     RecordReader rows1 = reader.rows(
-        new Reader.Options().include(new boolean[]{true, true, false}));
+        reader.options().include(new boolean[]{true, true, false}));
     RecordReader rows2 = reader.rows(
-        new Reader.Options().include(new boolean[]{true, false, true}));
+        reader.options().include(new boolean[]{true, false, true}));
     r1 = new Random(1);
     r2 = new Random(2);
     VectorizedRowBatch batch1 = reader.getSchema().createRowBatch(1000);
@@ -1946,7 +1946,7 @@ public class TestVectorOrcFile {
     boolean[] columns = new boolean[reader.getStatistics().length];
     columns[5] = true; // long colulmn
     columns[9] = true; // text column
-    rows = reader.rows(new Reader.Options()
+    rows = reader.rows(reader.options()
         .range(offsetOfStripe2, offsetOfStripe4 - offsetOfStripe2)
         .include(columns));
     rows.seekToRow(lastRowOfStripe2);
@@ -2146,7 +2146,7 @@ public class TestVectorOrcFile {
           .lessThan("int1", PredicateLeaf.Type.LONG, 600000L)
         .end()
         .build();
-    RecordReader rows = reader.rows(new Reader.Options()
+    RecordReader rows = reader.rows(reader.options()
         .range(0L, Long.MAX_VALUE)
         .include(new boolean[]{true, true, true})
         .searchArgument(sarg, new String[]{null, "int1", "string1"}));
@@ -2171,7 +2171,7 @@ public class TestVectorOrcFile {
           .lessThan("int1", PredicateLeaf.Type.LONG, 0L)
         .end()
         .build();
-    rows = reader.rows(new Reader.Options()
+    rows = reader.rows(reader.options()
         .range(0L, Long.MAX_VALUE)
         .include(new boolean[]{true, true, true})
         .searchArgument(sarg, new String[]{null, "int1", "string1"}));
@@ -2187,7 +2187,7 @@ public class TestVectorOrcFile {
           .end()
         .end()
         .build();
-    rows = reader.rows(new Reader.Options()
+    rows = reader.rows(reader.options()
         .range(0L, Long.MAX_VALUE)
         .include(new boolean[]{true, true, true})
         .searchArgument(sarg, new String[]{null, "int1", "string1"}));

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -1687,7 +1687,7 @@ public class TestRecordReaderImpl {
     writer.close();
     Reader reader = OrcFile.createReader(path, OrcFile.readerOptions(conf));
 
-    RecordReader recordReader = reader.rows(new Reader.Options()
+    RecordReader recordReader = reader.rows(reader.options()
         .dataReader(mockedDataReader));
 
     recordReader.close();

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -17,12 +17,14 @@
  */
 package org.apache.orc.impl;
 
+import static junit.framework.TestCase.assertSame;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -45,6 +47,7 @@ public class TestSchemaEvolution {
   public TestName testCaseName = new TestName();
 
   Configuration conf;
+  Reader.Options options;
   Path testFilePath;
   FileSystem fs;
   Path workDir = new Path(System.getProperty("test.tmp.dir",
@@ -53,6 +56,7 @@ public class TestSchemaEvolution {
   @Before
   public void setup() throws Exception {
     conf = new Configuration();
+    options = new Reader.Options(conf);
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestOrcFile." +
         testCaseName.getMethodName() + ".orc");
@@ -65,25 +69,26 @@ public class TestSchemaEvolution {
         .addField("f1", TypeDescription.createInt())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(10));
-    SchemaEvolution same1 = new SchemaEvolution(fileStruct1, null);
+    SchemaEvolution same1 = new SchemaEvolution(fileStruct1, options);
     assertFalse(same1.hasConversion());
     TypeDescription readerStruct1 = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(10));
-    SchemaEvolution both1 = new SchemaEvolution(fileStruct1, readerStruct1, null);
+    SchemaEvolution both1 = new SchemaEvolution(fileStruct1, readerStruct1, options);
     assertFalse(both1.hasConversion());
     TypeDescription readerStruct1diff = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createLong())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(10));
-    SchemaEvolution both1diff = new SchemaEvolution(fileStruct1, readerStruct1diff, null);
+    SchemaEvolution both1diff = new SchemaEvolution(fileStruct1, readerStruct1diff, options);
     assertTrue(both1diff.hasConversion());
     TypeDescription readerStruct1diffPrecision = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(12).withScale(10));
-    SchemaEvolution both1diffPrecision = new SchemaEvolution(fileStruct1, readerStruct1diffPrecision, null);
+    SchemaEvolution both1diffPrecision = new SchemaEvolution(fileStruct1,
+        readerStruct1diffPrecision, options);
     assertTrue(both1diffPrecision.hasConversion());
   }
 
@@ -99,7 +104,7 @@ public class TestSchemaEvolution {
             .addField("f4", TypeDescription.createDouble())
             .addField("f5", TypeDescription.createBoolean()))
         .addField("f6", TypeDescription.createChar().withMaxLength(100));
-    SchemaEvolution same2 = new SchemaEvolution(fileStruct2, null);
+    SchemaEvolution same2 = new SchemaEvolution(fileStruct2, options);
     assertFalse(same2.hasConversion());
     TypeDescription readerStruct2 = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createUnion()
@@ -111,7 +116,7 @@ public class TestSchemaEvolution {
             .addField("f4", TypeDescription.createDouble())
             .addField("f5", TypeDescription.createBoolean()))
         .addField("f6", TypeDescription.createChar().withMaxLength(100));
-    SchemaEvolution both2 = new SchemaEvolution(fileStruct2, readerStruct2, null);
+    SchemaEvolution both2 = new SchemaEvolution(fileStruct2, readerStruct2, options);
     assertFalse(both2.hasConversion());
     TypeDescription readerStruct2diff = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createUnion()
@@ -123,7 +128,7 @@ public class TestSchemaEvolution {
             .addField("f4", TypeDescription.createDouble())
             .addField("f5", TypeDescription.createByte()))
         .addField("f6", TypeDescription.createChar().withMaxLength(100));
-    SchemaEvolution both2diff = new SchemaEvolution(fileStruct2, readerStruct2diff, null);
+    SchemaEvolution both2diff = new SchemaEvolution(fileStruct2, readerStruct2diff, options);
     assertTrue(both2diff.hasConversion());
     TypeDescription readerStruct2diffChar = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createUnion()
@@ -135,7 +140,7 @@ public class TestSchemaEvolution {
             .addField("f4", TypeDescription.createDouble())
             .addField("f5", TypeDescription.createBoolean()))
         .addField("f6", TypeDescription.createChar().withMaxLength(80));
-    SchemaEvolution both2diffChar = new SchemaEvolution(fileStruct2, readerStruct2diffChar, null);
+    SchemaEvolution both2diffChar = new SchemaEvolution(fileStruct2, readerStruct2diffChar, options);
     assertTrue(both2diffChar.hasConversion());
   }
 
@@ -159,7 +164,7 @@ public class TestSchemaEvolution {
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
     TypeDescription schemaOnRead = TypeDescription.createDouble();
-    RecordReader rows = reader.rows(new Reader.Options().schema(schemaOnRead));
+    RecordReader rows = reader.rows(reader.options().schema(schemaOnRead));
     batch = schemaOnRead.createRowBatch();
     rows.nextBatch(batch);
     assertEquals(74.72, ((DoubleColumnVector) batch.cols[0]).vector[0], 0.00000000001);
@@ -172,14 +177,14 @@ public class TestSchemaEvolution {
         .addField("f1", TypeDescription.createInt())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(10));
-    SchemaEvolution same1 = new SchemaEvolution(fileStruct1, null);
+    SchemaEvolution same1 = new SchemaEvolution(fileStruct1, options);
     assertTrue(same1.isPPDSafeConversion(0));
     assertFalse(same1.hasConversion());
     TypeDescription readerStruct1 = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(10));
-    SchemaEvolution both1 = new SchemaEvolution(fileStruct1, readerStruct1, null);
+    SchemaEvolution both1 = new SchemaEvolution(fileStruct1, readerStruct1, options);
     assertFalse(both1.hasConversion());
     assertTrue(both1.isPPDSafeConversion(0));
     assertTrue(both1.isPPDSafeConversion(1));
@@ -191,7 +196,7 @@ public class TestSchemaEvolution {
         .addField("f1", TypeDescription.createLong())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(10));
-    SchemaEvolution both1diff = new SchemaEvolution(fileStruct1, readerStruct1diff, null);
+    SchemaEvolution both1diff = new SchemaEvolution(fileStruct1, readerStruct1diff, options);
     assertTrue(both1diff.hasConversion());
     assertFalse(both1diff.isPPDSafeConversion(0));
     assertTrue(both1diff.isPPDSafeConversion(1));
@@ -203,8 +208,9 @@ public class TestSchemaEvolution {
         .addField("f1", TypeDescription.createInt())
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(12).withScale(10));
-    SchemaEvolution both1diffPrecision = new SchemaEvolution(fileStruct1, readerStruct1diffPrecision,
-        new boolean[] {true, false, false, true});
+    options.include(new boolean[] {true, false, false, true});
+    SchemaEvolution both1diffPrecision = new SchemaEvolution(fileStruct1,
+        readerStruct1diffPrecision, options);
     assertTrue(both1diffPrecision.hasConversion());
     assertFalse(both1diffPrecision.isPPDSafeConversion(0));
     assertFalse(both1diffPrecision.isPPDSafeConversion(1)); // column not included
@@ -217,7 +223,8 @@ public class TestSchemaEvolution {
         .addField("f2", TypeDescription.createString())
         .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(10))
         .addField("f4", TypeDescription.createBoolean());
-    both1 = new SchemaEvolution(fileStruct1, readerStruct1, null);
+    options.include(null);
+    both1 = new SchemaEvolution(fileStruct1, readerStruct1, options);
     assertTrue(both1.hasConversion());
     assertFalse(both1.isPPDSafeConversion(0));
     assertTrue(both1.isPPDSafeConversion(1));
@@ -231,13 +238,13 @@ public class TestSchemaEvolution {
     // byte -> short -> int -> long
     TypeDescription fileSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createByte());
-    SchemaEvolution schemaEvolution = new SchemaEvolution(fileSchema, null);
+    SchemaEvolution schemaEvolution = new SchemaEvolution(fileSchema, options);
     assertFalse(schemaEvolution.hasConversion());
 
     // byte -> short
     TypeDescription readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createShort());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
@@ -245,7 +252,7 @@ public class TestSchemaEvolution {
     // byte -> int
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
@@ -253,7 +260,7 @@ public class TestSchemaEvolution {
     // byte -> long
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createLong());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
@@ -261,13 +268,13 @@ public class TestSchemaEvolution {
     // short -> int -> long
     fileSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createShort());
-    schemaEvolution = new SchemaEvolution(fileSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, options);
     assertFalse(schemaEvolution.hasConversion());
 
     // unsafe conversion short -> byte
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createByte());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -275,7 +282,7 @@ public class TestSchemaEvolution {
     // short -> int
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
@@ -283,7 +290,7 @@ public class TestSchemaEvolution {
     // short -> long
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createLong());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
@@ -291,13 +298,13 @@ public class TestSchemaEvolution {
     // int -> long
     fileSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt());
-    schemaEvolution = new SchemaEvolution(fileSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, options);
     assertFalse(schemaEvolution.hasConversion());
 
     // unsafe conversion int -> byte
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createByte());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -305,7 +312,7 @@ public class TestSchemaEvolution {
     // unsafe conversion int -> short
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createShort());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -313,7 +320,7 @@ public class TestSchemaEvolution {
     // int -> long
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createLong());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
@@ -321,14 +328,14 @@ public class TestSchemaEvolution {
     // long
     fileSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createLong());
-    schemaEvolution = new SchemaEvolution(fileSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, options);
     assertTrue(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.hasConversion());
 
     // unsafe conversion long -> byte
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createByte());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -336,7 +343,7 @@ public class TestSchemaEvolution {
     // unsafe conversion long -> short
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createShort());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -344,7 +351,7 @@ public class TestSchemaEvolution {
     // unsafe conversion long -> int
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -352,7 +359,7 @@ public class TestSchemaEvolution {
     // invalid
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createString());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -360,7 +367,7 @@ public class TestSchemaEvolution {
     // invalid
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createFloat());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -368,7 +375,7 @@ public class TestSchemaEvolution {
     // invalid
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createTimestamp());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -378,14 +385,14 @@ public class TestSchemaEvolution {
   public void testSafePpdEvaluationForStrings() throws IOException {
     TypeDescription fileSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createString());
-    SchemaEvolution schemaEvolution = new SchemaEvolution(fileSchema, null);
+    SchemaEvolution schemaEvolution = new SchemaEvolution(fileSchema, options);
     assertTrue(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.hasConversion());
 
     // string -> char
     TypeDescription readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createChar());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -393,21 +400,21 @@ public class TestSchemaEvolution {
     // string -> varchar
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createVarchar());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
 
     fileSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createChar());
-    schemaEvolution = new SchemaEvolution(fileSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, options);
     assertTrue(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.hasConversion());
 
     // char -> string
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createString());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -415,21 +422,21 @@ public class TestSchemaEvolution {
     // char -> varchar
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createVarchar());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
 
     fileSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createVarchar());
-    schemaEvolution = new SchemaEvolution(fileSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, options);
     assertTrue(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.hasConversion());
 
     // varchar -> string
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createString());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertTrue(schemaEvolution.isPPDSafeConversion(1));
@@ -437,7 +444,7 @@ public class TestSchemaEvolution {
     // varchar -> char
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createChar());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -445,7 +452,7 @@ public class TestSchemaEvolution {
     // invalid
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createDecimal());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -453,7 +460,7 @@ public class TestSchemaEvolution {
     // invalid
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createDate());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
@@ -461,9 +468,532 @@ public class TestSchemaEvolution {
     // invalid
     readerSchema = TypeDescription.createStruct()
         .addField("f1", TypeDescription.createInt());
-    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, null);
+    schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
     assertTrue(schemaEvolution.hasConversion());
     assertFalse(schemaEvolution.isPPDSafeConversion(0));
     assertFalse(schemaEvolution.isPPDSafeConversion(1));
+  }
+
+  private boolean[] includeAll(TypeDescription readerType) {
+    int numColumns = readerType.getMaximumId() + 1;
+    boolean[] result = new boolean[numColumns];
+    Arrays.fill(result, true);
+    return result;
+  }
+
+  @Test
+  public void testAddFieldToEnd() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,b:string,c:double>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // b -> b
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(2);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testAddFieldBeforeEnd() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,c:double,b:string>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+
+    // b -> b
+    reader = readerType.getChildren().get(2);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testRemoveLastField() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string,c:double>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // b -> b
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testRemoveFieldBeforeEnd() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string,c:double>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,c:double>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c -> b
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(2);
+    assertSame(original, mapped);
+
+  }
+
+  @Test
+  public void testRemoveAndAddField() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:int,c:double>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testReorderFields() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:int,b:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<b:string,a:int>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // b -> b
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+
+    // a -> a
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testAddFieldEndOfStruct() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:struct<b:int>,c:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:struct<b:int,d:double>,c:string>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    TypeDescription readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    TypeDescription originalChild = original.getChildren().get(0);
+    assertSame(originalChild, mapped);
+
+    // a.d -> null
+    readerChild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerChild);
+    originalChild = null;
+    assertSame(originalChild, mapped);
+
+    // c -> c
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testAddFieldBeforeEndOfStruct() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:struct<b:int>,c:string>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:struct<d:double,b:int>,c:string>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    TypeDescription readerChild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerChild);
+    TypeDescription originalChild = original.getChildren().get(0);
+    assertSame(originalChild, mapped);
+
+    // a.d -> null
+    readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    originalChild = null;
+    assertSame(originalChild, mapped);
+
+    // c -> c
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  /**
+   * Two structs can be equal but in different locations. They can converge to this.
+   */
+  @Test
+  public void testAddSimilarField() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:struct<b:int>>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:struct<b:int>,c:struct<b:int>>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    TypeDescription readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    TypeDescription originalChild = original.getChildren().get(0);
+    assertSame(originalChild, mapped);
+
+    // c -> null
+    reader = readerType.getChildren().get(1);
+    mapped = transition.getFileType(reader);
+    original = null;
+    assertSame(original, mapped);
+
+    // c.b -> null
+    readerChild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerChild);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  /**
+   * Two structs can be equal but in different locations. They can converge to this.
+   */
+  @Test
+  public void testConvergentEvolution() {
+    TypeDescription fileType = TypeDescription
+        .fromString("struct<a:struct<a:int,b:string>,c:struct<a:int>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<a:struct<a:int,b:string>,c:struct<a:int,b:string>>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // c -> c
+    TypeDescription reader = readerType.getChildren().get(1);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(1);
+    assertSame(original, mapped);
+
+    // c.a -> c.a
+    TypeDescription readerchild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // c.b -> null
+    readerchild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerchild);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testMapEvolution() {
+    TypeDescription fileType =
+        TypeDescription
+            .fromString("struct<a:map<struct<a:int>,struct<a:int>>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<a:map<struct<a:int,b:string>,struct<a:int,c:string>>>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.key -> a.key
+    TypeDescription readerchild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.value -> a.value
+    readerchild = reader.getChildren().get(1);
+    mapped = transition.getFileType(readerchild);
+    original = fileType.getChildren().get(0).getChildren().get(1);
+    assertSame(original, mapped);
+  }
+
+  @Test
+  public void testListEvolution() {
+    TypeDescription fileType =
+        TypeDescription.fromString("struct<a:array<struct<b:int>>>");
+    TypeDescription readerType =
+        TypeDescription.fromString("struct<a:array<struct<b:int,c:string>>>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+
+    // a -> a
+    TypeDescription reader = readerType.getChildren().get(0);
+    TypeDescription mapped = transition.getFileType(reader);
+    TypeDescription original = fileType.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.element -> a.element
+    TypeDescription readerchild = reader.getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.b -> a.b
+    readerchild = reader.getChildren().get(0).getChildren().get(0);
+    mapped = transition.getFileType(readerchild);
+    original = original.getChildren().get(0);
+    assertSame(original, mapped);
+
+    // a.c -> null
+    readerchild = reader.getChildren().get(0).getChildren().get(1);
+    mapped = transition.getFileType(readerchild);
+    original = null;
+    assertSame(original, mapped);
+  }
+
+  @Test(expected = SchemaEvolution.IllegalEvolutionException.class)
+  public void testIncompatibleTypes() {
+    TypeDescription fileType = TypeDescription.fromString("struct<a:int>");
+    TypeDescription readerType = TypeDescription.fromString("struct<a:date>");
+    boolean[] included = includeAll(readerType);
+    options.tolerateMissingSchema(false);
+    SchemaEvolution transition =
+        new SchemaEvolution(fileType, readerType, options.include(included));
+  }
+
+  @Test
+  public void testAcidNamedEvolution() {
+    TypeDescription fileType = TypeDescription.fromString(
+        "struct<operation:int,originalTransaction:bigint,bucket:int," +
+            "rowId:bigint,currentTransaction:bigint," +
+            "row:struct<x:int,z:bigint,y:string>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<x:int,y:string,z:bigint>");
+    SchemaEvolution evo = new SchemaEvolution(fileType, readerType, options);
+    assertTrue(evo.isAcid());
+    assertEquals("struct<operation:int,originalTransaction:bigint,bucket:int," +
+        "rowId:bigint,currentTransaction:bigint," +
+        "row:struct<x:int,y:string,z:bigint>>", evo.getReaderSchema().toString());
+    assertEquals("struct<x:int,y:string,z:bigint>",
+        evo.getReaderBaseSchema().toString());
+    // the first stuff should be an identity
+    for(int c=0; c < 8; ++c) {
+      assertEquals("column " + c, c, evo.getFileType(c).getId());
+    }
+    // y and z should swap places
+    assertEquals(9, evo.getFileType(8).getId());
+    assertEquals(8, evo.getFileType(9).getId());
+  }
+
+  @Test
+  public void testAcidPositionEvolutionAddField() {
+    TypeDescription fileType = TypeDescription.fromString(
+        "struct<operation:int,originalTransaction:bigint,bucket:int," +
+            "rowId:bigint,currentTransaction:bigint," +
+            "row:struct<_col0:int,_col1:string>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<x:int,y:string,z:bigint>");
+    SchemaEvolution evo = new SchemaEvolution(fileType, readerType, options);
+    assertTrue(evo.isAcid());
+    assertEquals("struct<operation:int,originalTransaction:bigint,bucket:int," +
+        "rowId:bigint,currentTransaction:bigint," +
+        "row:struct<x:int,y:string,z:bigint>>", evo.getReaderSchema().toString());
+    assertEquals("struct<x:int,y:string,z:bigint>",
+        evo.getReaderBaseSchema().toString());
+    // the first stuff should be an identity
+    for(int c=0; c < 9; ++c) {
+      assertEquals("column " + c, c, evo.getFileType(c).getId());
+    }
+    // the file doesn't have z
+    assertEquals(null, evo.getFileType(9));
+  }
+
+  @Test
+  public void testAcidPositionEvolutionRemoveField() {
+    TypeDescription fileType = TypeDescription.fromString(
+        "struct<operation:int,originalTransaction:bigint,bucket:int," +
+            "rowId:bigint,currentTransaction:bigint," +
+            "row:struct<_col0:int,_col1:string,_col2:double>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<x:int,y:string>");
+    SchemaEvolution evo = new SchemaEvolution(fileType, readerType, options);
+    assertTrue(evo.isAcid());
+    assertEquals("struct<operation:int,originalTransaction:bigint,bucket:int," +
+        "rowId:bigint,currentTransaction:bigint," +
+        "row:struct<x:int,y:string>>", evo.getReaderSchema().toString());
+    assertEquals("struct<x:int,y:string>",
+        evo.getReaderBaseSchema().toString());
+    // the first stuff should be an identity
+    boolean[] fileInclude = evo.getFileIncluded();
+    for(int c=0; c < 9; ++c) {
+      assertEquals("column " + c, c, evo.getFileType(c).getId());
+      assertTrue("column " + c, fileInclude[c]);
+    }
+    // don't read the last column
+    assertFalse(fileInclude[9]);
+  }
+
+  @Test
+  public void testAcidPositionSubstructure() {
+    TypeDescription fileType = TypeDescription.fromString(
+        "struct<operation:int,originalTransaction:bigint,bucket:int," +
+            "rowId:bigint,currentTransaction:bigint," +
+            "row:struct<_col0:int,_col1:struct<z:int,x:double,y:string>," +
+            "_col2:double>>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<a:int,b:struct<x:double,y:string,z:int>,c:double>");
+    SchemaEvolution evo = new SchemaEvolution(fileType, readerType, options);
+    assertTrue(evo.isAcid());
+    // the first stuff should be an identity
+    boolean[] fileInclude = evo.getFileIncluded();
+    for(int c=0; c < 9; ++c) {
+      assertEquals("column " + c, c, evo.getFileType(c).getId());
+    }
+    assertEquals(10, evo.getFileType(9).getId());
+    assertEquals(11, evo.getFileType(10).getId());
+    assertEquals(9, evo.getFileType(11).getId());
+    assertEquals(12, evo.getFileType(12).getId());
+    assertEquals(13, fileInclude.length);
+    for(int c=0; c < fileInclude.length; ++c) {
+      assertTrue("column " + c, fileInclude[c]);
+    }
+  }
+
+  @Test
+  public void testNonAcidPositionSubstructure() {
+    TypeDescription fileType = TypeDescription.fromString(
+        "struct<_col0:int,_col1:struct<x:double,z:int>," +
+            "_col2:double>");
+    TypeDescription readerType = TypeDescription.fromString(
+        "struct<a:int,b:struct<x:double,y:string,z:int>,c:double>");
+    SchemaEvolution evo = new SchemaEvolution(fileType, readerType, options);
+    assertFalse(evo.isAcid());
+    // the first stuff should be an identity
+    boolean[] fileInclude = evo.getFileIncluded();
+    assertEquals(0, evo.getFileType(0).getId());
+    assertEquals(1, evo.getFileType(1).getId());
+    assertEquals(2, evo.getFileType(2).getId());
+    assertEquals(3, evo.getFileType(3).getId());
+    assertEquals(null, evo.getFileType(4));
+    assertEquals(4, evo.getFileType(5).getId());
+    assertEquals(5, evo.getFileType(6).getId());
+    assertEquals(6, fileInclude.length);
+    for(int c=0; c < fileInclude.length; ++c) {
+      assertTrue("column " + c, fileInclude[c]);
+    }
+  }
+
+  @Test
+  public void testFileIncludeWithNoEvolution() {
+    TypeDescription fileType = TypeDescription.fromString(
+        "struct<a:int,b:double,c:string>");
+    SchemaEvolution evo = new SchemaEvolution(fileType,
+        options.include(new boolean[]{true, false, true, false}));
+    assertFalse(evo.isAcid());
+    assertEquals("struct<a:int,b:double,c:string>",
+        evo.getReaderBaseSchema().toString());
+    boolean[] fileInclude = evo.getFileIncluded();
+    assertTrue(fileInclude[0]);
+    assertFalse(fileInclude[1]);
+    assertTrue(fileInclude[2]);
+    assertFalse(fileInclude[3]);
   }
 }

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
@@ -110,10 +110,11 @@ public class OrcInputFormat<V extends WritableComparable>
                                             long length) {
     TypeDescription schema =
         TypeDescription.fromString(OrcConf.MAPRED_INPUT_SCHEMA.getString(conf));
-    Reader.Options options = new Reader.Options()
+    Reader.Options options = reader.options()
         .range(start, length)
         .useZeroCopy(OrcConf.USE_ZEROCOPY.getBoolean(conf))
-        .skipCorruptRecords(OrcConf.SKIP_CORRUPT_DATA.getBoolean(conf));
+        .skipCorruptRecords(OrcConf.SKIP_CORRUPT_DATA.getBoolean(conf))
+        .tolerateMissingSchema(OrcConf.TOLERATE_MISSING_SCHEMA.getBoolean(conf));
     if (schema != null) {
       options.schema(schema);
     } else {

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -1,0 +1,331 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.mapred;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.*;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.orc.*;
+import org.apache.orc.TypeDescription.Category;
+import org.apache.orc.impl.SchemaEvolution;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TestName;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Test the behavior of ORC's schema evolution
+ */
+public class TestOrcFileEvolution {
+
+  // These utility methods are just to make writing tests easier. The values
+  // created here will not feed directly to the ORC writers, but are converted
+  // within checkEvolution().
+  private List<Object> struct(Object... fields) {
+    return list(fields);
+  }
+
+  private List<Object> list(Object... elements) {
+    return Arrays.asList(elements);
+  }
+
+  private Map<Object, Object> map(Object... kvs) {
+    if (kvs.length != 2) {
+      throw new IllegalArgumentException(
+          "Map must be provided an even number of arguments");
+    }
+
+    Map<Object, Object> result = new HashMap<>();
+    for (int i = 0; i < kvs.length; i += 2) {
+      result.put(kvs[i], kvs[i + 1]);
+    }
+    return result;
+  }
+
+  Path workDir = new Path(System.getProperty("test.tmp.dir",
+      "target" + File.separator + "test" + File.separator + "tmp"));
+
+  Configuration conf;
+  FileSystem fs;
+  Path testFilePath;
+
+  @Rule
+  public TestName testCaseName = new TestName();
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  @Before
+  public void openFileSystem() throws Exception {
+    conf = new Configuration();
+    fs = FileSystem.getLocal(conf);
+    testFilePath = new Path(workDir, "TestOrcFile." +
+        testCaseName.getMethodName() + ".orc");
+    fs.delete(testFilePath, false);
+  }
+
+  @Test
+  public void testAddFieldToEnd() {
+    checkEvolution("struct<a:int,b:string>", "struct<a:int,b:string,c:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null));
+  }
+
+  @Test
+  public void testAddFieldBeforeEnd() {
+    checkEvolution("struct<a:int,b:string>", "struct<a:int,c:double,b:string>",
+        struct(1, "foo"),
+        struct(1, null, "foo"));
+  }
+
+  @Test
+  public void testRemoveLastField() {
+    checkEvolution("struct<a:int,b:string,c:double>", "struct<a:int,b:string>",
+        struct(1, "foo", 3.14),
+        struct(1, "foo"));
+  }
+
+  @Test
+  public void testRemoveFieldBeforeEnd() {
+    checkEvolution("struct<a:int,b:string,c:double>", "struct<a:int,c:double>",
+        struct(1, "foo", 3.14),
+        struct(1, 3.14));
+  }
+
+  @Test
+  public void testRemoveAndAddField() {
+    checkEvolution("struct<a:int,b:string>", "struct<a:int,c:double>",
+        struct(1, "foo"), struct(1, null));
+  }
+
+  @Test
+  public void testReorderFields() {
+    checkEvolution("struct<a:int,b:string>", "struct<b:string,a:int>",
+        struct(1, "foo"), struct("foo", 1));
+  }
+
+  @Test
+  public void testAddFieldEndOfStruct() {
+    checkEvolution("struct<a:struct<b:int>,c:string>",
+        "struct<a:struct<b:int,d:double>,c:string>",
+        struct(struct(2), "foo"), struct(struct(2, null), "foo"));
+  }
+
+  @Test
+  public void testAddFieldBeforeEndOfStruct() {
+    checkEvolution("struct<a:struct<b:int>,c:string>",
+        "struct<a:struct<d:double,b:int>,c:string>",
+        struct(struct(2), "foo"), struct(struct(null, 2), "foo"));
+  }
+
+  @Test
+  public void testAddSimilarField() {
+    checkEvolution("struct<a:struct<b:int>>",
+        "struct<a:struct<b:int>,c:struct<b:int>>", struct(struct(2)),
+        struct(struct(2), null));
+  }
+
+  @Test
+  public void testConvergentEvolution() {
+    checkEvolution("struct<a:struct<a:int,b:string>,c:struct<a:int>>",
+        "struct<a:struct<a:int,b:string>,c:struct<a:int,b:string>>",
+        struct(struct(2, "foo"), struct(3)),
+        struct(struct(2, "foo"), struct(3, null)));
+  }
+
+  @Test
+  public void testMapKeyEvolution() {
+    checkEvolution("struct<a:map<struct<a:int>,int>>",
+        "struct<a:map<struct<a:int,b:string>,int>>",
+        struct(map(struct(1), 2)),
+        struct(map(struct(1, null), 2)));
+  }
+
+  @Test
+  public void testMapValueEvolution() {
+    checkEvolution("struct<a:map<int,struct<a:int>>>",
+        "struct<a:map<int,struct<a:int,b:string>>>",
+        struct(map(2, struct(1))),
+        struct(map(2, struct(1, null))));
+  }
+
+  @Test
+  public void testListEvolution() {
+    checkEvolution("struct<a:array<struct<b:int>>>",
+        "struct<a:array<struct<b:int,c:string>>>",
+        struct(list(struct(1), struct(2))),
+        struct(list(struct(1, null), struct(2, null))));
+  }
+
+  @Test
+  public void testPreHive4243CheckEqual() {
+    // Expect success on equal schemas
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<_col0:int,_col1:string>",
+        struct(1, "foo"),
+        struct(1, "foo", null), false);
+  }
+
+  @Test
+  public void testPreHive4243Check() {
+    // Expect exception on strict compatibility check
+    thrown.expectMessage("HIVE-4243");
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<_col0:int,_col1:string,_col2:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null), false);
+  }
+
+  @Test
+  public void testPreHive4243AddColumn() {
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<_col0:int,_col1:string,_col2:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null), true);
+  }
+
+  @Test
+  public void testPreHive4243AddColumnMiddle() {
+    // Expect exception on type mismatch
+    thrown.expect(SchemaEvolution.IllegalEvolutionException.class);
+    checkEvolution("struct<_col0:int,_col1:double>",
+        "struct<_col0:int,_col1:date,_col2:double>",
+        struct(1, 1.0),
+        null, true);
+  }
+
+  @Test
+  public void testPreHive4243AddColumnWithFix() {
+    checkEvolution("struct<_col0:int,_col1:string>",
+        "struct<a:int,b:string,c:double>",
+        struct(1, "foo"),
+        struct(1, "foo", null), true);
+  }
+
+  @Test
+  public void testPreHive4243AddColumnMiddleWithFix() {
+    // Expect exception on type mismatch
+    thrown.expect(SchemaEvolution.IllegalEvolutionException.class);
+    checkEvolution("struct<_col0:int,_col1:double>",
+        "struct<a:int,b:date,c:double>",
+        struct(1, 1.0),
+        null, true);
+  }
+
+  private void checkEvolution(String writerType, String readerType,
+      Object inputRow, Object expectedOutput) {
+    checkEvolution(writerType, readerType,
+        inputRow, expectedOutput,
+        (boolean) OrcConf.TOLERATE_MISSING_SCHEMA.getDefaultValue());
+  }
+
+  private void checkEvolution(String writerType, String readerType,
+      Object inputRow, Object expectedOutput, boolean tolerateSchema) {
+    TypeDescription readTypeDescr = TypeDescription.fromString(readerType);
+    TypeDescription writerTypeDescr = TypeDescription.fromString(writerType);
+
+    OrcStruct inputStruct = assembleStruct(writerTypeDescr, inputRow);
+    OrcStruct expectedStruct = assembleStruct(readTypeDescr, expectedOutput);
+    try {
+      Writer writer = OrcFile.createWriter(testFilePath,
+          OrcFile.writerOptions(conf).setSchema(writerTypeDescr)
+              .stripeSize(100000).bufferSize(10000)
+              .version(OrcFile.Version.CURRENT));
+
+      OrcMapredRecordWriter<OrcStruct> recordWriter =
+          new OrcMapredRecordWriter<OrcStruct>(writer);
+      recordWriter.write(NullWritable.get(), inputStruct);
+      recordWriter.close(mock(Reporter.class));
+      Reader reader = OrcFile.createReader(testFilePath,
+          OrcFile.readerOptions(conf).filesystem(fs));
+      OrcMapredRecordReader<OrcStruct> recordReader =
+          new OrcMapredRecordReader<>(reader,
+              reader.options().schema(readTypeDescr)
+                  .tolerateMissingSchema(tolerateSchema));
+      OrcStruct result = recordReader.createValue();
+      recordReader.next(recordReader.createKey(), result);
+      assertEquals(expectedStruct, result);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private OrcStruct assembleStruct(TypeDescription type, Object row) {
+    Preconditions.checkArgument(
+        type.getCategory() == Category.STRUCT, "Top level type must be STRUCT");
+
+    return (OrcStruct) assembleRecord(type, row);
+  }
+
+  private WritableComparable assembleRecord(TypeDescription type, Object row) {
+    if (row == null) {
+      return null;
+    }
+    switch (type.getCategory()) {
+    case STRUCT:
+      OrcStruct structResult = new OrcStruct(type);
+      for (int i = 0; i < structResult.getNumFields(); i++) {
+        List<TypeDescription> childTypes = type.getChildren();
+        structResult.setFieldValue(i,
+            assembleRecord(childTypes.get(i), ((List<Object>) row).get(i)));
+      }
+      return structResult;
+    case LIST:
+      OrcList<WritableComparable> listResult = new OrcList<>(type);
+      TypeDescription elemType = type.getChildren().get(0);
+      List<Object> elems = (List<Object>) row;
+      for (int i = 0; i < elems.size(); i++) {
+        listResult.add(assembleRecord(elemType, elems.get(i)));
+      }
+      return listResult;
+    case MAP:
+      OrcMap<WritableComparable, WritableComparable> mapResult =
+          new OrcMap<>(type);
+      TypeDescription keyType = type.getChildren().get(0);
+      TypeDescription valueType = type.getChildren().get(1);
+      for (Map.Entry<Object, Object> entry : ((Map<Object, Object>) row)
+          .entrySet()) {
+        mapResult.put(assembleRecord(keyType, entry.getKey()),
+            assembleRecord(valueType, entry.getValue()));
+      }
+      return mapResult;
+    case INT:
+      return new IntWritable((Integer) row);
+    case DOUBLE:
+      return new DoubleWritable((Double) row);
+    case STRING:
+      return new Text((String) row);
+    default:
+      throw new UnsupportedOperationException(String
+          .format("Not expecting to have a field of type %s in unit tests",
+              type.getCategory()));
+    }
+  }
+}


### PR DESCRIPTION
This is an updated version of Mark's patch that fixes evolution of ACID files and rebases it to the current trunk.