### PR TITLE
ORC-49. Create RLE-based encoding for short decimals in ORCv2.

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -34,6 +34,8 @@ import org.apache.orc.impl.MemoryManagerImpl;
 import org.apache.orc.impl.OrcTail;
 import org.apache.orc.impl.ReaderImpl;
 import org.apache.orc.impl.WriterImpl;
+import org.apache.orc.impl.WriterInternal;
+import org.apache.orc.impl.writer.WriterImplV2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -773,8 +775,16 @@ public class OrcFile {
                                     ) throws IOException {
     FileSystem fs = opts.getFileSystem() == null ?
         path.getFileSystem(opts.getConfiguration()) : opts.getFileSystem();
-
-    return new WriterImpl(fs, path, opts);
+    switch (opts.getVersion()) {
+      case V_0_11:
+      case V_0_12:
+        return new WriterImpl(fs, path, opts);
+      case UNSTABLE_PRE_2_0:
+        return new WriterImplV2(fs, path, opts);
+      default:
+        throw new IllegalArgumentException("Unknown version " +
+            opts.getVersion());
+    }
   }
 
   /**
@@ -927,7 +937,7 @@ public class OrcFile {
           mergeMetadata(userMetadata, reader);
           if (bufferSize < reader.getCompressionSize()) {
             bufferSize = reader.getCompressionSize();
-            ((WriterImpl) output).increaseCompressionSize(bufferSize);
+            ((WriterInternal) output).increaseCompressionSize(bufferSize);
           }
         }
         List<OrcProto.StripeStatistics> statList =

--- a/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
@@ -100,6 +100,13 @@ public final class OrcCodecPool {
     }
   }
 
+  /**
+   * Clear the codec pool. Mostly used for testing.
+   */
+  public static void clear() {
+    POOL.clear();
+  }
+
   private OrcCodecPool() {
     // prevent instantiation
   }

