### PR TITLE
Covert tool should create a lowercase schema

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
@@ -51,6 +51,7 @@ public class ConvertTool {
 
   private final List<FileInformation> fileList;
   private final TypeDescription schema;
+  private final TypeDescription lowerSchema;
   private final char csvSeparator;
   private final char csvQuote;
   private final char csvEscape;
@@ -181,8 +182,10 @@ public class ConvertTool {
     fileList = buildFileList(opts.getArgs(), conf);
     if (opts.hasOption('s')) {
       this.schema = TypeDescription.fromString(opts.getOptionValue('s'));
+      this.lowerSchema = TypeDescription.fromString(opts.getOptionValue('s').toLowerCase());
     } else {
       this.schema = buildSchema(fileList, conf);
+      this.lowerSchema = this.schema;
     }
     this.csvQuote = getCharOption(opts, 'q', '"');
     this.csvEscape = getCharOption(opts, 'e', '\\');
@@ -193,8 +196,8 @@ public class ConvertTool {
     String outFilename = opts.hasOption('o')
         ? opts.getOptionValue('o') : "output.orc";
     writer = OrcFile.createWriter(new Path(outFilename),
-        OrcFile.writerOptions(conf).setSchema(schema));
-    batch = schema.createRowBatch();
+        OrcFile.writerOptions(conf).setSchema(lowerSchema));
+    batch = lowerSchema.createRowBatch();
   }
 
   void run() throws IOException {


### PR DESCRIPTION
Mixed-case struct field names don't work in Hive.  There should be a way to convert a camel-cased JSON document into ORC without having to pre-process the JSON.

This pull request is a proof-of-concept which generates two schemas, one using the default case which is provided to the JsonReader as usual, and another schema which is lower cased and is provided to OrcFile.

TypeDescription is immutable and non-trivial to manually clone using public accessors, so to make the idea clear, I do the conversion at schema ingest rather than where it's provided to OrcFile.  The downside of this approach is that automatic schema detection doesn't benefit from these changes.  A more experienced implementer could certainly do better.