### PR TITLE
ORC-284: [C++] add missing tests for C++ tools

### DIFF
--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -26,8 +26,10 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS} ${WARN_FLAGS}")
 add_executable (tool-test
   gzip.cc
   TestCSVFileImport.cc
+  TestFileContents.cc
   TestFileMetadata.cc
   TestFileScan.cc
+  TestFileStatistics.cc
   TestMatch.cc
   ToolTest.cc
 )

--- a/tools/test/TestFileContents.cc
+++ b/tools/test/TestFileContents.cc
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "orc/OrcFile.hh"
+
+#include "Adaptor.hh"
+#include "ToolTest.hh"
+
+#include "wrap/gmock.h"
+#include "wrap/gtest-wrapper.h"
+
+TEST (TestFileContents, testRaw) {
+  const std::string pgm = findProgram("tools/src/orc-contents");
+  const std::string file = findExample("TestOrcFile.test1.orc");
+  const std::string expected =
+    "{\"boolean1\": false, \"byte1\": 1, \"short1\": 1024, \"int1\": 65536, "
+      "\"long1\": 9223372036854775807, \"float1\": 1, \"double1\": -15,"
+      " \"bytes1\": [0, 1, 2, 3, 4], \"string1\": \"hi\", \"middle\": "
+      "{\"list\": [{\"int1\": 1, \"string1\": \"bye\"}, {\"int1\": 2, "
+      "\"string1\": \"sigh\"}]}, \"list\": [{\"int1\": 3, \"string1\": "
+      "\"good\"}, {\"int1\": 4, \"string1\": \"bad\"}], \"map\": []}\n"
+      "{\"boolean1\": true, \"byte1\": 100, \"short1\": 2048, \"int1\": 65536,"
+      " \"long1\": 9223372036854775807, \"float1\": 2, \"double1\": -5, "
+      "\"bytes1\": [], \"string1\": \"bye\", \"middle\": {\"list\": "
+      "[{\"int1\": 1, \"string1\": \"bye\"}, {\"int1\": 2, \"string1\":"
+      " \"sigh\"}]}, \"list\": [{\"int1\": 100000000, \"string1\": \"cat\"},"
+      " {\"int1\": -100000, \"string1\": \"in\"}, {\"int1\": 1234, "
+      "\"string1\": \"hat\"}], \"map\": [{\"key\": \"chani\", \"value\": "
+      "{\"int1\": 5, \"string1\": \"chani\"}}, {\"key\": \"mauddib\", "
+      "\"value\": {\"int1\": 1, \"string1\": \"mauddib\"}}]}";
+
+  std::string output;
+  std::string error;
+
+  EXPECT_EQ(0, runProgram({pgm, file}, output, error));
+  EXPECT_EQ(expected, output);
+  EXPECT_EQ("", error);
+}
+
+TEST (TestFileContents, testSelectedColumns) {
+  const std::string pgm = findProgram("tools/src/orc-contents");
+  const std::string file = findExample("TestOrcFile.test1.orc");
+  const std::string options = "--columns=1,3,5,7";
+  const std::string expected =
+    "{\"byte1\": 1, \"int1\": 65536, \"float1\": 1, \"bytes1\": [0, 1, 2, 3, 4]}\n"
+      "{\"byte1\": 100, \"int1\": 65536, \"float1\": 2, \"bytes1\": []}";
+
+  std::string output;
+  std::string error;
+
+  EXPECT_EQ(0, runProgram({pgm, options, file}, output, error));
+  EXPECT_EQ(expected, output);
+  EXPECT_EQ("", error);
+}

