### PR TITLE
ORC-416: Avoid opening data reader when there is no stripe

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -249,7 +249,6 @@ public class RecordReaderImpl implements RecordReader {
               .withZeroCopy(zeroCopy)
               .build());
     }
-    this.dataReader.open();
     firstRow = skippedRows;
     totalRowCount = rows;
     Boolean skipCorrupt = options.getSkipCorruptRecords();


### PR DESCRIPTION
Currently, `RecordReaderImpl` invokes `dataReader.open` in the middle of the constructor. We can postpone this until `advanceToNextRow` reads the stripe at the end of the constructor.
```
this.dataReader.open();
```
This will reduce the chance of potential open-file leakages due to IOException and OOM during `RecordReaderImpl` construction. Also, we can avoid it completely when there is no stripe in the file.