### PR TITLE
ORC-438 - Fix possible NPEs in StringStatisticsImpl.merge()

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -605,27 +605,15 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     public void merge(ColumnStatisticsImpl other) {
       if (other instanceof StringStatisticsImpl) {
         StringStatisticsImpl str = (StringStatisticsImpl) other;
-        if (minimum == null) {
-          if (str.minimum != null) {
-            maximum = new Text(str.getMaximum());
-            minimum = new Text(str.getMinimum());
-          }
-          /* str.minimum == null when lower bound set */
-          else if (str.isLowerBoundSet) {
-            minimum = new Text(str.getLowerBound());
+        if (count == 0) {
+          if (str.count != 0) {
+            minimum = new Text(str.minimum);
             isLowerBoundSet = str.isLowerBoundSet;
-
-            /* check for upper bound before setting max */
-            if (str.isUpperBoundSet) {
-              maximum = new Text(str.getUpperBound());
-              isUpperBoundSet = str.isUpperBoundSet;
-            } else {
-              maximum = new Text(str.getMaximum());
-            }
-          }
-          else {
+            maximum = new Text(str.maximum);
+            isUpperBoundSet = str.isUpperBoundSet;
+          } else {
           /* both are empty */
-            maximum = minimum = null;
+          maximum = minimum = null;
           }
         } else if (str.minimum != null) {
           if (minimum.compareTo(str.minimum) > 0) {
@@ -660,8 +648,10 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       OrcProto.StringStatistics.Builder str =
         OrcProto.StringStatistics.newBuilder();
       if (getNumberOfValues() != 0) {
-        str.setMinimum(getMinimum());
-        str.setMaximum(getMaximum());
+        /* getLowerBound() will ALWAYS return min value */
+        str.setMinimum(getLowerBound());
+        /* getUpperBound() will ALWAYS return max value */
+        str.setMaximum(getUpperBound());
         str.setSum(sum);
       }
       result.setStringStatistics(str);
@@ -1638,7 +1628,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     }
   }
 
-  private long count = 0;
+  protected long count = 0;
   private boolean hasNull = false;
   private long bytesOnDisk = 0;
 

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -98,11 +98,14 @@ public class TestColumnStatistics {
 
     ColumnStatisticsImpl stats1 = ColumnStatisticsImpl.create(schema);
     ColumnStatisticsImpl stats2 = ColumnStatisticsImpl.create(schema);
+    stats1.increment(3);
     stats1.updateString(new Text("bob"));
     stats1.updateString(new Text("david"));
     stats1.updateString(new Text("charles"));
+    stats2.increment(2);
     stats2.updateString(new Text("anne"));
     byte[] erin = new byte[]{0, 1, 2, 3, 4, 5, 101, 114, 105, 110};
+    stats2.increment();
     stats2.updateString(erin, 6, 4, 5);
     assertEquals(24, ((StringColumnStatistics)stats2).getSum());
     stats1.merge(stats2);
@@ -111,6 +114,7 @@ public class TestColumnStatistics {
     assertEquals("erin", typed.getMaximum());
     assertEquals(39, typed.getSum());
     stats1.reset();
+    stats1.increment(2);
     stats1.updateString(new Text("aaa"));
     stats1.updateString(new Text("zzz"));
     stats1.merge(stats2);
@@ -131,6 +135,7 @@ public class TestColumnStatistics {
     final ColumnStatisticsImpl stats2 = ColumnStatisticsImpl.create(schema);
 
     /* test a scenario for the first max string */
+    stats1.increment();
     stats1.updateString(new Text(test));
 
     final StringColumnStatistics typed = (StringColumnStatistics) stats1;
@@ -146,6 +151,7 @@ public class TestColumnStatistics {
     stats1.reset();
 
     /* test a scenario for the first max bytes */
+    stats1.increment();
     stats1.updateString(test.getBytes(StandardCharsets.UTF_8), 0,
         test.getBytes(StandardCharsets.UTF_8).length, 0);
 
@@ -157,10 +163,12 @@ public class TestColumnStatistics {
 
     stats1.reset();
     /* test upper bound - merging  */
+    stats1.increment(3);
     stats1.updateString(new Text("bob"));
     stats1.updateString(new Text("david"));
     stats1.updateString(new Text("charles"));
 
+    stats2.increment(2);
     stats2.updateString(new Text("anne"));
     stats2.updateString(new Text(fragment));
 
@@ -177,9 +185,10 @@ public class TestColumnStatistics {
     stats1.reset();
     stats2.reset();
 
+    stats1.increment(2);
     stats1.updateString(new Text("david"));
     stats1.updateString(new Text("charles"));
-
+    stats2.increment(2);
     stats2.updateString(new Text("jane"));
     stats2.updateString(new Text(fragmentLowerBound));
 


### PR DESCRIPTION
While working on ORC-422 I came across this bug. These changes should prevent NPEs in the StringStatisticsImpl.merge(). 

@omalley would be great if you can review this PR.