### PR TITLE
ORC-313: Check subtype count of LIST, MAP and UNION types

### DIFF
--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -379,6 +379,12 @@ namespace orc {
     case proto::Type_Kind_MAP:
     case proto::Type_Kind_UNION: {
       TypeImpl* result = new TypeImpl(static_cast<TypeKind>(type.kind()));
+      if (type.kind() == proto::Type_Kind_LIST && type.subtypes_size() != 1)
+        throw ParseError("Illegal LIST type that doesn't contain one subtype");
+      if (type.kind() == proto::Type_Kind_MAP && type.subtypes_size() != 2)
+        throw ParseError("Illegal MAP type that doesn't contain two subtypes");
+      if (type.kind() == proto::Type_Kind_UNION && type.subtypes_size() == 0)
+        throw ParseError("Illegal UNION type that doesn't contain any subtypes");
       for(int i=0; i < type.subtypes_size(); ++i) {
         result->addUnionChild(convertType(footer.types(static_cast<int>
                                                        (type.subtypes(i))),

--- a/java/core/src/java/org/apache/orc/OrcUtils.java
+++ b/java/core/src/java/org/apache/orc/OrcUtils.java
@@ -505,14 +505,14 @@ public class OrcUtils {
       }
       case LIST:
         if (type.getSubtypesCount() != 1) {
-          throw new FileFormatException("LIST type should contains exactly " +
+          throw new FileFormatException("LIST type should contain exactly " +
                   "one subtype but has " + type.getSubtypesCount());
         }
         return TypeDescription.createList(
             convertTypeFromProtobuf(types, type.getSubtypes(0)));
       case MAP:
         if (type.getSubtypesCount() != 2) {
-          throw new FileFormatException("MAP type should contains exactly " +
+          throw new FileFormatException("MAP type should contain exactly " +
                   "two subtypes but has " + type.getSubtypesCount());
         }
         return TypeDescription.createMap(
@@ -528,7 +528,7 @@ public class OrcUtils {
       }
       case UNION: {
         if (type.getSubtypesCount() == 0) {
-          throw new FileFormatException("UNION type should contains at least" +
+          throw new FileFormatException("UNION type should contain at least" +
                   " one subtype but has none");
         }
         TypeDescription result = TypeDescription.createUnion();

--- a/java/core/src/test/org/apache/orc/TestCorruptTypes.java
+++ b/java/core/src/test/org/apache/orc/TestCorruptTypes.java
@@ -1,0 +1,46 @@
+package org.apache.orc;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.fail;
+
+public class TestCorruptTypes {
+
+  @Test
+  public void testIllType() {
+    testCorruptHelper(OrcProto.Type.Kind.LIST, 0,
+            "LIST type should contain exactly one subtype but has 0");
+    testCorruptHelper(OrcProto.Type.Kind.LIST, 2,
+            "LIST type should contain exactly one subtype but has 2");
+    testCorruptHelper(OrcProto.Type.Kind.MAP, 1,
+            "MAP type should contain exactly two subtypes but has 1");
+    testCorruptHelper(OrcProto.Type.Kind.MAP, 3,
+            "MAP type should contain exactly two subtypes but has 3");
+    testCorruptHelper(OrcProto.Type.Kind.UNION, 0,
+            "UNION type should contain at least one subtype but has none");
+  }
+
+  private void testCorruptHelper(OrcProto.Type.Kind type,
+                                 int subTypesCnt,
+                                 String errMsg) {
+
+    List<OrcProto.Type> types = new ArrayList<OrcProto.Type>();
+    OrcProto.Type.Builder builder = OrcProto.Type.newBuilder().setKind(type);
+    for (int i = 0; i < subTypesCnt; ++i) {
+      builder.addSubtypes(i + 2);
+    }
+    types.add(builder.build());
+    try {
+      OrcUtils.convertTypeFromProtobuf(types, 0);
+      fail("Should throw FileFormatException for ill types");
+    } catch (FileFormatException e) {
+      assertEquals(errMsg, e.getMessage());
+    } catch (Throwable e) {
+      fail("Should only trow FileFormatException for ill types");
+    }
+  }
+}

--- a/java/core/src/test/org/apache/orc/TestCorruptTypes.java
+++ b/java/core/src/test/org/apache/orc/TestCorruptTypes.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.orc;
 
 import org.junit.Test;

--- a/java/tools/src/java/org/apache/orc/tools/PrintData.java
+++ b/java/tools/src/java/org/apache/orc/tools/PrintData.java
@@ -242,6 +242,7 @@ public class PrintData {
           System.out.println(FileDump.SEPARATOR);
         } catch (Exception e) {
           System.err.println("Unable to dump data for file: " + file);
+          e.printStackTrace();
           continue;
         }
       }


### PR DESCRIPTION
We need to verify the subtype count of LIST, MAP and UNION types. Otherwise, the ill types will lead the c++ reader to crash. The java reader also has this problem.

Files attached to the JIRA can reproduce the crash.