### PR TITLE
ORC-216: VectorRowBatch creation from TypeDescription invalidates batch size

### DIFF
--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -678,6 +678,7 @@ public class TypeDescription
       result.cols[0] = createColumn(maxSize);
     }
     result.reset();
+    result.size = maxSize;
     return result;
   }
 

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -19,6 +19,7 @@ package org.apache.orc;
 
 import static org.junit.Assert.assertEquals;
 
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -219,5 +220,12 @@ public class TestTypeDescription {
     assertEquals(2, leaf.getId());
     assertEquals(0, type.getId());
     assertEquals(2, leaf.getId());
+  }
+
+  @Test
+  public void testVRBSize() {
+    TypeDescription typeDescription = TypeDescription.fromString("string");
+    VectorizedRowBatch vrb = typeDescription.createRowBatch(100);
+    assertEquals(100, vrb.size);
   }
 }


### PR DESCRIPTION
TypeDescription.createRowBatch() always resets the size to 0.
https://github.com/apache/orc/blob/1ef78bbfc7e834deca973ee8f9517c8575737fcf/java/core/src/java/org/apache/orc/TypeDescription.java#L669-L680