### PR TITLE
ORC-478: [C++] Add move constructor for DataBuffer

### DIFF
--- a/c++/include/orc/MemoryPool.hh
+++ b/c++/include/orc/MemoryPool.hh
@@ -51,6 +51,9 @@ namespace orc {
 
   public:
     DataBuffer(MemoryPool& pool, uint64_t _size = 0);
+
+    DataBuffer(DataBuffer<T>&& buffer) noexcept;
+
     virtual ~DataBuffer();
 
     T* data() {

--- a/c++/src/MemoryPool.cc
+++ b/c++/src/MemoryPool.cc
@@ -62,6 +62,17 @@ namespace orc {
   }
 
   template <class T>
+  DataBuffer<T>::DataBuffer(DataBuffer<T>&& buffer
+                      ) noexcept:
+                      memoryPool(buffer.memoryPool),
+                      buf(buffer.buf),
+                      currentSize(buffer.currentSize),
+                      currentCapacity(buffer.currentCapacity)  {
+    buffer.buf = nullptr;
+    buffer.currentSize = 0;
+  }
+
+  template <class T>
   DataBuffer<T>::~DataBuffer(){
     for(uint64_t i=currentSize; i > 0; --i) {
       (buf + i - 1)->~T();

--- a/c++/src/MemoryPool.cc
+++ b/c++/src/MemoryPool.cc
@@ -70,6 +70,7 @@ namespace orc {
                       currentCapacity(buffer.currentCapacity)  {
     buffer.buf = nullptr;
     buffer.currentSize = 0;
+    buffer.currentCapacity = 0;
   }
 
   template <class T>


### PR DESCRIPTION
Add move constructor for DataBuffer to enable memory ownership transfer