### PR TITLE
ORC-162. Handle 0 byte files as empty ORC files.

### DIFF
--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -315,12 +315,17 @@ public class TypeDescription
 
   static void parseStruct(TypeDescription type, StringPosition source) {
     requireChar(source, '<');
-    do {
+    boolean needComma = false;
+    while (!consumeChar(source, '>')) {
+      if (needComma) {
+        requireChar(source, ',');
+      } else {
+        needComma = true;
+      }
       String fieldName = parseName(source);
       requireChar(source, ':');
       type.addField(fieldName, parseType(source));
-    } while (consumeChar(source, ','));
-    requireChar(source, '>');
+    }
   }
 
   static TypeDescription parseType(StringPosition source) {

--- a/java/core/src/test/org/apache/orc/TestReader.java
+++ b/java/core/src/test/org/apache/orc/TestReader.java
@@ -49,13 +49,14 @@ public class TestReader {
     fs.delete(testFilePath, false);
   }
 
-  @Test(expected=FileFormatException.class)
+  @Test
   public void testReadZeroLengthFile() throws Exception {
     FSDataOutputStream fout = fs.create(testFilePath);
     fout.close();
     assertEquals(0, fs.getFileStatus(testFilePath).getLen());
-    OrcFile.createReader(testFilePath,
+    Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals(0, reader.getNumberOfRows());
   }
 
   @Test(expected=FileFormatException.class)

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -3249,5 +3249,29 @@ public class TestVectorOrcFile {
     assertEquals(fromString("bar"), reader.getMetadataValue("b"));
     assertEquals(fromString("baz"), reader.getMetadataValue("c"));
     assertEquals(fromString("bat"), reader.getMetadataValue("d"));
+  }
+
+  Path exampleDir = new Path(System.getProperty("example.dir",
+      "../../examples/"));
+
+  @Test
+  public void testZeroByteOrcFile() throws Exception {
+    Path zeroFile = new Path(exampleDir, "zero.orc");
+    Reader reader = OrcFile.createReader(zeroFile, OrcFile.readerOptions(conf));
+    assertEquals(0, reader.getNumberOfRows());
+    assertEquals("struct<>", reader.getSchema().toString());
+    assertEquals(CompressionKind.NONE, reader.getCompressionKind());
+    assertEquals(0, reader.getRawDataSize());
+    assertEquals(0, reader.getRowIndexStride());
+    assertEquals(0, reader.getCompressionSize());
+    assertEquals(0, reader.getMetadataSize());
+    assertEquals(OrcFile.Version.CURRENT, reader.getFileVersion());
+    assertEquals(0, reader.getStripes().size());
+    assertEquals(0, reader.getStatistics().length);
+    assertEquals(0, reader.getMetadataKeys().size());
+    assertEquals(OrcFile.CURRENT_WRITER, reader.getWriterVersion());
+    VectorizedRowBatch batch =
+        TypeDescription.fromString("struct<>").createRowBatch();
+    assertEquals(false, reader.rows().nextBatch(batch));
   }
 }

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
@@ -24,6 +24,7 @@ import com.esotericsoftware.kryo.io.Output;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentImpl;
 import org.apache.hadoop.io.WritableComparable;
@@ -32,6 +33,7 @@ import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.RecordReader;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.hadoop.io.NullWritable;
@@ -150,5 +152,27 @@ public class OrcInputFormat<V extends WritableComparable>
             .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(conf)));
     return new OrcMapredRecordReader<>(file, buildOptions(conf,
         file, split.getStart(), split.getLength()));
+  }
+
+  /**
+   * Filter out the 0 byte files, so that we don't generate splits for the
+   * empty ORC files.
+   * @param job the job configuration
+   * @return a list of files that need to be read
+   * @throws IOException
+   */
+  protected FileStatus[] listStatus(JobConf job) throws IOException {
+    FileStatus[] result = super.listStatus(job);
+    List<FileStatus> ok = new ArrayList<>(result.length);
+    for(FileStatus stat: result) {
+      if (stat.getLen() != 0) {
+        ok.add(stat);
+      }
+    }
+    if (ok.size() == result.length) {
+      return result;
+    } else {
+      return ok.toArray(new FileStatus[ok.size()]);
+    }
   }
 }

--- a/java/mapreduce/src/java/org/apache/orc/mapreduce/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapreduce/OrcInputFormat.java
@@ -19,9 +19,11 @@
 package org.apache.orc.mapreduce;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
@@ -29,6 +31,8 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.hadoop.io.NullWritable;
 import org.apache.orc.OrcConf;
@@ -67,5 +71,16 @@ public class OrcInputFormat<V extends WritableComparable>
     return new OrcMapreduceRecordReader<>(file,
         org.apache.orc.mapred.OrcInputFormat.buildOptions(conf,
             file, split.getStart(), split.getLength()));
+  }
+
+  protected List<FileStatus> listStatus(JobContext job) throws IOException {
+    List<FileStatus> complete = super.listStatus(job);
+    List<FileStatus> result = new ArrayList<>(complete.size());
+    for(FileStatus stat: complete) {
+      if (stat.getLen() != 0) {
+        result.add(stat);
+      }
+    }
+    return result;
   }
 }


### PR DESCRIPTION
Treat 0 byte files as an empty ORC file with schema of struct<>.