### PR TITLE
ORC-467. Upgrade storage-api to 2.7.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 
     <min.hadoop.version>2.2.0</min.hadoop.version>
     <hadoop.version>2.7.3</hadoop.version>
-    <storage-api.version>2.6.0</storage-api.version>
+    <storage-api.version>2.7.0</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>
 


### PR DESCRIPTION
This PR Upgrade storage-api to [2.7.0](https://github.com/apache/hive/releases/tag/rel%2Fstorage-release-2.7.0).
