### PR TITLE
Fix a table row ending markup

### DIFF
--- a/site/_docs/hive-config.md
+++ b/site/_docs/hive-config.md
@@ -109,7 +109,7 @@ There are many Hive configuration properties related to ORC files:
       available size within the block is more than 3.2Mb, a new
       smaller stripe will be inserted to fit within that space. This
       will make sure that no stripe written will cross block
-      boundaries and cause remote reads within a node local task.</t>
+      boundaries and cause remote reads within a node local task.</td>
 </tr>
 <tr>
   <td>hive.exec.orc.default.compress</td>


### PR DESCRIPTION
Currently, a table in ORC website is broken. This is a trivial documentation issue and this PR aims to fix it.

- https://orc.apache.org/docs/hive-config.html

**Before**
![before](https://user-images.githubusercontent.com/9700541/46514237-a69b6080-c811-11e8-9f7c-61eb9df89a37.png)

**After**
![after](https://user-images.githubusercontent.com/9700541/46514240-a9965100-c811-11e8-8b28-7aa6ec413d32.png)
