### PR TITLE
ORC-314: Check scale range when parsing decimals

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -1177,7 +1177,7 @@ namespace orc {
       } else if (scale < currentScale &&
           static_cast<uint64_t>(currentScale - scale) <= MAX_PRECISION_64) {
         value /= POWERS_OF_TEN[currentScale - scale];
-      } else {
+      } else if (scale != currentScale) {
         throw ParseError("Decimal scale out of range");
       }
     }

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -1171,10 +1171,14 @@ namespace orc {
         }
       }
       value = unZigZag(static_cast<uint64_t>(value));
-      if (scale > currentScale) {
+      if (scale > currentScale &&
+          static_cast<uint64_t>(scale - currentScale) <= MAX_PRECISION_64) {
         value *= POWERS_OF_TEN[scale - currentScale];
-      } else if (scale < currentScale) {
+      } else if (scale < currentScale &&
+          static_cast<uint64_t>(currentScale - scale) <= MAX_PRECISION_64) {
         value /= POWERS_OF_TEN[currentScale - scale];
+      } else {
+        throw ParseError("Decimal scale out of range");
       }
     }
 


### PR DESCRIPTION
The scale of decimals may be out of range in corrupt files. We should check this to avoid crashing.
The attached file in the JIRA can reproduce this bug.