### PR TITLE
ORC-172: Fix C++ build issue with Centos6

### DIFF
--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -590,7 +590,7 @@ namespace orc {
   public:
     TimezoneImpl(const std::string& name,
                  const std::vector<unsigned char> bytes);
-    ~TimezoneImpl();
+    virtual ~TimezoneImpl();
 
     /**
      * Get the variant for the given time (time_t).

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -461,8 +461,8 @@ namespace orc {
   /**
    * Parse the POSIX TZ string.
    */
-  std::unique_ptr<FutureRule> parseFutureRule(const std::string& ruleString) {
-    std::unique_ptr<FutureRule> result(new FutureRuleImpl());
+  std::shared_ptr<FutureRule> parseFutureRule(const std::string& ruleString) {
+    std::shared_ptr<FutureRule> result(new FutureRuleImpl());
     FutureRuleParser parser(ruleString,
                             dynamic_cast<FutureRuleImpl*>(result.get()));
     return result;
@@ -590,7 +590,7 @@ namespace orc {
   public:
     TimezoneImpl(const std::string& name,
                  const std::vector<unsigned char> bytes);
-    virtual ~TimezoneImpl();
+    ~TimezoneImpl();
 
     /**
      * Get the variant for the given time (time_t).
@@ -636,7 +636,7 @@ namespace orc {
     uint64_t ancientVariant;
 
     // the rule for future times
-    std::unique_ptr<FutureRule> futureRule;
+    std::shared_ptr<FutureRule> futureRule;
 
     // the last explicit transition after which we use the future rule
     int64_t lastTransition;
@@ -651,7 +651,7 @@ namespace orc {
     DIAGNOSTIC_IGNORE("-Wexit-time-destructors")
   #endif
   static std::mutex timezone_mutex;
-  static std::map<std::string, std::unique_ptr<Timezone> > timezoneCache;
+  static std::map<std::string, std::shared_ptr<Timezone> > timezoneCache;
   DIAGNOSTIC_POP
 
   Timezone::~Timezone() {
@@ -691,7 +691,7 @@ namespace orc {
   const Timezone& getTimezoneByFilename(const std::string& filename) {
     // ORC-110
     std::lock_guard<std::mutex> timezone_lock(timezone_mutex);
-    std::map<std::string, std::unique_ptr<Timezone> >::iterator itr =
+    std::map<std::string, std::shared_ptr<Timezone> >::iterator itr =
       timezoneCache.find(filename);
     if (itr != timezoneCache.end()) {
       return *(itr->second).get();
@@ -729,7 +729,7 @@ namespace orc {
       err << "failed to close " << filename << " - " << strerror(errno);
       throw TimezoneError(err.str());
     }
-    timezoneCache[filename].reset(new TimezoneImpl(filename, buffer));
+    timezoneCache[filename] = std::shared_ptr<Timezone>(new TimezoneImpl(filename, buffer));
     return *timezoneCache[filename].get();
   }
 

--- a/c++/src/Timezone.hh
+++ b/c++/src/Timezone.hh
@@ -49,7 +49,7 @@ namespace orc {
    */
   class Timezone {
   public:
-    virtual ~Timezone();
+    virtual ~Timezone() = 0;
 
     /**
      * Get the variant for the given time (time_t).
@@ -116,7 +116,7 @@ namespace orc {
   /**
    * Parse the POSIX TZ string.
    */
-  std::unique_ptr<FutureRule> parseFutureRule(const std::string& ruleString);
+  std::shared_ptr<FutureRule> parseFutureRule(const std::string& ruleString);
 }
 
 #endif

--- a/c++/src/Timezone.hh
+++ b/c++/src/Timezone.hh
@@ -49,7 +49,7 @@ namespace orc {
    */
   class Timezone {
   public:
-    virtual ~Timezone() = 0;
+    virtual ~Timezone();
 
     /**
      * Get the variant for the given time (time_t).

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -59,7 +59,7 @@ namespace orc {
    * Parse a future rule string and return the parsed rule as a string.
    */
   std::string stringifyRule(const std::string& ruleString) {
-    std::unique_ptr<FutureRule> rule = parseFutureRule(ruleString);
+    std::shared_ptr<FutureRule> rule = parseFutureRule(ruleString);
     std::stringstream buffer;
     rule->print(buffer);
     return buffer.str();
@@ -130,7 +130,7 @@ namespace orc {
   }
 
   TEST(TestTimezone, useFutureRule) {
-    std::unique_ptr<FutureRule> rule =
+    std::shared_ptr<FutureRule> rule =
       parseFutureRule("FOO8BAR,M3.2.0,M11.1.0");
     // 1970
     EXPECT_EQ("FOO", getZoneFromRule(rule.get(), "1970-01-01 00:00:00"));


### PR DESCRIPTION
The patch for ORC-122 requires explicit `copy` and `move` of the `Timezone` class since it contains a `unique_ptr` as one of its member. The simpler fix is to make the member a shared_ptr. A similar change is made for the `TimezoneCache` map. This is reasonable since this code is not on the critical path.