### PR TITLE
[ORC-218] Cache timezone information in the library.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ compiler:
 jdk:
   - openjdk7
 before_script:
+env:
+  - MAVEN_OPTS=-Xmx2g MAVEN_SKIP_RC=true TZ_CACHE= STATIC_TZ=
+  - MAVEN_OPTS=-Xmx2g MAVEN_SKIP_RC=true TZ_CACHE=-DEMBEDDED_TZ_DB=ON STATIC_TZ=
+  - MAVEN_OPTS=-Xmx2g MAVEN_SKIP_RC=true TZ_CACHE=-DEMBEDDED_TZ_DB=ON STATIC_TZ=-DSTATIC_TZ=UTC
+script:
   - mkdir build
   - cd build
-  - cmake ..
-env:
-  - MAVEN_OPTS=-Xmx2g MAVEN_SKIP_RC=true
-script:
+  - cmake .. $TZ_CACHE
   - make package test-out

--- a/c++/file2array.sh
+++ b/c++/file2array.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+# Convert file to a C++11 vector of unsigned char
+#
+set -e
+
+arrname=""
+modifiers=""
+
+usage () {
+  echo "Usage: $0 [options] [input file] " >&2
+  echo "Options:" >&2
+  echo "  -v <c array variable name>" >&2
+  echo "     Name of C variable in output file. Must be provided." >&2
+  echo "  -m <array variable modifiers>" >&2
+  echo "     Modifiers for C variable in output file. Default is const." >&2
+  exit 1
+}
+
+while getopts "m:v:" opt; do
+  case $opt in
+    m)
+      if [[ $modifiers != "" ]]; then
+        echo "-m specified twice" >&2
+        usage
+      fi
+      modifiers=$OPTARG
+      ;;
+    v)
+      if [[ $arrname != "" ]]; then
+        echo "-v specified twice" >&2
+        usage
+      fi
+      arrname=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      usage
+  esac
+done
+shift $((OPTIND - 1))
+
+infile=$1
+if [[ $# > 1 ]]; then
+  echo "Too many remaining arguments: $@" >&2
+  usage
+fi
+
+if [ -z "$arrname" ]; then
+  echo "-v not provided or empty." >&2
+  usage
+fi
+
+if [ -z "$modifiers" ]; then
+  # Default is const with global linking visibility
+  modifiers="const"
+fi
+
+echo "#include <vector>" # For size_t
+echo
+# Preceding extern declaration guarantees external linkage in C++
+echo "extern $modifiers std::vector<unsigned char> $arrname;";
+echo
+echo "$modifiers std::vector<unsigned char> $arrname = {"
+xxd -i < $infile
+echo "};"

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -125,6 +125,79 @@ include_directories (
   ${LZ4_INCLUDE_DIRS}
   )
 
+# To avoid reading the Timezone database from disk, we load the file during the
+# build and inject them as binary into the library. This can increase the size
+# of library but avoids doing system calls at runtime. The behavior can be
+# disabled by using the CMake flag NO_EMBEDDED_TZ_DB
+set(TZ_DEPS "")
+if (EMBEDDED_TZ_DB)
+  message(STATUS "Caching of timezone data enabled.")
+  set(DEFAULT_TIMEZONE_DIR "/usr/share/zoneinfo")
+
+  # Check if zone1970.tab is present, otherwise select zone.tab
+  # Parse zone tab to extract all availble zones
+  execute_process(COMMAND find ${DEFAULT_TIMEZONE_DIR} -type f
+    COMMAND grep -v "posix"
+    COMMAND grep -v "right"
+    COMMAND grep -v "tab"
+    COMMAND grep -v "leap" # ignore leap seconds file
+    RESULT_VARIABLE TZ_LIST_RC
+    OUTPUT_VARIABLE TZ_LIST_OUTPUT
+    ERROR_VARIABLE TZ_ERROR)
+
+  if (TZ_LIST_RC)
+    message(FATAL_ERROR "Could not parse Timezone database.")
+  endif()
+
+  set(FILE2ARRAY "${CMAKE_CURRENT_SOURCE_DIR}/../file2array.sh")
+
+  # Add each target to dependency on Timezone.cc
+  string(REPLACE "\n" ";" TZ_LIST_OUT ${TZ_LIST_OUTPUT})
+  set(TZ_CLOBBERED)
+  set(TZ_CLOBBERED "${TZ_CLOBBERED}#include <map>\n")
+  set(TZ_CLOBBERED "${TZ_CLOBBERED}#include <string>\n")
+  set(TZ_CLOBBERED "${TZ_CLOBBERED}#include <vector>\n")
+  set(TZ_CLOBBERED "${TZ_CLOBBERED}\n")
+
+  # First, generate all header files.
+  foreach(TZ_PATH ${TZ_LIST_OUT})
+    string(REPLACE "${DEFAULT_TIMEZONE_DIR}/" "" OF_NAME ${TZ_PATH})
+    string(REPLACE "/" "_" OF_NAME ${OF_NAME})
+    string(REPLACE "-" "_" OF_NAME ${OF_NAME})
+    string(REPLACE "+" "__" OF_NAME ${OF_NAME})
+
+    add_custom_command(OUTPUT "${OF_NAME}.h"
+      COMMAND ${FILE2ARRAY} -v ${OF_NAME} ${TZ_PATH} >"${OF_NAME}.h"
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+    list(APPEND TZ_DEPS "${OF_NAME}.h")
+    set(TZ_CLOBBERED "${TZ_CLOBBERED}#include \"${OF_NAME}.h\"\n")
+  endforeach()
+
+  # Second, generate the initializer list for the map of timezone buffers.
+  set(TZ_CLOBBERED "${TZ_CLOBBERED}extern std::map<std::string, std::vector<unsigned char>> TZ_DATABASE\;\n")
+  set(TZ_CLOBBERED "${TZ_CLOBBERED}std::map<std::string, std::vector<unsigned char>> TZ_DATABASE = {\n")
+  foreach(TZ_PATH ${TZ_LIST_OUT})
+    string(REPLACE "${DEFAULT_TIMEZONE_DIR}/" "" REL_PATH ${TZ_PATH})
+    string(REPLACE "/" "_" OF_NAME ${REL_PATH})
+    string(REPLACE "-" "_" OF_NAME ${OF_NAME})
+    string(REPLACE "+" "__" OF_NAME ${OF_NAME})
+    set(TZ_CLOBBERED "${TZ_CLOBBERED}{ \"${REL_PATH}\", ${OF_NAME} }, \n")
+  endforeach()
+  set(TZ_CLOBBERED "${TZ_CLOBBERED}}\;\n")
+
+  # To make it easier to include the TZ files, generated a clobbered file.
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/tz_db_clobbered.h ${TZ_CLOBBERED})
+
+  add_definitions(-DUSE_TZ_DB)
+
+  if (STATIC_TZ)
+    add_definitions(-DTZ_DB_STATIC_TZ=${STATIC_TZ})
+  endif()
+  list(APPEND TZ_DEPS "tz_db_clobbered")
+else()
+  message(STATUS "Caching of timezone information disabled.")
+endif()
+
 add_custom_command(OUTPUT orc_proto.pb.h orc_proto.pb.cc
    COMMAND ${PROTOBUF_EXECUTABLE}
         -I ${CMAKE_SOURCE_DIR}/proto
@@ -134,6 +207,7 @@ add_custom_command(OUTPUT orc_proto.pb.h orc_proto.pb.cc
 
 add_library (orc STATIC
   "${CMAKE_CURRENT_BINARY_DIR}/Adaptor.hh"
+  ${TZ_DEPS}
   orc_proto.pb.h
   io/InputStream.cc
   io/OutputStream.cc


### PR DESCRIPTION
Right now, for every lookup of a timezone, the library will go to
disk and parse the timezone file. While the results are cached,
doing these system calls should be avoided in environments with
restricted system calls.

This patch loads all the time zone files into the binary at
build time and instead of accessing disk for the TZ
information will simply load the buffer from memory. In addition,
this allows the user to compile the library with a static
timezone to be assumed for local use. This comes in handy to avoid
yet another set of system calls to assume the local timezone.

The following CMake flags control this feature:

  * EMBEDED_TZ_DB - disables this feature if set to OFF
  * STATIC_TZ=Val - sets a specific timezone