### PR TITLE
Orc 250 - Create sha256 mask

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
@@ -22,17 +22,232 @@ import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.orc.DataMask;
 import org.apache.orc.TypeDescription;
 
+import javax.xml.bind.DatatypeConverter;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+/**
+ * Masking strategy that masks String, Varchar, Char and Binary types
+ * as SHA 256 hash.
+ * <p>
+ * <b>For String type:</b><br/>
+ * All string type of any length will be converted to 64 length SHA256 hash.<br/><br/>
+ * <p>
+ * <b>For Varchar type:</b><br/>
+ * For Varchar type, max-length property will be honored i.e.
+ * if the length is less than max-length then the SHA256 hash will be truncated
+ * to max-length. If max-length is greater than 64 then the output is the sha256
+ * length, which is 64.<br/><br/>
+ * <p>
+ * <b>For Char type:</b><br/>
+ * For Char type, the length of mask will always be equal to specified max-length.
+ * If the given length (max-length) is less than SHA256 hash length (64)
+ * the mask will be truncated.
+ * If the given length (max-length) is greater than SHA256 hash length (64)
+ * then the mask will be padded by blank spaces.<br/><br/>
+ * <p>
+ * <b>For Binary type:</b><br/>
+ * All Binary type of any length will be converted to 64 length SHA256 hash.<br/>
+ */
 public class SHA256MaskFactory extends MaskFactory {
 
+  final MessageDigest md;
 
   public SHA256MaskFactory(final String... params) {
     super();
+    try {
+      md = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
   }
 
-  class Stringmask implements DataMask {
+  /**
+   * Mask a string by finding the character category of each character
+   * and replacing it with the matching literal.
+   *
+   * @param source the source column vector
+   * @param row    the value index
+   * @param target the target column vector
+   * @param schema schema
+   */
+  void maskString(final BytesColumnVector source, final int row,
+      final BytesColumnVector target, final TypeDescription schema) {
+    final ByteBuffer sourceBytes = ByteBuffer
+        .wrap(source.vector[row], source.start[row], source.length[row]);
+
+    // take SHA-256 Hash and convert to HEX
+    byte[] hash = DatatypeConverter
+        .printHexBinary(md.digest(sourceBytes.array()))
+        .getBytes(StandardCharsets.UTF_8);
+    int targetLength = hash.length;
+
+    /* For type varchar */
+    if (schema.getCategory() == TypeDescription.Category.VARCHAR) {
+
+      /* truncate the hash if max length for varchar is less than hash length
+       * on the other hand if if the max length is more than hash length (64 bytes)
+       * we use the hash length (64 bytes) always.
+       */
+      if (schema.getMaxLength() < hash.length) {
+        targetLength = schema.getMaxLength();
+      }
+
+    }
+
+    /* For type char */
+    if (schema.getCategory() == TypeDescription.Category.CHAR) {
+      /* for char the length is always constant */
+      targetLength = schema.getMaxLength();
+    }
+
+    // ensure we have enough space, if the masked data is the same size
+    target.ensureValPreallocated(targetLength);
+    byte[] outputBuffer = target.getValPreallocatedBytes();
+    int outputOffset = target.getValPreallocatedStart();
+
+    if (targetLength > hash.length) {
+
+      System.arraycopy(hash, 0, outputBuffer, 0, hash.length);
+      Arrays.fill(outputBuffer, hash.length, targetLength - 1, (byte) ' ');
+
+    } else {
+      System.arraycopy(hash, 0, outputBuffer, outputOffset, targetLength);
+    }
+
+    target.setValPreallocated(row, targetLength);
+
+  }
+
+  /**
+   * Helper function to mask binary data with it's SHA-256 hash.
+   *
+   * @param source
+   * @param row
+   * @param target
+   */
+  void maskBinary(final BytesColumnVector source, final int row,
+      final BytesColumnVector target) {
+
+    final ByteBuffer sourceBytes = ByteBuffer
+        .wrap(source.vector[row], source.start[row], source.length[row]);
+
+    // take SHA-256 Hash and convert to HEX
+    byte[] hash = DatatypeConverter
+        .printHexBinary(md.digest(sourceBytes.array()))
+        .getBytes(StandardCharsets.UTF_8);
+    int targetLength = hash.length;
+
+    // ensure we have enough space, if the masked data is the same size
+    target.ensureValPreallocated(targetLength);
+    byte[] outputBuffer = target.getValPreallocatedBytes();
+    int outputOffset = target.getValPreallocatedStart();
+
+    System.arraycopy(hash, 0, outputBuffer, outputOffset, targetLength);
+
+    target.setValPreallocated(row, targetLength);
+
+  }
+
+  @Override
+  protected DataMask buildBinaryMask(TypeDescription schema) {
+    return new BinaryMask();
+  }
+
+  @Override
+  protected DataMask buildBooleanMask(TypeDescription schema) {
+    return new NullifyMask();
+  }
+
+  @Override
+  protected DataMask buildLongMask(TypeDescription schema) {
+    return new NullifyMask();
+  }
+
+  @Override
+  protected DataMask buildDecimalMask(TypeDescription schema) {
+    return new NullifyMask();
+  }
+
+  @Override
+  protected DataMask buildDoubleMask(TypeDescription schema) {
+    return new NullifyMask();
+  }
+
+  @Override
+  protected DataMask buildStringMask(final TypeDescription schema) {
+    return new StringMask(schema);
+  }
+
+  @Override
+  protected DataMask buildDateMask(TypeDescription schema) {
+    return new NullifyMask();
+  }
+
+  @Override
+  protected DataMask buildTimestampMask(TypeDescription schema) {
+    return new NullifyMask();
+  }
+
+  /**
+   * Data mask for String, Varchar and Char types.
+   */
+  class StringMask implements DataMask {
+
+    final TypeDescription schema;
 
     /* create an instance */
-    public Stringmask() {
+    public StringMask(TypeDescription schema) {
+      super();
+      this.schema = schema;
+    }
+
+    /**
+     * Mask the given range of values
+     *
+     * @param original the original input data
+     * @param masked   the masked output data
+     * @param start    the first data element to mask
+     * @param length   the number of data elements to mask
+     */
+    @Override
+    public void maskData(final ColumnVector original, final ColumnVector masked,
+        final int start, final int length) {
+
+      final BytesColumnVector target = (BytesColumnVector) masked;
+      final BytesColumnVector source = (BytesColumnVector) original;
+
+      target.noNulls = original.noNulls;
+      target.isRepeating = original.isRepeating;
+
+      if (original.isRepeating) {
+        target.isNull[0] = source.isNull[0];
+        if (target.noNulls || !target.isNull[0]) {
+          maskString(source, 0, target, schema);
+        }
+      } else {
+        for (int r = start; r < start + length; ++r) {
+          target.isNull[r] = source.isNull[r];
+          if (target.noNulls || !target.isNull[r]) {
+            maskString(source, r, target, schema);
+          }
+        }
+      }
+
+    }
+
+  }
+
+  /**
+   * Mask for binary data
+   */
+  class BinaryMask implements DataMask {
+
+    /* create an instance */
+    public BinaryMask() {
       super();
     }
 
@@ -45,8 +260,8 @@ public class SHA256MaskFactory extends MaskFactory {
      * @param length   the number of data elements to mask
      */
     @Override
-    public void maskData(final ColumnVector original, final ColumnVector masked, final int start,
-        final int length) {
+    public void maskData(final ColumnVector original, final ColumnVector masked,
+        final int start, final int length) {
 
       final BytesColumnVector target = (BytesColumnVector) masked;
       final BytesColumnVector source = (BytesColumnVector) original;
@@ -57,13 +272,13 @@ public class SHA256MaskFactory extends MaskFactory {
       if (original.isRepeating) {
         target.isNull[0] = source.isNull[0];
         if (target.noNulls || !target.isNull[0]) {
-          maskStringHelper(source, 0, target);
+          maskBinary(source, 0, target);
         }
       } else {
-        for(int r = start; r < start + length; ++r) {
+        for (int r = start; r < start + length; ++r) {
           target.isNull[r] = source.isNull[r];
           if (target.noNulls || !target.isNull[r]) {
-            maskStringHelper(source, r, target);
+            maskBinary(source, r, target);
           }
         }
       }
@@ -72,55 +287,4 @@ public class SHA256MaskFactory extends MaskFactory {
 
   }
 
-  /**
-   * Mask a string by finding the character category of each character
-   * and replacing it with the matching literal.
-   * @param source the source column vector
-   * @param row the value index
-   * @param target the target column vector
-   */
-  void maskStringHelper(final BytesColumnVector source, final int row, final BytesColumnVector target) {
-
-  }
-
-
-  @Override
-  protected DataMask buildBooleanMask(TypeDescription schema) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected DataMask buildLongMask(TypeDescription schema) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected DataMask buildDecimalMask(TypeDescription schema) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected DataMask buildDoubleMask(TypeDescription schema) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected DataMask buildStringMask(TypeDescription schema) {
-    return new Stringmask();
-  }
-
-  @Override
-  protected DataMask buildDateMask(TypeDescription schema) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected DataMask buildTimestampMask(TypeDescription schema) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  protected DataMask buildBinaryMask(TypeDescription schema) {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/java/core/src/test/org/apache/orc/impl/mask/TestSHA256Mask.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestSHA256Mask.java
@@ -1,0 +1,170 @@
+package org.apache.orc.impl.mask;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.orc.TypeDescription;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+public class TestSHA256Mask {
+
+  final byte[] inputLong = (
+      "Lorem ipsum dolor sit amet, consectetur adipiscing "
+          + "elit. Curabitur quis vehicula ligula. In hac habitasse platea dictumst."
+          + " Curabitur mollis finibus erat fringilla vestibulum. In eu leo eget"
+          + " massa luctus convallis nec vitae ligula. Donec vitae diam convallis,"
+          + " efficitur orci in, imperdiet turpis. In quis semper ex. Duis faucibus "
+          + "tellus vitae molestie convallis. Fusce fermentum vestibulum lacus "
+          + "vel malesuada. Pellentesque viverra odio a justo aliquet tempus.")
+      .getBytes(StandardCharsets.UTF_8);
+
+  final byte[] input32 = "Every flight begins with a fall."
+      .getBytes(StandardCharsets.UTF_8);
+
+  final byte[] inputShort = "\uD841\uDF0E".getBytes(StandardCharsets.UTF_8);
+
+  public TestSHA256Mask() {
+    super();
+  }
+
+  /**
+   * Test to make sure that the output is always 64 bytes (equal to hash len) <br>
+   * This is because String type does not have bounds on length.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testStringSHA256Masking() throws Exception {
+    final SHA256MaskFactory sha256Mask = new SHA256MaskFactory();
+    final BytesColumnVector source = new BytesColumnVector();
+    final BytesColumnVector target = new BytesColumnVector();
+
+    target.reset();
+
+    source.setRef(0, input32, 0, input32.length);
+    source.setRef(1, inputShort, 0, inputShort.length);
+
+    for (int r = 0; r < 2; ++r) {
+      sha256Mask.maskString(source, r, target, TypeDescription.createString());
+    }
+
+    /* Make sure the the mask length is equal to 64 length of SHA-256 */
+    assertEquals(64, target.length[0]);
+    assertEquals(64, target.length[1]);
+
+  }
+
+  /**
+   * Test to make sure that the length of input is equal to the output. <br>
+   * If input is shorter than the hash, truncate it. <br>
+   * If the input is larger than hash (64) pad it with blank space. <br>
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testChar256Masking() throws Exception {
+    final SHA256MaskFactory sha256Mask = new SHA256MaskFactory();
+    final BytesColumnVector source = new BytesColumnVector();
+    final BytesColumnVector target = new BytesColumnVector();
+
+    target.reset();
+
+    int[] length = new int[3];
+
+    length[0] = input32.length;
+    source.setRef(0, input32, 0, input32.length);
+
+    length[1] = inputShort.length;
+    source.setRef(1, inputShort, 0, inputShort.length);
+
+    length[2] = inputLong.length;
+    source.setRef(2, inputLong, 0, inputLong.length);
+
+    for (int r = 0; r < 3; ++r) {
+      sha256Mask.maskString(source, r, target,
+          TypeDescription.createChar().withMaxLength(length[r]));
+    }
+
+    /* Make sure the the mask length is equal to 64 length of SHA-256 */
+    assertEquals(length[0], target.length[0]);
+    assertEquals(length[1], target.length[1]);
+    assertEquals(length[2], target.length[2]);
+
+  }
+
+  @Test
+  public void testVarChar256Masking() throws Exception {
+    final SHA256MaskFactory sha256Mask = new SHA256MaskFactory();
+    final BytesColumnVector source = new BytesColumnVector();
+    final BytesColumnVector target = new BytesColumnVector();
+
+    target.reset();
+
+    source.setRef(0, input32, 0, input32.length);
+    source.setRef(1, inputShort, 0, inputShort.length);
+    source.setRef(2, inputLong, 0, inputLong.length);
+
+    for (int r = 0; r < 3; ++r) {
+      sha256Mask.maskString(source, r, target,
+          TypeDescription.createVarchar().withMaxLength(32));
+    }
+
+    // Hash is 64 in length greater than max len 32, so make sure output length is 32
+    assertEquals(32, target.length[0]);
+    assertEquals(32, target.length[1]);
+    assertEquals(32, target.length[2]);
+
+    for (int r = 0; r < 3; ++r) {
+      sha256Mask.maskString(source, r, target,
+          TypeDescription.createVarchar().withMaxLength(100));
+    }
+
+    /* Hash is 64 in length, less than max len 100 so the outpur will always be 64 */
+    assertEquals(64, target.length[0]);
+    assertEquals(64, target.length[1]);
+    assertEquals(64, target.length[2]);
+
+  }
+
+  @Test
+  public void testBinary() {
+    final SHA256MaskFactory sha256Mask = new SHA256MaskFactory();
+    final BytesColumnVector source = new BytesColumnVector();
+    final BytesColumnVector target = new BytesColumnVector();
+
+    target.reset();
+
+    source.setRef(0, input32, 0, input32.length);
+    source.setRef(1, inputShort, 0, inputShort.length);
+    source.setRef(2, inputLong, 0, inputLong.length);
+
+    for (int r = 0; r < 3; ++r) {
+      sha256Mask.maskBinary(source, r, target);
+    }
+
+    /* Hash is 64 in length, less than max len 100 so the outpur will always be 64 */
+    assertEquals(64, target.length[0]);
+    assertEquals(64, target.length[1]);
+    assertEquals(64, target.length[2]);
+
+  }
+
+}

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -34,9 +34,9 @@ add_executable (tool-test
 target_link_libraries (tool-test
   orc
   protobuf
-  gmock
   zlib
   snappy
+  ${GTEST_LIBRARIES}
 )
 
 add_test (tool-test tool-test ${EXAMPLE_DIRECTORY} ${PROJECT_BINARY_DIR})


### PR DESCRIPTION
 Masking strategy that masks String, Varchar, Char and Binary types
as SHA 256 hash.

For String type:
 All string type of any length will be converted to 64 length SHA256 hash.

For Varchar type:
 For Varchar type, max-length property will be honored i.e.
 if the length is less than max-length then the SHA256 hash will be truncated
 to max-length. If max-length is greater than 64 then the output is the sha256
 length, which is 64.

For Char type:
 For Char type, the length of mask will always be equal to specified max-length.
 If the given length (max-length) is less than SHA256 hash length (64)
 the mask will be truncated.
 If the given length (max-length) is greater than SHA256 hash length (64)
 then the mask will be padded by blank spaces.

For Binary type:
 All Binary type of any length will be converted to 64 length SHA256 hash.
