### PR TITLE
ORC-261: [C++] Fix installation to include all header files

### DIFF
--- a/c++/include/CMakeLists.txt
+++ b/c++/include/CMakeLists.txt
@@ -12,19 +12,15 @@
 
 configure_file (
   "orc/orc-config.hh.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/orc/orc-config.hh"
+  "orc/orc-config.hh"
   )
 
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/orc/orc-config.hh"
-  "orc/ColumnPrinter.hh"
-  "orc/Common.hh"
-  "orc/Int128.hh"
-  "orc/MemoryPool.hh"
-  "orc/OrcFile.hh"
-  "orc/Reader.hh"
-  "orc/Type.hh"
-  "orc/Vector.hh"
-  "orc/Statistics.hh"
   DESTINATION "include/orc"
   )
+
+install(DIRECTORY
+        "orc/"
+        DESTINATION "include/orc"
+        FILES_MATCHING PATTERN "*.hh")

--- a/c++/include/orc/Common.hh
+++ b/c++/include/orc/Common.hh
@@ -21,8 +21,7 @@
 
 #include "orc/Vector.hh"
 #include "orc/Type.hh"
-#include "Exceptions.hh"
-#include "wrap/orc-proto-wrapper.hh"
+#include "orc/Exceptions.hh"
 
 #include <string>
 

--- a/c++/include/orc/Exceptions.hh
+++ b/c++/include/orc/Exceptions.hh
@@ -19,8 +19,6 @@
 #ifndef ORC_EXCEPTIONS_HH
 #define ORC_EXCEPTIONS_HH
 
-#include "Adaptor.hh"
-
 #include <stdexcept>
 #include <string>
 

--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -22,7 +22,7 @@
 #include <utility>
 
 #include "ByteRLE.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 namespace orc {
 

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -21,7 +21,7 @@
 #include "Adaptor.hh"
 #include "ByteRLE.hh"
 #include "ColumnReader.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "RLE.hh"
 
 #include <math.h>

--- a/c++/src/ColumnWriter.hh
+++ b/c++/src/ColumnWriter.hh
@@ -23,7 +23,7 @@
 
 #include "ByteRLE.hh"
 #include "Compression.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "Statistics.hh"
 
 #include "wrap/orc-proto-wrapper.hh"

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -18,7 +18,7 @@
 
 #include "Adaptor.hh"
 #include "Compression.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "LzoDecompressor.hh"
 #include "lz4.h"
 

