### PR TITLE
ORC-373: Option to disable dictionary encoding

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -43,6 +43,7 @@ import org.apache.orc.StripeInformation;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.impl.writer.TreeWriter;
+import org.apache.orc.impl.writer.TreeWriterBase;
 import org.apache.orc.impl.writer.WriterContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -681,5 +682,13 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
       }
     }
     return false;
+  }
+
+  // This is just for testing purpose and is not exposed via TreeWriter interface
+  public int getDictionaryFlushCount() {
+    if (treeWriter == null || !(treeWriter instanceof TreeWriterBase)) {
+      return -1;
+    }
+    return ((TreeWriterBase) treeWriter).getDictionaryFlushCount();
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
@@ -81,6 +81,10 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
     strideDictionaryCheck =
         OrcConf.ROW_INDEX_STRIDE_DICTIONARY_CHECK.getBoolean(conf);
     doneDictionaryCheck = false;
+    if (dictionaryKeySizeThreshold <= 0.0) {
+      useDictionaryEncoding = false;
+      doneDictionaryCheck = true;
+    }
   }
 
   private void checkDictionaryEncoding() {

--- a/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
@@ -132,6 +132,7 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
     final int[] dumpOrder = new int[dictionary.size()];
 
     if (useDictionaryEncoding) {
+      dictionaryFlushCount++;
       // Write the dictionary by traversing the red-black tree writing out
       // the bytes and lengths; and creating the map from the original order
       // to the final sorted order.

--- a/java/core/src/java/org/apache/orc/impl/writer/TreeWriterBase.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/TreeWriterBase.java
@@ -18,6 +18,9 @@
 
 package org.apache.orc.impl.writer;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
@@ -35,9 +38,6 @@ import org.apache.orc.impl.StreamName;
 import org.apache.orc.util.BloomFilter;
 import org.apache.orc.util.BloomFilterIO;
 import org.apache.orc.util.BloomFilterUtf8;
-
-import java.io.IOException;
-import java.util.List;
 
 /**
  * The parent class of all of the writers for each column. Each column
@@ -65,6 +65,7 @@ public abstract class TreeWriterBase implements TreeWriter {
   private OutStream isPresentOutStream;
   private final WriterContext streamFactory;
   private final TypeDescription schema;
+  protected int dictionaryFlushCount = 0;
 
   /**
    * Create a tree writer.
@@ -384,5 +385,9 @@ public abstract class TreeWriterBase implements TreeWriter {
     public void addPosition(long position) {
       builder.addPositions(position);
     }
+  }
+
+  public int getDictionaryFlushCount() {
+    return dictionaryFlushCount;
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/WriterImplV2.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/WriterImplV2.java
@@ -624,4 +624,12 @@ public class WriterImplV2 implements WriterInternal, MemoryManager.Callback {
     }
     return false;
   }
+
+  // This is just for testing purpose and is not exposed via TreeWriter interface
+  public int getDictionaryFlushCount() {
+    if (treeWriter == null || !(treeWriter instanceof TreeWriterBase)) {
+      return -1;
+    }
+    return ((TreeWriterBase) treeWriter).getDictionaryFlushCount();
+  }
 }


### PR DESCRIPTION
disables dictionary encoding at the time of string tree writer initialization.