### PR TITLE
ORC-265: [C++] Add documentation for C++ build support

### DIFF
--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -70,3 +70,20 @@ To build:
 % mvn package
 ~~~
 
+## Building just C++
+
+~~~ shell
+% mkdir build
+% cd build
+% cmake .. -DBUILD_JAVA=OFF
+% make package test-out
+~~~
+
+## Specify third-party libraries for C++ build
+
+~~~ shell
+% mkdir build
+% cd build
+% cmake .. -DSNAPPY_HOME=<PATH> -DZLIB_HOME=<PATH> -DLZ4_HOME=<PATH> -DGTEST_HOME=<PATH> -DPROTOBUF_HOME=<PATH>
+% make package test-out
+~~~


### PR DESCRIPTION
I verified the modified page by building locally.