### PR TITLE
Allow custom timestamp format to be provided to CSV-ORC converter

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
@@ -47,6 +47,8 @@ import java.util.zip.GZIPInputStream;
  * A conversion tool to convert CSV or JSON files into ORC files.
  */
 public class ConvertTool {
+  static final String DEFAULT_TIMESTAMP_FORMAT = "yyyy[[-][/]]MM[[-][/]]dd[['T'][ ]]HH:mm:ss[ ][XXX][X]";
+
   private final List<FileInformation> fileList;
   private final TypeDescription schema;
   private final char csvSeparator;
@@ -54,6 +56,7 @@ public class ConvertTool {
   private final char csvEscape;
   private final int csvHeaderLines;
   private final String csvNullString;
+  private final String timestampFormat;
   private final Writer writer;
   private final VectorizedRowBatch batch;
 
@@ -148,7 +151,7 @@ public class ConvertTool {
         case CSV: {
           FSDataInputStream underlying = filesystem.open(path);
           return new CsvReader(getReader(underlying), underlying, size, schema,
-              csvSeparator, csvQuote, csvEscape, csvHeaderLines, csvNullString);
+              csvSeparator, csvQuote, csvEscape, csvHeaderLines, csvNullString, timestampFormat);
         }
         default:
           throw new IllegalArgumentException("Unhandled format " + format +
@@ -186,6 +189,7 @@ public class ConvertTool {
     this.csvSeparator = getCharOption(opts, 'S', ',');
     this.csvHeaderLines = getIntOption(opts, 'H', 0);
     this.csvNullString = opts.getOptionValue('n', "");
+    this.timestampFormat = opts.getOptionValue("tsf", DEFAULT_TIMESTAMP_FORMAT);
     String outFilename = opts.hasOption('o')
         ? opts.getOptionValue('o') : "output.orc";
     writer = OrcFile.createWriter(new Path(outFilename),
@@ -246,6 +250,9 @@ public class ConvertTool {
             .hasArg().build());
     options.addOption(
         Option.builder("H").longOpt("header").desc("CSV header lines")
+            .hasArg().build());
+    options.addOption(
+            Option.builder("tsf").longOpt("timestampformat").desc("Timestamp Format")
             .hasArg().build());
     CommandLine cli = new DefaultParser().parse(options, args);
     if (cli.hasOption('h') || cli.getArgs().length == 0) {

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -17,6 +17,7 @@
  */
 package org.apache.orc.tools.convert;
 
+import com.opencsv.CSVReader;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
@@ -36,16 +37,11 @@ import org.threeten.bp.ZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.temporal.TemporalAccessor;
 
-import com.opencsv.CSVReader;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 
 public class CsvReader implements RecordReader {
-  private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(
-      "yyyy[[-][/]]MM[[-][/]]dd[['T'][ ]]HH:mm:ss[ ][XXX][X]");
-
   private long rowNumber = 0;
   private final Converter converter;
   private final int columns;
@@ -53,6 +49,7 @@ public class CsvReader implements RecordReader {
   private final String nullString;
   private final FSDataInputStream underlying;
   private final long totalSize;
+  private final DateTimeFormatter dateTimeFormatter;
 
   /**
    * Create a CSV reader
@@ -66,6 +63,7 @@ public class CsvReader implements RecordReader {
    * @param escapeChar the escape character
    * @param headerLines the number of header lines
    * @param nullString the string that is translated to null
+   * @param timestampFormat the format to use for parsing timestamps
    * @throws IOException
    */
   public CsvReader(java.io.Reader reader,
@@ -76,7 +74,8 @@ public class CsvReader implements RecordReader {
                    char quoteChar,
                    char escapeChar,
                    int headerLines,
-                   String nullString) throws IOException {
+                   String nullString,
+                   String timestampFormat) {
     this.underlying = input;
     this.reader = new CSVReader(reader, separatorChar, quoteChar, escapeChar,
         headerLines);
@@ -85,6 +84,7 @@ public class CsvReader implements RecordReader {
     IntWritable nextColumn = new IntWritable(0);
     this.converter = buildConverter(nextColumn, schema);
     this.columns = nextColumn.get();
+    this.dateTimeFormatter = DateTimeFormatter.ofPattern(timestampFormat);
   }
 
   interface Converter {
@@ -252,7 +252,7 @@ public class CsvReader implements RecordReader {
       } else {
         TimestampColumnVector vector = (TimestampColumnVector) column;
         TemporalAccessor temporalAccessor =
-            DATE_TIME_FORMATTER.parseBest(values[offset],
+            dateTimeFormatter.parseBest(values[offset],
                 ZonedDateTime.FROM, LocalDateTime.FROM);
         if (temporalAccessor instanceof ZonedDateTime) {
           vector.set(row, new Timestamp(


### PR DESCRIPTION
* new command line argument `-tsf | --timestampformat` which takes a timestamp format string