### PR TITLE
ORC-474: Add a clear() method to ColumnVectorBatch

### DIFF
--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -68,6 +68,12 @@ namespace orc {
     virtual void resize(uint64_t capacity);
 
     /**
+     * Empties the vector from all its elements, recursively.
+     * Do not alter the current capacity.
+     */
+    virtual void clear();
+
+    /**
      * Heap memory used by the batch.
      */
     virtual uint64_t getMemoryUsage();
@@ -89,6 +95,7 @@ namespace orc {
     DataBuffer<int64_t> data;
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
   };
 
@@ -97,6 +104,7 @@ namespace orc {
     virtual ~DoubleVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
 
     DataBuffer<double> data;
@@ -107,6 +115,7 @@ namespace orc {
     virtual ~StringVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
 
     // pointers to the start of each string
@@ -154,6 +163,7 @@ namespace orc {
     virtual ~StructVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
     bool hasVariableLength();
 
@@ -165,6 +175,7 @@ namespace orc {
     virtual ~ListVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
     bool hasVariableLength();
 
@@ -183,6 +194,7 @@ namespace orc {
     virtual ~MapVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
     bool hasVariableLength();
 
@@ -203,6 +215,7 @@ namespace orc {
     virtual ~UnionVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
     bool hasVariableLength();
 
@@ -235,6 +248,7 @@ namespace orc {
     virtual ~Decimal64VectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
 
     // total number of digits
@@ -260,6 +274,7 @@ namespace orc {
     virtual ~Decimal128VectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
 
     // total number of digits
@@ -291,6 +306,7 @@ namespace orc {
     virtual ~TimestampVectorBatch();
     std::string toString() const;
     void resize(uint64_t capacity);
+    void clear();
     uint64_t getMemoryUsage();
 
     // the number of seconds past 1 Jan 1970 00:00 UTC (aka time_t)

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -49,6 +49,10 @@ namespace orc {
     }
   }
 
+  void ColumnVectorBatch::clear() {
+    numElements = 0;
+  }
+
   uint64_t ColumnVectorBatch::getMemoryUsage() {
     return static_cast<uint64_t>(notNull.capacity() * sizeof(char));
   }
@@ -80,6 +84,10 @@ namespace orc {
     }
   }
 
+  void LongVectorBatch::clear() {
+    numElements = 0;
+  }
+
   uint64_t LongVectorBatch::getMemoryUsage() {
     return ColumnVectorBatch::getMemoryUsage() +
         static_cast<uint64_t>(data.capacity() * sizeof(int64_t));
@@ -106,6 +114,10 @@ namespace orc {
       ColumnVectorBatch::resize(cap);
       data.resize(cap);
     }
+  }
+
+  void DoubleVectorBatch::clear() {
+    numElements = 0;
   }
 
   uint64_t DoubleVectorBatch::getMemoryUsage() {
@@ -161,6 +173,10 @@ namespace orc {
     }
   }
 
+  void StringVectorBatch::clear() {
+    numElements = 0;
+  }
+
   uint64_t StringVectorBatch::getMemoryUsage() {
     return ColumnVectorBatch::getMemoryUsage()
           + static_cast<uint64_t>(data.capacity() * sizeof(char*)
@@ -192,6 +208,13 @@ namespace orc {
 
   void StructVectorBatch::resize(uint64_t cap) {
     ColumnVectorBatch::resize(cap);
+  }
+
+  void StructVectorBatch::clear() {
+    for(size_t i=0; i < fields.size(); i++) {
+      fields[i]->clear();
+    }
+    numElements = 0;
   }
 
   uint64_t StructVectorBatch::getMemoryUsage() {
@@ -235,6 +258,11 @@ namespace orc {
     }
   }
 
+  void ListVectorBatch::clear() {
+    numElements = 0;
+    elements->clear();
+  }
+
   uint64_t ListVectorBatch::getMemoryUsage() {
     return ColumnVectorBatch::getMemoryUsage()
            + static_cast<uint64_t>(offsets.capacity() * sizeof(int64_t))
@@ -268,6 +296,12 @@ namespace orc {
       ColumnVectorBatch::resize(cap);
       offsets.resize(cap + 1);
     }
+  }
+
+  void MapVectorBatch::clear() {
+    keys->clear();
+    elements->clear();
+    numElements = 0;
   }
 
   uint64_t MapVectorBatch::getMemoryUsage() {
@@ -313,6 +347,13 @@ namespace orc {
       tags.resize(cap);
       offsets.resize(cap);
     }
+  }
+
+  void UnionVectorBatch::clear() {
+    for(size_t i=0; i < children.size(); i++) {
+      children[i]->clear();
+    }
+    numElements = 0;
   }
 
   uint64_t UnionVectorBatch::getMemoryUsage() {
@@ -362,6 +403,10 @@ namespace orc {
     }
   }
 
+  void Decimal64VectorBatch::clear() {
+    numElements = 0;
+  }
+
   uint64_t Decimal64VectorBatch::getMemoryUsage() {
     return ColumnVectorBatch::getMemoryUsage()
           + static_cast<uint64_t>(
@@ -394,6 +439,10 @@ namespace orc {
       values.resize(cap);
       readScales.resize(cap);
     }
+  }
+
+  void Decimal128VectorBatch::clear() {
+    numElements = 0;
   }
 
   uint64_t Decimal128VectorBatch::getMemoryUsage() {
@@ -453,6 +502,10 @@ namespace orc {
       data.resize(cap);
       nanoseconds.resize(cap);
     }
+  }
+
+  void TimestampVectorBatch::clear() {
+    numElements = 0;
   }
 
   uint64_t TimestampVectorBatch::getMemoryUsage() {


### PR DESCRIPTION
So that users can merely call it after a batch is written to empty it
recursively before adding new elements for the next batch.

Without that method I can think of no better way to reset a batch than to overload all the ColumnVectorBatch to add this method.