### PR TITLE
ORC-122:  Timezone.cc leaks memory

### DIFF
--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -651,7 +651,7 @@ namespace orc {
     DIAGNOSTIC_IGNORE("-Wexit-time-destructors")
   #endif
   static std::mutex timezone_mutex;
-  static std::map<std::string, Timezone*> timezoneCache;
+  static std::map<std::string, std::unique_ptr<Timezone> > timezoneCache;
   DIAGNOSTIC_POP
 
   Timezone::~Timezone() {
@@ -691,10 +691,10 @@ namespace orc {
   const Timezone& getTimezoneByFilename(const std::string& filename) {
     // ORC-110
     std::lock_guard<std::mutex> timezone_lock(timezone_mutex);
-    std::map<std::string, Timezone*>::iterator itr =
+    std::map<std::string, std::unique_ptr<Timezone> >::iterator itr =
       timezoneCache.find(filename);
     if (itr != timezoneCache.end()) {
-      return *(itr->second);
+      return *(itr->second).get();
     }
     int in = open(filename.c_str(), O_RDONLY);
     if (in == -1) {
@@ -729,9 +729,8 @@ namespace orc {
       err << "failed to close " << filename << " - " << strerror(errno);
       throw TimezoneError(err.str());
     }
-    Timezone* result = new TimezoneImpl(filename, buffer);
-    timezoneCache[filename] = result;
-    return *result;
+    timezoneCache[filename].reset(new TimezoneImpl(filename, buffer));
+    return *timezoneCache[filename].get();
   }
 
   /**


### PR DESCRIPTION
Use unique_ptr to wrap Timezone instances