### PR TITLE
ORC-422 - Fix issue with Predicate push down when lower/upper bounds are set

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -35,8 +35,13 @@ import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
 
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.TimeZone;
 
 public class ColumnStatisticsImpl implements ColumnStatistics {

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -677,7 +677,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public String getMaximum() {
-      /* if we have upper bound is set (in case of truncation)
+      /* if we have upper bound set (in case of truncation)
       getMaximum will be null */
       if(isUpperBoundSet) {
         return null;

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -35,13 +35,8 @@ import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
 
-import java.nio.ByteBuffer;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.util.Arrays;
 import java.util.TimeZone;
 
 public class ColumnStatisticsImpl implements ColumnStatistics {

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -52,7 +52,6 @@ import org.apache.orc.TypeDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.common.io.DiskRange;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
 import org.apache.hadoop.hive.common.io.DiskRangeList.CreateHelper;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -359,7 +358,7 @@ public class RecordReaderImpl implements RecordReader {
     } else if (index instanceof DoubleColumnStatistics) {
       return ((DoubleColumnStatistics) index).getMaximum();
     } else if (index instanceof StringColumnStatistics) {
-      return ((StringColumnStatistics) index).getMaximum();
+      return ((StringColumnStatistics) index).getUpperBound();
     } else if (index instanceof DateColumnStatistics) {
       return ((DateColumnStatistics) index).getMaximum();
     } else if (index instanceof DecimalColumnStatistics) {
@@ -406,7 +405,7 @@ public class RecordReaderImpl implements RecordReader {
     } else if (index instanceof DoubleColumnStatistics) {
       return ((DoubleColumnStatistics) index).getMinimum();
     } else if (index instanceof StringColumnStatistics) {
-      return ((StringColumnStatistics) index).getMinimum();
+      return ((StringColumnStatistics) index).getLowerBound();
     } else if (index instanceof DateColumnStatistics) {
       return ((DateColumnStatistics) index).getMinimum();
     } else if (index instanceof DecimalColumnStatistics) {

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -37,7 +37,6 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.TimeZone;
 
 import static junit.framework.Assert.assertEquals;

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -37,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.TimeZone;
 
 import static junit.framework.Assert.assertEquals;

--- a/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
@@ -20,28 +20,29 @@ package org.apache.orc.impl;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
-import org.apache.orc.ColumnStatistics;
-import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.util.BloomFilter;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
+import static org.apache.orc.impl.TestRecordReaderImpl.createPredicateLeaf;
 
 public class TestPredicatePushDownBounds {
 
   /**
-   * This test case handles the Equals corner case where the predicate is
-   * equal to truncated upper and lower bounds.
+   * This test case handles the Equals corner case where the predicate is equal
+   * to truncated upper and lower bounds.
+   *
    * @throws Exception
    */
   @Test
-  public void testCornerCases() throws Exception {
+  public void testCornerCases() {
 
     int stringLength = 1100;
-    //int stringLength = 11;
     byte[] utf8F;
     byte[] utf8P;
 
@@ -51,49 +52,58 @@ public class TestPredicatePushDownBounds {
     BloomFilter bf = new BloomFilter(100);
     // FFF... to PPP...
     for (int i = 70; i <= 80; i++) {
-      final String inputString = StringUtils.repeat(Character.toString((char)i), stringLength);
+      final String inputString = StringUtils
+          .repeat(Character.toString((char) i), stringLength);
       bf.addString(inputString);
     }
 
-    final String longStringF = StringUtils.repeat(Character.toString('F'), stringLength);
-    final String longStringP = StringUtils.repeat(Character.toString('P'), stringLength);
+    final String longStringF = StringUtils
+        .repeat(Character.toString('F'), stringLength);
+    final String longStringP = StringUtils
+        .repeat(Character.toString('P'), stringLength);
 
     /* String that matches the upperbound value after truncation */
-    final String upperboundString = StringUtils.repeat(Character.toString('P'), 1023) + "Q";
+    final String upperboundString =
+        StringUtils.repeat(Character.toString('P'), 1023) + "Q";
     /* String that matches the lower value after truncation */
-    final String lowerboundString = StringUtils.repeat(Character.toString('F'), 1024);
-
+    final String lowerboundString = StringUtils
+        .repeat(Character.toString('F'), 1024);
 
     final String shortStringF = StringUtils.repeat(Character.toString('F'), 50);
-    final String shortStringP = StringUtils.repeat(Character.toString('P'), 50) + "Q";
-
+    final String shortStringP =
+        StringUtils.repeat(Character.toString('P'), 50) + "Q";
 
     /* Test for a case EQUALS where only upperbound is set */
-    final PredicateLeaf predicateUpperBoundEquals = TestRecordReaderImpl.createPredicateLeaf(
-        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x", upperboundString, null);
+    final PredicateLeaf predicateUpperBoundEquals = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.EQUALS,
+            PredicateLeaf.Type.STRING, "x", upperboundString, null);
 
     /* Test for a case LESS_THAN where only upperbound is set */
-    final PredicateLeaf predicateUpperBoundLessThan = TestRecordReaderImpl.createPredicateLeaf(
-        PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.STRING, "x", upperboundString, null);
+    final PredicateLeaf predicateUpperBoundLessThan = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN,
+            PredicateLeaf.Type.STRING, "x", upperboundString, null);
 
     /* Test for a case LESS_THAN_EQUALS where only upperbound is set */
-    final PredicateLeaf predicateUpperBoundLessThanEquals = TestRecordReaderImpl.createPredicateLeaf(
-        PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.STRING, "x", upperboundString, null);
+    final PredicateLeaf predicateUpperBoundLessThanEquals = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN_EQUALS,
+            PredicateLeaf.Type.STRING, "x", upperboundString, null);
 
     utf8F = shortStringF.getBytes(StandardCharsets.UTF_8);
     stat.increment();
     stat.updateString(utf8F, 0, utf8F.length, 1);
 
-
     utf8P = longStringP.getBytes(StandardCharsets.UTF_8);
     stat.increment();
     stat.updateString(utf8P, 0, utf8P.length, 1);
 
-    //assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateUpperBoundEquals, null));
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl
+        .evaluatePredicate(stat, predicateUpperBoundEquals, null));
 
-    //assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(stat, predicateUpperBoundLessThan, null));
+    assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl
+        .evaluatePredicate(stat, predicateUpperBoundLessThan, null));
 
-    //assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(stat, predicateUpperBoundLessThanEquals, null));
+    assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl
+        .evaluatePredicate(stat, predicateUpperBoundLessThanEquals, null));
 
     stat.reset();
 
@@ -101,37 +111,40 @@ public class TestPredicatePushDownBounds {
     stat.increment();
     stat.updateString(utf8F, 0, utf8F.length, 1);
 
-
     utf8P = shortStringP.getBytes(StandardCharsets.UTF_8);
     stat.increment();
     stat.updateString(utf8P, 0, utf8P.length, 1);
 
     /* Test for a case Equals where only lowerbound is set */
-    final PredicateLeaf predicateLowerBoundEquals = TestRecordReaderImpl.createPredicateLeaf(
-        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x", lowerboundString, null);
+    final PredicateLeaf predicateLowerBoundEquals = createPredicateLeaf(
+        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x",
+        lowerboundString, null);
 
     /* Test for a case LESS_THAN where only lowerbound is set */
-    final PredicateLeaf predicateLowerBoundLessThan = TestRecordReaderImpl.createPredicateLeaf(
-        PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.STRING, "x", lowerboundString, null);
+    final PredicateLeaf predicateLowerBoundLessThan = createPredicateLeaf(
+        PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.STRING, "x",
+        lowerboundString, null);
 
     /* Test for a case LESS_THAN_EQUALS where only lowerbound is set */
-    final PredicateLeaf predicateLowerBoundLessThanEquals = TestRecordReaderImpl.createPredicateLeaf(
-        PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.STRING, "x", lowerboundString, null);
+    final PredicateLeaf predicateLowerBoundLessThanEquals = createPredicateLeaf(
+        PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.STRING, "x",
+        lowerboundString, null);
 
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl
+        .evaluatePredicate(stat, predicateLowerBoundEquals, null));
 
-    //assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateLowerBoundEquals, null));
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl
+        .evaluatePredicate(stat, predicateLowerBoundLessThan, bf));
 
-    //FIXME should be YES ?
-    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateLowerBoundLessThan, bf));
-
-    //FIXME should be YES ?
-    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateLowerBoundLessThanEquals, null));
-
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl
+        .evaluatePredicate(stat, predicateLowerBoundLessThanEquals, null));
 
   }
 
   /**
-   * A case where the search values fall within the upperbound and lower bound range.
+   * A case where the search values fall within the upperbound and lower bound
+   * range.
+   *
    * @throws Exception
    */
   @Test
