### PR TITLE
Orc 256 unmask range option

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/mask/RedactMaskFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/mask/RedactMaskFactory.java
@@ -33,7 +33,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TimeZone;
@@ -121,8 +120,7 @@ public class RedactMaskFactory extends MaskFactory {
   private final boolean maskTimestamp;
 
   // index tuples that are not to be masked
-  private final SortedMap<Integer,Integer> unmaskIndexRanges = Collections.synchronizedSortedMap(new TreeMap());
-
+  private final SortedMap<Integer,Integer> unmaskIndexRanges = new TreeMap();
 
   public RedactMaskFactory(String... params) {
     ByteBuffer param = params.length < 1 ? ByteBuffer.allocate(0) :
@@ -1019,7 +1017,7 @@ public class RedactMaskFactory extends MaskFactory {
   private SortedMap<Integer,Integer> getPositiveUnmaskRangeIndexes(final int length) {
 
     /* Always return a sorted map */
-    final SortedMap<Integer,Integer> result = Collections.synchronizedSortedMap(new TreeMap());
+    final SortedMap<Integer,Integer> result = new TreeMap();
 
     for(final Map.Entry<Integer, Integer> pair : unmaskIndexRanges.entrySet()) {
       int start = 0;
@@ -1090,7 +1088,5 @@ public class RedactMaskFactory extends MaskFactory {
     return inverse;
 
   }
-
-
 
 }

--- a/java/core/src/test/org/apache/orc/impl/mask/TestUnmaskRange.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestUnmaskRange.java
@@ -1,0 +1,165 @@
+package org.apache.orc.impl.mask;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test Unmask option
+ */
+public class TestUnmaskRange {
+
+  public TestUnmaskRange() {
+    super();
+  }
+
+  /* Test for Long */
+  @Test
+  public void testSimpleLongRangeMask() {
+    RedactMaskFactory mask = new RedactMaskFactory("9", "", "0:2");
+    long result = mask.maskLong(123456);
+    assertEquals(123_999, result);
+
+    // negative index
+    mask = new RedactMaskFactory("9", "", "-3:-1");
+    result = mask.maskLong(123456);
+    assertEquals(999_456, result);
+
+    // out of range mask, return the original mask
+    mask = new RedactMaskFactory("9", "", "7:10");
+    result = mask.maskLong(123456);
+    assertEquals(999999, result);
+
+  }
+
+  @Test
+  public void testDefaultRangeMask() {
+    RedactMaskFactory mask = new RedactMaskFactory("9", "", "");
+    long result = mask.maskLong(123456);
+    assertEquals(999999, result);
+
+    mask = new RedactMaskFactory("9");
+    result = mask.maskLong(123456);
+    assertEquals(999999, result);
+
+  }
+
+  @Test
+  public void testCCRangeMask() {
+    long cc = 4716885592186382L;
+    long maskedCC = 4716_77777777_6382L;
+    // Range unmask for first 4 and last 4 of credit card number
+    final RedactMaskFactory mask = new RedactMaskFactory("Xx7", "", "0:3,-4:-1");
+    long result = mask.maskLong(cc);
+
+    assertEquals(String.valueOf(cc).length(), String.valueOf(result).length());
+    assertEquals(4716_77777777_6382L, result);
+  }
+
+  /* Tests for Double */
+  @Test
+  public void testSimpleDoubleRangeMask() {
+    RedactMaskFactory mask = new RedactMaskFactory("Xx7", "", "0:2");
+    assertEquals(1237.77, mask.maskDouble(1234.99), 0.000001);
+    assertEquals(12377.7, mask.maskDouble(12345.9), 0.000001);
+
+    mask = new RedactMaskFactory("Xx7", "", "-3:-1");
+    assertEquals(7774.9, mask.maskDouble(1234.9), 0.000001);
+
+  }
+
+  /* test for String */
+  @Test
+  public void testStringRangeMask() {
+
+    BytesColumnVector source = new BytesColumnVector();
+    BytesColumnVector target = new BytesColumnVector();
+    target.reset();
+
+    byte[] input = "Mary had 1 little lamb!!".getBytes(StandardCharsets.UTF_8);
+    source.setRef(0, input, 0, input.length);
+
+    // Set a 4 byte chinese character (U+2070E), which is letter other
+    input = "\uD841\uDF0E".getBytes(StandardCharsets.UTF_8);
+    source.setRef(1, input, 0, input.length);
+
+    RedactMaskFactory mask = new RedactMaskFactory("", "", "0:3, -5:-1");
+    for(int r=0; r < 2; ++r) {
+      mask.maskString(source, r, target);
+    }
+
+    assertEquals("Mary xxx 9 xxxxxx xamb!!", new String(target.vector[0],
+        target.start[0], target.length[0], StandardCharsets.UTF_8));
+    assertEquals("\uD841\uDF0E", new String(target.vector[1],
+        target.start[1], target.length[1], StandardCharsets.UTF_8));
+
+    // test defaults, no-unmask range
+    mask = new RedactMaskFactory();
+    for(int r=0; r < 2; ++r) {
+      mask.maskString(source, r, target);
+    }
+
+    assertEquals("Xxxx xxx 9 xxxxxx xxxx..", new String(target.vector[0],
+        target.start[0], target.length[0], StandardCharsets.UTF_8));
+    assertEquals("ª", new String(target.vector[1],
+        target.start[1], target.length[1], StandardCharsets.UTF_8));
+
+
+    // test out of range string mask
+    mask = new RedactMaskFactory("", "", "-1:-5");
+    for(int r=0; r < 2; ++r) {
+      mask.maskString(source, r, target);
+    }
+
+    assertEquals("Xxxx xxx 9 xxxxxx xxxx..", new String(target.vector[0],
+        target.start[0], target.length[0], StandardCharsets.UTF_8));
+    assertEquals("ª", new String(target.vector[1],
+        target.start[1], target.length[1], StandardCharsets.UTF_8));
+
+  }
+
+  /* test for Decimal */
+  @Test
+  public void testDecimalRangeMask() {
+
+    RedactMaskFactory mask = new RedactMaskFactory("Xx7", "", "0:3");
+    assertEquals(new HiveDecimalWritable("123477.777"),
+        mask.maskDecimal(new HiveDecimalWritable("123456.789")));
+
+    // try with a reverse index
+    mask = new RedactMaskFactory("Xx7", "", "-3:-1, 0:3");
+    assertEquals(new HiveDecimalWritable("123477777.777654"),
+        mask.maskDecimal(new HiveDecimalWritable("123456789.987654")));
+
+    // test removal of leading and  trailing zeros.
+    /*
+    assertEquals(new HiveDecimalWritable("777777777777777777.7777"),
+        mask.maskDecimal(new HiveDecimalWritable("0123456789123456789.01230")));
+        */
+
+
+
+  }
+
+}

--- a/java/core/src/test/org/apache/orc/impl/mask/TestUnmaskRange.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestUnmaskRange.java
@@ -152,14 +152,6 @@ public class TestUnmaskRange {
     assertEquals(new HiveDecimalWritable("123477777.777654"),
         mask.maskDecimal(new HiveDecimalWritable("123456789.987654")));
 
-    // test removal of leading and  trailing zeros.
-    /*
-    assertEquals(new HiveDecimalWritable("777777777777777777.7777"),
-        mask.maskDecimal(new HiveDecimalWritable("0123456789123456789.01230")));
-        */
-
-
-
   }
 
 }


### PR DESCRIPTION
This PR contains changes that enables unmasking range option for redact mask (ORC-256).

1. The react mask would accept an additional option (option #3 in this case) that has the configuration for leaving certain ranges of strings unmasked
2. The options will look like "0:4,-4:-1"
3. Range unmasking is available for 1. Long 2. Double 3. String 4. Decimal

  
