### PR TITLE
ORC-318. Change KeyProvider API to separate createLocalKey

### DIFF
--- a/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
+++ b/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.security.Key;
+import java.util.Random;
 
 /**
  * Test {@link InMemoryKeystore} class
@@ -39,17 +40,23 @@ public class TestInMemoryKeystore {
 
   @Before
   public void init() throws IOException {
-
+    // For testing, use a fixed random number generator so that everything
+    // is repeatable.
+    Random random = new Random(2);
     memoryKeystore =
-        new InMemoryKeystore()
+        new InMemoryKeystore(random)
             .addKey("key128", EncryptionAlgorithm.AES_128, "123".getBytes())
             .addKey("key256", EncryptionAlgorithm.AES_256, "secret123".getBytes())
             .addKey("key256short", EncryptionAlgorithm.AES_256, "5".getBytes());
 
   }
 
+  private static String stringify(byte[] buffer) {
+    return new BytesWritable(buffer).toString();
+  }
+
   @Test
-  public void testGetKeyNames() throws IOException {
+  public void testGetKeyNames() {
 
     Assert.assertTrue(memoryKeystore.getKeyNames().contains("key128"));
     Assert.assertTrue(memoryKeystore.getKeyNames().contains("key256"));
@@ -77,13 +84,48 @@ public class TestInMemoryKeystore {
   @Test
   public void testGetLocalKey() {
 
-    HadoopShims.KeyMetadata metadata = memoryKeystore
+    HadoopShims.KeyMetadata metadata128 = memoryKeystore
         .getCurrentKeyVersion("key128");
-    byte[] iv = new byte[EncryptionAlgorithm.AES_128.getIvLength()];
 
-    final Key key128 = memoryKeystore.getLocalKey(metadata, iv);
-    Assert.assertEquals("AES", key128.getAlgorithm());
+    HadoopShims.LocalKey key128 = memoryKeystore.createLocalKey(metadata128);
+    // we are sure the key is the same because of the random generator.
+    Assert.assertEquals("39 72 2c bb f8 b9 1a 4b 90 45 c5 e6 17 5f 10 01",
+        stringify(key128.decryptedKey.getEncoded()));
+    // used online aes/cbc calculator to encrypt key
+    Assert.assertEquals("7f 41 4a 46 81 ee 7c d1 2a 0f ed 39 a8 49 e2 89",
+        stringify(key128.encryptedKey));
+    Assert.assertEquals("AES", key128.decryptedKey.getAlgorithm());
 
+    // now decrypt the key again
+    Key decryptKey = memoryKeystore.decryptLocalKey(metadata128,
+        key128.encryptedKey);
+    Assert.assertEquals(stringify(key128.decryptedKey.getEncoded()),
+        stringify(decryptKey.getEncoded()));
+
+    HadoopShims.KeyMetadata metadata256 = memoryKeystore
+        .getCurrentKeyVersion("key256");
+    HadoopShims.LocalKey key256 = memoryKeystore.createLocalKey(metadata256);
+    // this is forced by the fixed Random in the keystore for this test
+    if (InMemoryKeystore.SUPPORTS_AES_256) {
+      Assert.assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08 0f 7b" +
+              " 6c db 79 e5 51 ec 9c 9c c7 fc bd 60 ee 73",
+          stringify(key256.decryptedKey.getEncoded()));
+      // used online aes/cbc calculator to encrypt key
+      Assert.assertEquals("ea 73 33 5b 14 5d 70 d8 3f e9 d1 05 2b 2d 62 a0 86 16"+
+              " ad a0 2a d6 8a 20 46 1d 00 ce f9 2a 31 48",
+          stringify(key256.encryptedKey));
+    } else {
+      Assert.assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08",
+          stringify(key256.decryptedKey.getEncoded()));
+      Assert.assertEquals("87 df d0 2a 68 1a b9 cb a7 88 ec f4 83 49 95 e0",
+          stringify(key256.encryptedKey));
+    }
+    Assert.assertEquals("AES", key256.decryptedKey.getAlgorithm());
+
+    // now decrypt the key again
+    decryptKey = memoryKeystore.decryptLocalKey(metadata256, key256.encryptedKey);
+    Assert.assertEquals(stringify(key256.decryptedKey.getEncoded()),
+        stringify(decryptKey.getEncoded()));
   }
 
   @Test
@@ -94,7 +136,6 @@ public class TestInMemoryKeystore {
     memoryKeystore.addKey("key128", 1, EncryptionAlgorithm.AES_128, "NewSecret".getBytes());
     Assert.assertEquals(1,
         memoryKeystore.getCurrentKeyVersion("key128").getVersion());
-
   }
 
   @Test
@@ -114,8 +155,7 @@ public class TestInMemoryKeystore {
    * 1. Scenario where key with smaller version then existing should not be allowed
    * 2. Test multiple versions of the key
    * 3. Test get current version
-   *
-   * @throws IOException
+   * 4. Ensure the different versions of the key have different material.
    */
   @Test
   public void testMultipleVersion() throws IOException {
@@ -139,9 +179,15 @@ public class TestInMemoryKeystore {
         memoryKeystore.getCurrentKeyVersion("key256").getVersion());
 
     // make sure that all 3 versions of key256 exist and have different secrets
-    Key key0 = memoryKeystore.getLocalKey(memoryKeystore.getKeyVersion("key256", 0, null), new byte[16]);
-    Key key1 = memoryKeystore.getLocalKey(memoryKeystore.getKeyVersion("key256", 1, null), new byte[16]);
-    Key key2 = memoryKeystore.getLocalKey(memoryKeystore.getKeyVersion("key256", 2, null), new byte[16]);
+    Key key0 = memoryKeystore.decryptLocalKey(
+        new HadoopShims.KeyMetadata("key256", 0, EncryptionAlgorithm.AES_256),
+        new byte[16]);
+    Key key1 = memoryKeystore.decryptLocalKey(
+        new HadoopShims.KeyMetadata("key256", 1, EncryptionAlgorithm.AES_256),
+        new byte[16]);
+    Key key2 = memoryKeystore.decryptLocalKey(
+        new HadoopShims.KeyMetadata("key256", 2, EncryptionAlgorithm.AES_256),
+        new byte[16]);
     Assert.assertNotEquals(new BytesWritable(key0.getEncoded()).toString(),
         new BytesWritable(key1.getEncoded()).toString());
     Assert.assertNotEquals(new BytesWritable(key1.getEncoded()).toString(),

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.EnumSet;
+import java.util.Random;
 
 /**
  * Shims for recent versions of Hadoop
@@ -60,9 +61,8 @@ public class HadoopShimsCurrent implements HadoopShims {
   }
 
   @Override
-  public KeyProvider getKeyProvider(Configuration conf) throws IOException {
-    return new HadoopShimsPre2_7.KeyProviderImpl(conf);
+  public KeyProvider getKeyProvider(Configuration conf,
+                                    Random random) throws IOException {
+    return HadoopShimsPre2_7.createKeyProvider(conf, random);
   }
-
-
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
@@ -23,6 +23,10 @@ import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
 
 /**
  * Shims for versions of Hadoop up to and including 2.2.x
@@ -64,9 +68,30 @@ public class HadoopShimsPre2_3 implements HadoopShims {
   }
 
   @Override
-  public KeyProvider getKeyProvider(Configuration conf) {
-    // Not supported
-    return null;
+  public KeyProvider getKeyProvider(Configuration conf, Random random) {
+    return new NullKeyProvider();
   }
 
+  static class NullKeyProvider implements KeyProvider {
+
+    @Override
+    public List<String> getKeyNames() {
+      return new ArrayList<>();
+    }
+
+    @Override
+    public KeyMetadata getCurrentKeyVersion(String keyName) {
+      throw new IllegalArgumentException("Unknown key " + keyName);
+    }
+
+    @Override
+    public LocalKey createLocalKey(KeyMetadata key) {
+      throw new IllegalArgumentException("Unknown key " + key);
+    }
+
+    @Override
+    public Key decryptLocalKey(KeyMetadata key, byte[] encryptedKey) {
+      return null;
+    }
+  }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Random;
 
 /**
  * Shims for versions of Hadoop less than 2.6
@@ -129,8 +130,7 @@ public class HadoopShimsPre2_6 implements HadoopShims {
   }
 
   @Override
-  public KeyProvider getKeyProvider(Configuration conf) {
-    // not supported
-    return null;
+  public KeyProvider getKeyProvider(Configuration conf, Random random) {
+    return new HadoopShimsPre2_3.NullKeyProvider();
   }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -20,7 +20,6 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
-import org.apache.hadoop.crypto.key.KeyProviderExtension;
 import org.apache.hadoop.crypto.key.KeyProviderFactory;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.orc.EncryptionAlgorithm;
@@ -33,6 +32,7 @@ import java.io.OutputStream;
 import java.security.GeneralSecurityException;
 import java.security.Key;
 import java.util.List;
+import java.util.Random;
 
 /**
  * Shims for versions of Hadoop less than 2.7.
@@ -70,20 +70,61 @@ public class HadoopShimsPre2_7 implements HadoopShims {
   }
 
   /**
-   * Shim implementation for Hadoop's KeyProvider API that lets applications get
-   * access to encryption keys.
+   * Shim implementation for ORC's KeyProvider API that uses Hadoop's
+   * KeyProvider API and implementations. Most users use a Hadoop or Ranger
+   * KMS and thus should use this default implementation.
+   *
+   * The main two methods of ORC's KeyProvider are createLocalKey and
+   * decryptLocalKey. These are very similar to Hadoop's
+   * <pre>
+   *   EncryptedKeyVersion generateEncryptedKey(String keyVersionName);
+   *   KeyVersion decryptEncryptedKey(EncryptedKeyVersion encrypted)
+   * </pre>
+   * but there are some important differences.
+   * <ul>
+   * <li>Hadoop's generateEncryptedKey doesn't return the decrypted key, so it
+   *     would require two round trips (generateEncryptedKey and then
+   *     decryptEncryptedKey)to the KMS.</li>
+   * <li>Hadoop's methods require storing both the IV and the encrypted key, so
+   *     for AES256, it is 48 random bytes.</li>
+   * </ul>
+   *
+   * However, since the encryption in the KMS is using AES/CTR we know that the
+   * flow is:
+   *
+   * <pre>
+   *   tmpKey = aes(masterKey, iv);
+   *   cypher = xor(tmpKey, plain);
+   * </pre>
+   *
+   * which means that encryption and decryption are symmetric. Therefore, if we
+   * use the KMS' decryptEncryptedKey, and feed in a random iv and the right
+   * number of 0's as the encrypted key, we get the right length of a tmpKey.
+   * Since it is symmetric, we can use it for both encryption and decryption
+   * and we only need to store the random iv. Since the iv is 16 bytes, it is
+   * only a third the size of the other solution, and only requires one trip to
+   * the KMS.
+   *
+   * So the flow looks like:
+   * <pre>
+   *   encryptedKey = securely random 16 bytes
+   *   --- on KMS ---
+   *   tmpKey0 = aes(masterKey, encryptedKey)
+   *   tmpKey1 = aes(masterKey, encryptedKey+1)
+   *   decryptedKey = xor(tmpKey0, 0) + xor(tmpKey1, 0)
+   * </pre>
+   *
+   * In the long term, we should probably fix Hadoop's generateEncryptedKey
+   * to either take the random key or pass it back.
    */
   static class KeyProviderImpl implements KeyProvider {
     private final org.apache.hadoop.crypto.key.KeyProvider provider;
+    private final Random random;
 
-    KeyProviderImpl(Configuration conf) throws IOException {
-      List<org.apache.hadoop.crypto.key.KeyProvider> result =
-          KeyProviderFactory.getProviders(conf);
-      if (result.size() != 1) {
-        throw new IllegalArgumentException("Can't get KeyProvider for ORC" +
-            " encryption. Got " + result.size() + " results.");
-      }
-      provider = result.get(0);
+    KeyProviderImpl(org.apache.hadoop.crypto.key.KeyProvider provider,
+                    Random random) {
+      this.provider = provider;
+      this.random = random;
     }
 
     @Override
@@ -93,92 +134,92 @@ public class HadoopShimsPre2_7 implements HadoopShims {
 
     @Override
     public KeyMetadata getCurrentKeyVersion(String keyName) throws IOException {
-      return new KeyMetadataImpl(keyName, provider.getMetadata(keyName));
+      org.apache.hadoop.crypto.key.KeyProvider.Metadata meta =
+          provider.getMetadata(keyName);
+      return new KeyMetadata(keyName, meta.getVersions() - 1,
+          findAlgorithm(meta));
     }
 
     @Override
-    public KeyMetadata getKeyVersion(String keyName, int version,
-                                     EncryptionAlgorithm algorithm) {
-      return new KeyMetadataImpl(keyName, version, algorithm);
-    }
-
-    @Override
-    public Key getLocalKey(KeyMetadata key, byte[] iv) throws IOException {
+    public LocalKey createLocalKey(KeyMetadata key) throws IOException {
       EncryptionAlgorithm algorithm = key.getAlgorithm();
-      KeyProviderCryptoExtension.EncryptedKeyVersion encryptedKey =
+      byte[] encryptedKey = new byte[algorithm.getIvLength()];
+      random.nextBytes(encryptedKey);
+      KeyProviderCryptoExtension.EncryptedKeyVersion param =
           KeyProviderCryptoExtension.EncryptedKeyVersion.createForDecryption(
-              key.getKeyName(), buildKeyVersionName(key), iv,
+              key.getKeyName(), buildKeyVersionName(key), encryptedKey,
+              algorithm.getZeroKey());
+      try {
+        KeyProviderCryptoExtension.KeyVersion decryptedKey =
+            ((KeyProviderCryptoExtension) provider)
+                .decryptEncryptedKey(param);
+        return new LocalKey(new SecretKeySpec(decryptedKey.getMaterial(),
+                                              algorithm.getAlgorithm()),
+                            encryptedKey);
+      } catch (GeneralSecurityException e) {
+        throw new IOException("Can't create local encryption key for " + key, e);
+      }
+    }
+
+    @Override
+    public Key decryptLocalKey(KeyMetadata key,
+                               byte[] encryptedKey) throws IOException {
+      EncryptionAlgorithm algorithm = key.getAlgorithm();
+      KeyProviderCryptoExtension.EncryptedKeyVersion param =
+          KeyProviderCryptoExtension.EncryptedKeyVersion.createForDecryption(
+              key.getKeyName(), buildKeyVersionName(key), encryptedKey,
               algorithm.getZeroKey());
       try {
         KeyProviderCryptoExtension.KeyVersion decrypted =
-            ((KeyProviderCryptoExtension.CryptoExtension) provider)
-                .decryptEncryptedKey(encryptedKey);
+            ((KeyProviderCryptoExtension) provider)
+                .decryptEncryptedKey(param);
         return new SecretKeySpec(decrypted.getMaterial(),
             algorithm.getAlgorithm());
       } catch (GeneralSecurityException e) {
-        throw new IOException("Problem decrypting key " + key.getKeyName(), e);
+        return null;
       }
     }
   }
 
-  static class KeyMetadataImpl implements KeyMetadata {
-    private final String keyName;
-    private final int version;
-    private final EncryptionAlgorithm algorithm;
-
-    KeyMetadataImpl(String keyName, KeyProviderExtension.Metadata metadata) {
-      this.keyName = keyName;
-      version = metadata.getVersions() - 1;
-      algorithm = findAlgorithm(metadata);
+  static KeyProvider createKeyProvider(Configuration conf,
+                                       Random random) throws IOException {
+    List<org.apache.hadoop.crypto.key.KeyProvider> result =
+        KeyProviderFactory.getProviders(conf);
+    if (result.size() == 0) {
+      LOG.info("Can't get KeyProvider for ORC encryption from" +
+          " hadoop.security.key.provider.path.");
+      return new HadoopShimsPre2_3.NullKeyProvider();
+    } else {
+      return new KeyProviderImpl(result.get(0), random);
     }
+  }
 
-    KeyMetadataImpl(String keyName, int version, EncryptionAlgorithm algorithm){
-      this.keyName = keyName;
-      this.version = version;
-      this.algorithm = algorithm;
-    }
-
-    @Override
-    public String getKeyName() {
-      return keyName;
-    }
-
-    @Override
-    public EncryptionAlgorithm getAlgorithm() {
-      return algorithm;
-    }
-
-    @Override
-    public int getVersion() {
-      return version;
-    }
-
-    /**
-     * Find the correct algorithm based on the key's metadata.
-     * @param meta the key's metadata
-     * @return the correct algorithm
-     */
-    static EncryptionAlgorithm findAlgorithm(KeyProviderCryptoExtension.Metadata meta) {
-      String cipher = meta.getCipher();
-      if (cipher.startsWith("AES/")) {
-        int bitLength = meta.getBitLength();
-        if (bitLength == 128) {
-          return EncryptionAlgorithm.AES_128;
-        } else {
-          if (bitLength != 256) {
-            LOG.info("ORC column encryption does not support " + bitLength +
-                " bit keys. Using 256 bits instead.");
-          }
-          return EncryptionAlgorithm.AES_256;
+  /**
+   * Find the correct algorithm based on the key's metadata.
+   * @param meta the key's metadata
+   * @return the correct algorithm
+   */
+  static EncryptionAlgorithm findAlgorithm(KeyProviderCryptoExtension.Metadata meta) {
+    String cipher = meta.getCipher();
+    if (cipher.startsWith("AES/")) {
+      int bitLength = meta.getBitLength();
+      if (bitLength == 128) {
+        return EncryptionAlgorithm.AES_128;
+      } else {
+        if (bitLength != 256) {
+          LOG.info("ORC column encryption does not support " + bitLength +
+              " bit keys. Using 256 bits instead.");
         }
+        return EncryptionAlgorithm.AES_256;
       }
-      throw new IllegalArgumentException("ORC column encryption only supports" +
-          " AES and not " + cipher);
     }
+    throw new IllegalArgumentException("ORC column encryption only supports" +
+        " AES and not " + cipher);
   }
 
   @Override
-  public KeyProvider getKeyProvider(Configuration conf) throws IOException {
-    return new KeyProviderImpl(conf);
+  public KeyProvider getKeyProvider(Configuration conf,
+                                    Random random) throws IOException {
+    return createKeyProvider(conf, random);
   }
 }

--- a/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
+++ b/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
@@ -18,43 +18,186 @@
 
 package org.apache.orc.impl;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
+import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
+import org.apache.hadoop.crypto.key.KeyProviderFactory;
 import org.apache.hadoop.crypto.key.kms.KMSClientProvider;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.orc.EncryptionAlgorithm;
-import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.net.URI;
+import java.security.Key;
 import java.sql.Date;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
 
 import static junit.framework.Assert.assertEquals;
 
 public class TestHadoopShimsPre2_7 {
 
   @Test(expected = IllegalArgumentException.class)
-  public void testFindingUnknownEncryption() throws Exception {
+  public void testFindingUnknownEncryption() {
     KeyProvider.Metadata meta = new KMSClientProvider.KMSMetadata(
         "XXX/CTR/NoPadding", 128, "", new HashMap<String, String>(),
         new Date(0), 1);
-    HadoopShimsPre2_7.KeyMetadataImpl.findAlgorithm(meta);
+    HadoopShimsPre2_7.findAlgorithm(meta);
   }
 
   @Test
-  public void testFindingAesEncryption() throws Exception {
+  public void testFindingAesEncryption()  {
     KeyProvider.Metadata meta = new KMSClientProvider.KMSMetadata(
         "AES/CTR/NoPadding", 128, "", new HashMap<String, String>(),
         new Date(0), 1);
     assertEquals(EncryptionAlgorithm.AES_128,
-        HadoopShimsPre2_7.KeyMetadataImpl.findAlgorithm(meta));
+        HadoopShimsPre2_7.findAlgorithm(meta));
     meta = new KMSClientProvider.KMSMetadata(
         "AES/CTR/NoPadding", 256, "", new HashMap<String, String>(),
         new Date(0), 1);
     assertEquals(EncryptionAlgorithm.AES_256,
-        HadoopShimsPre2_7.KeyMetadataImpl.findAlgorithm(meta));
+        HadoopShimsPre2_7.findAlgorithm(meta));
     meta = new KMSClientProvider.KMSMetadata(
         "AES/CTR/NoPadding", 512, "", new HashMap<String, String>(),
         new Date(0), 1);
     assertEquals(EncryptionAlgorithm.AES_256,
-        HadoopShimsPre2_7.KeyMetadataImpl.findAlgorithm(meta));
+        HadoopShimsPre2_7.findAlgorithm(meta));
+  }
+
+  @Test
+  public void testHadoopKeyProvider() throws IOException {
+    HadoopShims shims = new HadoopShimsPre2_7();
+    Configuration conf = new Configuration();
+    conf.set("hadoop.security.key.provider.path", "test:///");
+    // Hard code the random so that we know the bytes that will come out.
+    HadoopShims.KeyProvider provider = shims.getKeyProvider(conf, new Random(24));
+    List<String> keyNames = provider.getKeyNames();
+    assertEquals(2, keyNames.size());
+    assertEquals(true, keyNames.contains("pii"));
+    assertEquals(true, keyNames.contains("secret"));
+    HadoopShims.KeyMetadata piiKey = provider.getCurrentKeyVersion("pii");
+    assertEquals(1, piiKey.getVersion());
+    HadoopShims.LocalKey localKey = provider.createLocalKey(piiKey);
+    Key key = provider.decryptLocalKey(piiKey, localKey.encryptedKey);
+    assertEquals(new BytesWritable(localKey.decryptedKey.getEncoded()).toString(),
+        new BytesWritable(key.getEncoded()).toString());
+  }
+
+  /**
+   * Create a Hadoop KeyProvider that lets us test the interaction
+   * with the Hadoop code.
+   * Must only be used in unit tests!
+   */
+  public static class TestKeyProviderFactory extends KeyProviderFactory {
+
+    @Override
+    public KeyProvider createProvider(URI uri,
+                                      Configuration conf) throws IOException {
+      if ("test".equals(uri.getScheme())) {
+        KeyProvider provider = new TestKeyProvider(conf);
+        // populate a couple keys into the provider
+        byte[] piiKey = new byte[]{0,1,2,3,4,5,6,7,8,9,0xa,0xb,0xc,0xd,0xe,0xf};
+        KeyProvider.Options aes128 = new KeyProvider.Options(conf);
+        provider.createKey("pii", piiKey, aes128);
+        byte[] piiKey2 = new byte[]{0x10,0x11,0x12,0x13,0x14,0x15,0x16,0x17,
+            0x18,0x19,0x1a,0x1b,0x1c,0x1d,0x1e,0x1f};
+        provider.rollNewVersion("pii", piiKey2);
+        byte[] secretKey = new byte[]{0x20,0x21,0x22,0x23,0x24,0x25,0x26,0x27,
+            0x28,0x29,0x2a,0x2b,0x2c,0x2d,0x2e,0x2f};
+        provider.createKey("secret", secretKey, aes128);
+        return KeyProviderCryptoExtension.createKeyProviderCryptoExtension(provider);
+      }
+      return null;
+    }
+  }
+
+  /**
+   * A Hadoop KeyProvider that lets us test the interaction
+   * with the Hadoop code.
+   * Must only be used in unit tests!
+   */
+  static class TestKeyProvider extends KeyProvider {
+    // map from key name to metadata
+    private final Map<String, TestMetadata> keyMetdata = new HashMap<>();
+    // map from key version name to material
+    private final Map<String, KeyVersion> keyVersions = new HashMap<>();
+
+    public TestKeyProvider(Configuration conf) {
+      super(conf);
+    }
+
+    @Override
+    public KeyVersion getKeyVersion(String name) {
+      return keyVersions.get(name);
+    }
+
+    @Override
+    public List<String> getKeys() {
+      return new ArrayList<>(keyMetdata.keySet());
+    }
+
+    @Override
+    public List<KeyVersion> getKeyVersions(String name) {
+      List<KeyVersion> result = new ArrayList<>();
+      Metadata meta = getMetadata(name);
+      for(int v=0; v < meta.getVersions(); ++v) {
+        String versionName = buildVersionName(name, v);
+        KeyVersion material = keyVersions.get(versionName);
+        if (material != null) {
+          result.add(material);
+        }
+      }
+      return result;
+    }
+
+    @Override
+    public Metadata getMetadata(String name)  {
+      return keyMetdata.get(name);
+    }
+
+    @Override
+    public KeyVersion createKey(String name, byte[] bytes, Options options) {
+      String versionName = buildVersionName(name, 0);
+      keyMetdata.put(name, new TestMetadata(options.getCipher(),
+          options.getBitLength(), 1));
+      KeyVersion result = new KMSClientProvider.KMSKeyVersion(name, versionName, bytes);
+      keyVersions.put(versionName, result);
+      return result;
+    }
+
+    @Override
+    public void deleteKey(String name) {
+      throw new UnsupportedOperationException("Can't delete keys");
+    }
+
+    @Override
+    public KeyVersion rollNewVersion(String name, byte[] bytes) {
+      TestMetadata key = keyMetdata.get(name);
+      String versionName = buildVersionName(name, key.addVersion());
+      KeyVersion result = new KMSClientProvider.KMSKeyVersion(name, versionName,
+          bytes);
+      keyVersions.put(versionName, result);
+      return result;
+    }
+
+    @Override
+    public void flush() {
+      // Nothing
+    }
+
+    static class TestMetadata extends KeyProvider.Metadata {
+
+      protected TestMetadata(String cipher, int bitLength, int versions) {
+        super(cipher, bitLength, null, null, null, versions);
+      }
+
+      public int addVersion() {
+        return super.addVersion();
+      }
+    }
   }
 }

--- a/java/shims/src/test/resources/META-INF/services/org.apache.hadoop.crypto.key.KeyProviderFactory
+++ b/java/shims/src/test/resources/META-INF/services/org.apache.hadoop.crypto.key.KeyProviderFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.orc.impl.TestHadoopShimsPre2_7$TestKeyProviderFactory

--- a/java/tools/src/java/org/apache/orc/tools/KeyTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/KeyTool.java
@@ -34,6 +34,7 @@ import org.codehaus.jettison.json.JSONWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintStream;
+import java.security.SecureRandom;
 
 /**
  * Print the information about the encryption keys.
@@ -55,7 +56,7 @@ public class KeyTool {
     writer.key("version");
     writer.value(meta.getVersion());
     byte[] iv = new byte[algorithm.getIvLength()];
-    byte[] key = provider.getLocalKey(meta, iv).getEncoded();
+    byte[] key = provider.decryptLocalKey(meta, iv).getEncoded();
     writer.key("key 0");
     writer.value(new BytesWritable(key).toString());
     writer.endObject();
@@ -79,7 +80,7 @@ public class KeyTool {
 
   void run() throws IOException, JSONException {
     HadoopShims.KeyProvider provider =
-        HadoopShimsFactory.get().getKeyProvider(conf);
+        HadoopShimsFactory.get().getKeyProvider(conf, new SecureRandom());
     if (provider == null) {
       System.err.println("No key provider available.");
       System.exit(1);


### PR DESCRIPTION
Separate createLocalKey from decryptLocalKey in HadoopShims.KeyProvider.

It also:
- changes HadoopShims.KeyMetadata from an interface to a concrete class
- creates a NullKeyProvider for Hadoop versions < 2.7
