### PR TITLE
ORC-289: [C++] replace Adaptor.hh by orc-config.hh

### DIFF
--- a/c++/include/orc/Exceptions.hh
+++ b/c++/include/orc/Exceptions.hh
@@ -19,7 +19,7 @@
 #ifndef ORC_EXCEPTIONS_HH
 #define ORC_EXCEPTIONS_HH
 
-#include "Adaptor.hh"
+#include "orc/orc-config.hh"
 
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
BTW: probably Adaptor.hh and orc-config.hh should be merged/cleaned up since they share some code.