### PR TITLE
ORC-370:[C++] Reset BooleanRleDecoder remainingbits to zero on seek

### DIFF
--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -521,6 +521,7 @@ namespace orc {
   void BooleanRleDecoderImpl::seek(PositionProvider& location) {
     ByteRleDecoderImpl::seek(location);
     uint64_t consumed = location.next();
+    remainingBits = 0;
     if (consumed > 8) {
       throw ParseError("bad position");
     }


### PR DESCRIPTION
- Reset remaingbits to zero on seek to make sure correct data is read.