### PR TITLE
ORC-117 ConvertTreeReaderFactory gets an index out of bounds

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -2693,8 +2693,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                    Context context) throws IOException {
     final SchemaEvolution evolution = context.getSchemaEvolution();
 
-    int columnId = readerType.getId();
-    TypeDescription fileType = evolution.getFileType(readerType);
+    TypeDescription fileType = evolution.getFileType(readerType.getId());
+    int columnId = fileType.getId();
 
     switch (fileType.getCategory()) {
 


### PR DESCRIPTION
ConvertTreeReaderFactory gets an ArrayIndexOutOfBoundsException when columns are added and types changed.