### PR TITLE
Install missing Statistics.hh header file

### DIFF
--- a/c++/include/CMakeLists.txt
+++ b/c++/include/CMakeLists.txt
@@ -80,5 +80,6 @@ install(FILES
   "orc/Reader.hh"
   "orc/Type.hh"
   "orc/Vector.hh"
+  "orc/Statistics.hh"
   DESTINATION "include/orc"
   )


### PR DESCRIPTION
After installing orc, I couldn't include any of the header files because Statistics.hh is missing in the installed include directory.