### PR TITLE
ORC-403: [C++] Add checks to avoid invalid offsets in InputStream

### DIFF
--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -190,7 +190,7 @@ namespace orc {
     // internal methods
     void readMetadata() const;
     void checkOrcVersion();
-    void getRowIndexStatistics(uint64_t stripeOffset,
+    void getRowIndexStatistics(const proto::StripeInformation& stripeInfo, uint64_t stripeIndex,
                                const proto::StripeFooter& currentStripeFooter,
                                std::vector<std::vector<proto::ColumnStatistics> >* indexStats) const;
 

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -83,8 +83,15 @@ namespace orc {
       if (stream.has_kind() &&
           stream.kind() == kind &&
           stream.column() == static_cast<uint64_t>(columnId)) {
-        uint64_t myBlock = shouldStream ? input.getNaturalReadSize():
-          stream.length();
+        uint64_t streamLength = stream.length();
+        uint64_t myBlock = shouldStream ? input.getNaturalReadSize(): streamLength;
+        if (offset + streamLength > input.getLength()) {
+          std::stringstream msg;
+          msg << "Malformed stream meta at stream index " << i
+              << ": streamOffset=" << offset << ", streamLength=" << streamLength
+              << ", fileLength=" << input.getLength();
+          throw ParseError(msg.str());
+        }
         return createDecompressor(reader.getCompression(),
                                   std::unique_ptr<SeekableInputStream>
                                   (new SeekableFileInputStream

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -25,13 +25,16 @@
 
 namespace orc {
 
-  StripeStreamsImpl::StripeStreamsImpl(const RowReaderImpl& _reader,
+  StripeStreamsImpl::StripeStreamsImpl(const RowReaderImpl& _reader, uint64_t _index,
+                                       const proto::StripeInformation& _stripeInfo,
                                        const proto::StripeFooter& _footer,
                                        uint64_t _stripeStart,
                                        InputStream& _input,
                                        const Timezone& _writerTimezone
                                        ): reader(_reader),
+                                          stripeInfo(_stripeInfo),
                                           footer(_footer),
+                                          stripeIndex(_index),
                                           stripeStart(_stripeStart),
                                           input(_input),
                                           writerTimezone(_writerTimezone) {
@@ -77,6 +80,7 @@ namespace orc {
                                proto::Stream_Kind kind,
                                bool shouldStream) const {
     uint64_t offset = stripeStart;
+    uint64_t dataEnd = stripeInfo.offset() + stripeInfo.indexlength() + stripeInfo.datalength();
     MemoryPool *pool = reader.getFileContents().pool;
     for(int i = 0; i < footer.streams_size(); ++i) {
       const proto::Stream& stream = footer.streams(i);
@@ -85,11 +89,12 @@ namespace orc {
           stream.column() == static_cast<uint64_t>(columnId)) {
         uint64_t streamLength = stream.length();
         uint64_t myBlock = shouldStream ? input.getNaturalReadSize(): streamLength;
-        if (offset + streamLength > input.getLength()) {
+        if (offset + streamLength > dataEnd) {
           std::stringstream msg;
-          msg << "Malformed stream meta at stream index " << i
+          msg << "Malformed stream meta at stream index " << i << " in stripe " << stripeIndex
               << ": streamOffset=" << offset << ", streamLength=" << streamLength
-              << ", fileLength=" << input.getLength();
+              << ", stripeOffset=" << stripeInfo.offset() << ", stripeIndexLength="
+              << stripeInfo.indexlength() << ", stripeDataLength=" << stripeInfo.datalength();
           throw ParseError(msg.str());
         }
         return createDecompressor(reader.getCompression(),

--- a/c++/src/StripeStream.hh
+++ b/c++/src/StripeStream.hh
@@ -37,13 +37,16 @@ namespace orc {
   class StripeStreamsImpl: public StripeStreams {
   private:
     const RowReaderImpl& reader;
+    const proto::StripeInformation& stripeInfo;
     const proto::StripeFooter& footer;
+    const uint64_t stripeIndex;
     const uint64_t stripeStart;
     InputStream& input;
     const Timezone& writerTimezone;
 
   public:
-    StripeStreamsImpl(const RowReaderImpl& reader,
+    StripeStreamsImpl(const RowReaderImpl& reader, uint64_t index,
+                      const proto::StripeInformation& stripeInfo,
                       const proto::StripeFooter& footer,
                       uint64_t stripeStart,
                       InputStream& input,


### PR DESCRIPTION
We should check offsets and lengths got from the protobuf objects. The attached files in the JIRA can reveal the errors.