### PR TITLE
ORC-346: [C++] Add one second when writing negative Timestamp's with non zero nanos …

### DIFF
--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1199,6 +1199,10 @@ namespace orc {
         tsStats->increase(1);
         tsStats->update(millsUTC);
 
+        if (secs[i] < 0 && nanos[i] != 0) {
+          secs[i] += 1;
+        }
+
         secs[i] -= timezone.getEpoch();
         nanos[i] = formatNano(nanos[i]);
       } else if (!hasNull) {

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -570,8 +570,8 @@ namespace orc {
 
     std::vector<std::time_t> times(rowCount);
     for (uint64_t i = 0; i < rowCount; ++i) {
-      time_t currTime = std::time(nullptr);
-      times[i] = static_cast<int64_t>(currTime) - static_cast<int64_t >(i * 60);
+      time_t currTime = -14210715; // 1969-07-20 12:34:45
+      times[i] = static_cast<int64_t>(currTime) + static_cast<int64_t >(i * 3660);
       tsBatch->data[i] = times[i];
       tsBatch->nanoseconds[i] = static_cast<int64_t>(i * 1000);
     }


### PR DESCRIPTION
…to match the reader code.