### PR TITLE
ORC-501: [C++]Move blob ownership from StringColumnReader to StringVectorBatch to avoid data overriden

### DIFF
--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -122,6 +122,8 @@ namespace orc {
     DataBuffer<char*> data;
     // the length of each string
     DataBuffer<int64_t> length;
+    // string blob
+    DataBuffer<char> blob;
   };
 
   struct StringDictionary {

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -151,7 +151,8 @@ namespace orc {
   StringVectorBatch::StringVectorBatch(uint64_t capacity, MemoryPool& pool
                ): ColumnVectorBatch(capacity, pool),
                   data(pool, capacity),
-                  length(pool, capacity) {
+                  length(pool, capacity),
+                  blob(pool) {
     // PASS
   }
 


### PR DESCRIPTION
- Move blob ownership from StringColumnReader to StringVectorBatch to avoid data overriden
- Enforce memcpy on StringColumnReader to make sure string blob is owned by external user