### PR TITLE
ORC-363: Enable zstd for java writer/reader

### DIFF
--- a/java/core/src/java/org/apache/orc/CompressionKind.java
+++ b/java/core/src/java/org/apache/orc/CompressionKind.java
@@ -23,5 +23,5 @@ package org.apache.orc;
  * can be applied to ORC files.
  */
 public enum CompressionKind {
-  NONE, ZLIB, SNAPPY, LZO, LZ4
+  NONE, ZLIB, SNAPPY, LZO, LZ4, ZSTD
 }

--- a/java/core/src/java/org/apache/orc/impl/HadoopShimsFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/HadoopShimsFactory.java
@@ -30,6 +30,8 @@ public class HadoopShimsFactory {
       "org.apache.orc.impl.HadoopShimsPre2_6";
   private static final String PRE_2_7_SHIM_NAME =
       "org.apache.orc.impl.HadoopShimsPre2_7";
+  private static final String PRE_2_9_SHIM_NAME =
+      "org.apache.orc.impl.HadoopShimsPre2_9";
 
   private static HadoopShims SHIMS = null;
 
@@ -58,6 +60,8 @@ public class HadoopShimsFactory {
         SHIMS = createShimByName(PRE_2_6_SHIM_NAME);
       } else if (major == 2 && minor < 7) {
         SHIMS = createShimByName(PRE_2_7_SHIM_NAME);
+      } else if (major == 2 && minor < 9) {
+        SHIMS = createShimByName(PRE_2_9_SHIM_NAME);
       } else {
         SHIMS = createShimByName(CURRENT_SHIM_NAME);
       }

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -411,6 +411,7 @@ public class ReaderImpl implements Reader {
       case SNAPPY:
       case LZO:
       case LZ4:
+      case ZSTD:
         break;
       default:
         throw new IllegalArgumentException("Unknown compression");

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -249,6 +249,8 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
       case LZ4:
         return new AircompressorCodec(kind, new Lz4Compressor(),
             new Lz4Decompressor());
+      case ZSTD:
+        return new ZstdCodec();
       default:
         throw new IllegalArgumentException("Unknown compression codec: " +
             kind);

--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -25,13 +25,31 @@ import org.apache.orc.CompressionCodec;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.EnumSet;
 
 public class ZstdCodec implements DirectDecompressionCodec {
   private static final HadoopShims SHIMS = HadoopShimsFactory.get();
   // Note: shim path does not care about levels and strategies (only used for decompression).
   private HadoopShims.DirectDecompressor decompressShim = null;
   private Boolean direct = null;
+
+  /**
+   * Return an options object that doesn't do anything
+   * @return a new options object
+   */
+  @Override
+  public Options createOptions() {
+    return new Options() {
+      @Override
+      public Options setSpeed(SpeedModifier newValue) {
+        return this;
+      }
+
+      @Override
+      public Options setData(DataKind newValue) {
+        return this;
+      }
+    };
+  }
 
   private final org.apache.hadoop.io.compress.CompressionCodec zstdCodec;
 
@@ -41,7 +59,8 @@ public class ZstdCodec implements DirectDecompressionCodec {
   }
 
   @Override
-  public boolean compress(ByteBuffer in, ByteBuffer out, ByteBuffer overflow)
+  public boolean compress(ByteBuffer in, ByteBuffer out, ByteBuffer overflow,
+                          Options options)
           throws IOException {
     int length = in.remaining();
     int outSize = 0;
@@ -136,12 +155,6 @@ public class ZstdCodec implements DirectDecompressionCodec {
     if (decompressShim != null) {
       decompressShim.end();
     }
-  }
-
-  @Override
-  public CompressionCodec modify(EnumSet<Modifier> modifiers) {
-    // zstd allows no modifications
-    return this;
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.io.compress.Compressor;
+import org.apache.hadoop.io.compress.Decompressor;
+import org.apache.orc.CompressionKind;
+import org.apache.orc.CompressionCodec;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.EnumSet;
+
+public class ZstdCodec implements DirectDecompressionCodec {
+  private static final HadoopShims SHIMS = HadoopShimsFactory.get();
+  // Note: shim path does not care about levels and strategies (only used for decompression).
+  private HadoopShims.DirectDecompressor decompressShim = null;
+  private Boolean direct = null;
+
+  private final org.apache.hadoop.io.compress.CompressionCodec zstdCodec;
+
+  public ZstdCodec() {
+    // create a default zstd codec
+    zstdCodec = SHIMS.createZstdCodec();
+  }
+
+  @Override
+  public boolean compress(ByteBuffer in, ByteBuffer out, ByteBuffer overflow)
+          throws IOException {
+    int length = in.remaining();
+    int outSize = 0;
+    Compressor compressor = zstdCodec.createCompressor();
+    try {
+      compressor.setInput(in.array(), in.arrayOffset() + in.position(), length);
+      compressor.finish();
+      int offset = out.arrayOffset() + out.position();
+      while (!compressor.finished() && (length > outSize)) {
+        int size = compressor.compress(out.array(), offset, out.remaining());
+        out.position(size + out.position());
+        outSize += size;
+        offset += size;
+        // if we run out of space in the out buffer, use the overflow
+        if (out.remaining() == 0) {
+          if (overflow == null) {
+            return false;
+          }
+          out = overflow;
+          offset = out.arrayOffset() + out.position();
+        }
+      }
+    } finally {
+      compressor.end();
+    }
+    return length > outSize;
+  }
+
+  @Override
+  public void decompress(ByteBuffer in, ByteBuffer out)
+          throws IOException {
+    if (in.isDirect() && out.isDirect()) {
+      directDecompress(in, out);
+      return;
+    }
+
+    Decompressor decompressor = zstdCodec.createDecompressor();
+    try {
+      decompressor.setInput(in.array(), in.arrayOffset() + in.position(),
+              in.remaining());
+      while (!(decompressor.finished() || decompressor.needsDictionary() ||
+              decompressor.needsInput())) {
+        int count = decompressor.decompress(out.array(),
+                out.arrayOffset() + out.position(),
+                out.remaining());
+        out.position(count + out.position());
+      }
+      out.flip();
+    } finally {
+      decompressor.end();
+    }
+    in.position(in.limit());
+  }
+
+  @Override
+  public boolean isAvailable() {
+    if (direct == null) {
+      // see nowrap option in new Inflater(boolean) which disables zlib headers
+      try {
+        ensureShim();
+        direct = (decompressShim != null);
+      } catch (UnsatisfiedLinkError ule) {
+        direct = Boolean.valueOf(false);
+      }
+    }
+    return direct.booleanValue();
+  }
+
+  private void ensureShim() {
+    if (decompressShim == null) {
+      decompressShim = SHIMS.getDirectDecompressor(
+              HadoopShims.DirectCompressionType.ZSTD);
+    }
+  }
+
+  @Override
+  public void directDecompress(ByteBuffer in, ByteBuffer out) throws IOException {
+    ensureShim();
+    decompressShim.decompress(in, out);
+    out.flip(); // flip for read
+  }
+
+  @Override
+  public void reset() {
+    if (decompressShim != null) {
+      decompressShim.reset();
+    }
+  }
+
+  @Override
+  public void close() {
+    if (decompressShim != null) {
+      decompressShim.end();
+    }
+  }
+
+  @Override
+  public CompressionCodec modify(EnumSet<Modifier> modifiers) {
+    // zstd allows no modifications
+    return this;
+  }
+
+  @Override
+  public CompressionKind getKind() {
+    return CompressionKind.ZSTD;
+  }
+}

--- a/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.util.Progressable;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
@@ -277,6 +278,11 @@ public class TestPhysicalFsWriter {
 
     @Override
     public KeyProvider getKeyProvider(Configuration conf, Random random) throws IOException {
+      return null;
+    }
+
+    @Override
+    public CompressionCodec createZstdCodec() {
       return null;
     }
   }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -69,7 +69,7 @@
     <example.dir>${project.basedir}/../../examples</example.dir>
 
     <min.hadoop.version>2.2.0</min.hadoop.version>
-    <hadoop.version>2.7.3</hadoop.version>
+    <hadoop.version>2.9.0</hadoop.version>
     <storage-api.version>2.6.0</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.orc.EncryptionAlgorithm;
 
 import java.io.Closeable;
@@ -37,6 +38,7 @@ public interface HadoopShims {
     ZLIB_NOHEADER,
     ZLIB,
     SNAPPY,
+    ZSTD
   }
 
   interface DirectDecompressor {
@@ -242,4 +244,9 @@ public interface HadoopShims {
   KeyProvider getKeyProvider(Configuration conf,
                              Random random) throws IOException;
 
+  /**
+   * Create a ZstdCodec
+   * @return ZstdCodec
+   */
+  CompressionCodec createZstdCodec();
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
@@ -103,6 +103,8 @@ public class HadoopShimsCurrent implements HadoopShims {
   public CompressionCodec createZstdCodec() {
     // check if native zstd library is loaded; otherwise RuntimeException will be thrown
     ZStandardCodec.checkNativeCodeLoaded();
-    return new ZStandardCodec();
+    ZStandardCodec zStandardCodec = new ZStandardCodec();
+    zStandardCodec.setConf(new Configuration());
+    return zStandardCodec;
   }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.io.compress.CompressionCodec;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -80,5 +81,10 @@ public class HadoopShimsPre2_3 implements HadoopShims {
     public Key decryptLocalKey(KeyMetadata key, byte[] encryptedKey) {
       return null;
     }
+  }
+
+  @Override
+  public CompressionCodec createZstdCodec() {
+    return null;
   }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.snappy.SnappyDecompressor.SnappyDirectDecompressor;
 import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
 
@@ -131,5 +132,10 @@ public class HadoopShimsPre2_6 implements HadoopShims {
   @Override
   public KeyProvider getKeyProvider(Configuration conf, Random random) {
     return new HadoopShimsPre2_3.NullKeyProvider();
+  }
+
+  @Override
+  public CompressionCodec createZstdCodec() {
+    return null;
   }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.crypto.key.KeyProviderFactory;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.orc.EncryptionAlgorithm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -220,5 +221,10 @@ public class HadoopShimsPre2_7 implements HadoopShims {
   public KeyProvider getKeyProvider(Configuration conf,
                                     Random random) throws IOException {
     return createKeyProvider(conf, random);
+  }
+
+  @Override
+  public CompressionCodec createZstdCodec() {
+    return null;
   }
 }


### PR DESCRIPTION
Use org.apache.hadoop.io.compress.ZStandardCodec in hadoop 2.9.0