### PR TITLE
ORC-434: Fix incorrect documentation for Date/Timestamp ColumnStatistics

### DIFF
--- a/site/specification/ORCv0.md
+++ b/site/specification/ORCv0.md
@@ -297,7 +297,7 @@ message DecimalStatistics {
 ```
 
 Date columns record the minimum and maximum values as the number of
-days since the epoch (1/1/2015).
+days since the UNIX epoch (1/1/1970 in UTC).
 
 ```
 message DateStatistics {
@@ -308,7 +308,7 @@ message DateStatistics {
 ```
 
 Timestamp columns record the minimum and maximum values as the number of
-milliseconds since the epoch (1/1/2015).
+milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
 
 ```
 message TimestampStatistics {

--- a/site/specification/ORCv0.md
+++ b/site/specification/ORCv0.md
@@ -308,7 +308,7 @@ message DateStatistics {
 ```
 
 Timestamp columns record the minimum and maximum values as the number of
-milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
+milliseconds since the epoch (1/1/2015).
 
 ```
 message TimestampStatistics {

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -308,13 +308,18 @@ message DateStatistics {
 ```
 
 Timestamp columns record the minimum and maximum values as the number of
-milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
+milliseconds since the epoch (1/1/2015) before ORC-135. After ORC-135
+Timestamp columns record the minimumUtc and maximumUtc values as
+the number of milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
 
 ```
 message TimestampStatistics {
  // min,max values saved as milliseconds since epoch
  optional sint64 minimum = 1;
  optional sint64 maximum = 2;
+ // min,max values saved as milliseconds since UNIX epoch
+ optional sint64 minimumUtc = 3;
+ optional sint64 maximumUtc = 4;
 }
 ```
 

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -297,7 +297,7 @@ message DecimalStatistics {
 ```
 
 Date columns record the minimum and maximum values as the number of
-days since the epoch (1/1/2015).
+days since the UNIX epoch (1/1/1970 in UTC).
 
 ```
 message DateStatistics {
@@ -308,7 +308,7 @@ message DateStatistics {
 ```
 
 Timestamp columns record the minimum and maximum values as the number of
-milliseconds since the epoch (1/1/2015).
+milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
 
 ```
 message TimestampStatistics {

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -317,7 +317,7 @@ message DecimalStatistics {
 ```
 
 Date columns record the minimum and maximum values as the number of
-days since the epoch (1/1/2015).
+days since the UNIX epoch (1/1/1970 in UTC).
 
 ```
 message DateStatistics {
@@ -328,7 +328,7 @@ message DateStatistics {
 ```
 
 Timestamp columns record the minimum and maximum values as the number of
-milliseconds since the epoch (1/1/2015).
+milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
 
 ```
 message TimestampStatistics {

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -328,13 +328,18 @@ message DateStatistics {
 ```
 
 Timestamp columns record the minimum and maximum values as the number of
-milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
+milliseconds since the epoch (1/1/2015) before ORC-135. After ORC-135
+Timestamp columns record the minimumUtc and maximumUtc values as
+the number of milliseconds since the UNIX epoch (1/1/1970 00:00:00 in UTC).
 
 ```
 message TimestampStatistics {
  // min,max values saved as milliseconds since epoch
  optional sint64 minimum = 1;
  optional sint64 maximum = 2;
+ // min,max values saved as milliseconds since UNIX epoch
+ optional sint64 minimumUtc = 3;
+ optional sint64 maximumUtc = 4;
 }
 ```
 


### PR DESCRIPTION
The old specification says Date and Timestamp ColumnStatistics stores the difference from epoch 1/1/2015. This is incorrect and should be changed to UNIX epoch time.