### PR TITLE
ORC-388: Fix isSafeSubtract to use logic operator instead of bit operator

### DIFF
--- a/c++/src/RLEV2Util.hh
+++ b/c++/src/RLEV2Util.hh
@@ -134,7 +134,7 @@ namespace orc {
   }
 
   inline bool isSafeSubtract(int64_t left, int64_t right) {
-    return ((left ^ right) >= 0) | ((left ^ (left - right)) >= 0);
+    return ((left ^ right) >= 0) || ((left ^ (left - right)) >= 0);
   }
 
   inline uint32_t RleEncoderV2::getOpCode(EncodingType encoding) {

--- a/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
@@ -1309,7 +1309,7 @@ public final class SerializationUtils {
   // Do not want to use Guava LongMath.checkedSubtract() here as it will throw
   // ArithmeticException in case of overflow
   public boolean isSafeSubtract(long left, long right) {
-    return (left ^ right) >= 0 | (left ^ (left - right)) >= 0;
+    return (left ^ right) >= 0 || (left ^ (left - right)) >= 0;
   }
 
   public static long convertFromUtc(TimeZone local, long time) {


### PR DESCRIPTION
Both java and c++ have this issue.