### PR TITLE
ORC-431: [C++] Fix typo in exception message and simplify code logic.

### DIFF
--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -135,7 +135,7 @@ namespace orc {
       privateBits->fileVersion = version;
       return *this;
     }
-    throw std::logic_error("Unpoorted file version specified.");
+    throw std::logic_error("Unsupported file version specified.");
   }
 
   FileVersion WriterOptions::getFileVersion() const {
@@ -571,7 +571,8 @@ namespace orc {
     *footer.add_types() = protoType;
 
     for (uint64_t i = 0; i < t.getSubtypeCount(); ++i) {
-      if (t.getKind() != LIST && t.getKind() != MAP && t.getKind() != UNION) {
+      // only add subtypes' field names if this type is STRUCT
+      if (t.getKind() == STRUCT) {
         footer.mutable_types(pos)->add_fieldnames(t.getFieldName(i));
       }
       footer.mutable_types(pos)->add_subtypes(++index);

--- a/c++/src/io/OutputStream.cc
+++ b/c++/src/io/OutputStream.cc
@@ -51,7 +51,7 @@ namespace orc {
       newCapacity += dataBuffer->capacity();
     }
     dataBuffer->reserve(newCapacity);
-    dataBuffer->resize(dataBuffer->size() + blockSize);
+    dataBuffer->resize(newSize);
     *buffer = dataBuffer->data() + oldSize;
     return true;
   }
@@ -92,7 +92,7 @@ namespace orc {
 
   uint64_t BufferedOutputStream::flush() {
     uint64_t dataSize = dataBuffer->size();
-    outputStream->write(dataBuffer->data(), dataBuffer->size());
+    outputStream->write(dataBuffer->data(), dataSize);
     dataBuffer->resize(0);
     return dataSize;
   }


### PR DESCRIPTION
1. Fix typo in the exception message in WriterOptions::setFileVersion(): "Unpoorted" should be "Unsupported".
2. Simplify some code in Writer.cc and OutputStream.cc to avoid re-computation.
3. Simplify a condition check in WriterImpl::buildFooterType().