### PR TITLE
ORC-293: [C++] Fix RleEncoderV1 for case when sizeof(long) < sizeof(int64_t)

### DIFF
--- a/c++/include/orc/Common.hh
+++ b/c++/include/orc/Common.hh
@@ -69,7 +69,7 @@ namespace orc {
     UNKNOWN_WRITER = INT32_MAX
   };
 
-  enum CompressionKind {
+  enum CompressionKind : std::int64_t {
     CompressionKind_NONE = 0,
     CompressionKind_ZLIB = 1,
     CompressionKind_SNAPPY = 2,
@@ -84,7 +84,7 @@ namespace orc {
    */
   std::string compressionKindToString(CompressionKind kind);
 
-  enum WriterVersion {
+  enum WriterVersion : std::int64_t {
     WriterVersion_ORIGINAL = 0,
     WriterVersion_HIVE_8732 = 1,
     WriterVersion_HIVE_4243 = 2,

--- a/c++/include/orc/Common.hh
+++ b/c++/include/orc/Common.hh
@@ -69,7 +69,7 @@ namespace orc {
     UNKNOWN_WRITER = INT32_MAX
   };
 
-  enum CompressionKind : std::int64_t {
+  enum CompressionKind {
     CompressionKind_NONE = 0,
     CompressionKind_ZLIB = 1,
     CompressionKind_SNAPPY = 2,
@@ -84,7 +84,7 @@ namespace orc {
    */
   std::string compressionKindToString(CompressionKind kind);
 
-  enum WriterVersion : std::int64_t {
+  enum WriterVersion {
     WriterVersion_ORIGINAL = 0,
     WriterVersion_HIVE_8732 = 1,
     WriterVersion_HIVE_4243 = 2,

--- a/c++/src/RLEv1.cc
+++ b/c++/src/RLEv1.cc
@@ -28,7 +28,7 @@ namespace orc {
 const int MINIMUM_REPEAT = 3;
 const int MAXIMUM_REPEAT = 127 + MINIMUM_REPEAT;
 
-const int BASE_128_MASK = 0x7f;
+const int64_t BASE_128_MASK = 0x7f;
 
 const int MAX_DELTA = 127;
 const int MIN_DELTA = -128;
@@ -148,7 +148,7 @@ void RleEncoderV1::write(int64_t value) {
         numLiterals += 1;
       } else {
         numLiterals -= static_cast<int>(MINIMUM_REPEAT - 1);
-        long base = literals[numLiterals];
+        int64_t base = literals[numLiterals];
         writeValues();
         literals[0] = base;
         repeat = true;
@@ -169,11 +169,11 @@ void RleEncoderV1::writeVslong(int64_t val) {
 
 void RleEncoderV1::writeVulong(int64_t val) {
   while (true) {
-    if ((val & ~0x7f) == 0) {
+    if ((val & ~BASE_128_MASK) == 0) {
       writeByte(static_cast<char>(val));
       return;
     } else {
-      writeByte(static_cast<char>(0x80 | (val & 0x7f)));
+      writeByte(static_cast<char>(0x80 | (val & BASE_128_MASK)));
       // cast val to unsigned so as to force 0-fill right shift
       val = (static_cast<uint64_t>(val) >> 7);
     }


### PR DESCRIPTION
and minor related changes.