### PR TITLE
ORC-135: PPD for timestamp is wrong when reader and writer timezones are different

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -56,6 +56,7 @@ namespace orc {
     WriterVersion_HIVE_12055 = 3,
     WriterVersion_HIVE_13083 = 4,
     WriterVersion_ORC_101 = 5,
+    WriterVersion_ORC_135 = 6,
     WriterVersion_MAX = INT64_MAX
   };
 

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -69,6 +69,8 @@ namespace orc {
       return "HIVE-13083";
     case WriterVersion_ORC_101:
       return "ORC-101";
+    case WriterVersion_ORC_135:
+      return "ORC-135";
     }
     std::stringstream buffer;
     buffer << "future - " << version;

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -119,6 +119,7 @@ public class OrcFile {
     HIVE_12055(3), // vectorized writer
     HIVE_13083(4), // decimal writer updating present stream wrongly
     ORC_101(5),    // bloom filters use utf8
+    ORC_135(6), // timestamp stats use utc
 
     // Don't use any magic numbers here except for the below:
     FUTURE(Integer.MAX_VALUE); // a version from a future writer
@@ -172,7 +173,7 @@ public class OrcFile {
   /**
    * The WriterVersion for this version of the software.
    */
-  public static final WriterVersion CURRENT_WRITER = WriterVersion.ORC_101;
+  public static final WriterVersion CURRENT_WRITER = WriterVersion.ORC_135;
 
   public enum EncodingStrategy {
     SPEED, COMPRESSION

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -19,6 +19,9 @@ package org.apache.orc.impl;
 
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
 
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -1123,6 +1126,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (timestampStats.hasMinimum()) {
         minimum = timestampStats.getMinimum();
       }
+      if (timestampStats.hasMaximumUtc()) {
+        maximum = timestampStats.getMaximumUtc();
+      }
+      if (timestampStats.hasMinimumUtc()) {
+        minimum = timestampStats.getMinimumUtc();
+      }
     }
 
     @Override
@@ -1185,8 +1194,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       OrcProto.TimestampStatistics.Builder timestampStats = OrcProto.TimestampStatistics
           .newBuilder();
       if (getNumberOfValues() != 0 && minimum != null) {
-        timestampStats.setMinimum(minimum);
-        timestampStats.setMaximum(maximum);
+        timestampStats.setMinimumUtc(minimum);
+        timestampStats.setMaximumUtc(maximum);
       }
       result.setTimestampStatistics(timestampStats);
       return result;

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -21,12 +21,19 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
+import org.apache.hadoop.util.Time;
 import org.apache.orc.OrcFile;
 import org.apache.orc.util.BloomFilter;
 import org.apache.orc.util.BloomFilterIO;
@@ -363,6 +370,13 @@ public class RecordReaderImpl implements RecordReader {
     ColumnStatistics cs = ColumnStatisticsImpl.deserialize(statsProto);
     Object minValue = getMin(cs);
     Object maxValue = getMax(cs);
+    // files written before ORC-135 stores timestamp wrt to local timezone causing issues with PPD.
+    // disable PPD for timestamp for all old files
+    if (type.equals(TypeDescription.Category.TIMESTAMP) && !writerVersion.includes(OrcFile.WriterVersion.ORC_135)) {
+      LOG.warn("Not using bloom filter for timestamp column as bloom filter is missing encoding kind (new reader is" +
+        " trying to read old files)");
+      return TruthValue.YES_NO_NULL;
+    }
     return evaluatePredicateRange(predicate, minValue, maxValue, cs.hasNull(),
         BloomFilterIO.deserialize(kind, writerVersion, type, bloomFilter));
   }
@@ -398,6 +412,11 @@ public class RecordReaderImpl implements RecordReader {
 
     TruthValue result;
     Object baseObj = predicate.getLiteral();
+    // correction for timezone. Min/Max stats are stored in UTC as of ORC-135.
+    // Convert timestamp literals to UTC as well for correct PPD evaluation.
+    if (min != null && min instanceof Timestamp && baseObj instanceof Timestamp) {
+        baseObj = getUtcTimestamp(baseObj.toString());
+    }
     try {
       // Predicate object and stats objects are converted to the type of the predicate object.
       Object minValue = getBaseObjectForComparison(predicate.getType(), min);
@@ -428,6 +447,22 @@ public class RecordReaderImpl implements RecordReader {
       }
     }
     return result;
+  }
+
+  static Timestamp getUtcTimestamp(String ts) {
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    TimeZone utcTz = TimeZone.getTimeZone("UTC");
+    dateFormat.setTimeZone(utcTz);
+    java.util.Date date;
+    try {
+      date = dateFormat.parse(ts);
+      if (date == null) {
+        return null;
+      }
+    } catch (ParseException e) {
+      return null;
+    }
+    return new Timestamp(date.getTime());
   }
 
   private static boolean shouldEvaluateBloomFilter(PredicateLeaf predicate,
@@ -493,6 +528,9 @@ public class RecordReaderImpl implements RecordReader {
           // set
           for (Object arg : predicate.getLiteralList()) {
             predObj = getBaseObjectForComparison(predicate.getType(), arg);
+            if (predObj instanceof Timestamp) {
+              predObj = getUtcTimestamp(predObj.toString());
+            }
             loc = compareToRange((Comparable) predObj, minValue, maxValue);
             if (loc == Location.MIN) {
               return hasNull ? TruthValue.YES_NULL : TruthValue.YES;
@@ -503,6 +541,9 @@ public class RecordReaderImpl implements RecordReader {
           // are all of the values outside of the range?
           for (Object arg : predicate.getLiteralList()) {
             predObj = getBaseObjectForComparison(predicate.getType(), arg);
+            if (predObj instanceof Timestamp) {
+              predObj = getUtcTimestamp(predObj.toString());
+            }
             loc = compareToRange((Comparable) predObj, minValue, maxValue);
             if (loc == Location.MIN || loc == Location.MIDDLE ||
                 loc == Location.MAX) {
@@ -514,11 +555,16 @@ public class RecordReaderImpl implements RecordReader {
       case BETWEEN:
         List<Object> args = predicate.getLiteralList();
         Object predObj1 = getBaseObjectForComparison(predicate.getType(), args.get(0));
+        if (predObj1 instanceof Timestamp) {
+          predObj1 = getUtcTimestamp(predObj1.toString());
+        }
 
         loc = compareToRange((Comparable) predObj1, minValue, maxValue);
         if (loc == Location.BEFORE || loc == Location.MIN) {
           Object predObj2 = getBaseObjectForComparison(predicate.getType(), args.get(1));
-
+          if (predObj2 instanceof Timestamp) {
+            predObj2 = getUtcTimestamp(predObj2.toString());
+          }
           Location loc2 = compareToRange((Comparable) predObj2, minValue, maxValue);
           if (loc2 == Location.AFTER || loc2 == Location.MAX) {
             return hasNull ? TruthValue.YES_NULL : TruthValue.YES;
@@ -552,6 +598,9 @@ public class RecordReaderImpl implements RecordReader {
         for (Object arg : predicate.getLiteralList()) {
           // if atleast one value in IN list exist in bloom filter, qualify the row group/stripe
           Object predObjItem = getBaseObjectForComparison(predicate.getType(), arg);
+          if (predObjItem instanceof Timestamp) {
+            predObjItem = getUtcTimestamp(predObjItem.toString());
+          }
           TruthValue result = checkInBloomFilter(bloomFilter, predObjItem, hasNull);
           if (result == TruthValue.YES_NO_NULL || result == TruthValue.YES_NO) {
             return result;

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -26,14 +26,11 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
-import org.apache.hadoop.util.Time;
 import org.apache.orc.OrcFile;
 import org.apache.orc.util.BloomFilter;
 import org.apache.orc.util.BloomFilterIO;
@@ -372,7 +369,10 @@ public class RecordReaderImpl implements RecordReader {
     Object maxValue = getMax(cs);
     // files written before ORC-135 stores timestamp wrt to local timezone causing issues with PPD.
     // disable PPD for timestamp for all old files
-    if (type.equals(TypeDescription.Category.TIMESTAMP) && !writerVersion.includes(OrcFile.WriterVersion.ORC_135)) {
+    if (type.equals(TypeDescription.Category.TIMESTAMP)
+      && !writerVersion.includes(OrcFile.WriterVersion.ORC_135)
+      && bloomFilter.hasEncoding()
+      && bloomFilter.getEncoding().equals(OrcProto.BloomFilter.Encoding.TIMESTAMP_UTC_UTF8)) {
       LOG.warn("Not using bloom filter for timestamp column as bloom filter is missing encoding kind (new reader is" +
         " trying to read old files)");
       return TruthValue.YES_NO_NULL;

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -53,6 +53,8 @@ public class RecordReaderUtils {
         return !version.includes(OrcFile.WriterVersion.HIVE_12055);
       case DECIMAL:
         return true;
+      case TIMESTAMP:
+        return !version.includes(OrcFile.WriterVersion.ORC_135);
       default:
         return false;
     }

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -22,6 +22,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -478,7 +481,7 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
     protected final boolean createBloomFilter;
     private final OrcProto.BloomFilterIndex.Builder bloomFilterIndex;
     private final OrcProto.BloomFilterIndex.Builder bloomFilterIndexUtf8;
-    private final OrcProto.BloomFilter.Builder bloomFilterEntry;
+    protected final OrcProto.BloomFilter.Builder bloomFilterEntry;
     private boolean foundNulls;
     private OutStream isPresentOutStream;
     private final List<OrcProto.StripeStatistics.Builder> stripeStatsBuilders;
@@ -1749,17 +1752,17 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
     }
   }
 
-  public static long MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
-  public static long NANOS_PER_MILLI = 1000000;
   public static final int MILLIS_PER_SECOND = 1000;
-  static final int NANOS_PER_SECOND = 1000000000;
   public static final String BASE_TIMESTAMP_STRING = "2015-01-01 00:00:00";
 
   private static class TimestampTreeWriter extends TreeWriter {
     private final IntegerWriter seconds;
     private final IntegerWriter nanos;
     private final boolean isDirectV2;
-    private final long base_timestamp;
+    private final long baseEpochSecsLocalTz;
+    private final ThreadLocal<DateFormat> threadLocalDateFormatUtc;
+    private final TimeZone tzUtc;
+    private long baseEpochMillisUtc;
 
     TimestampTreeWriter(int columnId,
                      TypeDescription schema,
@@ -1774,8 +1777,16 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
       if (rowIndexPosition != null) {
         recordPosition(rowIndexPosition);
       }
+      if (createBloomFilter && bloomFilterEntry != null) {
+        this.bloomFilterEntry.setEncoding(OrcProto.BloomFilter.Encoding.TIMESTAMP_UTC_UTF8);
+      }
+      this.tzUtc = TimeZone.getTimeZone("UTC");
+      this.threadLocalDateFormatUtc = new ThreadLocal<>();
+      this.threadLocalDateFormatUtc.set(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
+      this.threadLocalDateFormatUtc.get().setTimeZone(tzUtc);
+      this.baseEpochMillisUtc = getMillisUtc(BASE_TIMESTAMP_STRING);
       // for unit tests to set different time zones
-      this.base_timestamp = Timestamp.valueOf(BASE_TIMESTAMP_STRING).getTime() / MILLIS_PER_SECOND;
+      this.baseEpochSecsLocalTz = Timestamp.valueOf(BASE_TIMESTAMP_STRING).getTime() / MILLIS_PER_SECOND;
       writer.useWriterTimeZone(true);
     }
 
@@ -1799,14 +1810,15 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
         if (vector.noNulls || !vector.isNull[0]) {
           val = vec.asScratchTimestamp(0);
           long millis = val.getTime();
-          indexStatistics.updateTimestamp(millis);
+          long millisUtc = getMillisUtc(val.toString());
+          indexStatistics.updateTimestamp(millisUtc);
           if (createBloomFilter) {
             if (bloomFilter != null) {
               bloomFilter.addLong(millis);
             }
-            bloomFilterUtf8.addLong(millis);
+            bloomFilterUtf8.addLong(millisUtc);
           }
-          final long secs = millis / MILLIS_PER_SECOND - base_timestamp;
+          final long secs = millis / MILLIS_PER_SECOND - baseEpochSecsLocalTz;
           final long nano = formatNanos(val.getNanos());
           for(int i=0; i < length; ++i) {
             seconds.write(secs);
@@ -1818,18 +1830,31 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
           if (vec.noNulls || !vec.isNull[i + offset]) {
             val = vec.asScratchTimestamp(i + offset);
             long millis = val.getTime();
-            long secs = millis / MILLIS_PER_SECOND - base_timestamp;
+            long secs = millis / MILLIS_PER_SECOND - baseEpochSecsLocalTz;
             seconds.write(secs);
             nanos.write(formatNanos(val.getNanos()));
-            indexStatistics.updateTimestamp(millis);
+            long utcMillis = getMillisUtc(val.toString());
+            indexStatistics.updateTimestamp(utcMillis);
             if (createBloomFilter) {
               if (bloomFilter != null) {
                 bloomFilter.addLong(millis);
               }
-              bloomFilterUtf8.addLong(millis);
+              bloomFilterUtf8.addLong(utcMillis);
             }
           }
         }
+      }
+    }
+
+    private Long getMillisUtc(String tsString) {
+      try {
+        java.util.Date date = threadLocalDateFormatUtc.get().parse(tsString);
+        if (date == null) {
+          return null;
+        }
+        return date.getTime();
+      } catch (ParseException err) {
+        return null;
       }
     }
 

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -1762,7 +1762,6 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
     private final long baseEpochSecsLocalTz;
     private final ThreadLocal<DateFormat> threadLocalDateFormatUtc;
     private final TimeZone tzUtc;
-    private long baseEpochMillisUtc;
 
     TimestampTreeWriter(int columnId,
                      TypeDescription schema,
@@ -1784,7 +1783,6 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
       this.threadLocalDateFormatUtc = new ThreadLocal<>();
       this.threadLocalDateFormatUtc.set(new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
       this.threadLocalDateFormatUtc.get().setTimeZone(tzUtc);
-      this.baseEpochMillisUtc = getMillisUtc(BASE_TIMESTAMP_STRING);
       // for unit tests to set different time zones
       this.baseEpochSecsLocalTz = Timestamp.valueOf(BASE_TIMESTAMP_STRING).getTime() / MILLIS_PER_SECOND;
       writer.useWriterTimeZone(true);
@@ -1833,13 +1831,13 @@ public class WriterImpl implements Writer, MemoryManager.Callback {
             long secs = millis / MILLIS_PER_SECOND - baseEpochSecsLocalTz;
             seconds.write(secs);
             nanos.write(formatNanos(val.getNanos()));
-            long utcMillis = getMillisUtc(val.toString());
-            indexStatistics.updateTimestamp(utcMillis);
+            long millisUtc = getMillisUtc(val.toString());
+            indexStatistics.updateTimestamp(millisUtc);
             if (createBloomFilter) {
               if (bloomFilter != null) {
                 bloomFilter.addLong(millis);
               }
-              bloomFilterUtf8.addLong(utcMillis);
+              bloomFilterUtf8.addLong(millisUtc);
             }
           }
         }

--- a/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
@@ -1,0 +1,403 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.orc;
+
+import static junit.framework.Assert.assertEquals;
+
+import java.io.File;
+import java.sql.Timestamp;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentImpl;
+import org.apache.orc.impl.OrcIndex;
+import org.apache.orc.impl.RecordReaderImpl;
+import org.apache.orc.util.BloomFilter;
+import org.apache.orc.util.BloomFilterIO;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.google.common.collect.Lists;
+
+/**
+ *
+ */
+@RunWith(Parameterized.class)
+public class TestOrcTimezonePPD {
+  Path workDir = new Path(System.getProperty("test.tmp.dir",
+    "target" + File.separator + "test" + File.separator + "tmp"));
+  Configuration conf;
+  FileSystem fs;
+  Path testFilePath;
+  String writerTimeZone;
+  String readerTimeZone;
+  static TimeZone defaultTimeZone = TimeZone.getDefault();
+  TimeZone utcTz = TimeZone.getTimeZone("UTC");
+  DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+  public TestOrcTimezonePPD(String writerTZ, String readerTZ) {
+    this.writerTimeZone = writerTZ;
+    this.readerTimeZone = readerTZ;
+  }
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    List<Object[]> result = Arrays.asList(new Object[][]{
+      {"US/Eastern", "America/Los_Angeles"},
+      {"US/Eastern", "UTC"},
+        /* Extreme timezones */
+      {"GMT-12:00", "GMT+14:00"},
+        /* No difference in DST */
+      {"America/Los_Angeles", "America/Los_Angeles"}, /* same timezone both with DST */
+      {"Europe/Berlin", "Europe/Berlin"}, /* same as above but europe */
+      {"America/Phoenix", "Asia/Kolkata"} /* Writer no DST, Reader no DST */,
+      {"Europe/Berlin", "America/Los_Angeles"} /* Writer DST, Reader DST */,
+      {"Europe/Berlin", "America/Chicago"} /* Writer DST, Reader DST */,
+        /* With DST difference */
+      {"Europe/Berlin", "UTC"},
+      {"UTC", "Europe/Berlin"} /* Writer no DST, Reader DST */,
+      {"America/Los_Angeles", "Asia/Kolkata"} /* Writer DST, Reader no DST */,
+      {"Europe/Berlin", "Asia/Kolkata"} /* Writer DST, Reader no DST */,
+        /* Timezone offsets for the reader has changed historically */
+      {"Asia/Saigon", "Pacific/Enderbury"},
+      {"UTC", "Asia/Jerusalem"},
+    });
+    return result;
+  }
+
+  @Rule
+  public TestName testCaseName = new TestName();
+
+  @Before
+  public void openFileSystem() throws Exception {
+    conf = new Configuration();
+    fs = FileSystem.getLocal(conf);
+    testFilePath = new Path(workDir, "TestOrcFile." +
+      testCaseName.getMethodName() + ".orc");
+    fs.delete(testFilePath, false);
+  }
+
+  @After
+  public void restoreTimeZone() {
+    TimeZone.setDefault(defaultTimeZone);
+  }
+
+  public static PredicateLeaf createPredicateLeaf(PredicateLeaf.Operator operator,
+    PredicateLeaf.Type type,
+    String columnName,
+    Object literal,
+    List<Object> literalList) {
+    return new SearchArgumentImpl.PredicateLeafImpl(operator, type, columnName,
+      literal, literalList);
+  }
+
+  @Test
+  public void testTimestampPPDMinMax() throws Exception {
+    TypeDescription schema = TypeDescription.createTimestamp();
+
+    TimeZone.setDefault(TimeZone.getTimeZone(writerTimeZone));
+    Writer writer = OrcFile.createWriter(testFilePath,
+      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+        .bufferSize(10000));
+    assertEquals(writerTimeZone, TimeZone.getDefault().getID());
+    List<String> ts = Lists.newArrayList();
+    ts.add("2007-08-01 00:00:00.0");
+    ts.add("2007-08-01 04:00:00.0");
+    VectorizedRowBatch batch = schema.createRowBatch();
+    TimestampColumnVector times = (TimestampColumnVector) batch.cols[0];
+    for (String t : ts) {
+      times.set(batch.size++, Timestamp.valueOf(t));
+    }
+    writer.addRowBatch(batch);
+    writer.close();
+
+    TimeZone.setDefault(TimeZone.getTimeZone(readerTimeZone));
+    Reader reader = OrcFile.createReader(testFilePath,
+      OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals(readerTimeZone, TimeZone.getDefault().getID());
+    RecordReader rows = reader.rows();
+    batch = reader.getSchema().createRowBatch();
+    times = (TimestampColumnVector) batch.cols[0];
+    int idx = 0;
+    while (rows.nextBatch(batch)) {
+      for (int r = 0; r < batch.size; ++r) {
+        assertEquals(ts.get(idx++), times.asScratchTimestamp(r).toString());
+      }
+    }
+    rows.close();
+    ColumnStatistics[] colStats = reader.getStatistics();
+    Timestamp expectedMin = getUtcTimestamp("2007-08-01 00:00:00.0");
+    Timestamp gotMin = ((TimestampColumnStatistics) colStats[0]).getMinimum();
+    assertEquals(expectedMin, gotMin);
+
+    Timestamp expectedMax = getUtcTimestamp("2007-08-01 04:00:00.0");
+    Timestamp gotMax = ((TimestampColumnStatistics) colStats[0]).getMaximum();
+    assertEquals(expectedMax, gotMax);
+
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+      SearchArgumentFactory.newBuilder().equals
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0")).build().getLeaves().get(0),
+      null));
+
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+      SearchArgumentFactory.newBuilder().equals
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0")).build().getLeaves().get(0),
+      null));
+
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+      SearchArgumentFactory.newBuilder().between
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 05:00:00.0"),
+          Timestamp.valueOf("2007-08-01 06:00:00.0")).build().getLeaves().get(0),
+      null));
+
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+      SearchArgumentFactory.newBuilder().between
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0"),
+          Timestamp.valueOf("2007-08-01 03:00:00.0")).build().getLeaves().get(0),
+      null));
+
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+      SearchArgumentFactory.newBuilder().in
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0"),
+          Timestamp.valueOf("2007-08-01 03:00:00.0")).build().getLeaves().get(0),
+      null));
+
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+      SearchArgumentFactory.newBuilder().in
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0"),
+          Timestamp.valueOf("2007-08-02 03:00:00.0")).build().getLeaves().get(0),
+      null));
+  }
+
+  @Test
+  public void testTimestampPPDBloomFilter() throws Exception {
+    TypeDescription schema = TypeDescription.createStruct().addField("ts", TypeDescription.createTimestamp());
+
+    TimeZone.setDefault(TimeZone.getTimeZone(writerTimeZone));
+    Writer writer = OrcFile.createWriter(testFilePath,
+      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+        .bufferSize(10000).bloomFilterColumns("ts").writerVersion(OrcFile.WriterVersion.ORC_101));
+    assertEquals(writerTimeZone, TimeZone.getDefault().getID());
+    List<String> ts = Lists.newArrayList();
+    ts.add("2007-08-01 00:00:00.0");
+    ts.add("2007-08-01 04:00:00.0");
+    VectorizedRowBatch batch = schema.createRowBatch();
+    TimestampColumnVector times = (TimestampColumnVector) batch.cols[0];
+    for (String t : ts) {
+      times.set(batch.size++, Timestamp.valueOf(t));
+    }
+    writer.addRowBatch(batch);
+    writer.close();
+
+    TimeZone.setDefault(TimeZone.getTimeZone(readerTimeZone));
+    Reader reader = OrcFile.createReader(testFilePath,
+      OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals(readerTimeZone, TimeZone.getDefault().getID());
+    RecordReader rows = reader.rows();
+    batch = reader.getSchema().createRowBatch();
+    times = (TimestampColumnVector) batch.cols[0];
+    int idx = 0;
+    while (rows.nextBatch(batch)) {
+      for (int r = 0; r < batch.size; ++r) {
+        assertEquals(ts.get(idx++), times.asScratchTimestamp(r).toString());
+      }
+    }
+    boolean[] sargColumns = new boolean[2];
+    Arrays.fill(sargColumns, true);
+    OrcIndex indices = ((RecordReaderImpl) rows).readRowIndex(0, null, sargColumns);
+    rows.close();
+    ColumnStatistics[] colStats = reader.getStatistics();
+    Timestamp expectedMin = getUtcTimestamp("2007-08-01 00:00:00.0");
+    Timestamp gotMin = ((TimestampColumnStatistics) colStats[1]).getMinimum();
+    assertEquals(expectedMin, gotMin);
+
+    Timestamp expectedMax = getUtcTimestamp("2007-08-01 04:00:00.0");
+    Timestamp gotMax = ((TimestampColumnStatistics) colStats[1]).getMaximum();
+    assertEquals(expectedMax, gotMax);
+
+    OrcProto.BloomFilterIndex[] bloomFilterIndices = indices.getBloomFilterIndex();
+    OrcProto.BloomFilter bloomFilter = bloomFilterIndices[1].getBloomFilter(0);
+    BloomFilter bf = BloomFilterIO.deserialize(OrcProto.Stream.Kind.BLOOM_FILTER_UTF8, reader.getWriterVersion(),
+      TypeDescription.Category.TIMESTAMP, bloomFilter);
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+      SearchArgumentFactory.newBuilder().equals
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0")).build().getLeaves().get(0),
+      bf));
+
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+      SearchArgumentFactory.newBuilder().equals
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0")).build().getLeaves().get(0),
+      bf));
+
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+      SearchArgumentFactory.newBuilder().in
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0"),
+          Timestamp.valueOf("2007-08-01 03:00:00.0")).build().getLeaves().get(0),
+      bf));
+
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+      SearchArgumentFactory.newBuilder().in
+        ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0"),
+          Timestamp.valueOf("2007-08-02 03:00:00.0")).build().getLeaves().get(0),
+      bf));
+  }
+
+  @Test
+  public void testTimestampMinMaxAndBloomFilter() throws Exception {
+    TypeDescription schema = TypeDescription.createStruct().addField("ts", TypeDescription.createTimestamp());
+
+    TimeZone.setDefault(TimeZone.getTimeZone(writerTimeZone));
+    Writer writer = OrcFile.createWriter(testFilePath,
+      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+        .bufferSize(10000).bloomFilterColumns("ts"));
+    assertEquals(writerTimeZone, TimeZone.getDefault().getID());
+    List<String> ts = Lists.newArrayList();
+    ts.add("2007-08-01 00:00:00.0");
+    ts.add("2007-08-01 04:00:00.0");
+    VectorizedRowBatch batch = schema.createRowBatch();
+    TimestampColumnVector times = (TimestampColumnVector) batch.cols[0];
+    for (String t : ts) {
+      times.set(batch.size++, Timestamp.valueOf(t));
+    }
+    writer.addRowBatch(batch);
+    writer.close();
+
+    TimeZone.setDefault(TimeZone.getTimeZone(readerTimeZone));
+    Reader reader = OrcFile.createReader(testFilePath,
+      OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals(readerTimeZone, TimeZone.getDefault().getID());
+    RecordReader rows = reader.rows();
+    batch = reader.getSchema().createRowBatch();
+    times = (TimestampColumnVector) batch.cols[0];
+    int idx = 0;
+    while (rows.nextBatch(batch)) {
+      for (int r = 0; r < batch.size; ++r) {
+        assertEquals(ts.get(idx++), times.asScratchTimestamp(r).toString());
+      }
+    }
+    boolean[] sargColumns = new boolean[2];
+    Arrays.fill(sargColumns, true);
+    OrcIndex indices = ((RecordReaderImpl) rows).readRowIndex(0, null, sargColumns);
+    rows.close();
+    ColumnStatistics[] colStats = reader.getStatistics();
+    Timestamp expectedMin = getUtcTimestamp("2007-08-01 00:00:00.0");
+    Timestamp gotMin = ((TimestampColumnStatistics) colStats[1]).getMinimum();
+    assertEquals(expectedMin, gotMin);
+
+    Timestamp expectedMax = getUtcTimestamp("2007-08-01 04:00:00.0");
+    Timestamp gotMax = ((TimestampColumnStatistics) colStats[1]).getMaximum();
+    assertEquals(expectedMax, gotMax);
+
+    OrcProto.BloomFilterIndex[] bloomFilterIndices = indices.getBloomFilterIndex();
+    OrcProto.BloomFilter bloomFilter = bloomFilterIndices[1].getBloomFilter(0);
+    BloomFilter bf = BloomFilterIO.deserialize(OrcProto.Stream.Kind.BLOOM_FILTER_UTF8, reader.getWriterVersion(),
+      TypeDescription.Category.TIMESTAMP, bloomFilter);
+    PredicateLeaf pred = createPredicateLeaf(
+      PredicateLeaf.Operator.NULL_SAFE_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
+      Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+
+    pred = createPredicateLeaf(PredicateLeaf.Operator.NULL_SAFE_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
+      Timestamp.valueOf("2007-08-01 02:00:00.0"), null);
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+
+    bf.addLong(getUtcTimestamp("2007-08-01 02:00:00.0").getTime());
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+
+    pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.TIMESTAMP, "x",
+      Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+
+    pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
+      Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
+    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+
+    pred = createPredicateLeaf(PredicateLeaf.Operator.IS_NULL, PredicateLeaf.Type.TIMESTAMP, "x", null, null);
+    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+  }
+
+  @Test
+  public void testTimestampAllNulls() throws Exception {
+    TypeDescription schema = TypeDescription.createStruct().addField("ts", TypeDescription.createTimestamp());
+
+    TimeZone.setDefault(TimeZone.getTimeZone(writerTimeZone));
+    Writer writer = OrcFile.createWriter(testFilePath,
+      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+        .bufferSize(10000).bloomFilterColumns("ts"));
+    assertEquals(writerTimeZone, TimeZone.getDefault().getID());
+    VectorizedRowBatch batch = schema.createRowBatch();
+    TimestampColumnVector times = (TimestampColumnVector) batch.cols[0];
+    for (int i = 0; i < 3; i++) {
+      times.set(batch.size++, null);
+    }
+    writer.addRowBatch(batch);
+    writer.close();
+
+    TimeZone.setDefault(TimeZone.getTimeZone(readerTimeZone));
+    Reader reader = OrcFile.createReader(testFilePath,
+      OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals(readerTimeZone, TimeZone.getDefault().getID());
+    RecordReader rows = reader.rows();
+    boolean[] sargColumns = new boolean[2];
+    Arrays.fill(sargColumns, true);
+    OrcIndex indices = ((RecordReaderImpl) rows).readRowIndex(0, null, sargColumns);
+    rows.close();
+    ColumnStatistics[] colStats = reader.getStatistics();
+    Timestamp gotMin = ((TimestampColumnStatistics) colStats[1]).getMinimum();
+    Assert.assertNull(gotMin);
+
+    Timestamp gotMax = ((TimestampColumnStatistics) colStats[1]).getMaximum();
+    Assert.assertNull(gotMax);
+
+    OrcProto.BloomFilterIndex[] bloomFilterIndices = indices.getBloomFilterIndex();
+    OrcProto.BloomFilter bloomFilter = bloomFilterIndices[1].getBloomFilter(0);
+    BloomFilter bf = BloomFilterIO.deserialize(OrcProto.Stream.Kind.BLOOM_FILTER_UTF8, reader.getWriterVersion(),
+      TypeDescription.Category.TIMESTAMP, bloomFilter);
+    PredicateLeaf pred = createPredicateLeaf(
+      PredicateLeaf.Operator.NULL_SAFE_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
+      Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
+    Assert.assertEquals(SearchArgument.TruthValue.NULL, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+
+    pred = createPredicateLeaf(PredicateLeaf.Operator.IS_NULL, PredicateLeaf.Type.TIMESTAMP, "x", null, null);
+    Assert.assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+  }
+
+  private Timestamp getUtcTimestamp(String ts) throws ParseException {
+    dateFormat.setTimeZone(utcTz);
+    Date date = dateFormat.parse(ts);
+    return new Timestamp(date.getTime());
+  }
+}

--- a/java/tools/src/test/resources/orc-file-dump-bloomfilter.out
+++ b/java/tools/src/test/resources/orc-file-dump-bloomfilter.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_101
+File Version: 0.12 with ORC_135
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-dump-bloomfilter2.out
+++ b/java/tools/src/test/resources/orc-file-dump-bloomfilter2.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_101
+File Version: 0.12 with ORC_135
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-dump-dictionary-threshold.out
+++ b/java/tools/src/test/resources/orc-file-dump-dictionary-threshold.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_101
+File Version: 0.12 with ORC_135
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-dump.json
+++ b/java/tools/src/test/resources/orc-file-dump.json
@@ -1,7 +1,7 @@
 {
   "fileName": "TestFileDump.testDump.orc",
   "fileVersion": "0.12",
-  "writerVersion": "ORC_101",
+  "writerVersion": "ORC_135",
   "numberOfRows": 21000,
   "compression": "ZLIB",
   "compressionBufferSize": 4096,

--- a/java/tools/src/test/resources/orc-file-dump.out
+++ b/java/tools/src/test/resources/orc-file-dump.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_101
+File Version: 0.12 with ORC_135
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-has-null.out
+++ b/java/tools/src/test/resources/orc-file-has-null.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_101
+File Version: 0.12 with ORC_135
 Rows: 20000
 Compression: ZLIB
 Compression size: 4096

--- a/proto/orc_proto.proto
+++ b/proto/orc_proto.proto
@@ -59,6 +59,8 @@ message TimestampStatistics {
   // min,max values saved as milliseconds since epoch
   optional sint64 minimum = 1;
   optional sint64 maximum = 2;
+  optional sint64 minimumUtc = 3;
+  optional sint64 maximumUtc = 4;
 }
 
 message BinaryStatistics {
@@ -89,9 +91,14 @@ message RowIndex {
 }
 
 message BloomFilter {
+  // ORC-135 encodes timestamp in millis UTC, older version uses local timezone
+  enum Encoding {
+    TIMESTAMP_UTC_UTF8 = 1;
+  }
   optional uint32 numHashFunctions = 1;
   repeated fixed64 bitset = 2;
   optional bytes utf8bitset = 3;
+  optional Encoding encoding = 4;
 }
 
 message BloomFilterIndex {


### PR DESCRIPTION
When reader and writer timezones are different, PPD evaluation does not offset the timezone when reading the min and max values. This can result is wrong PPD evaluation and hence incorrect results.

Example:
Table written in US/Eastern timezone. All values in this table are "2007-08-01 00:00:00.0".
**PPD disabled**
```
hive> set hive.optimize.index.filter=false;
hive> select ORDER_DATE from ORDER_FACT_small where ORDER_DATE='2007-08-01 00:00:00.0' limit 1;
2007-08-01 00:00:00.0
OK
```

**PPD enabled**
```
set hive.optimize.index.filter=true;
select ORDER_DATE from ORDER_FACT_small where ORDER_DATE='2007-08-01 00:00:00.0' limit 1;
OK
```
No rows are returned when PPD is enabled (reader timezone is UTC)