--- a/c++/src/Exceptions.cc
+++ b/c++/src/Exceptions.cc
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 namespace orc {
 

--- a/c++/src/LzoDecompressor.cc
+++ b/c++/src/LzoDecompressor.cc
@@ -14,7 +14,7 @@
 
 #include "Adaptor.hh"
 #include "Compression.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <string>
 

--- a/c++/src/OrcFile.cc
+++ b/c++/src/OrcFile.cc
@@ -19,7 +19,7 @@
 #include "orc/OrcFile.hh"
 
 #include "Adaptor.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <errno.h>
 #include <fcntl.h>

--- a/c++/src/OrcHdfsFile.cc
+++ b/c++/src/OrcHdfsFile.cc
@@ -19,7 +19,7 @@
 #include "orc/OrcFile.hh"
 
 #include "Adaptor.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <errno.h>
 #include <fcntl.h>

--- a/c++/src/RLE.cc
+++ b/c++/src/RLE.cc
@@ -18,7 +18,7 @@
 
 #include "RLEv1.hh"
 #include "RLEv2.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 namespace orc {
 

--- a/c++/src/RLEv1.cc
+++ b/c++/src/RLEv1.cc
@@ -18,7 +18,7 @@
 
 #include "Adaptor.hh"
 #include "Compression.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "RLEv1.hh"
 
 #include <algorithm>

--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -20,7 +20,7 @@
 #define ORC_RLEV2_HH
 
 #include "Adaptor.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "RLE.hh"
 
 #include <vector>

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -24,7 +24,7 @@
 #include "orc/Reader.hh"
 
 #include "ColumnReader.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "RLE.hh"
 #include "TypeImpl.hh"
 

--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "RLE.hh"
 #include "Statistics.hh"
 

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "RLE.hh"
 #include "Reader.hh"
 #include "StripeStream.hh"

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -17,7 +17,7 @@
  */
 
 #include "Adaptor.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "TypeImpl.hh"
 
 #include <iostream>

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -19,7 +19,7 @@
 #include "orc/Vector.hh"
 
 #include "Adaptor.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <iostream>
 #include <sstream>

--- a/c++/src/io/InputStream.cc
+++ b/c++/src/io/InputStream.cc
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "InputStream.hh"
 
 #include <algorithm>

--- a/c++/src/io/OutputStream.cc
+++ b/c++/src/io/OutputStream.cc
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "OutputStream.hh"
 
 #include <sstream>

--- a/c++/test/TestColumnPrinter.cc
+++ b/c++/test/TestColumnPrinter.cc
@@ -18,7 +18,7 @@
 
 #include "orc/ColumnPrinter.hh"
 
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "wrap/gtest-wrapper.h"
 
 namespace orc {

--- a/c++/test/TestColumnReader.cc
+++ b/c++/test/TestColumnReader.cc
@@ -18,7 +18,7 @@
 
 #include "Adaptor.hh"
 #include "ColumnReader.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "OrcTest.hh"
 
 #include "wrap/orc-proto-wrapper.hh"

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -17,7 +17,7 @@
  */
 
 #include "Compression.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 #include "OrcTest.hh"
 #include "wrap/gtest-wrapper.h"
 

--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -10,10 +10,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO:
+# - orc-metadata relies on the protobuf routines, meaning protobuf and
+#   binary_dir/c++/src still need to be included
+# - timezone-dump relies on non-public timezone routines. I *think* this
+#   executable can just be removed, as it looks like it was written for testing
+#   alone.
+
 include_directories (
   ${PROJECT_SOURCE_DIR}/c++/include
-  ${PROJECT_SOURCE_DIR}/c++/src
   ${PROJECT_BINARY_DIR}/c++/include
+  ${PROJECT_SOURCE_DIR}/c++/src
   ${PROJECT_BINARY_DIR}/c++/src
   ${PROTOBUF_INCLUDE_DIRS}
   )
@@ -26,7 +33,6 @@ add_executable (orc-contents
 
 target_link_libraries (orc-contents
   orc
-  ${PROTOBUF_LIBRARIES}
   )
 
 add_executable (orc-scan
@@ -35,7 +41,6 @@ add_executable (orc-scan
 
 target_link_libraries (orc-scan
   orc
-  ${PROTOBUF_LIBRARIES}
   )
 
 add_executable (orc-metadata
@@ -53,7 +58,6 @@ target_link_libraries (orc-metadata
 
 target_link_libraries (orc-statistics
   orc
-  ${PROTOBUF_LIBRARIES}
   )
 
 add_executable (orc-memory
@@ -62,7 +66,6 @@ add_executable (orc-memory
 
 target_link_libraries (orc-memory
   orc
-  ${PROTOBUF_LIBRARIES}
   )
 
 add_executable (timezone-dump
@@ -71,7 +74,6 @@ add_executable (timezone-dump
 
 target_link_libraries (timezone-dump
   orc
-  ${PROTOBUF_LIBRARIES}
   )
 
 install(TARGETS

--- a/tools/src/FileContents.cc
+++ b/tools/src/FileContents.cc
@@ -18,8 +18,7 @@
 
 #include "orc/orc-config.hh"
 #include "orc/ColumnPrinter.hh"
-
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <memory>
 #include <string>

--- a/tools/src/FileMemory.cc
+++ b/tools/src/FileMemory.cc
@@ -18,7 +18,7 @@
 
 #include "orc/orc-config.hh"
 #include "orc/ColumnPrinter.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <string>
 #include <memory>

--- a/tools/src/FileMetadata.cc
+++ b/tools/src/FileMetadata.cc
@@ -24,8 +24,9 @@
 #include <sstream>
 
 #include "orc/OrcFile.hh"
-#include "Adaptor.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
+
+//#include "Adaptor.hh"
 #include "wrap/orc-proto-wrapper.hh"
 
 void printStripeInformation(std::ostream& out,

--- a/tools/src/FileScan.cc
+++ b/tools/src/FileScan.cc
@@ -18,7 +18,7 @@
 
 #include "orc/ColumnPrinter.hh"
 
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <getopt.h>
 #include <string>

--- a/tools/src/FileStatistics.cc
+++ b/tools/src/FileStatistics.cc
@@ -17,7 +17,7 @@
  */
 
 #include "orc/ColumnPrinter.hh"
-#include "Exceptions.hh"
+#include "orc/Exceptions.hh"
 
 #include <getopt.h>
 #include <string>

--- a/tools/src/TimezoneDump.cc
+++ b/tools/src/TimezoneDump.cc
@@ -16,9 +16,9 @@
  * limitations under the License.
  */
 
-#include "Timezone.hh"
+#include "orc/Exceptions.hh"
 
-#include "Exceptions.hh"
+#include "Timezone.hh"
 
 #include <string>
 #include <memory>


### PR DESCRIPTION
Addresses [issue 261](https://issues.apache.org/jira/projects/ORC/issues/ORC-261).

- Fixes installation to include all necessary header files in `include/orc`
- Removes a few unnecessary includes