### PR TITLE
ORC-338. Workaround C++ compiler bug in xcode 9.3 by removing an inline

### DIFF
--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -167,6 +167,18 @@ namespace orc {
     // PASS
   }
 
+  void IntegerColumnStatisticsImpl::update(int64_t value, int repetitions) {
+    _stats.updateMinMax(value);
+
+    if (_stats.hasSum()) {
+      bool wasPositive = _stats.getSum() >= 0;
+      _stats.setSum(value * repetitions + _stats.getSum());
+      if ((value >= 0) == wasPositive) {
+        _stats.setHasSum((_stats.getSum() >= 0) == wasPositive);
+      }
+    }
+  }
+
   StringColumnStatisticsImpl::~StringColumnStatisticsImpl() {
     // PASS
   }

--- a/c++/src/Statistics.hh
+++ b/c++/src/Statistics.hh
@@ -948,17 +948,7 @@ namespace orc {
       _stats.setSum(sum);
     }
 
-    void update(int64_t value, int repetitions) {
-      _stats.updateMinMax(value);
-
-      if (_stats.hasSum()) {
-        bool wasPositive = _stats.getSum() >= 0;
-        _stats.setSum(value * repetitions + _stats.getSum());
-        if ((value >= 0) == wasPositive) {
-          _stats.setHasSum((_stats.getSum() >= 0) == wasPositive);
-        }
-      }
-    }
+    void update(int64_t value, int repetitions);
 
     void merge(const MutableColumnStatistics& other) override {
       const IntegerColumnStatisticsImpl& intStats =

--- a/c++/test/TestColumnStatistics.cc
+++ b/c++/test/TestColumnStatistics.cc
@@ -82,6 +82,7 @@ namespace orc {
     EXPECT_TRUE(other->hasNull());
     EXPECT_EQ(9999, other->getMaximum());
     EXPECT_EQ(-9999, other->getMinimum());
+    EXPECT_TRUE(other->hasSum());
     EXPECT_EQ(100000, other->getSum());
 
     intStats->merge(*other);


### PR DESCRIPTION
function.