### PR TITLE
ORC-323: Predicate pushdown for nested fields

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -109,16 +109,29 @@ public class RecordReaderImpl implements RecordReader {
    */
   static int findColumns(SchemaEvolution evolution,
                          String columnName) {
-    TypeDescription readerSchema = evolution.getReaderBaseSchema();
+
+    TypeDescription result = evolution.getFileType(findColumns(evolution.getReaderBaseSchema(),columnName));
+    return result == null ? -1 : result.getId();
+  }
+
+  static TypeDescription findColumns(TypeDescription readerSchema,String columnName)
+  {
+    TypeDescription result = null;
     List<String> fieldNames = readerSchema.getFieldNames();
     List<TypeDescription> children = readerSchema.getChildren();
     for (int i = 0; i < fieldNames.size(); ++i) {
       if (columnName.equals(fieldNames.get(i))) {
-        TypeDescription result = evolution.getFileType(children.get(i));
-        return result == null ? -1 : result.getId();
+          return children.get(i);
+      }
+      if(children.get(i).getChildren() != null) {
+        result = findColumns(children.get(i),columnName);
+        if(result != null)
+        {
+          return result;
+        }
       }
     }
-    return -1;
+    return result;
   }
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -110,28 +110,30 @@ public class RecordReaderImpl implements RecordReader {
   static int findColumns(SchemaEvolution evolution,
                          String columnName) {
 
-    TypeDescription result = evolution.getFileType(findColumns(evolution.getReaderBaseSchema(),columnName));
+    String[] columnNamePath = columnName.split("\\.");
+    TypeDescription result = evolution.getFileType(findColumns(evolution.getReaderBaseSchema(),columnNamePath,0));
     return result == null ? -1 : result.getId();
   }
 
-  static TypeDescription findColumns(TypeDescription readerSchema,String columnName)
+  static TypeDescription findColumns(TypeDescription readerSchema,String[] columnNamePath,int position)
   {
     TypeDescription result = null;
-    List<String> fieldNames = readerSchema.getFieldNames();
-    List<TypeDescription> children = readerSchema.getChildren();
-    for (int i = 0; i < fieldNames.size(); ++i) {
-      if (columnName.equals(fieldNames.get(i))) {
-          return children.get(i);
-      }
-      if(children.get(i).getChildren() != null) {
-        result = findColumns(children.get(i),columnName);
-        if(result != null)
-        {
-          return result;
+    if(position == columnNamePath.length)
+    {
+      return readerSchema;
+    }
+    else {
+      String columnName = columnNamePath[position];
+      List<TypeDescription> children = readerSchema.getChildren();
+      List<String> fieldNames = readerSchema.getFieldNames();
+      for (int i = 0; i < readerSchema.getChildren().size(); ++i) {
+        if (columnName.equalsIgnoreCase(fieldNames.get(i))) {
+          result = findColumns(children.get(i), columnNamePath, ++position);
+          break;
         }
       }
+      return result;
     }
-    return result;
   }
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -104,7 +104,7 @@ public class RecordReaderImpl implements RecordReader {
    * Given a list of column names, find the given column and return the index.
    *
    * @param evolution the mapping from reader to file schema
-   * @param columnName  the column name to look for
+   * @param columnName  the Fully qualified column name to look for
    * @return the file column number or -1 if the column wasn't found
    */
   static int findColumns(SchemaEvolution evolution,
@@ -115,6 +115,14 @@ public class RecordReaderImpl implements RecordReader {
     return result == null ? -1 : result.getId();
   }
 
+  /**
+   * Recursion to match column name to columnId
+   *
+   * @param readerSchema schema to parse to generate ColumnId
+   * @param columnNamePath fully qualified Column name
+   * @param position position in columnNamePath
+   * @return
+   */
   static TypeDescription findColumns(TypeDescription readerSchema,String[] columnNamePath,int position)
   {
     TypeDescription result = null;

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -245,6 +245,14 @@ public class SchemaEvolution {
     return populatePpdSafeConversionForChildern(result,readerSchema.getChildren());
   }
 
+  /**
+   * Recursion to check the conversion of nested field.
+   *
+   * @param ppdSafeConversion boolean array to specify which column are safe.
+   * @param children reader schema children.
+   *
+   * @return boolean array to represent list of column safe or not.
+   */
   private boolean[] populatePpdSafeConversionForChildern(boolean[] ppdSafeConversion,List<TypeDescription> children ){
     boolean safePpd;
     if (children != null) {

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -242,15 +242,20 @@ public class SchemaEvolution {
     boolean[] result = new boolean[readerSchema.getMaximumId() + 1];
     boolean safePpd = validatePPDConversion(fileSchema, readerSchema);
     result[readerSchema.getId()] = safePpd;
-    List<TypeDescription> children = readerSchema.getChildren();
+    return populatePpdSafeConversionForChildern(result,readerSchema.getChildren());
+  }
+
+  private boolean[] populatePpdSafeConversionForChildern(boolean[] ppdSafeConversion,List<TypeDescription> children ){
+    boolean safePpd;
     if (children != null) {
       for (TypeDescription child : children) {
         TypeDescription fileType = getFileType(child.getId());
         safePpd = validatePPDConversion(fileType, child);
-        result[child.getId()] = safePpd;
+        ppdSafeConversion[child.getId()] = safePpd;
+        populatePpdSafeConversionForChildern(ppdSafeConversion,child.getChildren());
       }
     }
-    return result;
+    return  ppdSafeConversion;
   }
 
   private boolean validatePPDConversion(final TypeDescription fileType,

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -3372,26 +3372,31 @@ public class TestVectorOrcFile {
     SearchArgument sarg = SearchArgumentFactory.newBuilder()
             .startAnd()
             .startNot()
-            .lessThan("int2", PredicateLeaf.Type.LONG, 300000L)
+            .lessThan("complex.int2", PredicateLeaf.Type.LONG, 300000L)
             .end()
-            .lessThan("int2", PredicateLeaf.Type.LONG, 600000L)
+            .lessThan("complex.int2", PredicateLeaf.Type.LONG, 600000L)
             .end()
             .build();
+
     RecordReader rows = reader.rows(reader.options()
             .range(0L, Long.MAX_VALUE)
             .include(new boolean[]{true, true, true, true, true})
-            .searchArgument(sarg, new String[]{null, "int1", null,"int2","string1"}));
+            .searchArgument(sarg, new String[]{null, "int1", "complex","int2","string1"}));
     batch = reader.getSchema().createRowBatch(2000);
     LongColumnVector ints1 = (LongColumnVector) batch.cols[0];
     StructColumnVector struct1 = (StructColumnVector) batch.cols[1];
     LongColumnVector ints2 = (LongColumnVector) struct1.fields[0];
     BytesColumnVector strs = (BytesColumnVector) struct1.fields[1];
 
+    System.out.println("------------------------------------------------------------------------------------------------------------------------");
+    System.out.println(rows.getRowNumber());
+
     Assert.assertEquals(1000L, rows.getRowNumber());
     Assert.assertEquals(true, rows.nextBatch(batch));
     assertEquals(1000, batch.size);
 
     for(int i=1000; i < 2000; ++i) {
+      assertEquals(i,ints1.vector[i-1000]);
       assertEquals(300 * i, ints2.vector[i - 1000]);
       assertEquals(Integer.toHexString(10*i), strs.toString(i - 1000));
     }
@@ -3402,7 +3407,7 @@ public class TestVectorOrcFile {
     // look through the file with no rows selected
     sarg = SearchArgumentFactory.newBuilder()
             .startAnd()
-            .lessThan("int2", PredicateLeaf.Type.LONG, 0L)
+            .lessThan("complex.int2", PredicateLeaf.Type.LONG, 0L)
             .end()
             .build();
     rows = reader.rows(reader.options()
@@ -3415,9 +3420,9 @@ public class TestVectorOrcFile {
     // select first 100 and last 100 rows
     sarg = SearchArgumentFactory.newBuilder()
             .startOr()
-            .lessThan("int2", PredicateLeaf.Type.LONG, 300L * 100)
+            .lessThan("complex.int2", PredicateLeaf.Type.LONG, 300L * 100)
             .startNot()
-            .lessThan("int2", PredicateLeaf.Type.LONG, 300L * 3400)
+            .lessThan("complex.int2", PredicateLeaf.Type.LONG, 300L * 3400)
             .end()
             .end()
             .build();

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -930,6 +930,16 @@ public class TestVectorOrcFile {
         .addField("string1", TypeDescription.createString());
   }
 
+  private static TypeDescription createComplexInnerSchema()
+  {
+    return TypeDescription.createStruct()
+            .addField("int1", TypeDescription.createInt())
+            .addField("complex",
+                      TypeDescription.createStruct()
+                              .addField("int2", TypeDescription.createInt())
+                              .addField("String1",TypeDescription.createString()));
+  }
+
   private static TypeDescription createBigRowSchema() {
     return TypeDescription.createStruct()
         .addField("boolean1", TypeDescription.createBoolean())
@@ -3333,4 +3343,107 @@ public class TestVectorOrcFile {
     assertFalse(rows.nextBatch(batch));
     rows.close();
   }
+
+  @Test
+  public void testPredicatePushdownForComplex() throws Exception {
+    TypeDescription schema = createComplexInnerSchema();
+    Writer writer = OrcFile.createWriter(testFilePath,
+            OrcFile.writerOptions(conf)
+                    .setSchema(schema)
+                    .stripeSize(400000L)
+                    .compress(CompressionKind.NONE)
+                    .bufferSize(500)
+                    .rowIndexStride(1000));
+    VectorizedRowBatch batch = schema.createRowBatch();
+    batch.ensureSize(3500);
+    batch.size = 3500;
+    for(int i=0; i < 3500; ++i) {
+      ((LongColumnVector) batch.cols[0]).vector[i] = i;
+      ((LongColumnVector)((StructColumnVector) batch.cols[1]).fields[0]).vector[i] = i * 300;
+      ((BytesColumnVector)((StructColumnVector) batch.cols[1]).fields[1]).setVal(i,
+              Integer.toHexString(10*i).getBytes());
+    }
+    writer.addRowBatch(batch);
+    writer.close();
+    Reader reader = OrcFile.createReader(testFilePath,
+            OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals(3500, reader.getNumberOfRows());
+
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+            .startAnd()
+            .startNot()
+            .lessThan("int2", PredicateLeaf.Type.LONG, 300000L)
+            .end()
+            .lessThan("int2", PredicateLeaf.Type.LONG, 600000L)
+            .end()
+            .build();
+    RecordReader rows = reader.rows(reader.options()
+            .range(0L, Long.MAX_VALUE)
+            .include(new boolean[]{true, true, true, true, true})
+            .searchArgument(sarg, new String[]{null, "int1", null,"int2","string1"}));
+    batch = reader.getSchema().createRowBatch(2000);
+    LongColumnVector ints1 = (LongColumnVector) batch.cols[0];
+    StructColumnVector struct1 = (StructColumnVector) batch.cols[1];
+    LongColumnVector ints2 = (LongColumnVector) struct1.fields[0];
+    BytesColumnVector strs = (BytesColumnVector) struct1.fields[1];
+
+    Assert.assertEquals(1000L, rows.getRowNumber());
+    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(1000, batch.size);
+
+    for(int i=1000; i < 2000; ++i) {
+      assertEquals(300 * i, ints2.vector[i - 1000]);
+      assertEquals(Integer.toHexString(10*i), strs.toString(i - 1000));
+    }
+    Assert.assertEquals(false, rows.nextBatch(batch));
+    Assert.assertEquals(3500, rows.getRowNumber());
+
+
+    // look through the file with no rows selected
+    sarg = SearchArgumentFactory.newBuilder()
+            .startAnd()
+            .lessThan("int2", PredicateLeaf.Type.LONG, 0L)
+            .end()
+            .build();
+    rows = reader.rows(reader.options()
+            .range(0L, Long.MAX_VALUE)
+            .include(new boolean[]{true, true, true, true, true})
+            .searchArgument(sarg, new String[]{null, "int1",null,"int2","string1"}));
+    Assert.assertEquals(3500L, rows.getRowNumber());
+    assertTrue(!rows.nextBatch(batch));
+
+    // select first 100 and last 100 rows
+    sarg = SearchArgumentFactory.newBuilder()
+            .startOr()
+            .lessThan("int2", PredicateLeaf.Type.LONG, 300L * 100)
+            .startNot()
+            .lessThan("int2", PredicateLeaf.Type.LONG, 300L * 3400)
+            .end()
+            .end()
+            .build();
+    rows = reader.rows(reader.options()
+            .range(0L, Long.MAX_VALUE)
+            .include(new boolean[]{true, true,true,true, true})
+            .searchArgument(sarg, new String[]{null, "int1",null, "int2","string1"}));
+    Assert.assertEquals(0, rows.getRowNumber());
+    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(1000, batch.size);
+    Assert.assertEquals(3000, rows.getRowNumber());
+
+    for(int i=0; i < 1000; ++i) {
+      assertEquals(300 * i, ints2.vector[i]);
+      assertEquals(Integer.toHexString(10*i), strs.toString(i));
+    }
+
+    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(500, batch.size);
+    Assert.assertEquals(3500, rows.getRowNumber());
+    for(int i=3000; i < 3500; ++i) {
+      assertEquals(300 * i, ints2.vector[i - 3000]);
+      assertEquals(Integer.toHexString(10*i), strs.toString(i - 3000));
+    }
+    Assert.assertEquals(false, rows.nextBatch(batch));
+    Assert.assertEquals(3500, rows.getRowNumber());
+  }
+
 }


### PR DESCRIPTION
**1. Predicate Pushdown For Nested field**

**1.1 Objective**

In the ORC(Optimized Row Columnar) all the primitive type column consist of index. Predicate refer to the column name in where clause and pushdown mean skipping rows groups, strips and block while reading by comparing the meta store in the strips. Meta consist of max, sum ,min value present in the given column. 

Currently predicate pushdown only work for top level column of the schema. 

Extending the Predicate Pushdown for nested structure in hive.  


**1.2 Current state** 
 
**1.2.1 Schema**
struct<int1:int, complex:struct<int2:int,String1:string>>
 
**1.2.2 Search Argument**  
SearchArgument sarg = SearchArgumentFactory.newBuilder()
       .startAnd()
       .startNot()
       .lessThan(“int2", PredicateLeaf.Type.LONG, 300000L)
       .end()
       .lessThan("int2", PredicateLeaf.Type.LONG, 600000L)
       .end()
       .build();
 
 
 
 
**1.2.3 Pushdown Predicate not supported in Nested field in ORC**
 
private boolean[] populatePpdSafeConversion() {
    if (fileSchema == null || readerSchema == null || readerFileTypes == null) {
      return null;
    }

    boolean[] result = new boolean[readerSchema.getMaximumId() + 1];
    boolean safePpd = validatePPDConversion(fileSchema, readerSchema);
    result[readerSchema.getId()] = safePpd;
    List<TypeDescription> children = readerSchema.getChildren();
    if (children != null) {
      for (TypeDescription child : children) {
        TypeDescription fileType = getFileType(child.getId());
        safePpd = validatePPDConversion(fileType, child);
        result[child.getId()] = safePpd;
      }
    }
    return result;
  }

In populatePpdSafeConversion() this function only check the conversion validation for top level field. So validation of nested field search argument fails.


static int findColumns(SchemaEvolution evolution,
                         String columnName) {
    TypeDescription readerSchema = evolution.getReaderBaseSchema();
    List<String> fieldNames = readerSchema.getFieldNames();
    List<TypeDescription> children = readerSchema.getChildren();
    for (int i = 0; i < fieldNames.size(); ++i) {
      if (columnName.equals(fieldNames.get(i))) {
        TypeDescription result = evolution.getFileType(children.get(i));
        return result == null ? -1 : result.getId();
      }
    }
    return -1;
  }


In findColumns() all the only top level column is referred. “Int2” is nested column due to which  “-1” is return instead of index of “int2”.

**1.2.4 Result**

PPD is not working for int2 field in the search argument.


**1.3 Expected state**

**1.3.1 Schema**
struct<int1:int, complex:struct<int2:int,String1:string>>
 
**1.3.2 Query**
Replacing Column name in PredicateLeaf with fully qualified column path.
 
SearchArgument sarg = SearchArgumentFactory.newBuilder()
       .startAnd()
       .startNot()
       .lessThan(“complex.int2", PredicateLeaf.Type.LONG, 300000L)
       .end()
       .lessThan("complex.int2", PredicateLeaf.Type.LONG, 600000L)
       .end()
       .build();
 
**1.3.4 Result**

PPD is working for complex.int2 field in the search argument.