### PR TITLE
ORC-312: [C++] Fix buffer overflow in corrupt StringDictionaryColumn

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -552,7 +552,7 @@ namespace orc {
       for(uint64_t i=0; i < numValues; ++i) {
         if (notNull[i]) {
           int64_t entry = outputLengths[i];
-          if (entry < 0 || (uint64_t)entry >= dictionaryCount) {
+          if (entry < 0 || static_cast<uint64_t>(entry) >= dictionaryCount) {
             throw ParseError("Entry index out of range in StringDictionaryColumn");
           }
           outputStarts[i] = blob + dictionaryOffsets[entry];
@@ -563,7 +563,7 @@ namespace orc {
     } else {
       for(uint64_t i=0; i < numValues; ++i) {
         int64_t entry = outputLengths[i];
-        if (entry < 0 || (uint64_t)entry >= dictionaryCount) {
+        if (entry < 0 || static_cast<uint64_t>(entry) >= dictionaryCount) {
           throw ParseError("Entry index out of range in StringDictionaryColumn");
         }
         outputStarts[i] = blob + dictionaryOffsets[entry];

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -517,6 +517,8 @@ namespace orc {
     lengthDecoder->next(lengthArray + 1, dictionaryCount, nullptr);
     lengthArray[0] = 0;
     for(uint64_t i=1; i < dictionaryCount + 1; ++i) {
+      if (lengthArray[i] < 0)
+        throw ParseError("Negative dictionary entry length");
       lengthArray[i] += lengthArray[i-1];
     }
     int64_t blobSize = lengthArray[dictionaryCount];

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -468,6 +468,9 @@ namespace orc {
       if (!stream->Next(&chunk, &length)) {
         throw ParseError("bad read in readFully");
       }
+      if (posn + length > bufferSize) {
+        throw ParseError("Corrupt dictionary blob in StringDictionaryColumn");
+      }
       memcpy(buffer + posn, chunk, static_cast<size_t>(length));
       posn += length;
     }
@@ -549,6 +552,9 @@ namespace orc {
       for(uint64_t i=0; i < numValues; ++i) {
         if (notNull[i]) {
           int64_t entry = outputLengths[i];
+          if (entry < 0 || (uint64_t)entry >= dictionaryCount) {
+            throw ParseError("Entry index out of range in StringDictionaryColumn");
+          }
           outputStarts[i] = blob + dictionaryOffsets[entry];
           outputLengths[i] = dictionaryOffsets[entry+1] -
             dictionaryOffsets[entry];
@@ -557,6 +563,9 @@ namespace orc {
     } else {
       for(uint64_t i=0; i < numValues; ++i) {
         int64_t entry = outputLengths[i];
+        if (entry < 0 || (uint64_t)entry >= dictionaryCount) {
+          throw ParseError("Entry index out of range in StringDictionaryColumn");
+        }
         outputStarts[i] = blob + dictionaryOffsets[entry];
         outputLengths[i] = dictionaryOffsets[entry+1] -
           dictionaryOffsets[entry];


### PR DESCRIPTION
The crash is due to the buffer overflow in orc::readFully which only used in StringDictionaryColumnReader currently. The decoded length may larger than we expected if the file is corrupt.

This patch also adds checks for the range of entry indices in StringDictionaryColumnReader::next.