--- a/java/core/src/java/org/apache/orc/impl/OutStream.java
+++ b/java/core/src/java/org/apache/orc/impl/OutStream.java
@@ -108,7 +108,7 @@ public class OutStream extends PositionedOutputStream {
    * @param bufferSize The ORC compression buffer size being checked.
    * @throws IllegalArgumentException If bufferSize value exceeds threshold.
    */
-  static void assertBufferSizeValid(int bufferSize) throws IllegalArgumentException {
+  public static void assertBufferSizeValid(int bufferSize) throws IllegalArgumentException {
     if (bufferSize >= (1 << 23)) {
       throw new IllegalArgumentException("Illegal value of ORC compression buffer size: " + bufferSize);
     }

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -224,7 +224,8 @@ public class ReaderImpl implements Reader {
     return deserializeStats(fileStats);
   }
 
-  static ColumnStatistics[] deserializeStats(List<OrcProto.ColumnStatistics> fileStats){
+  public static ColumnStatistics[] deserializeStats(
+      List<OrcProto.ColumnStatistics> fileStats) {
     ColumnStatistics[] result = new ColumnStatistics[fileStats.size()];
     for(int i=0; i < result.length; ++i) {
       result[i] = ColumnStatisticsImpl.deserialize(fileStats.get(i));

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -259,10 +259,13 @@ public class RecordReaderImpl implements RecordReader {
       skipCorrupt = OrcConf.SKIP_CORRUPT_DATA.getBoolean(fileReader.conf);
     }
 
-    TreeReaderFactory.ReaderContext readerContext = new TreeReaderFactory.ReaderContext()
-      .setSchemaEvolution(evolution)
-      .skipCorrupt(skipCorrupt);
-    reader = TreeReaderFactory.createTreeReader(evolution.getReaderSchema(), readerContext);
+    TreeReaderFactory.ReaderContext readerContext =
+        new TreeReaderFactory.ReaderContext()
+          .setSchemaEvolution(evolution)
+          .skipCorrupt(skipCorrupt)
+          .fileFormat(fileReader.getFileVersion());
+    reader = TreeReaderFactory.createTreeReader(evolution.getReaderSchema(),
+        readerContext);
 
     this.fileIncluded = evolution.getFileIncluded();
     indexes = new OrcProto.RowIndex[types.size()];

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
@@ -363,9 +363,13 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
   public void nextVector(ColumnVector previous,
                          long[] data,
                          int previousLen) throws IOException {
+    // if all nulls, just return
+    if (previous.isRepeating && !previous.noNulls && previous.isNull[0]) {
+      return;
+    }
     previous.isRepeating = true;
     for (int i = 0; i < previousLen; i++) {
-      if (!previous.isNull[i]) {
+      if (previous.noNulls || !previous.isNull[i]) {
         data[i] = next();
       } else {
         // The default value of null for int type in vectorized

--- a/java/core/src/java/org/apache/orc/impl/WriterInternal.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterInternal.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.orc.Writer;
+
+/**
+ * The ORC internal API to the writer.
+ */
+public interface WriterInternal extends Writer {
+
+  /**
+   * Increase the buffer size for this writer.
+   * This function is internal only and should only be called by the
+   * ORC file merger.
+   * @param newSize the new buffer size.
+   */
+  void increaseCompressionSize(int newSize);
+
+}

--- a/java/core/src/java/org/apache/orc/impl/writer/Decimal64TreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/Decimal64TreeWriter.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.writer;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.Decimal64ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.util.JavaDataModel;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.OrcProto;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.OutStream;
+import org.apache.orc.impl.PositionRecorder;
+import org.apache.orc.impl.RunLengthIntegerWriterV2;
+
+import java.io.IOException;
+
+/**
+ * Writer for short decimals in ORCv2.
+ */
+public class Decimal64TreeWriter extends TreeWriterBase {
+  private final RunLengthIntegerWriterV2 valueWriter;
+  private final int scale;
+
+  public Decimal64TreeWriter(int columnId,
+                             TypeDescription schema,
+                             WriterContext writer,
+                             boolean nullable) throws IOException {
+    super(columnId, schema, writer, nullable);
+    OutStream stream = writer.createStream(id, OrcProto.Stream.Kind.DATA);
+    // Use RLEv2 until we have the new RLEv3.
+    valueWriter = new RunLengthIntegerWriterV2(stream, true, true);
+    scale = schema.getScale();
+    if (rowIndexPosition != null) {
+      recordPosition(rowIndexPosition);
+    }
+  }
+
+  private void writeBatch(DecimalColumnVector vector, int offset,
+                         int length) throws IOException {
+    if (vector.isRepeating) {
+      if (vector.noNulls || !vector.isNull[0]) {
+        HiveDecimalWritable value = vector.vector[0];
+        long lg = value.serialize64(scale);
+        indexStatistics.updateDecimal(value);
+        if (createBloomFilter) {
+          bloomFilterUtf8.addLong(lg);
+        }
+        for (int i = 0; i < length; ++i) {
+          valueWriter.write(lg);
+        }
+      }
+    } else {
+      for (int i = 0; i < length; ++i) {
+        if (vector.noNulls || !vector.isNull[i + offset]) {
+          HiveDecimalWritable value = vector.vector[i + offset];
+          long lg = value.serialize64(scale);
+          valueWriter.write(lg);
+          indexStatistics.updateDecimal(value);
+          if (createBloomFilter) {
+            bloomFilterUtf8.addLong(lg);
+          }
+        }
+      }
+    }
+  }
+
+  private void writeBatch(Decimal64ColumnVector vector, int offset,
+                          int length) throws IOException {
+    assert(scale == vector.scale);
+    if (vector.isRepeating) {
+      if (vector.noNulls || !vector.isNull[0]) {
+        HiveDecimalWritable value = vector.getScratchWritable();
+        long lg = vector.vector[0];
+        value.setFromLongAndScale(lg, vector.scale);
+        indexStatistics.updateDecimal(value);
+        if (createBloomFilter) {
+          bloomFilterUtf8.addLong(lg);
+        }
+        for (int i = 0; i < length; ++i) {
+          valueWriter.write(lg);
+        }
+      }
+    } else {
+      HiveDecimalWritable value = vector.getScratchWritable();
+      for (int i = 0; i < length; ++i) {
+        if (vector.noNulls || !vector.isNull[i + offset]) {
+          long lg = vector.vector[i + offset];
+          valueWriter.write(lg);
+          value.setFromLongAndScale(lg, vector.scale);
+          indexStatistics.updateDecimal(value);
+          if (createBloomFilter) {
+            bloomFilterUtf8.addLong(lg);
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void writeBatch(ColumnVector vector, int offset,
+                         int length) throws IOException {
+    super.writeBatch(vector, offset, length);
+    if (vector instanceof Decimal64ColumnVector) {
+      writeBatch((Decimal64ColumnVector) vector, offset, length);
+    } else {
+      writeBatch((DecimalColumnVector) vector, offset, length);
+    }
+  }
+
+  @Override
+  public void writeStripe(OrcProto.StripeFooter.Builder builder,
+                          OrcProto.StripeStatistics.Builder stats,
+                          int requiredIndexEntries) throws IOException {
+    super.writeStripe(builder, stats, requiredIndexEntries);
+    if (rowIndexPosition != null) {
+      recordPosition(rowIndexPosition);
+    }
+  }
+
+  @Override
+  void recordPosition(PositionRecorder recorder) throws IOException {
+    super.recordPosition(recorder);
+    valueWriter.getPosition(recorder);
+  }
+
+  @Override
+  public long estimateMemory() {
+    return super.estimateMemory() + valueWriter.estimateMemory();
+  }
+
+  @Override
+  public long getRawDataSize() {
+    return fileStatistics.getNumberOfValues() * JavaDataModel.get().primitive2();
+  }
+
+  @Override
+  public void flushStreams() throws IOException {
+    super.flushStreams();
+    valueWriter.flush();
+  }
+}

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -21,6 +21,7 @@ package org.apache.orc;
 import org.apache.hadoop.hive.ql.exec.vector.Decimal64ColumnVector;
 import org.apache.orc.impl.OrcCodecPool;
 
+import org.apache.orc.impl.PhysicalFsWriter;
 import org.apache.orc.impl.WriterImpl;
 
 import org.apache.orc.OrcFile.WriterOptions;
@@ -54,10 +55,13 @@ import org.apache.orc.impl.DataReaderProperties;
 import org.apache.orc.impl.OrcIndex;
 import org.apache.orc.impl.RecordReaderImpl;
 import org.apache.orc.impl.RecordReaderUtils;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -70,6 +74,7 @@ import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -82,7 +87,25 @@ import static org.junit.Assert.*;
 /**
  * Tests for the vectorized reader and writer for ORC files.
  */
+@RunWith(Parameterized.class)
 public class TestVectorOrcFile {
+
+  @Parameterized.Parameter
+  public OrcFile.Version fileFormat;
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> getParameters() {
+    OrcFile.Version[] params = new OrcFile.Version[]{
+        OrcFile.Version.V_0_11,
+        OrcFile.Version.V_0_12,
+        OrcFile.Version.UNSTABLE_PRE_2_0};
+
+    List<Object[]> result = new ArrayList<>();
+    for(OrcFile.Version v: params) {
+      result.add(new Object[]{v});
+    }
+    return result;
+  }
 
   public static String getFileFromClasspath(String name) {
     URL url = ClassLoader.getSystemResource(name);
@@ -177,12 +200,14 @@ public class TestVectorOrcFile {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestVectorOrcFile." +
-        testCaseName.getMethodName() + ".orc");
+        testCaseName.getMethodName().replaceFirst("\\[[0-9]+\\]", "")
+        + "." + fileFormat.getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
   @Test
   public void testReadFormat_0_11() throws Exception {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
     Path oldFilePath =
         new Path(getFileFromClasspath("orc-file-11-format.orc"));
     Reader reader = OrcFile.createReader(oldFilePath,
@@ -351,7 +376,7 @@ public class TestVectorOrcFile {
     TypeDescription schema = TypeDescription.createTimestamp();
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
-            .bufferSize(10000).version(org.apache.orc.OrcFile.Version.V_0_11));
+            .bufferSize(10000).version(fileFormat));
     List<Timestamp> tslist = Lists.newArrayList();
     tslist.add(Timestamp.valueOf("2037-01-01 00:00:00.000999"));
     tslist.add(Timestamp.valueOf("2003-01-01 00:00:00.000000222"));
@@ -407,7 +432,8 @@ public class TestVectorOrcFile {
                                          OrcFile.writerOptions(conf)
                                          .setSchema(schema)
                                          .stripeSize(100000)
-                                         .bufferSize(10000));
+                                         .bufferSize(10000)
+                                         .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 4;
     BytesColumnVector field1 = (BytesColumnVector) batch.cols[0];
@@ -456,7 +482,9 @@ public class TestVectorOrcFile {
     assertEquals("bar", ((StringColumnStatistics) stats[2]).getMinimum());
     assertEquals("hi", ((StringColumnStatistics) stats[2]).getMaximum());
     assertEquals(8, ((StringColumnStatistics) stats[2]).getSum());
-    assertEquals("count: 3 hasNull: true bytesOnDisk: 22 min: bar max: hi sum: 8",
+    assertEquals("count: 3 hasNull: true bytesOnDisk: " +
+            (fileFormat == OrcFile.Version.V_0_11 ? "30" : "22") +
+            " min: bar max: hi sum: 8",
         stats[2].toString());
 
     // check the inspectors
@@ -494,7 +522,8 @@ public class TestVectorOrcFile {
       .addField("dec1", TypeDescription.createDecimal());
 
     Writer writer = OrcFile.createWriter(testFilePath,
-      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000).bufferSize(10000));
+      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+          .bufferSize(10000).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 4;
     DecimalColumnVector field1 = (DecimalColumnVector) batch.cols[0];
@@ -527,7 +556,8 @@ public class TestVectorOrcFile {
         OrcFile.writerOptions(conf)
             .setSchema(schema)
             .stripeSize(100000)
-            .bufferSize(10000));
+            .bufferSize(10000)
+            .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1000;
     LongColumnVector field1 = (LongColumnVector) batch.cols[0];
@@ -970,7 +1000,8 @@ public class TestVectorOrcFile {
         OrcFile.writerOptions(conf)
             .setSchema(schema)
             .stripeSize(100000)
-            .bufferSize(10000));
+            .bufferSize(10000)
+            .version(fileFormat));
     assertEmptyStats(writer.getStatistics());
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 2;
@@ -1040,8 +1071,9 @@ public class TestVectorOrcFile {
     assertEquals(1024, ((IntegerColumnStatistics) stats[3]).getMinimum());
     assertEquals(true, ((IntegerColumnStatistics) stats[3]).isSumDefined());
     assertEquals(3072, ((IntegerColumnStatistics) stats[3]).getSum());
-    assertEquals("count: 2 hasNull: false bytesOnDisk: 9 min: 1024 max: 2048 sum: 3072",
-        stats[3].toString());
+    assertEquals("count: 2 hasNull: false bytesOnDisk: " +
+        (fileFormat == OrcFile.Version.V_0_11 ? "8" : "9") +
+            " min: 1024 max: 2048 sum: 3072", stats[3].toString());
 
     StripeStatistics ss = reader.getStripeStatistics().get(0);
     assertEquals(2, ss.getColumnStatistics()[0].getNumberOfValues());
@@ -1055,7 +1087,9 @@ public class TestVectorOrcFile {
     assertEquals("count: 2 hasNull: false bytesOnDisk: 15 min: -15.0 max: -5.0 sum: -20.0",
         stats[7].toString());
 
-    assertEquals("count: 2 hasNull: false bytesOnDisk: 14 min: bye max: hi sum: 5", stats[9].toString());
+    assertEquals("count: 2 hasNull: false bytesOnDisk: " +
+        (fileFormat == OrcFile.Version.V_0_11 ? "20" : "14") +
+        " min: bye max: hi sum: 5", stats[9].toString());
 
     // check the schema
     TypeDescription readerSchema = reader.getSchema();
@@ -1184,7 +1218,8 @@ public class TestVectorOrcFile {
                                          .stripeSize(1000)
                                          .compress(CompressionKind.NONE)
                                          .bufferSize(100)
-                                         .rowIndexStride(1000));
+                                         .rowIndexStride(1000)
+                                         .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     Random r1 = new Random(1);
     Random r2 = new Random(2);
@@ -1279,7 +1314,8 @@ public class TestVectorOrcFile {
                                          .setSchema(schema)
                                          .stripeSize(1000)
                                          .compress(CompressionKind.NONE)
-                                         .bufferSize(100));
+                                         .bufferSize(100)
+                                         .version(fileFormat));
     writer.close();
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
@@ -1301,7 +1337,8 @@ public class TestVectorOrcFile {
             .setSchema(schema)
             .stripeSize(1000)
             .compress(CompressionKind.NONE)
-            .bufferSize(100));
+            .bufferSize(100)
+            .version(fileFormat));
     writer.addUserMetadata("my.meta", byteBuf(1, 2, 3, 4, 5, 6, 7, -1, -2, 127,
                                               -128));
     writer.addUserMetadata("clobber", byteBuf(1, 2, 3));
@@ -1360,7 +1397,8 @@ public class TestVectorOrcFile {
             .setSchema(schema)
             .stripeSize(100000)
             .bufferSize(10000)
-            .blockPadding(false));
+            .blockPadding(false)
+            .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1000;
     TimestampColumnVector timestampColVector = (TimestampColumnVector) batch.cols[0];
@@ -1478,7 +1516,8 @@ public class TestVectorOrcFile {
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
             .setSchema(schema)
-            .compress(CompressionKind.NONE));
+            .compress(CompressionKind.NONE)
+            .version(fileFormat));
     Decimal64ColumnVector cv = (Decimal64ColumnVector) batch.cols[0];
     cv.precision = 18;
     cv.scale = 3;
@@ -1493,6 +1532,13 @@ public class TestVectorOrcFile {
 
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals("count: 19 hasNull: false", reader.getStatistics()[0].toString());
+    // the size of the column in the different formats
+    int size = (fileFormat == OrcFile.Version.V_0_11 ? 89 :
+      fileFormat == OrcFile.Version.V_0_12 ? 90 : 154);
+    assertEquals("count: 19 hasNull: false bytesOnDisk: " + size +
+            " min: -2 max: 100000000000000 sum: 111111111111109.111",
+        reader.getStatistics()[1].toString());
     RecordReader rows = reader.rows();
     batch = schema.createRowBatchV2();
     cv = (Decimal64ColumnVector) batch.cols[0];
@@ -1547,7 +1593,8 @@ public class TestVectorOrcFile {
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
             .setSchema(schema)
-            .compress(CompressionKind.NONE));
+            .compress(CompressionKind.NONE)
+            .version(fileFormat));
     DecimalColumnVector cv = (DecimalColumnVector) batch.cols[0];
     cv.precision = 18;
     cv.scale = 3;
@@ -1564,6 +1611,14 @@ public class TestVectorOrcFile {
     // test with new batch
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
+    assertEquals("count: 19 hasNull: false", reader.getStatistics()[0].toString());
+    // the size of the column in the different formats
+    int size = (fileFormat == OrcFile.Version.V_0_11 ? 63 :
+        fileFormat == OrcFile.Version.V_0_12 ? 65 : 154);
+    assertEquals("count: 19 hasNull: false bytesOnDisk: " + size +
+            " min: -2 max: 10000000000000 sum: 11111111111109.1111",
+        reader.getStatistics()[1].toString());
+
     RecordReader rows = reader.rows();
     batch = schema.createRowBatchV2();
     Decimal64ColumnVector newCv = (Decimal64ColumnVector) batch.cols[0];
@@ -1630,7 +1685,8 @@ public class TestVectorOrcFile {
                                          .stripeSize(1000)
                                          .compress(CompressionKind.NONE)
                                          .bufferSize(100)
-                                         .blockPadding(false));
+                                         .blockPadding(false)
+                                         .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 6;
     setUnion(batch, 0, Timestamp.valueOf("2000-03-12 15:00:00"), 0, 42, null,
@@ -1853,7 +1909,8 @@ public class TestVectorOrcFile {
                                          .setSchema(schema)
                                          .stripeSize(1000)
                                          .compress(CompressionKind.SNAPPY)
-                                         .bufferSize(100));
+                                         .bufferSize(100)
+                                         .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     Random rand;
     writeRandomIntBytesBatches(writer, batch, 10, 1000);
@@ -1892,7 +1949,8 @@ public class TestVectorOrcFile {
             .setSchema(schema)
             .stripeSize(10000)
             .compress(CompressionKind.LZO)
-            .bufferSize(1000));
+            .bufferSize(1000)
+            .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     Random rand = new Random(69);
     batch.size = 1000;
@@ -1941,7 +1999,8 @@ public class TestVectorOrcFile {
             .setSchema(schema)
             .stripeSize(10000)
             .compress(CompressionKind.LZ4)
-            .bufferSize(1000));
+            .bufferSize(1000)
+            .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     Random rand = new Random(3);
     batch.size = 1000;
@@ -1983,10 +2042,11 @@ public class TestVectorOrcFile {
    */
   @Test
   public void testCodecPool() throws Exception {
+    OrcCodecPool.clear();
     TypeDescription schema = createInnerSchema();
     VectorizedRowBatch batch = schema.createRowBatch();
     WriterOptions opts = OrcFile.writerOptions(conf)
-        .setSchema(schema).stripeSize(1000).bufferSize(100);
+        .setSchema(schema).stripeSize(1000).bufferSize(100).version(fileFormat);
 
     CompressionCodec snappyCodec, zlibCodec;
     snappyCodec = writeBatchesAndGetCodec(10, 1000, opts.compress(CompressionKind.SNAPPY), batch);
@@ -2022,12 +2082,17 @@ public class TestVectorOrcFile {
     assertTrue(snappyCodec == codec || snappyCodec2 == codec);
   }
 
-  private CompressionCodec writeBatchesAndGetCodec(int count, int size, WriterOptions opts,
-      VectorizedRowBatch batch) throws IOException {
+  private CompressionCodec writeBatchesAndGetCodec(int count,
+                                                   int size,
+                                                   WriterOptions opts,
+                                                   VectorizedRowBatch batch
+                                                   ) throws IOException {
     fs.delete(testFilePath, false);
-    Writer writer = OrcFile.createWriter(testFilePath, opts);
+    PhysicalWriter physical = new PhysicalFsWriter(fs, testFilePath, opts);
+    CompressionCodec codec = physical.getCompressionCodec();
+    Writer writer = OrcFile.createWriter(testFilePath,
+        opts.physicalWriter(physical));
     writeRandomIntBytesBatches(writer, batch, count, size);
-    CompressionCodec codec = ((WriterImpl)writer).getCompressionCodec();
     writer.close();
     return codec;
   }
@@ -2076,7 +2141,8 @@ public class TestVectorOrcFile {
                                          .stripeSize(5000)
                                          .compress(CompressionKind.SNAPPY)
                                          .bufferSize(1000)
-                                         .rowIndexStride(0));
+                                         .rowIndexStride(0)
+                                         .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     Random rand = new Random(24);
     batch.size = 5;
@@ -2303,6 +2369,8 @@ public class TestVectorOrcFile {
 
   @Test
   public void testMemoryManagementV11() throws Exception {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
+
     TypeDescription schema = createInnerSchema();
     MyMemoryManager memory = new MyMemoryManager(conf, 10000, 0.1);
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -2313,7 +2381,7 @@ public class TestVectorOrcFile {
             .bufferSize(100)
             .rowIndexStride(0)
             .memory(memory)
-            .version(OrcFile.Version.V_0_11));
+            .version(fileFormat));
     assertEquals(testFilePath, memory.path);
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1;
@@ -2339,6 +2407,7 @@ public class TestVectorOrcFile {
 
   @Test
   public void testMemoryManagementV12() throws Exception {
+    Assume.assumeTrue(fileFormat != OrcFile.Version.V_0_11);
     TypeDescription schema = createInnerSchema();
     MyMemoryManager memory = new MyMemoryManager(conf, 10000, 0.1);
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -2349,7 +2418,7 @@ public class TestVectorOrcFile {
                                          .bufferSize(100)
                                          .rowIndexStride(0)
                                          .memory(memory)
-                                         .version(OrcFile.Version.V_0_12));
+                                         .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     assertEquals(testFilePath, memory.path);
     batch.size = 1;
@@ -2385,7 +2454,8 @@ public class TestVectorOrcFile {
             .stripeSize(400000L)
             .compress(CompressionKind.NONE)
             .bufferSize(500)
-            .rowIndexStride(1000));
+            .rowIndexStride(1000)
+            .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.ensureSize(3500);
     batch.size = 3500;
@@ -2510,7 +2580,8 @@ public class TestVectorOrcFile {
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
             .setSchema(schema)
-            .rowIndexStride(1000));
+            .rowIndexStride(1000)
+            .version(fileFormat));
 
     // write 1024 repeating nulls
     batch.size = 1024;
@@ -2802,8 +2873,7 @@ public class TestVectorOrcFile {
         .addField("char", TypeDescription.createChar().withMaxLength(10))
         .addField("varchar", TypeDescription.createVarchar().withMaxLength(10));
     Writer writer = OrcFile.createWriter(testFilePath,
-        OrcFile.writerOptions(conf)
-            .setSchema(schema));
+        OrcFile.writerOptions(conf).setSchema(schema).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 4;
     for(int c=0; c < batch.cols.length; ++c) {
@@ -2848,12 +2918,14 @@ public class TestVectorOrcFile {
    */
   @Test
   public void testNonDictionaryRepeatingString() throws Exception {
+    Assume.assumeTrue(fileFormat != OrcFile.Version.V_0_11);
     TypeDescription schema = TypeDescription.createStruct()
         .addField("str", TypeDescription.createString());
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
             .setSchema(schema)
-            .rowIndexStride(1000));
+            .rowIndexStride(1000)
+            .version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1024;
     for(int r=0; r < batch.size; ++r) {
@@ -2891,7 +2963,7 @@ public class TestVectorOrcFile {
         .addField("struct", TypeDescription.createStruct()
             .addField("inner", TypeDescription.createLong()));
     Writer writer = OrcFile.createWriter(testFilePath,
-        OrcFile.writerOptions(conf).setSchema(schema));
+        OrcFile.writerOptions(conf).setSchema(schema).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1024;
     StructColumnVector outer = (StructColumnVector) batch.cols[0];
@@ -2935,7 +3007,7 @@ public class TestVectorOrcFile {
             .addUnionChild(TypeDescription.createInt())
             .addUnionChild(TypeDescription.createLong()));
     Writer writer = OrcFile.createWriter(testFilePath,
-        OrcFile.writerOptions(conf).setSchema(schema));
+        OrcFile.writerOptions(conf).setSchema(schema).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1024;
     UnionColumnVector outer = (UnionColumnVector) batch.cols[0];
@@ -3010,7 +3082,7 @@ public class TestVectorOrcFile {
         .addField("list",
             TypeDescription.createList(TypeDescription.createLong()));
     Writer writer = OrcFile.createWriter(testFilePath,
-        OrcFile.writerOptions(conf).setSchema(schema));
+        OrcFile.writerOptions(conf).setSchema(schema).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1024;
     ListColumnVector list = (ListColumnVector) batch.cols[0];
@@ -3084,7 +3156,7 @@ public class TestVectorOrcFile {
             TypeDescription.createMap(TypeDescription.createLong(),
                 TypeDescription.createLong()));
     Writer writer = OrcFile.createWriter(testFilePath,
-        OrcFile.writerOptions(conf).setSchema(schema));
+        OrcFile.writerOptions(conf).setSchema(schema).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 1024;
     MapColumnVector map = (MapColumnVector) batch.cols[0];
@@ -3157,7 +3229,7 @@ public class TestVectorOrcFile {
             "struct<list1:array<string>," +
                     "list2:array<binary>>");
     Writer writer = OrcFile.createWriter(testFilePath,
-        OrcFile.writerOptions(conf).setSchema(schema));
+        OrcFile.writerOptions(conf).setSchema(schema).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 2;
     ListColumnVector list1 = (ListColumnVector) batch.cols[0];
@@ -3189,6 +3261,8 @@ public class TestVectorOrcFile {
 
   @Test
   public void testWriterVersion() throws Exception {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
+
     // test writer implementation serialization
     assertEquals(OrcFile.WriterImplementation.ORC_JAVA,
         OrcFile.WriterImplementation.from(0));
@@ -3232,6 +3306,7 @@ public class TestVectorOrcFile {
 
   @Test(expected=IllegalArgumentException.class)
   public void testBadPrestoVersion() {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
     OrcFile.WriterVersion.from(OrcFile.WriterImplementation.PRESTO, 0);
   }
 
@@ -3241,6 +3316,7 @@ public class TestVectorOrcFile {
    */
   @Test
   public void testFileVersion() throws Exception {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
     assertEquals(OrcFile.Version.V_0_11, ReaderImpl.getFileVersion(null));
     assertEquals(OrcFile.Version.V_0_11, ReaderImpl.getFileVersion(new ArrayList<Integer>()));
     assertEquals(OrcFile.Version.V_0_11,
@@ -3253,6 +3329,7 @@ public class TestVectorOrcFile {
 
   @Test
   public void testMergeUnderstood() throws Exception {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
     Path p = new Path("test.orc");
     Reader futureVersion = Mockito.mock(Reader.class);
     Mockito.when(futureVersion.getFileVersion()).thenReturn(OrcFile.Version.FUTURE);
@@ -3278,11 +3355,14 @@ public class TestVectorOrcFile {
 
   @Test
   public void testMerge() throws Exception {
-    Path input1 = new Path(workDir, "TestVectorOrcFile.testMerge1.orc");
+    Path input1 = new Path(workDir, "TestVectorOrcFile.testMerge1-" +
+        fileFormat.getName() + ".orc");
     fs.delete(input1, false);
-    Path input2 = new Path(workDir, "TestVectorOrcFile.testMerge2.orc");
+    Path input2 = new Path(workDir, "TestVectorOrcFile.testMerge2-" +
+        fileFormat.getName() + ".orc");
     fs.delete(input2, false);
-    Path input3 = new Path(workDir, "TestVectorOrcFile.testMerge3.orc");
+    Path input3 = new Path(workDir, "TestVectorOrcFile.testMerge3-" +
+        fileFormat.getName() + ".orc");
     fs.delete(input3, false);
     TypeDescription schema = TypeDescription.fromString("struct<a:int,b:string>");
     // change all of the options away from default to find anything we
@@ -3293,7 +3373,7 @@ public class TestVectorOrcFile {
         .enforceBufferSize()
         .bufferSize(20*1024)
         .rowIndexStride(1000)
-        .version(OrcFile.Version.V_0_11)
+        .version(fileFormat)
         .writerVersion(OrcFile.WriterVersion.HIVE_8732);
 
     Writer writer = OrcFile.createWriter(input1, opts);
@@ -3334,7 +3414,8 @@ public class TestVectorOrcFile {
     writer.addUserMetadata("d", fromString("bat"));
     writer.close();
 
-    Path output1 = new Path(workDir, "TestVectorOrcFile.testMerge.out1.orc");
+    Path output1 = new Path(workDir, "TestVectorOrcFile.testMerge.out1-" +
+        fileFormat.getName() + ".orc");
     fs.delete(output1, false);
     List<Path> paths = OrcFile.mergeFiles(output1,
         OrcFile.writerOptions(conf), Arrays.asList(input1, input2, input3));
@@ -3344,7 +3425,7 @@ public class TestVectorOrcFile {
     assertEquals(CompressionKind.LZO, reader.getCompressionKind());
     assertEquals(30 * 1024, reader.getCompressionSize());
     assertEquals(1000, reader.getRowIndexStride());
-    assertEquals(OrcFile.Version.V_0_11, reader.getFileVersion());
+    assertEquals(fileFormat, reader.getFileVersion());
     assertEquals(OrcFile.WriterVersion.HIVE_8732, reader.getWriterVersion());
     assertEquals(3, reader.getStripes().size());
     assertEquals(4, reader.getMetadataKeys().size());
@@ -3354,7 +3435,8 @@ public class TestVectorOrcFile {
     assertEquals(fromString("bat"), reader.getMetadataValue("d"));
 
     TypeDescription schema4 = TypeDescription.fromString("struct<a:int>");
-    Path input4 = new Path(workDir, "TestVectorOrcFile.testMerge4.orc");
+    Path input4 = new Path(workDir, "TestVectorOrcFile.testMerge4-" +
+        fileFormat.getName() + ".orc");
     fs.delete(input4, false);
     opts.setSchema(schema4);
     writer = OrcFile.createWriter(input4, opts);
@@ -3366,7 +3448,8 @@ public class TestVectorOrcFile {
     writer.addRowBatch(batch);
     writer.close();
 
-    Path input5 = new Path(workDir, "TestVectorOrcFile.testMerge5.orc");
+    Path input5 = new Path(workDir, "TestVectorOrcFile.testMerge5-" +
+        fileFormat.getName() + ".orc");
     fs.delete(input5, false);
     opts.setSchema(schema)
         .compress(CompressionKind.NONE)
@@ -3381,7 +3464,8 @@ public class TestVectorOrcFile {
     writer.addRowBatch(batch);
     writer.close();
 
-    Path output2 = new Path(workDir, "TestVectorOrcFile.testMerge.out2.orc");
+    Path output2 = new Path(workDir, "TestVectorOrcFile.testMerge.out2-" +
+        fileFormat.getName() + ".orc");
     fs.delete(output2, false);
     paths = OrcFile.mergeFiles(output2, OrcFile.writerOptions(conf),
         Arrays.asList(input3, input4, input1, input5));
@@ -3391,7 +3475,7 @@ public class TestVectorOrcFile {
     assertEquals(CompressionKind.LZO, reader.getCompressionKind());
     assertEquals(20 * 1024, reader.getCompressionSize());
     assertEquals(1000, reader.getRowIndexStride());
-    assertEquals(OrcFile.Version.V_0_11, reader.getFileVersion());
+    assertEquals(fileFormat, reader.getFileVersion());
     assertEquals(OrcFile.WriterVersion.HIVE_8732, reader.getWriterVersion());
     assertEquals(2, reader.getStripes().size());
     assertEquals(4, reader.getMetadataKeys().size());
@@ -3406,6 +3490,7 @@ public class TestVectorOrcFile {
 
   @Test
   public void testZeroByteOrcFile() throws Exception {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
     Path zeroFile = new Path(exampleDir, "zero.orc");
     Reader reader = OrcFile.createReader(zeroFile, OrcFile.readerOptions(conf));
     assertEquals(0, reader.getNumberOfRows());
@@ -3427,6 +3512,7 @@ public class TestVectorOrcFile {
 
   @Test
   public void testFutureOrcFile() throws Exception {
+    Assume.assumeTrue(fileFormat == OrcFile.Version.V_0_11);
     Path zeroFile = new Path(exampleDir, "version1999.orc");
     try {
       Reader reader = OrcFile.createReader(zeroFile, OrcFile.readerOptions(conf));
@@ -3446,7 +3532,7 @@ public class TestVectorOrcFile {
         TypeDescription.fromString("struct<list1:array<double>," +
             "list2:array<float>>");
     Writer writer = OrcFile.createWriter(testFilePath,
-        OrcFile.writerOptions(conf).setSchema(schema));
+        OrcFile.writerOptions(conf).setSchema(schema).version(fileFormat));
     VectorizedRowBatch batch = schema.createRowBatch();
     batch.size = 2;
     ListColumnVector list1 = (ListColumnVector) batch.cols[0];

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -10,7 +10,7 @@ developers on the project.
 
 The list of things that we plan to change:
 
-* Create a decimal representation with fixed scale using rle.
+* Move decimal encoding to RLEv3 and remove variable length encoding.
 * Create a better float/double encoding that splits mantissa and
   exponent.
 * Create a dictionary encoding for float, double, and decimal.
@@ -821,22 +821,19 @@ DIRECT_V2     | PRESENT         | Yes      | Boolean RLE
 
 ## Decimal Columns
 
-Decimal was introduced in Hive 0.11 with infinite precision (the total
-number of digits). In Hive 0.13, the definition was change to limit
-the precision to a maximum of 38 digits, which conveniently uses 127
-bits plus a sign bit. The current encoding of decimal columns stores
-the integer representation of the value as an unbounded length zigzag
-encoded base 128 varint. The scale is stored in the SECONDARY stream
-as an signed integer.
+Since Hive 0.13, all decimals have had fixed precision and scale.
+The goal is to use RLEv3 for the value and use the fixed scale from
+the type. As an interim solution, we are using RLE v2 for short decimals
+(precision <= 18) and the old encoding for long decimals.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------
 DIRECT        | PRESENT         | Yes      | Boolean RLE
-              | DATA            | No       | Unbounded base 128 varints
-              | SECONDARY       | No       | Unsigned Integer RLE v1
+              | DATA            | No       | Signed Integer RLE v2
 DIRECT_V2     | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unbounded base 128 varints
               | SECONDARY       | No       | Unsigned Integer RLE v2
+
 
 ## Date Columns
 


### PR DESCRIPTION
Create the first pass of the new decimal encoding for ORCv2. For small decimals, it uses RLEv2 and the old format for long decimals.