### PR TITLE
Core Docs: Add a more advanced example

### DIFF
--- a/site/_docs/core-java.md
+++ b/site/_docs/core-java.md
@@ -234,7 +234,7 @@ VectorizedRowBatch batch = schema.createRowBatch();
 LongColumnVector x = (LongColumnVector) batch.cols[0];
 LongColumnVector y = (LongColumnVector) batch.cols[1];
 for(int r=0; r < 10000; ++r) {
-  int row = batch.size;
+  int row = batch.size++;
   x.vector[row] = r;
   y.vector[row] = r * 3;
   // If the batch is full, write it out and start over.
@@ -242,7 +242,6 @@ for(int r=0; r < 10000; ++r) {
     writer.addRowBatch(batch);
     batch.reset();
   }
-  batch.size++;
 }
 if (batch.size != 0) {
   writer.addRowBatch(batch);

--- a/site/_docs/core-java.md
+++ b/site/_docs/core-java.md
@@ -314,6 +314,7 @@ for(int r=0; r < 15; ++r) {
         if (batchSizeCounter + 2 + mapElementSize >= batch.getMaxSize()) {
                 writer.addRowBatch(batch);
                 batch.reset();
+                batchSizeCounter = 0;
         }
 }
 

--- a/site/_docs/core-java.md
+++ b/site/_docs/core-java.md
@@ -210,6 +210,7 @@ public class MapColumnVector extends ColumnVector {
 
 ## Writing ORC Files
 
+### Simple Example
 To write an ORC file, you need to define the schema and use the
 [OrcFile]({{site.url}}/api/orc-core/index.html?org/apache/orc/OrcFile.html)
 class to create a
@@ -245,6 +246,81 @@ for(int r=0; r < 10000; ++r) {
 }
 writer.close();
 ~~~
+
+### Advanced Example 
+
+~~~ java 
+Path testFilePath = new Path("/a/file/path.orc");
+Configuration conf = new Configuration();
+
+TypeDescription schema = TypeDescription
+        .fromString("struct<firstLong:int,secondLong:int,map:map<string,int>>");
+
+Writer writer = OrcFile.createWriter(
+        testFilePath,
+        OrcFile.writerOptions(conf)
+                .setSchema(schema)
+);
+
+VectorizedRowBatch batch = schema.createRowBatch(10);
+LongColumnVector firstLong = (LongColumnVector) batch.cols[0];
+LongColumnVector secondLong = (LongColumnVector) batch.cols[1];
+
+//Define map. You need also to cast the key and value vectors
+MapColumnVector map = (MapColumnVector) batch.cols[2];
+BytesColumnVector mapKey = (BytesColumnVector) map.keys;
+LongColumnVector mapValue = (LongColumnVector) map.values;
+
+Integer mapElementSize = 5;
+//Initialize a counter for the batch size. batch.size is only a counter for the rows
+Integer batchSizeCounter = 0;
+
+for(int r=0; r < 15; ++r) {
+        int row = batch.size++;
+        
+        firstLong.vector[row] = r;
+        secondLong.vector[row] = r * 3;
+
+        //Added all element except for map, so increment the counter by one
+        batchSizeCounter++;
+
+        map.lengths[row] = mapElementSize;
+        map.offsets[row] = map.childCount;
+
+        //Add mapElementSize times a key value pair to the current row map
+        for(int mapIndex=0; mapIndex <= mapElementSize -1; ++mapIndex){
+                byte[] byteString = ("row|"+r).getBytes();
+                mapKey.setVal(map.childCount, byteString);
+                mapValue.vector[map.childCount] = r;
+
+                map.childCount++;
+
+                //Increment batchSize by two. Map needs two spaces in the batch.
+                // One for the key, the other for the value
+                batchSizeCounter += 2;
+            }
+
+
+        /*
+        * If the current batch plus the next row is larger or equals the max batch size
+        * batchSizeCounter + firstColumn + secondColumn + MapKey + MapValue
+        * Each key value pair increases the batch size with 2
+        * A array element increases also the batch.size but only by once
+        * */
+        if (batchSizeCounter + 2 + mapElementSize >= batch.getMaxSize()) {
+                writer.addRowBatch(batch);
+                batch.reset();
+        }
+}
+
+if (batch.size != 0) {
+        writer.addRowBatch(batch);
+        batch.reset();
+}
+
+writer.close();
+~~~
+
 
 ## Reading ORC Files
 

--- a/site/_docs/core-java.md
+++ b/site/_docs/core-java.md
@@ -233,7 +233,7 @@ VectorizedRowBatch batch = schema.createRowBatch();
 LongColumnVector x = (LongColumnVector) batch.cols[0];
 LongColumnVector y = (LongColumnVector) batch.cols[1];
 for(int r=0; r < 10000; ++r) {
-  int row = batch.size++;
+  int row = batch.size;
   x.vector[row] = r;
   y.vector[row] = r * 3;
   // If the batch is full, write it out and start over.
@@ -241,6 +241,7 @@ for(int r=0; r < 10000; ++r) {
     writer.addRowBatch(batch);
     batch.reset();
   }
+  batch.size++;
 }
 writer.close();
 ~~~

--- a/site/_docs/core-java.md
+++ b/site/_docs/core-java.md
@@ -193,7 +193,7 @@ integers for the offset and lengths and two `ColumnVector`s for the
 keys and values.
 
 ~~~ java
-public class ListColumnVector extends ColumnVector {
+public class MapColumnVector extends ColumnVector {
   // for each row, the first offset of the child
   public long[] offsets;
   // for each row, the number of elements in the array


### PR DESCRIPTION
I added a more complex example to the docs. This example explains the handling of maps and also, indirectly, arrays.