### PR TITLE
ORC-463: Add `version` command

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -86,6 +86,7 @@ public class Driver {
           " [--define X=Y] <command> <args>");
       System.err.println();
       System.err.println("Commands:");
+      System.err.println("   version - print the version of this ORC tool");
       System.err.println("   meta - print the metadata about the ORC file");
       System.err.println("   data - print the data from the ORC file");
       System.err.println("   scan - scan the ORC file");
@@ -101,7 +102,9 @@ public class Driver {
     for(Map.Entry pair: confSettings.entrySet()) {
       conf.set(pair.getKey().toString(), pair.getValue().toString());
     }
-    if ("meta".equals(options.command)) {
+    if ("version".equals(options.command)) {
+      PrintVersion.main(conf, options.commandArgs);
+    } else if ("meta".equals(options.command)) {
       FileDump.main(conf, options.commandArgs);
     } else if ("data".equals(options.command)) {
       PrintData.main(conf, options.commandArgs);

--- a/java/tools/src/java/org/apache/orc/tools/PrintVersion.java
+++ b/java/tools/src/java/org/apache/orc/tools/PrintVersion.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.orc.tools;
+
+import org.apache.hadoop.conf.Configuration;
+
+import java.io.IOException;
+import java.util.Properties;
+
+/**
+ * Print the version of this ORC tool.
+ */
+public class PrintVersion {
+  public static final String UNKNOWN = "UNKNOWN";
+  public static final String FILE_NAME = "META-INF/maven/org.apache.orc/orc-tools/pom.properties";
+
+  static void main(Configuration conf, String[] args) throws IOException {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    try (java.io.InputStream resourceStream = classLoader.getResourceAsStream(FILE_NAME)) {
+      if (resourceStream == null) {
+        throw new IOException("Could not find " + FILE_NAME);
+      }
+      Properties props = new Properties();
+      props.load(resourceStream);
+      System.out.println("ORC " + props.getProperty("version", UNKNOWN));
+    }
+  }
+}


### PR DESCRIPTION
In the popular OS like Mac, many people uses `orc-tools` command instead of `java -jar orc-tools-1.6.0-SNAPSHOT-uber.jar`. This PR aims to add `version` command like the following.

```
$ orc-tools version
ORC 1.6.0-SNAPSHOT
```

```
$ orc-tools
ORC Java Tools

usage: java -jar orc-tools-*.jar [--help] [--define X=Y] <command> <args>

Commands:
version - print the version of this ORC tool
meta - print the metadata about the ORC file
data - print the data from the ORC file
scan - scan the ORC file
convert - convert CSV and JSON files to ORC
json-schema - scan JSON files to determine their schema
key - print information about the keys

To get more help, provide -h to the command
```