### PR TITLE
ORC-440. Fix deserialization of string column statistics with truncation

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -538,9 +538,15 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       OrcProto.StringStatistics str = stats.getStringStatistics();
       if (str.hasMaximum()) {
         maximum = new Text(str.getMaximum());
+      } else if (str.hasUpperBound()) {
+        maximum = new Text(str.getUpperBound());
+        isUpperBoundSet = true;
       }
       if (str.hasMinimum()) {
         minimum = new Text(str.getMinimum());
+      } else if (str.hasLowerBound()) {
+        minimum = new Text(str.getLowerBound());
+        isLowerBoundSet = true;
       }
       if(str.hasSum()) {
         sum = str.getSum();
@@ -642,10 +648,16 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       OrcProto.StringStatistics.Builder str =
         OrcProto.StringStatistics.newBuilder();
       if (getNumberOfValues() != 0) {
-        /* getLowerBound() will ALWAYS return min value */
-        str.setMinimum(getLowerBound());
-        /* getUpperBound() will ALWAYS return max value */
-        str.setMaximum(getUpperBound());
+        if (isLowerBoundSet) {
+          str.setLowerBound(minimum.toString());
+        } else {
+          str.setMinimum(minimum.toString());
+        }
+        if (isUpperBoundSet) {
+          str.setUpperBound(maximum.toString());
+        } else {
+          str.setMaximum(maximum.toString());
+        }
         str.setSum(sum);
       }
       result.setStringStatistics(str);

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -357,14 +357,24 @@ public class TestColumnStatistics {
     final ColumnStatisticsImpl stats1 = ColumnStatisticsImpl.create(schema);
     byte[] utf8 = input.getBytes(StandardCharsets.UTF_8);
     stats1.updateString(utf8, 0, utf8.length, 1);
-
+    stats1.increment();
     final StringColumnStatistics typed = (StringColumnStatistics) stats1;
 
     assertEquals(354, typed.getUpperBound().length());
     assertEquals(354, typed.getLowerBound().length());
+    assertEquals(1764L, typed.getSum());
 
     assertEquals(upperbound, typed.getUpperBound());
     assertEquals(lowerBound, typed.getLowerBound());
+    OrcProto.ColumnStatistics serial = stats1.serialize().build();
+    ColumnStatisticsImpl stats2 =
+        ColumnStatisticsImpl.deserialize(schema, serial);
+    StringColumnStatistics typed2 = (StringColumnStatistics) stats2;
+    assertEquals(null, typed2.getMinimum());
+    assertEquals(null, typed2.getMaximum());
+    assertEquals(lowerBound, typed2.getLowerBound());
+    assertEquals(upperbound, typed2.getUpperBound());
+    assertEquals(1764L, typed2.getSum());
   }
 
 


### PR DESCRIPTION
After ORC-202, we need to serialize the string statistics with the lower/upper bounds.