### PR TITLE
ORC-248. PhysicalFsWriter sometimes passes negative padding down to shims

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -152,7 +152,10 @@ public enum OrcConf {
   OVERWRITE_OUTPUT_FILE("orc.overwrite.output.file", "orc.overwrite.output.file", false,
     "A boolean flag to enable overwriting of the output file if it already exists.\n"),
   IS_SCHEMA_EVOLUTION_CASE_SENSITIVE("orc.schema.evolution.case.sensitive", "orc.schema.evolution.case.sensitive", true,
-          "A boolean flag to determine if the comparision of field names in schema evolution is case sensitive .\n")
+          "A boolean flag to determine if the comparision of field names in schema evolution is case sensitive .\n"),
+  WRITE_VARIABLE_LENGTH_BLOCKS("orc.write.variable.length.blocks", null, false,
+      "A boolean flag as to whether the ORC writer should write variable length\n"
+      + "HDFS blocks.")
   ;
 
   private final String attribute;

--- a/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import org.apache.orc.CompressionKind;
+import org.apache.orc.OrcFile;
+import org.apache.orc.OrcProto;
+import org.apache.orc.PhysicalWriter;
+import org.apache.orc.TypeDescription;
+import org.junit.Test;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestPhysicalFsWriter {
+
+  final Configuration conf = new Configuration();
+
+  static class MemoryOutputStream extends OutputStream {
+    private final List<byte[]> contents;
+
+    MemoryOutputStream(List<byte[]> contents) {
+      this.contents = contents;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      contents.add(new byte[]{(byte) b});
+    }
+
+    @Override
+    public void write(byte[] a, int offset, int length) {
+      byte[] buffer = new byte[length];
+      System.arraycopy(a, offset, buffer, 0, length);
+      contents.add(buffer);
+    }
+  }
+
+  static class MemoryFileSystem extends FileSystem {
+
+    @Override
+    public URI getUri() {
+      try {
+        return new URI("test:///");
+      } catch (URISyntaxException e) {
+        throw new IllegalStateException("bad url", e);
+      }
+    }
+
+    @Override
+    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+      return null;
+    }
+
+    @Override
+    public FSDataOutputStream create(Path f, FsPermission permission,
+                                     boolean overwrite, int bufferSize,
+                                     short replication, long blockSize,
+                                     Progressable progress) throws IOException {
+      List<byte[]> contents = new ArrayList<>();
+      fileContents.put(f, contents);
+      return new FSDataOutputStream(new MemoryOutputStream(contents));
+    }
+
+    @Override
+    public FSDataOutputStream append(Path f, int bufferSize,
+                                     Progressable progress) throws IOException {
+      throw new UnsupportedOperationException("append not supported");
+    }
+
+    @Override
+    public boolean rename(Path src, Path dst) throws IOException {
+      boolean result = fileContents.containsKey(src) &&
+          !fileContents.containsKey(dst);
+      if (result) {
+        List<byte[]> contents = fileContents.remove(src);
+        fileContents.put(dst, contents);
+      }
+      return result;
+    }
+
+    @Override
+    public boolean delete(Path f, boolean recursive) throws IOException {
+      boolean result = fileContents.containsKey(f);
+      fileContents.remove(f);
+      return result;
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path f) throws IOException {
+      return new FileStatus[]{getFileStatus(f)};
+    }
+
+    @Override
+    public void setWorkingDirectory(Path new_dir) {
+      currentWorkingDirectory = new_dir;
+    }
+
+    @Override
+    public Path getWorkingDirectory() {
+      return currentWorkingDirectory;
+    }
+
+    @Override
+    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+      return false;
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path f) throws IOException {
+      List<byte[]> contents = fileContents.get(f);
+      if (contents != null) {
+        long sum = 0;
+        for(byte[] b: contents) {
+          sum += b.length;
+        }
+        return new FileStatus(sum, false, 1, 256 * 1024, 0, f);
+      }
+      return null;
+    }
+
+    private final Map<Path, List<byte[]>> fileContents = new HashMap<>();
+    private Path currentWorkingDirectory = new Path("/");
+  }
+
+  @Test
+  public void testStripePadding() throws IOException {
+    TypeDescription schema = TypeDescription.fromString("int");
+    OrcFile.WriterOptions opts =
+        OrcFile.writerOptions(conf)
+            .stripeSize(32 * 1024)
+            .blockSize(64 * 1024)
+            .compress(CompressionKind.NONE)
+            .setSchema(schema);
+    MemoryFileSystem fs = new MemoryFileSystem();
+    PhysicalFsWriter writer = new PhysicalFsWriter(fs, new Path("test1.orc"),
+        opts);
+    writer.writeHeader();
+    StreamName stream0 = new StreamName(0, OrcProto.Stream.Kind.DATA);
+    PhysicalWriter.OutputReceiver output = writer.createDataStream(stream0);
+    byte[] buffer = new byte[1024];
+    for(int i=0; i < buffer.length; ++i) {
+      buffer[i] = (byte) i;
+    }
+    for(int i=0; i < 63; ++i) {
+      output.output(ByteBuffer.wrap(buffer));
+    }
+    OrcProto.StripeFooter.Builder footer = OrcProto.StripeFooter.newBuilder();
+    OrcProto.StripeInformation.Builder dirEntry =
+        OrcProto.StripeInformation.newBuilder();
+    writer.finalizeStripe(footer, dirEntry);
+    // check to make sure that it laid it out without padding
+    assertEquals(0L, dirEntry.getIndexLength());
+    assertEquals(63 * 1024L, dirEntry.getDataLength());
+    assertEquals(3, dirEntry.getOffset());
+    for(int i=0; i < 62; ++i) {
+      output.output(ByteBuffer.wrap(buffer));
+    }
+    footer = OrcProto.StripeFooter.newBuilder();
+    dirEntry = OrcProto.StripeInformation.newBuilder();
+    writer.finalizeStripe(footer, dirEntry);
+    // the second one should pad
+    assertEquals(64 * 1024, dirEntry.getOffset());
+    assertEquals(62 * 1024, dirEntry.getDataLength());
+    long endOfStripe = dirEntry.getOffset() + dirEntry.getIndexLength() +
+        dirEntry.getDataLength() + dirEntry.getFooterLength();
+
+    for(int i=0; i < 3; ++i) {
+      output.output(ByteBuffer.wrap(buffer));
+    }
+    footer = OrcProto.StripeFooter.newBuilder();
+    dirEntry = OrcProto.StripeInformation.newBuilder();
+    writer.finalizeStripe(footer, dirEntry);
+    // the third one should be over the padding limit
+    assertEquals(endOfStripe, dirEntry.getOffset());
+    assertEquals(3 * 1024, dirEntry.getDataLength());
+  }
+
+  @Test
+  public void testNoStripePadding() throws IOException {
+    TypeDescription schema = TypeDescription.fromString("int");
+    OrcFile.WriterOptions opts =
+        OrcFile.writerOptions(conf)
+            .blockPadding(false)
+            .stripeSize(32 * 1024)
+            .blockSize(64 * 1024)
+            .compress(CompressionKind.NONE)
+            .setSchema(schema);
+    MemoryFileSystem fs = new MemoryFileSystem();
+    PhysicalFsWriter writer = new PhysicalFsWriter(fs, new Path("test1.orc"),
+        opts);
+    writer.writeHeader();
+    StreamName stream0 = new StreamName(0, OrcProto.Stream.Kind.DATA);
+    PhysicalWriter.OutputReceiver output = writer.createDataStream(stream0);
+    byte[] buffer = new byte[1024];
+    for(int i=0; i < buffer.length; ++i) {
+      buffer[i] = (byte) i;
+    }
+    for(int i=0; i < 63; ++i) {
+      output.output(ByteBuffer.wrap(buffer));
+    }
+    OrcProto.StripeFooter.Builder footer = OrcProto.StripeFooter.newBuilder();
+    OrcProto.StripeInformation.Builder dirEntry =
+        OrcProto.StripeInformation.newBuilder();
+    writer.finalizeStripe(footer, dirEntry);
+    // check to make sure that it laid it out without padding
+    assertEquals(0L, dirEntry.getIndexLength());
+    assertEquals(63 * 1024L, dirEntry.getDataLength());
+    assertEquals(3, dirEntry.getOffset());
+    long endOfStripe = dirEntry.getOffset() + dirEntry.getDataLength()
+        + dirEntry.getFooterLength();
+    for(int i=0; i < 62; ++i) {
+      output.output(ByteBuffer.wrap(buffer));
+    }
+    footer = OrcProto.StripeFooter.newBuilder();
+    dirEntry = OrcProto.StripeInformation.newBuilder();
+    writer.finalizeStripe(footer, dirEntry);
+    // no padding, because we turned it off
+    assertEquals(endOfStripe, dirEntry.getOffset());
+    assertEquals(62 * 1024, dirEntry.getDataLength());
+  }
+
+  static class MockHadoopShim implements HadoopShims {
+    long lastShortBlock = -1;
+
+    @Override
+    public DirectDecompressor getDirectDecompressor(DirectCompressionType codec) {
+      return null;
+    }
+
+    @Override
+    public ZeroCopyReaderShim getZeroCopyReader(FSDataInputStream in, ByteBufferPoolShim pool) throws IOException {
+      return null;
+    }
+
+    @Override
+    public boolean endVariableLengthBlock(OutputStream output) throws IOException {
+      if (output instanceof FSDataOutputStream) {
+        lastShortBlock = ((FSDataOutputStream) output).getPos();
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public KeyProvider getKeyProvider(Configuration conf, Random random) throws IOException {
+      return null;
+    }
+  }
+
+  @Test
+  public void testShortBlock() throws IOException {
+    MockHadoopShim shim = new MockHadoopShim();
+    TypeDescription schema = TypeDescription.fromString("int");
+    OrcFile.WriterOptions opts =
+        OrcFile.writerOptions(conf)
+            .blockPadding(false)
+            .stripeSize(32 * 1024)
+            .blockSize(64 * 1024)
+            .compress(CompressionKind.NONE)
+            .setSchema(schema)
+            .setShims(shim)
+            .writeVariableLengthBlocks(true);
+    MemoryFileSystem fs = new MemoryFileSystem();
+    PhysicalFsWriter writer = new PhysicalFsWriter(fs, new Path("test1.orc"),
+        opts);
+    writer.writeHeader();
+    StreamName stream0 = new StreamName(0, OrcProto.Stream.Kind.DATA);
+    PhysicalWriter.OutputReceiver output = writer.createDataStream(stream0);
+    byte[] buffer = new byte[1024];
+    for(int i=0; i < buffer.length; ++i) {
+      buffer[i] = (byte) i;
+    }
+    for(int i=0; i < 63; ++i) {
+      output.output(ByteBuffer.wrap(buffer));
+    }
+    OrcProto.StripeFooter.Builder footer = OrcProto.StripeFooter.newBuilder();
+    OrcProto.StripeInformation.Builder dirEntry =
+        OrcProto.StripeInformation.newBuilder();
+    writer.finalizeStripe(footer, dirEntry);
+    // check to make sure that it laid it out without padding
+    assertEquals(0L, dirEntry.getIndexLength());
+    assertEquals(63 * 1024L, dirEntry.getDataLength());
+    assertEquals(3, dirEntry.getOffset());
+    long endOfStripe = dirEntry.getOffset() + dirEntry.getDataLength()
+        + dirEntry.getFooterLength();
+    for(int i=0; i < 62; ++i) {
+      output.output(ByteBuffer.wrap(buffer));
+    }
+    footer = OrcProto.StripeFooter.newBuilder();
+    dirEntry = OrcProto.StripeInformation.newBuilder();
+    writer.finalizeStripe(footer, dirEntry);
+    // we should get a short block and no padding
+    assertEquals(endOfStripe, dirEntry.getOffset());
+    assertEquals(62 * 1024, dirEntry.getDataLength());
+    assertEquals(endOfStripe, shim.lastShortBlock);
+  }
+}

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -116,11 +116,12 @@ public interface HadoopShims {
   }
 
   /**
-   * Allow block boundaries to be reached by zero-fill or variable length block
-   * markers (in HDFS).
-   * @return the number of bytes written
+   * End the OutputStream's current block at the current location.
+   * This is only available on HDFS on Hadoop >= 2.7, but will return false
+   * otherwise.
+   * @return was a variable length block created?
    */
-  long padStreamToBlock(OutputStream output, long padding) throws IOException;
+  boolean endVariableLengthBlock(OutputStream output) throws IOException;
 
   /**
    * A source of crypto keys. This is usually backed by a Ranger KMS.

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
@@ -49,15 +49,13 @@ public class HadoopShimsCurrent implements HadoopShims {
   }
 
   @Override
-  public long padStreamToBlock(OutputStream output,
-                               long padding) throws IOException {
+  public boolean endVariableLengthBlock(OutputStream output) throws IOException {
     if (output instanceof HdfsDataOutputStream) {
-      ((HdfsDataOutputStream) output).hsync(
-          EnumSet.of(HdfsDataOutputStream.SyncFlag.END_BLOCK));
-      return 0; // no padding
-    } else {
-      return HadoopShimsPre2_3.padStream(output, padding);
+      HdfsDataOutputStream hdfs = (HdfsDataOutputStream) output;
+      hdfs.hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.END_BLOCK));
+      return true;
     }
+    return false;
   }
 
   @Override

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
@@ -49,22 +49,9 @@ public class HadoopShimsPre2_3 implements HadoopShims {
     return null;
   }
 
-  private static final int BUFFER_SIZE = 256  * 1024;
-
-  static long padStream(OutputStream output,
-                        long padding) throws IOException {
-    byte[] pad = new byte[(int) Math.min(BUFFER_SIZE, padding)]; // always clear
-    while (padding > 0) {
-      int writeLen = (int) Math.min(padding, pad.length);
-      output.write(pad, 0, writeLen);
-      padding -= writeLen;
-    }
-    return padding;
-  }
-
   @Override
-  public long padStreamToBlock(OutputStream output, long padding) throws IOException {
-    return padStream(output, padding);
+  public boolean endVariableLengthBlock(OutputStream output) {
+    return false;
   }
 
   @Override

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
@@ -124,9 +124,8 @@ public class HadoopShimsPre2_6 implements HadoopShims {
   }
 
   @Override
-  public long padStreamToBlock(OutputStream output,
-                               long padding) throws IOException {
-    return HadoopShimsPre2_3.padStream(output, padding);
+  public boolean endVariableLengthBlock(OutputStream output) {
+    return false;
   }
 
   @Override

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -60,9 +60,8 @@ public class HadoopShimsPre2_7 implements HadoopShims {
   }
 
   @Override
-  public long padStreamToBlock(OutputStream output,
-                               long padding) throws IOException {
-    return HadoopShimsPre2_3.padStream(output, padding);
+  public boolean endVariableLengthBlock(OutputStream output) {
+    return false;
   }
 
   static String buildKeyVersionName(KeyMetadata key) {

--- a/site/_docs/hive-config.md
+++ b/site/_docs/hive-config.md
@@ -179,4 +179,11 @@ There are many Hive configuration properties related to ORC files:
       the compression level of higher level compression codec. Value can be
       SPEED or COMPRESSION.</td>
 </tr>
+<tr>
+  <td>orc.write.variable.length.blocks</td>
+  <td>false</td>
+  <td>Should the ORC writer use HDFS variable length blocks, if they are
+      available? If the new stripe would straddle a block, Hadoop is &ge; 2.7,
+      and this is enabled, it will end the block before the new stripe.</td>
+</tr>
 </table>


### PR DESCRIPTION
The PhysicalFsWriter sometimes pass down negative sizes for padding, which leads to exceptions.

My fix:
* Add a new option to enable writing variable length HDFS blocks "orc.write.shortened.blocks", which is off by default.
* Modified the shim to shortenBlock so that the PhysicalFsWriter can track the offsets.
* shortenBlock isn't gated by the padding tolerance, although it is called when the new stripe would cross a block boundary.