### PR TITLE
ORC-461. Replace `git-wip-us` with `gitbox`

### DIFF
--- a/develop/make-release/index.html
+++ b/develop/make-release/index.html
@@ -96,7 +96,7 @@
 <p>Commit the changes back to Apache along with a tag for the release candidate.</p>
 
 <div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>% git commit -s -S -am 'Preparing for release X.Y.Z'
-% git remote add apache https://git-wip-us.apache.org/repos/asf/orc.git
+% git remote add apache https://gitbox.apache.org/repos/asf/orc.git
 % git push apache branch-X.Y
 % git tag release-X.Y.Zrc0
 % git push apache release-X.Y.Zrc0
@@ -211,7 +211,7 @@ extra releases (say I.J.K) from the Apache dist area.
 % cd target
 Set up site/target to be a separate git workspace that tracks the asf-site branch.
 % git init
-% git remote add origin https://git-wip-us.apache.org/repos/asf/orc.git -t asf-site
+% git remote add origin https://gitbox.apache.org/repos/asf/orc.git -t asf-site
 % git fetch origin
 % git checkout asf-site
 % cd ..

--- a/doap_orc.rdf
+++ b/doap_orc.rdf
@@ -51,7 +51,7 @@ the values that are required for the current query.</description>
     </release>
     <repository>
       <GitRepository>
-        <location rdf:resource="https://git-wip-us.apache.org/repos/asf/orc.git"/>
+        <location rdf:resource="https://gitbox.apache.org/repos/asf/orc.git"/>
         <browse rdf:resource="https://github.com/apache/orc"/>
       </GitRepository>
     </repository>


### PR DESCRIPTION
This PR aims to replace the obsolete git-wip-us to gitbox URLs because git-wip-us is removed now. And, this is a generate result from #356 .