### PR TITLE
ORC-461. Replace `git-wip-us` with `gitbox`

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -6,7 +6,7 @@ This directory contains the code for the Apache ORC web site,
 ## Setup
 
 1. `cd site`
-2. `git clone https://git-wip-us.apache.org/repos/asf/orc.git -b asf-site target`
+2. `git clone https://gitbox.apache.org/repos/asf/orc.git -b asf-site target`
 3. `sudo gem install bundler`
 4. `sudo gem install github-pages jekyll`
 4. `bundle install`

--- a/site/develop/make-release.md
+++ b/site/develop/make-release.md
@@ -17,7 +17,7 @@ Commit the changes back to Apache along with a tag for the release candidate.
 
 ~~~
 % git commit -s -S -am 'Preparing for release X.Y.Z'
-% git remote add apache https://git-wip-us.apache.org/repos/asf/orc.git
+% git remote add apache https://gitbox.apache.org/repos/asf/orc.git
 % git push apache branch-X.Y
 % git tag release-X.Y.Zrc0
 % git push apache release-X.Y.Zrc0
@@ -136,7 +136,7 @@ Change directory in to site.
 % cd target
 Set up site/target to be a separate git workspace that tracks the asf-site branch.
 % git init
-% git remote add origin https://git-wip-us.apache.org/repos/asf/orc.git -t asf-site
+% git remote add origin https://gitbox.apache.org/repos/asf/orc.git -t asf-site
 % git fetch origin
 % git checkout asf-site
 % cd ..

--- a/site/doap_orc.rdf
+++ b/site/doap_orc.rdf
@@ -51,7 +51,7 @@ the values that are required for the current query.</description>
     </release>
     <repository>
       <GitRepository>
-        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/orc.git"/>
+        <location rdf:resource="https://gitbox.apache.org/repos/asf/orc.git"/>
         <browse rdf:resource="https://github.com/apache/orc"/>
       </GitRepository>
     </repository>


### PR DESCRIPTION
This PR aims to replace the obsolete `git-wip-us` to `gitbox` URLs because `git-wip-us` is removed now.