### PR TITLE
ORC-454. Use Spark 2.4.0 in benchmark

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -44,7 +44,7 @@
     <orc.version>1.5.2</orc.version>
     <parquet.version>1.8.3</parquet.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <spark.version>2.3.1</spark.version>
+    <spark.version>2.4.0</spark.version>
     <storage-api.version>2.6.1</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>
@@ -57,11 +57,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.databricks</groupId>
-        <artifactId>spark-avro_2.11</artifactId>
-        <version>3.2.0</version>
-      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
@@ -437,6 +432,11 @@
             <artifactId>orc-mapreduce</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-avro_2.11</artifactId>
+        <version>${spark.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.janino</groupId>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -40,10 +40,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.databricks</groupId>
-      <artifactId>spark-avro_2.11</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.google.auto.service</groupId>
       <artifactId>auto-service</artifactId>
     </dependency>
@@ -103,6 +99,17 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.11</artifactId>
+    </dependency>
+    <!-- Spark 2.4 uses Parquet 1.10.0 -->
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
+      <version>1.10.0</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-avro_2.11</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.janino</groupId>

--- a/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
+++ b/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
@@ -28,6 +28,7 @@ import org.apache.orc.bench.core.OrcBenchmark;
 import org.apache.orc.bench.core.ReadCounters;
 import org.apache.orc.bench.core.Utilities;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.avro.AvroFileFormat;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.execution.datasources.FileFormat;
 import org.apache.spark.sql.execution.datasources.PartitionedFile;
@@ -133,7 +134,7 @@ public class SparkBenchmark implements OrcBenchmark {
       }
       switch (format) {
         case "avro":
-          formatObject = new com.databricks.spark.avro.DefaultSource();
+          formatObject = new AvroFileFormat();
           break;
         case "orc":
           formatObject = new OrcFileFormat();


### PR DESCRIPTION
This PR aims to use the latest Spark 2.4.0 and the Spark's built-in Avro data source in the benchmark.