### PR TITLE
ORC-419: Ensure to call `close` at RecordReaderImpl constructor exception

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -269,7 +269,14 @@ public class RecordReaderImpl implements RecordReader {
     indexes = new OrcProto.RowIndex[types.size()];
     bloomFilterIndices = new OrcProto.BloomFilterIndex[types.size()];
     bloomFilterKind = new OrcProto.Stream.Kind[types.size()];
-    advanceToNextRow(reader, 0L, true);
+
+    try {
+      advanceToNextRow(reader, 0L, true);
+    } catch (IOException e) {
+      // Try to close since this happens in constructor.
+      close();
+      throw e;
+    }
   }
 
   public static final class PositionProviderImpl implements PositionProvider {


### PR DESCRIPTION

Currently, there is no way to call `RecordReaderImpl.close` if `RecordReader.rows` fails at creating `RecordReaderImpl`. This PR aims to try to invoke `close` in the constructor in case of Exceptions.

```java
  @Override
  public RecordReader rows(Options options) throws IOException {
    LOG.info("Reading ORC rows from " + path + " with " + options);
    return new RecordReaderImpl(this, options);
  }
```