### PR TITLE
ORC-142. Fix TimestampColumnStatistics when reading from old

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -1123,7 +1123,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
             timestampStats.getMaximum());
       }
       if (timestampStats.hasMinimum()) {
-        maximum = SerializationUtils.convertToUtc(TimeZone.getDefault(),
+        minimum = SerializationUtils.convertToUtc(TimeZone.getDefault(),
             timestampStats.getMinimum());
       }
       if (timestampStats.hasMaximumUtc()) {

--- a/java/core/src/test/org/apache/orc/impl/TestColumnStatisticsImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestColumnStatisticsImpl.java
@@ -18,10 +18,18 @@
 
 package org.apache.orc.impl;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.orc.ColumnStatistics;
+import org.apache.orc.OrcFile;
 import org.apache.orc.OrcProto;
+import org.apache.orc.Reader;
+import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.junit.Test;
+
+import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -60,5 +68,17 @@ public class TestColumnStatisticsImpl {
     assertEquals(minimum, protoStat.getMinimum());
     assertTrue(protoStat.hasMaximum());
     assertEquals(maximum, protoStat.getMaximum());
+  }
+
+  @Test
+  public void testOldTimestamps() throws IOException {
+    Path exampleDir = new Path(System.getProperty("example.dir"));
+    Path file = new Path(exampleDir, "TestOrcFile.testTimestamp.orc");
+    Configuration conf = new Configuration();
+    Reader reader = OrcFile.createReader(file, OrcFile.readerOptions(conf));
+    TimestampColumnStatistics stats =
+        (TimestampColumnStatistics) reader.getStatistics()[0];
+    assertEquals("1995-01-01 00:00:00.688", stats.getMinimum().toString());
+    assertEquals("2037-01-01 00:00:00.0", stats.getMaximum().toString());
   }
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -67,6 +67,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
+    <example.dir>${project.basedir}/../../examples</example.dir>
 
     <hadoop.version>2.6.4</hadoop.version>
     <storage-api.version>2.2.0</storage-api.version>
@@ -137,6 +138,7 @@
           <failIfNoTests>false</failIfNoTests>
           <systemPropertyVariables>
             <test.tmp.dir>${test.tmp.dir}</test.tmp.dir>
+            <example.dir>${example.dir}</example.dir>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
files (pre ORC-135).

Signed-off-by: Owen O'Malley <omalley@apache.org>