--- a/tools/test/TestFileContents.cc
+++ b/tools/test/TestFileContents.cc
@@ -42,7 +42,7 @@ TEST (TestFileContents, testRaw) {
       " {\"int1\": -100000, \"string1\": \"in\"}, {\"int1\": 1234, "
       "\"string1\": \"hat\"}], \"map\": [{\"key\": \"chani\", \"value\": "
       "{\"int1\": 5, \"string1\": \"chani\"}}, {\"key\": \"mauddib\", "
-      "\"value\": {\"int1\": 1, \"string1\": \"mauddib\"}}]}";
+      "\"value\": {\"int1\": 1, \"string1\": \"mauddib\"}}]}\n";
 
   std::string output;
   std::string error;
@@ -58,7 +58,7 @@ TEST (TestFileContents, testSelectedColumns) {
   const std::string options = "--columns=1,3,5,7";
   const std::string expected =
     "{\"byte1\": 1, \"int1\": 65536, \"float1\": 1, \"bytes1\": [0, 1, 2, 3, 4]}\n"
-      "{\"byte1\": 100, \"int1\": 65536, \"float1\": 2, \"bytes1\": []}";
+      "{\"byte1\": 100, \"int1\": 65536, \"float1\": 2, \"bytes1\": []}\n";
 
   std::string output;
   std::string error;

--- a/tools/test/TestFileStatistics.cc
+++ b/tools/test/TestFileStatistics.cc
@@ -68,7 +68,7 @@ TEST (TestFileStatistics, testNormal) {
       "Has null: no\n"
       "Minimum: 1000\n"
       "Maximum: 9a\n"
-      "Total length: 23892\n";
+      "Total length: 23892\n\n";
 
   std::string output;
   std::string error;
@@ -179,7 +179,7 @@ TEST (TestFileStatistics, testOptions) {
       "Has null: no\n"
       "Minimum: 4001\n"
       "Maximum: 6000\n"
-      "Total length: 8000\n";
+      "Total length: 8000\n\n";
 
   std::string output;
   std::string error;

--- a/tools/test/TestFileStatistics.cc
+++ b/tools/test/TestFileStatistics.cc
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "orc/OrcFile.hh"
+
+#include "Adaptor.hh"
+#include "ToolTest.hh"
+
+#include "wrap/gmock.h"
+#include "wrap/gtest-wrapper.h"
+
+TEST (TestFileStatistics, testNormal) {
+  const std::string pgm = findProgram("tools/src/orc-statistics");
+  const std::string file = findExample("orc_index_int_string.orc");
+  const std::string expected =
+    "File " + file + " has 3 columns\n"
+      "*** Column 0 ***\n"
+      "Column has 6000 values and has null value: no\n"
+      "\n"
+      "*** Column 1 ***\n"
+      "Data type: Integer\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1\n"
+      "Maximum: 6000\n"
+      "Sum: 18003000\n"
+      "\n"
+      "*** Column 2 ***\n"
+      "Data type: String\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1000\n"
+      "Maximum: 9a\n"
+      "Total length: 23892\n"
+      "\n"
+      "File " + file + " has 1 stripes\n"
+      "*** Stripe 0 ***\n"
+      "\n"
+      "--- Column 0 ---\n"
+      "Column has 6000 values and has null value: no\n"
+      "\n"
+      "--- Column 1 ---\n"
+      "Data type: Integer\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1\n"
+      "Maximum: 6000\n"
+      "Sum: 18003000\n"
+      "\n"
+      "--- Column 2 ---\n"
+      "Data type: String\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1000\n"
+      "Maximum: 9a\n"
+      "Total length: 23892\n";
+
+  std::string output;
+  std::string error;
+
+  EXPECT_EQ(0, runProgram({pgm, file}, output, error));
+  EXPECT_EQ(expected, output);
+  EXPECT_EQ("", error);
+}
+
+TEST (TestFileStatistics, testOptions) {
+  const std::string pgm = findProgram("tools/src/orc-statistics");
+  const std::string file = findExample("orc_index_int_string.orc");
+  const std::string expected =
+    "File " + file + " has 3 columns\n"
+      "*** Column 0 ***\n"
+      "Column has 6000 values and has null value: no\n"
+      "\n"
+      "*** Column 1 ***\n"
+      "Data type: Integer\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1\n"
+      "Maximum: 6000\n"
+      "Sum: 18003000\n"
+      "\n"
+      "*** Column 2 ***\n"
+      "Data type: String\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1000\n"
+      "Maximum: 9a\n"
+      "Total length: 23892\n"
+      "\n"
+      "File " + file + " has 1 stripes\n"
+      "*** Stripe 0 ***\n"
+      "\n"
+      "--- Column 0 ---\n"
+      "Column has 6000 values and has null value: no\n"
+      "\n"
+      "--- RowIndex 0 ---\n"
+      "Column has 2000 values and has null value: no\n"
+      "\n"
+      "--- RowIndex 1 ---\n"
+      "Column has 2000 values and has null value: no\n"
+      "\n"
+      "--- RowIndex 2 ---\n"
+      "Column has 2000 values and has null value: no\n"
+      "\n"
+      "--- Column 1 ---\n"
+      "Data type: Integer\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1\n"
+      "Maximum: 6000\n"
+      "Sum: 18003000\n"
+      "\n"
+      "--- RowIndex 0 ---\n"
+      "Data type: Integer\n"
+      "Values: 2000\n"
+      "Has null: no\n"
+      "Minimum: 1\n"
+      "Maximum: 2000\n"
+      "Sum: 2001000\n"
+      "\n"
+      "--- RowIndex 1 ---\n"
+      "Data type: Integer\n"
+      "Values: 2000\n"
+      "Has null: no\n"
+      "Minimum: 2001\n"
+      "Maximum: 4000\n"
+      "Sum: 6001000\n"
+      "\n"
+      "--- RowIndex 2 ---\n"
+      "Data type: Integer\n"
+      "Values: 2000\n"
+      "Has null: no\n"
+      "Minimum: 4001\n"
+      "Maximum: 6000\n"
+      "Sum: 10001000\n"
+      "\n"
+      "--- Column 2 ---\n"
+      "Data type: String\n"
+      "Values: 6000\n"
+      "Has null: no\n"
+      "Minimum: 1000\n"
+      "Maximum: 9a\n"
+      "Total length: 23892\n"
+      "\n"
+      "--- RowIndex 0 ---\n"
+      "Data type: String\n"
+      "Values: 2000\n"
+      "Has null: no\n"
+      "Minimum: 1000\n"
+      "Maximum: 9a\n"
+      "Total length: 7892\n"
+      "\n"
+      "--- RowIndex 1 ---\n"
+      "Data type: String\n"
+      "Values: 2000\n"
+      "Has null: no\n"
+      "Minimum: 2001\n"
+      "Maximum: 4000\n"
+      "Total length: 8000\n"
+      "\n"
+      "--- RowIndex 2 ---\n"
+      "Data type: String\n"
+      "Values: 2000\n"
+      "Has null: no\n"
+      "Minimum: 4001\n"
+      "Maximum: 6000\n"
+      "Total length: 8000\n";
+
+  std::string output;
+  std::string error;
+
+  EXPECT_EQ(0, runProgram({pgm, "-i", file}, output, error));
+  EXPECT_EQ(expected, output);
+  EXPECT_EQ("", error);
+}
+


### PR DESCRIPTION
Added two tool tests for FileStatistics and FileContents.