@@ -150,18 +163,23 @@ public class TestPredicatePushDownBounds {
     BloomFilter bf = new BloomFilter(100);
     // FFF... to PPP...
     for (int i = 70; i <= 80; i++) {
-      final String inputString = StringUtils.repeat(Character.toString((char)i), bfStringLength);
+      final String inputString = StringUtils
+          .repeat(Character.toString((char) i), bfStringLength);
       bf.addString(inputString);
     }
 
-    final String longStringF = StringUtils.repeat(Character.toString('F'), stringLength);
-    final String longStringP = StringUtils.repeat(Character.toString('P'), stringLength);
-    final String predicateString = StringUtils.repeat(Character.toString('I'), 50);
+    final String longStringF = StringUtils
+        .repeat(Character.toString('F'), stringLength);
+    final String longStringP = StringUtils
+        .repeat(Character.toString('P'), stringLength);
+    final String predicateString = StringUtils
+        .repeat(Character.toString('I'), 50);
 
 
     /* Test for a case where only upperbound is set */
-    final PredicateLeaf predicateEquals = TestRecordReaderImpl.createPredicateLeaf(
-        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x", predicateString, null);
+    final PredicateLeaf predicateEquals = createPredicateLeaf(
+        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x",
+        predicateString, null);
 
     /* trigger lower bound */
     utf8F = longStringF.getBytes(StandardCharsets.UTF_8);
@@ -173,11 +191,141 @@ public class TestPredicatePushDownBounds {
     stat.increment();
     stat.updateString(utf8P, 0, utf8P.length, 1);
 
-    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(stat, predicateEquals, bf));
-
-    stat.reset();
+    assertEquals(SearchArgument.TruthValue.YES_NO,
+        RecordReaderImpl.evaluatePredicate(stat, predicateEquals, bf));
 
   }
 
+  /**
+   * Test for IN search arg when upper and lower bounds are set.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testIN() throws Exception {
+    int stringLength = 1100;
+    byte[] utf8F;
+    byte[] utf8P;
+
+    final TypeDescription schema = TypeDescription.createString();
+    final ColumnStatisticsImpl stat = ColumnStatisticsImpl.create(schema);
+
+    final BloomFilter bf = new BloomFilter(100);
+    // FFF... to PPP...
+    for (int i = 70; i <= 80; i++) {
+      final String inputString = StringUtils
+          .repeat(Character.toString((char) i), stringLength);
+      bf.addString(inputString);
+    }
+
+    final String longStringF = StringUtils
+        .repeat(Character.toString('F'), stringLength);
+    final String longStringP = StringUtils
+        .repeat(Character.toString('P'), stringLength);
+
+    /* String that matches the upperbound value after truncation */
+    final String upperboundString =
+        StringUtils.repeat(Character.toString('P'), 1023) + "Q";
+    /* String that matches the lower value after truncation */
+    final String lowerboundString = StringUtils
+        .repeat(Character.toString('F'), 1024);
+
+    final String shortStringF = StringUtils.repeat(Character.toString('F'), 50);
+    final String shortStringP =
+        StringUtils.repeat(Character.toString('P'), 50) + "Q";
+
+    final List<Object> args = new ArrayList<Object>();
+    args.add(upperboundString);
+
+    /* set upper bound */
+    utf8F = shortStringF.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8F, 0, utf8F.length, 1);
+
+    utf8P = longStringP.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8P, 0, utf8P.length, 1);
+
+    /* Test for a case IN where only upper bound is set and test literal is equal to upperbound */
+    final PredicateLeaf predicateUpperBoundSet = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.IN,
+            PredicateLeaf.Type.STRING, "x", null, args);
+
+    assertEquals(SearchArgument.TruthValue.NO,
+        RecordReaderImpl.evaluatePredicate(stat, predicateUpperBoundSet, null));
+
+    /* Test for lower bound set only */
+    args.clear();
+    args.add(lowerboundString);
+
+    stat.reset();
+    /* set lower bound */
+    utf8F = longStringF.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8F, 0, utf8F.length, 1);
+
+    utf8P = shortStringP.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8P, 0, utf8P.length, 1);
+
+    /* Test for a case IN where only lower bound is set and the test literal is lowerbound string */
+    final PredicateLeaf predicateLowerBoundSet = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.IN,
+            PredicateLeaf.Type.STRING, "x", null, args);
+
+    assertEquals(SearchArgument.TruthValue.NO,
+        RecordReaderImpl.evaluatePredicate(stat, predicateLowerBoundSet, null));
+
+    /* Test for a case LESS_THAN_EQUALS where only upperbound is set */
+    final PredicateLeaf predicateUpperBoundLessThanEquals = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.IN,
+            PredicateLeaf.Type.STRING, "x", null, args);
+
+
+    /* Test the case were both upper and lower bounds are set */
+    args.clear();
+    args.add(lowerboundString);
+    args.add(upperboundString);
+
+    stat.reset();
+    /* set upper and lower bound */
+    utf8F = longStringF.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8F, 0, utf8F.length, 1);
+
+    utf8P = longStringP.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8P, 0, utf8P.length, 1);
+
+    final PredicateLeaf predicateUpperLowerBoundSet = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.IN,
+            PredicateLeaf.Type.STRING, "x", null, args);
+
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl
+        .evaluatePredicate(stat, predicateUpperLowerBoundSet, null));
+
+    /* test the boundary condition */
+    args.clear();
+    args.add(longStringF);
+    args.add(longStringP);
+
+    stat.reset();
+    /* set upper and lower bound */
+    utf8F = longStringF.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8F, 0, utf8F.length, 1);
+
+    utf8P = longStringP.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8P, 0, utf8P.length, 1);
+
+    final PredicateLeaf predicateUpperLowerBoundSetBoundary = TestRecordReaderImpl
+        .createPredicateLeaf(PredicateLeaf.Operator.IN,
+            PredicateLeaf.Type.STRING, "x", null, args);
+
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl
+        .evaluatePredicate(stat, predicateUpperLowerBoundSetBoundary, null));
+
+  }
 
 }

