### PR TITLE
ORC-125. Fix deserialization of WriterVersion

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -141,8 +141,16 @@ public class OrcFile {
       }
     }
 
+    /**
+     * Convert the integer from OrcProto.PostScript.writerVersion
+     * to the enumeration with unknown versions being mapped to FUTURE.
+     * @param val the serialized writer version
+     * @return the corresponding enumeration value
+     */
     public static WriterVersion from(int val) {
-      if (val == FUTURE.id) return FUTURE; // Special handling for the magic value.
+      if (val >= values.length) {
+        return FUTURE;
+      }
       return values[val];
     }
 
@@ -150,6 +158,10 @@ public class OrcFile {
       return id >= other.id;
     }
   }
+
+  /**
+   * The WriterVersion for this version of the software.
+   */
   public static final WriterVersion CURRENT_WRITER = WriterVersion.ORC_101;
 
   public enum EncodingStrategy {

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -2923,4 +2923,11 @@ public class TestVectorOrcFile {
     assertFalse(rows.nextBatch(batch));
     rows.close();
   }
+
+  @Test
+  public void testWriterVersion() throws Exception {
+    assertEquals(OrcFile.WriterVersion.FUTURE, OrcFile.WriterVersion.from(99));
+    assertEquals(OrcFile.WriterVersion.ORIGINAL, OrcFile.WriterVersion.from(0));
+    assertEquals(OrcFile.WriterVersion.HIVE_4243, OrcFile.WriterVersion.from(2));
+  }
 }


### PR DESCRIPTION
Prevent future WriterVersions from causing runtime errors.

Signed-off-by: Owen O'Malley <omalley@apache.org>