### PR TITLE
ORC-410: Fix a locale-dependent test in TestCsvReader

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/convert/TestCsvReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestCsvReader.java
@@ -28,10 +28,12 @@ import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.StringReader;
+import java.util.Locale;
 
 import static org.apache.orc.tools.convert.ConvertTool.DEFAULT_TIMESTAMP_FORMAT;
 import static org.junit.Assert.assertEquals;
@@ -39,10 +41,22 @@ import static org.junit.Assert.assertEquals;
 public class TestCsvReader {
 
   Configuration conf;
+  Locale defaultLocale;
 
   @Before
   public void openFileSystem () throws Exception {
     conf = new Configuration();
+  }
+
+  @Before
+  public void storeDefaultLocale() {
+    defaultLocale = Locale.getDefault();
+    Locale.setDefault(Locale.US);
+  }
+
+  @After
+  public void restoreDefaultLocale() {
+    Locale.setDefault(defaultLocale);
   }
 
   @Test


### PR DESCRIPTION
## Problem

`testCustomTimestampFormat` in `TestCsvReader` fails in some environments because the test is locale-dependent.

In this test, we try to parse a DateTime string (such as '21 Mar 2018 12:23:34') with a given timestamp format. The problem is that English month abbreviations (such as 'Mar') are locale-dependent. When the locale of Java Virtual Machine is a locale where the language is English (e.g., en_US and en_GB), this test passes without any problems. However, when the locale of JVM is a locale where the language is non-English (e.g., ja_JP and zh_CN), the test fails as follows.

```
[INFO] Running org.apache.orc.tools.convert.TestCsvReader
[ERROR] Tests run: 5, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.237 s <<< FAILURE! - in org.apache.orc.tools.convert.TestCsvReader
[ERROR] testCustomTimestampFormat(org.apache.orc.tools.convert.TestCsvReader)  Time elapsed: 0.143 s  <<< ERROR!
org.threeten.bp.format.DateTimeParseException: Text '21 Mar 2018 12:23:34' could not be parsed at index 3
        at org.apache.orc.tools.convert.TestCsvReader.testCustomTimestampFormat(TestCsvReader.java:189)
```

## Solution

The following two solutions can be considered to fix this problem by updating the test:
(1) Make this test be locale-independent.
(2) Set the locale to en_US in this test.

(1) is better, but it's not an easy task to construct a DateTime string which can be successfully parsed in all existing locales.
Thus, I adopt (2) and modify the test.