### PR TITLE
ORC-497 - Fix build failures for maven 3.6.x

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -176,7 +176,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.3</version>
+          <version>3.0.5</version>
           <configuration>
             <effort>Max</effort>
             <excludeFilterFile>${basedir}/src/findbugs/exclude.xml</excludeFilterFile>


### PR DESCRIPTION
While building the java side, with -Panalyze option, ORC build fails, this is because 'findbugs-maven-plugin' version 3.0.3 is not compatible with maven 3.6.X, upgrading 'findbugs-maven-plugin' to 3.0.5 (latest) fixes the issue. The patch is tested with older maven version (3.3.9)