### PR TITLE
ORC-300 Provide additional constructor to JsonReader (java orc tools)

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
@@ -50,6 +50,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.util.Iterator;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
@@ -58,7 +59,7 @@ public class JsonReader implements RecordReader {
     "yyyy[[-][/]]MM[[-][/]]dd[['T'][ ]]HH:mm:ss[ ][XXX][X]");
 
   private final TypeDescription schema;
-  private final JsonStreamParser parser;
+  private final Iterator<JsonElement> parser;
   private final JsonConverter[] converters;
   private final long totalSize;
   private final FSDataInputStream input;
@@ -256,13 +257,20 @@ public class JsonReader implements RecordReader {
                     FSDataInputStream underlying,
                     long size,
                     TypeDescription schema) throws IOException {
+    this(new JsonStreamParser(reader), underlying, size, schema);
+  }
+
+  public JsonReader(Iterator<JsonElement> parser,
+                    FSDataInputStream underlying,
+                    long size,
+                    TypeDescription schema) throws IOException {
     this.schema = schema;
     if (schema.getCategory() != TypeDescription.Category.STRUCT) {
       throw new IllegalArgumentException("Root must be struct - " + schema);
     }
     this.input = underlying;
     this.totalSize = size;
-    parser = new JsonStreamParser(reader);
+    this.parser = parser;
     List<TypeDescription> fieldTypes = schema.getChildren();
     converters = new JsonConverter[fieldTypes.size()];
     for(int c = 0; c < converters.length; ++c) {


### PR DESCRIPTION
Provide additional constructor to JsonReader so that embedding code can use its own JsonParser implementation. Intended to plug in a parser that transforms JSON while reading (flattening nested structs, renaming and filtering capabilities).

Rationale: Our application often gets JSON files that have deeply nested arrays with structs where the innermost elements are generic like <name:string,type:tinyint,value:something>.
I would like to be able to move the value element into separate, correctly typed elements that hold
either bigints, doubles, strings or boolean (etc.) so that compression and value handling is improved. It is intended to leverage JOLT (https://github.com/bazaarvoice/jolt) for this. I would like
to read the original files, transform them in memory to the target shape JSON objects and then
create ORC files from that representation.
Adding just another ctor would allow us to implement such a transformation step.
