### PR TITLE
ORC-486: Fix doc for nanoseconds encoding

### DIFF
--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1664,8 +1664,9 @@ namespace orc {
 
   // Because the number of nanoseconds often has a large number of trailing zeros,
   // the number has trailing decimal zero digits removed and the last three bits
-  // are used to record how many zeros were removed. Thus 1000 nanoseconds would
-  // be serialized as 0x0b and 100000 would be serialized as 0x0d.
+  // are used to record how many zeros were removed if the trailing zeros are
+  // more than 2. Thus 1000 nanoseconds would be serialized as 0x0a and
+  // 100000 would be serialized as 0x0c.
   static int64_t formatNano(int64_t nanos) {
     if (nanos == 0) {
       return 0;

--- a/site/specification/ORCv0.md
+++ b/site/specification/ORCv0.md
@@ -691,9 +691,9 @@ number of nanoseconds.
 
 Because the number of nanoseconds often has a large number of trailing
 zeros, the number has trailing decimal zero digits removed and the
-last three bits are used to record how many zeros were removed. Thus
-1000 nanoseconds would be serialized as 0x0b and 100000 would be
-serialized as 0x0d.
+last three bits are used to record how many zeros were removed. if the
+trailing zeros are more than 2. Thus 1000 nanoseconds would be
+serialized as 0x0a and 100000 would be serialized as 0x0c.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -864,9 +864,9 @@ number of nanoseconds.
 
 Because the number of nanoseconds often has a large number of trailing
 zeros, the number has trailing decimal zero digits removed and the
-last three bits are used to record how many zeros were removed. Thus
-1000 nanoseconds would be serialized as 0x0b and 100000 would be
-serialized as 0x0d.
+last three bits are used to record how many zeros were removed. if the
+trailing zeros are more than 2. Thus 1000 nanoseconds would be
+serialized as 0x0a and 100000 would be serialized as 0x0c.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -880,9 +880,9 @@ number of nanoseconds.
 
 Because the number of nanoseconds often has a large number of trailing
 zeros, the number has trailing decimal zero digits removed and the
-last three bits are used to record how many zeros were removed. Thus
-1000 nanoseconds would be serialized as 0x0b and 100000 would be
-serialized as 0x0d.
+last three bits are used to record how many zeros were removed. if the
+trailing zeros are more than 2. Thus 1000 nanoseconds would be
+serialized as 0x0a and 100000 would be serialized as 0x0c.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------


### PR DESCRIPTION
Fixes #468

Signed-off-by: Tadahito Kobayashi <takobayashi@nvidia.com>