### PR TITLE
ORC-470: [C++] Fix BooleanRleDecoderImpl::skip() read over end of stream

### DIFF
--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -537,8 +537,12 @@ namespace orc {
       numValues -= remainingBits;
       uint64_t bytesSkipped = numValues / 8;
       ByteRleDecoderImpl::skip(bytesSkipped);
-      ByteRleDecoderImpl::next(&lastByte, 1, nullptr);
-      remainingBits = 8 - (numValues % 8);
+      if (numValues % 8 != 0) {
+        ByteRleDecoderImpl::next(&lastByte, 1, nullptr);
+        remainingBits = 8 - (numValues % 8);
+      } else {
+        remainingBits = 0;
+      }
     }
   }
 


### PR DESCRIPTION
If boolean RLE input stream skips all remaining boolean values, we will get an exception since BooleanRLEDecoder still tries to read one last byte from underlying input stream even if the requested number of bits are multiple of 8 and then it reads over the end of stream. This patch fixes this by checking if BooleanRLEDecoder does not need to read one last byte.