### PR TITLE
ORC-360. Add Java error checking on the types when reading.

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcUtils.java
+++ b/java/core/src/java/org/apache/orc/OrcUtils.java
@@ -19,6 +19,7 @@ package org.apache.orc;
 
 import org.apache.orc.impl.ReaderImpl;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -245,7 +246,7 @@ public class OrcUtils {
       {
         // Make room for MAP type.
         result.add(null);
-  
+
         // Add MAP type pair in order to determine their subtype values.
         appendOrcTypesRebuildSubtypes(result, children.get(0));
         int subtype2 = result.size();
@@ -383,7 +384,7 @@ public class OrcUtils {
       {
         // Make room for MAP type.
         result.add(null);
-  
+
         // Add MAP type pair in order to determine their subtype values.
         columnId = appendOrcTypesRebuildSubtypes(result, types, columnId);
         int subtype2 = result.size();
@@ -450,6 +451,57 @@ public class OrcUtils {
     return columnId;
   }
 
+  /**
+   * Checks whether the list of protobuf types from the file are valid or not.
+   * @param types the list of types from the protobuf
+   * @param root the top of the tree to check
+   * @return the next available id
+   * @throws java.io.IOException if the tree is invalid
+   */
+  public static int isValidTypeTree(List<OrcProto.Type> types,
+                                    int root) throws IOException  {
+    if (root < 0 || root >= types.size()) {
+      throw new IOException("Illegal type id " + root +
+          ". The valid range is 0 to " + (types.size() - 1));
+    }
+    OrcProto.Type rootType = types.get(root);
+    int current = root+1;
+    List<Integer> children = rootType.getSubtypesList();
+    if (!rootType.hasKind()) {
+      throw new IOException("Type " + root + " has an unknown kind.");
+    }
+    // ensure that we have the right number of children
+    switch(rootType.getKind()) {
+      case LIST:
+        if (children == null || children.size() != 1) {
+          throw new IOException("Wrong number of type children in list " + root);
+        }
+        break;
+      case MAP:
+        if (children == null || children.size() != 2) {
+          throw new IOException("Wrong number of type children in map " + root);
+        }
+        break;
+      case UNION:
+      case STRUCT:
+        break;
+      default:
+        if (children != null && children.size() != 0) {
+          throw new IOException("Type children under primitive type " + root);
+        }
+    }
+    // ensure the children are also correct
+    if (children != null) {
+      for(int child: children) {
+        if (child != current) {
+          throw new IOException("Unexpected child type id " + child + " when " +
+              current + " was expected.");
+        }
+        current = isValidTypeTree(types, current);
+      }
+    }
+    return current;
+  }
   /**
    * Translate the given rootColumn from the list of types to a TypeDescription.
    * @param types all of the types

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -387,6 +387,7 @@ public class ReaderImpl implements Reader {
       this.stripes = tail.getStripes();
       this.stripeStats = tail.getStripeStatisticsProto();
     }
+    OrcUtils.isValidTypeTree(this.types, 0);
     this.schema = OrcUtils.convertTypeFromProtobuf(this.types, 0);
   }
 


### PR DESCRIPTION
This patch adds a check on the types in the footer to ensure that the type is properly formed before we start building the tree.