### PR TITLE
ORC-270: fix target_link_libraries for tool-test

### DIFF
--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -34,9 +34,9 @@ add_executable (tool-test
 target_link_libraries (tool-test
   orc
   protobuf
-  gmock
   zlib
   snappy
+  ${GTEST_LIBRARIES}
 )
 
 add_test (tool-test tool-test ${EXAMPLE_DIRECTORY} ${PROJECT_BINARY_DIR})


### PR DESCRIPTION
gmock depends on pthread library, but use ${GTEST_LIBRARIES} similar to c++\test\CMakeLists.txt