### PR TITLE
Move install location of LICENSE/NOTICE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,7 @@ add_subdirectory(c++)
 
 install(
   FILES LICENSE NOTICE
-  DESTINATION .)
+  DESTINATION "share/doc/orc")
 
 if (BUILD_JAVA)
   add_subdirectory(java)


### PR DESCRIPTION
Currently these are put in the root directory on `make install`, which is not where they should go. Moves them to `share/doc/orc/`, as discussed in https://github.com/apache/orc/pull/193#issuecomment-349063277.