### PR TITLE
ORC-466: Show `mode` for `NoSuchPaddingException`

### DIFF
--- a/java/shims/src/java/org/apache/orc/EncryptionAlgorithm.java
+++ b/java/shims/src/java/org/apache/orc/EncryptionAlgorithm.java
@@ -60,7 +60,7 @@ public enum EncryptionAlgorithm {
     } catch (NoSuchAlgorithmException e) {
       throw new IllegalArgumentException("Bad algorithm " + algorithm);
     } catch (NoSuchPaddingException e) {
-      throw new IllegalArgumentException("Bad padding " + algorithm);
+      throw new IllegalArgumentException("Bad padding " + mode);
     }
   }
 


### PR DESCRIPTION
Since `NoSuchPaddingException` is thrown when a particular padding mechanism is requested but is not available in the environment, we had better show `mode` instead of `algorithm` in the exception message.