### PR TITLE
ORC-462. Add `Dongjoon Hyun` to the committers page

### DIFF
--- a/site/develop/committers.md
+++ b/site/develop/committers.md
@@ -16,6 +16,7 @@ Chinna Rao Lalam        | chinnaraol   | Committer
 Chaoyu Tang             | ctang        | Committer
 Carl Steinbach          | cws          | Committer
 Daniel Dai              | daijy        | Committer
+Dongjoon Hyun           | dongjoon     | Committer
 Deepak Majeti           | mdeepak      | PMC
 Eugene Koifman          | ekoifman     | PMC
 Gang Wu                 | gangwu       | Committer


### PR DESCRIPTION
This PR adds `Dongjoon Hyun` to the committer page like the following.

![committer](https://user-images.githubusercontent.com/9700541/51562789-884c8580-1e3f-11e9-96de-fa320f1c40cc.png)
