### PR TITLE
[ORC-499][C++] Change databuffer resize and refill previous data

### DIFF
--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -90,7 +90,13 @@ void fillStringValues(const std::vector<std::string>& data,
     } else {
       batch->notNull[i] = 1;
       if (buffer.size() - offset < col.size()) {
-        buffer.reserve(buffer.size() * 2);
+        char* old_buffer = buffer.data();
+        buffer.resize(buffer.size() * 2);
+        char* new_buffer = buffer.data();
+        for (uint64_t refill_index = 0; refill_index < i; ++refill_index){
+          stringBatch->data[refill_index] = stringBatch->data[refill_index] - old_buffer + new_buffer;
+        }
+        std::cout << std::endl;
       }
       memcpy(buffer.data() + offset,
              col.c_str(),

--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -95,7 +95,7 @@ void fillStringValues(const std::vector<std::string>& data,
         buffer.resize(buffer.size() * 2);
       }
       char* newBufferAddress = buffer.data();
-      // Refill the new address to the stringBatch->data, if buffer's address has changed.
+      // Refill stringBatch->data with the new address, if buffer's address has changed.
       if (newBufferAddress != oldBufferAddress){
         for (uint64_t refillIndex = 0; refillIndex < i; ++refillIndex){
         stringBatch->data[refillIndex] = stringBatch->data[refillIndex] - oldBufferAddress + newBufferAddress;

--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -89,14 +89,17 @@ void fillStringValues(const std::vector<std::string>& data,
       hasNull = true;
     } else {
       batch->notNull[i] = 1;
-      if (buffer.size() - offset < col.size()) {
-        char* old_buffer = buffer.data();
+      char* oldBufferAddress = buffer.data();
+      // Resize the buffer in case buffer does not have remaining space to store the next string.
+      while (buffer.size() - offset < col.size()) {
         buffer.resize(buffer.size() * 2);
-        char* new_buffer = buffer.data();
-        for (uint64_t refill_index = 0; refill_index < i; ++refill_index){
-          stringBatch->data[refill_index] = stringBatch->data[refill_index] - old_buffer + new_buffer;
+      }
+      char* newBufferAddress = buffer.data();
+      // Refill the new address to the stringBatch->data, if buffer's address has changed.
+      if (newBufferAddress != oldBufferAddress){
+        for (uint64_t refillIndex = 0; refillIndex < i; ++refillIndex){
+        stringBatch->data[refillIndex] = stringBatch->data[refillIndex] - oldBufferAddress + newBufferAddress;
         }
-        std::cout << std::endl;
       }
       memcpy(buffer.data() + offset,
              col.c_str(),

--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -95,7 +95,7 @@ void fillStringValues(const std::vector<std::string>& data,
         buffer.resize(buffer.size() * 2);
       }
       char* newBufferAddress = buffer.data();
-      // Refill stringBatch->data with the new address, if buffer's address has changed.
+      // Refill stringBatch->data with the new addresses, if buffer's address has changed.
       if (newBufferAddress != oldBufferAddress){
         for (uint64_t refillIndex = 0; refillIndex < i; ++refillIndex){
         stringBatch->data[refillIndex] = stringBatch->data[refillIndex] - oldBufferAddress + newBufferAddress;


### PR DESCRIPTION
[C++] CSVFileImport.cc has error when DataBuffer running out and doubling size

CSVFileImport was using Databuffer::reserve() but this will not change the size.

Even the size was changed, the new buffer has totally different address, which will make previous stringBatch->data[i], (i is the already finished ones) stores the wrong address.