--- a/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.orc.impl;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.orc.ColumnStatistics;
+import org.apache.orc.OrcProto;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.util.BloomFilter;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static junit.framework.Assert.assertEquals;
+
+public class TestPredicatePushDownBounds {
+
+  /**
+   * This test case handles the Equals corner case where the predicate is
+   * equal to truncated upper and lower bounds.
+   * @throws Exception
+   */
+  @Test
+  public void testCornerCases() throws Exception {
+
+    int stringLength = 1100;
+    //int stringLength = 11;
+    byte[] utf8F;
+    byte[] utf8P;
+
+    final TypeDescription schema = TypeDescription.createString();
+    final ColumnStatisticsImpl stat = ColumnStatisticsImpl.create(schema);
+
+    BloomFilter bf = new BloomFilter(100);
+    // FFF... to PPP...
+    for (int i = 70; i <= 80; i++) {
+      final String inputString = StringUtils.repeat(Character.toString((char)i), stringLength);
+      bf.addString(inputString);
+    }
+
+    final String longStringF = StringUtils.repeat(Character.toString('F'), stringLength);
+    final String longStringP = StringUtils.repeat(Character.toString('P'), stringLength);
+
+    /* String that matches the upperbound value after truncation */
+    final String upperboundString = StringUtils.repeat(Character.toString('P'), 1023) + "Q";
+    /* String that matches the lower value after truncation */
+    final String lowerboundString = StringUtils.repeat(Character.toString('F'), 1024);
+
+
+    final String shortStringF = StringUtils.repeat(Character.toString('F'), 50);
+    final String shortStringP = StringUtils.repeat(Character.toString('P'), 50) + "Q";
+
+
+    /* Test for a case EQUALS where only upperbound is set */
+    final PredicateLeaf predicateUpperBoundEquals = TestRecordReaderImpl.createPredicateLeaf(
+        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x", upperboundString, null);
+
+    /* Test for a case LESS_THAN where only upperbound is set */
+    final PredicateLeaf predicateUpperBoundLessThan = TestRecordReaderImpl.createPredicateLeaf(
+        PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.STRING, "x", upperboundString, null);
+
+    /* Test for a case LESS_THAN_EQUALS where only upperbound is set */
+    final PredicateLeaf predicateUpperBoundLessThanEquals = TestRecordReaderImpl.createPredicateLeaf(
+        PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.STRING, "x", upperboundString, null);
+
+    utf8F = shortStringF.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8F, 0, utf8F.length, 1);
+
+
+    utf8P = longStringP.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8P, 0, utf8P.length, 1);
+
+    //assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateUpperBoundEquals, null));
+
+    //assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(stat, predicateUpperBoundLessThan, null));
+
+    //assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(stat, predicateUpperBoundLessThanEquals, null));
+
+    stat.reset();
+
+    utf8F = longStringF.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8F, 0, utf8F.length, 1);
+
+
+    utf8P = shortStringP.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8P, 0, utf8P.length, 1);
+
+    /* Test for a case Equals where only lowerbound is set */
+    final PredicateLeaf predicateLowerBoundEquals = TestRecordReaderImpl.createPredicateLeaf(
+        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x", lowerboundString, null);
+
+    /* Test for a case LESS_THAN where only lowerbound is set */
+    final PredicateLeaf predicateLowerBoundLessThan = TestRecordReaderImpl.createPredicateLeaf(
+        PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.STRING, "x", lowerboundString, null);
+
+    /* Test for a case LESS_THAN_EQUALS where only lowerbound is set */
+    final PredicateLeaf predicateLowerBoundLessThanEquals = TestRecordReaderImpl.createPredicateLeaf(
+        PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.STRING, "x", lowerboundString, null);
+
+
+    //assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateLowerBoundEquals, null));
+
+    //FIXME should be YES ?
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateLowerBoundLessThan, bf));
+
+    //FIXME should be YES ?
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(stat, predicateLowerBoundLessThanEquals, null));
+
+
+  }
+
+  /**
+   * A case where the search values fall within the upperbound and lower bound range.
+   * @throws Exception
+   */
+  @Test
+  public void testNormalCase() throws Exception {
+
+    int stringLength = 1100;
+    /* length of string in BF */
+    int bfStringLength = 50;
+    //int stringLength = 11;
+    byte[] utf8F;
+    byte[] utf8P;
+
+    final TypeDescription schema = TypeDescription.createString();
+    final ColumnStatisticsImpl stat = ColumnStatisticsImpl.create(schema);
+
+    BloomFilter bf = new BloomFilter(100);
+    // FFF... to PPP...
+    for (int i = 70; i <= 80; i++) {
+      final String inputString = StringUtils.repeat(Character.toString((char)i), bfStringLength);
+      bf.addString(inputString);
+    }
+
+    final String longStringF = StringUtils.repeat(Character.toString('F'), stringLength);
+    final String longStringP = StringUtils.repeat(Character.toString('P'), stringLength);
+    final String predicateString = StringUtils.repeat(Character.toString('I'), 50);
+
+
+    /* Test for a case where only upperbound is set */
+    final PredicateLeaf predicateEquals = TestRecordReaderImpl.createPredicateLeaf(
+        PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.STRING, "x", predicateString, null);
+
+    /* trigger lower bound */
+    utf8F = longStringF.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8F, 0, utf8F.length, 1);
+
+    /* trigger upper bound */
+    utf8P = longStringP.getBytes(StandardCharsets.UTF_8);
+    stat.increment();
+    stat.updateString(utf8P, 0, utf8P.length, 1);
+
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(stat, predicateEquals, bf));
+
+    stat.reset();
+
+  }
+
+
+}

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -223,61 +223,61 @@ public class TestRecordReaderImpl {
   @Test
   public void testCompareToRangeInt() throws Exception {
     assertEquals(Location.BEFORE,
-      RecordReaderImpl.compareToRange(19L, 20L, 40L, false, false));
+      RecordReaderImpl.compareToRange(19L, 20L, 40L, null, null));
     assertEquals(Location.AFTER,
-      RecordReaderImpl.compareToRange(41L, 20L, 40L, false, false));
+      RecordReaderImpl.compareToRange(41L, 20L, 40L, null, null));
     assertEquals(Location.MIN,
-        RecordReaderImpl.compareToRange(20L, 20L, 40L, false, false));
+        RecordReaderImpl.compareToRange(20L, 20L, 40L, null, null));
     assertEquals(Location.MIDDLE,
-        RecordReaderImpl.compareToRange(21L, 20L, 40L, false, false));
+        RecordReaderImpl.compareToRange(21L, 20L, 40L, null, null));
     assertEquals(Location.MAX,
-      RecordReaderImpl.compareToRange(40L, 20L, 40L, false, false));
+      RecordReaderImpl.compareToRange(40L, 20L, 40L, null, null));
     assertEquals(Location.BEFORE,
-      RecordReaderImpl.compareToRange(0L, 1L, 1L, false, false));
+      RecordReaderImpl.compareToRange(0L, 1L, 1L, null, null));
     assertEquals(Location.MIN,
-      RecordReaderImpl.compareToRange(1L, 1L, 1L, false, false));
+      RecordReaderImpl.compareToRange(1L, 1L, 1L, null, null));
     assertEquals(Location.AFTER,
-      RecordReaderImpl.compareToRange(2L, 1L, 1L, false, false));
+      RecordReaderImpl.compareToRange(2L, 1L, 1L, null, null));
   }
 
   @Test
   public void testCompareToRangeString() throws Exception {
     assertEquals(Location.BEFORE,
-        RecordReaderImpl.compareToRange("a", "b", "c", false, false));
+        RecordReaderImpl.compareToRange("a", "b", "c", null, null));
     assertEquals(Location.AFTER,
-        RecordReaderImpl.compareToRange("d", "b", "c", false, false));
+        RecordReaderImpl.compareToRange("d", "b", "c", null, null));
     assertEquals(Location.MIN,
-        RecordReaderImpl.compareToRange("b", "b", "c", false, false));
+        RecordReaderImpl.compareToRange("b", "b", "c", null, null));
     assertEquals(Location.MIDDLE,
-        RecordReaderImpl.compareToRange("bb", "b", "c", false, false));
+        RecordReaderImpl.compareToRange("bb", "b", "c", null, null));
     assertEquals(Location.MAX,
-        RecordReaderImpl.compareToRange("c", "b", "c", false, false));
+        RecordReaderImpl.compareToRange("c", "b", "c", null, null));
     assertEquals(Location.BEFORE,
-        RecordReaderImpl.compareToRange("a", "b", "b", false, false));
+        RecordReaderImpl.compareToRange("a", "b", "b", null, null));
     assertEquals(Location.MIN,
-        RecordReaderImpl.compareToRange("b", "b", "b", false, false));
+        RecordReaderImpl.compareToRange("b", "b", "b", null, null));
     assertEquals(Location.AFTER,
-        RecordReaderImpl.compareToRange("c", "b", "b", false, false));
+        RecordReaderImpl.compareToRange("c", "b", "b", null, null));
   }
 
   @Test
   public void testCompareToCharNeedConvert() throws Exception {
     assertEquals(Location.BEFORE,
-      RecordReaderImpl.compareToRange("apple", "hello", "world", false, false));
+      RecordReaderImpl.compareToRange("apple", "hello", "world", null, null));
     assertEquals(Location.AFTER,
-      RecordReaderImpl.compareToRange("zombie", "hello", "world", false, false));
+      RecordReaderImpl.compareToRange("zombie", "hello", "world", null, null));
     assertEquals(Location.MIN,
-        RecordReaderImpl.compareToRange("hello", "hello", "world", false, false));
+        RecordReaderImpl.compareToRange("hello", "hello", "world", null, null));
     assertEquals(Location.MIDDLE,
-        RecordReaderImpl.compareToRange("pilot", "hello", "world", false, false));
+        RecordReaderImpl.compareToRange("pilot", "hello", "world", null, null));
     assertEquals(Location.MAX,
-      RecordReaderImpl.compareToRange("world", "hello", "world", false, false));
+      RecordReaderImpl.compareToRange("world", "hello", "world", null, null));
     assertEquals(Location.BEFORE,
-      RecordReaderImpl.compareToRange("apple", "hello", "hello", false, false));
+      RecordReaderImpl.compareToRange("apple", "hello", "hello", null, null));
     assertEquals(Location.MIN,
-      RecordReaderImpl.compareToRange("hello", "hello", "hello", false, false));
+      RecordReaderImpl.compareToRange("hello", "hello", "hello", null, null));
     assertEquals(Location.AFTER,
-      RecordReaderImpl.compareToRange("zombie", "hello", "hello", false, false));
+      RecordReaderImpl.compareToRange("zombie", "hello", "hello", null, null));
   }
 
   @Test


### PR DESCRIPTION
This PR fixes a bug where Predicate push down will not return proper values when upper and lower bounds are set for StringStatisticsImpl.
This patch also contains removing some unused imports as part of cleanup.