### PR TITLE
ORC-510: Cleanup StreamOptions and CompressionCodec.Options

### DIFF
--- a/java/core/src/java/org/apache/orc/CompressionCodec.java
+++ b/java/core/src/java/org/apache/orc/CompressionCodec.java
@@ -17,11 +17,15 @@
  */
 package org.apache.orc;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.EnumSet;
 
-public interface CompressionCodec {
+/**
+ * The API for compression codecs for ORC.
+ * Closeable.close() returns this codec to the OrcCodecPool.
+ */
+public interface CompressionCodec extends Closeable {
 
   enum SpeedModifier {
     /* speed/compression tradeoffs */
@@ -36,15 +40,32 @@ public interface CompressionCodec {
   }
 
   interface Options {
+    /**
+     * Make a copy before making changes.
+     * @return a new copy
+     */
+    Options copy();
+
+    /**
+     * Set the speed for the compression.
+     * @param newValue how aggressively to compress
+     * @return this
+     */
     Options setSpeed(SpeedModifier newValue);
+
+    /**
+     * Set the kind of data for the compression.
+     * @param newValue what kind of data this is
+     * @return this
+     */
     Options setData(DataKind newValue);
   }
 
   /**
-   * Create an instance of the default options for this codec.
-   * @return a new options object
+   * Get the default options for this codec.
+   * @return the default options object
    */
-  Options createOptions();
+  Options getDefaultOptions();
 
   /**
    * Compress the in buffer to the out buffer.
@@ -70,10 +91,16 @@ public interface CompressionCodec {
   void reset();
 
   /** Closes the codec, releasing the resources. */
-  void close();
+  void destroy();
 
   /**
    * Get the compression kind.
    */
   CompressionKind getKind();
+
+  /**
+   * Return the codec to the pool.
+   */
+  @Override
+  void close();
 }

--- a/java/core/src/java/org/apache/orc/impl/AircompressorCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/AircompressorCodec.java
@@ -98,24 +98,36 @@ public class AircompressorCodec implements CompressionCodec {
     out.flip();
   }
 
-  /**
-   * Return an options object that doesn't do anything
-   * @return a new options object
-   */
+  private static final Options NULL_OPTION = new Options() {
+    @Override
+    public Options copy() {
+      return this;
+    }
+
+    @Override
+    public Options setSpeed(SpeedModifier newValue) {
+      return this;
+    }
+
+    @Override
+    public Options setData(DataKind newValue) {
+      return this;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other != null && getClass() == other.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+  };
+
   @Override
-  public Options createOptions() {
-    return new Options() {
-
-      @Override
-      public Options setSpeed(SpeedModifier newValue) {
-        return this;
-      }
-
-      @Override
-      public Options setData(DataKind newValue) {
-        return this;
-      }
-    };
+  public Options getDefaultOptions() {
+    return NULL_OPTION;
   }
 
   @Override
@@ -124,12 +136,17 @@ public class AircompressorCodec implements CompressionCodec {
   }
 
   @Override
-  public void close() {
+  public void destroy() {
     // Nothing to do.
   }
 
   @Override
   public CompressionKind getKind() {
     return kind;
+  }
+
+  @Override
+  public void close() {
+    OrcCodecPool.returnCodec(kind, this);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/CryptoUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/CryptoUtils.java
@@ -18,8 +18,9 @@
 
 package org.apache.orc.impl;
 
-import org.apache.orc.EncryptionAlgorithm;
-import java.security.SecureRandom;
+import org.apache.orc.OrcProto;
+
+import java.util.function.Consumer;
 
 /**
  * This class has routines to work with encryption within ORC files.
@@ -36,43 +37,77 @@ public class CryptoUtils {
   static final int MAX_STRIPE = 0xffffff;
 
   /**
-   * Create a unique IV for each stream within a single key.
+   * Update the unique IV for each stream within a single key.
    * The top bytes are set with the column, stream kind, and stripe id and the
    * lower 8 bytes are always 0.
    * @param name the stream name
    * @param stripeId the stripe id
-   * @return the iv for the stream
    */
-  public static byte[] createIvForStream(EncryptionAlgorithm algorithm,
-                                         StreamName name,
-                                         int stripeId) {
-    byte[] iv = new byte[algorithm.getIvLength()];
-    int columnId = name.getColumn();
+  public static Consumer<byte[]> modifyIvForStream(StreamName name,
+                                                   long stripeId) {
+    return modifyIvForStream(name.getColumn(), name.getKind(), stripeId);
+  }
+
+  /**
+   * Update the unique IV for each stream within a single key.
+   * The top bytes are set with the column, stream kind, and stripe id and the
+   * lower 8 bytes are always 0.
+   * @param columnId the column id
+   * @param kind the stream kind
+   * @param stripeId the stripe id
+   */
+  public static Consumer<byte[]> modifyIvForStream(int columnId,
+                                                   OrcProto.Stream.Kind kind,
+                                                   long stripeId) {
     if (columnId < 0 || columnId > MAX_COLUMN) {
       throw new IllegalArgumentException("ORC encryption is limited to " +
-          MAX_COLUMN + " columns. Value = " + columnId);
+                                             MAX_COLUMN + " columns. Value = " + columnId);
     }
-    int k = name.getKind().getNumber();
+    int k = kind.getNumber();
     if (k < 0 || k > MAX_KIND) {
       throw new IllegalArgumentException("ORC encryption is limited to " +
-          MAX_KIND + " stream kinds. Value = " + k);
+                                             MAX_KIND + " stream kinds. Value = " + k);
     }
-    if (stripeId < 0 || stripeId > MAX_STRIPE){
+    return (byte[] iv) -> {
+      // the rest of the iv is used for counting within the stream
+      if (iv.length - (COLUMN_ID_LENGTH + KIND_LENGTH + STRIPE_ID_LENGTH) < MIN_COUNT_BYTES) {
+        throw new IllegalArgumentException("Not enough space in the iv for the count");
+      }
+      iv[0] = (byte) (columnId >> 16);
+      iv[1] = (byte) (columnId >> 8);
+      iv[2] = (byte) columnId;
+      iv[COLUMN_ID_LENGTH] = (byte) (k >> 8);
+      iv[COLUMN_ID_LENGTH + 1] = (byte) (k);
+      modifyIvForStripe(stripeId).accept(iv);
+    };
+  }
+
+  /**
+   * Modify the IV for the given stripe id and make sure the low bytes are
+   * set to 0.
+   * @param stripeId the stripe id
+   */
+  public static Consumer<byte[]> modifyIvForStripe(long stripeId) {
+    if (stripeId < 1 || stripeId > MAX_STRIPE) {
       throw new IllegalArgumentException("ORC encryption is limited to " +
-          MAX_STRIPE + " stripes. Value = " + stripeId);
+                                             MAX_STRIPE + " stripes. Value = " +
+                                             stripeId);
     }
-    // the rest of the iv is used for counting within the stream
-    if (iv.length - (COLUMN_ID_LENGTH + KIND_LENGTH + STRIPE_ID_LENGTH) < MIN_COUNT_BYTES) {
-      throw new IllegalArgumentException("Not enough space in the iv for the count");
+    return (byte[] iv) -> {
+      iv[COLUMN_ID_LENGTH + KIND_LENGTH] = (byte) (stripeId >> 16);
+      iv[COLUMN_ID_LENGTH + KIND_LENGTH + 1] = (byte) (stripeId >> 8);
+      iv[COLUMN_ID_LENGTH + KIND_LENGTH + 2] = (byte) stripeId;
+      clearCounter(iv);
+    };
+  }
+
+  /**
+   * Clear the counter part of the IV.
+   * @param iv the IV to modify
+   */
+  public static void clearCounter(byte[] iv) {
+    for(int i= COLUMN_ID_LENGTH + KIND_LENGTH + STRIPE_ID_LENGTH; i < iv.length; ++i) {
+      iv[i] = 0;
     }
-    iv[0] = (byte)(columnId >> 16);
-    iv[1] = (byte)(columnId >> 8);
-    iv[2] = (byte)columnId;
-    iv[COLUMN_ID_LENGTH] = (byte)(k >> 8);
-    iv[COLUMN_ID_LENGTH+1] = (byte)(k);
-    iv[COLUMN_ID_LENGTH+KIND_LENGTH] = (byte)(stripeId >> 16);
-    iv[COLUMN_ID_LENGTH+KIND_LENGTH+1] = (byte)(stripeId >> 8);
-    iv[COLUMN_ID_LENGTH+KIND_LENGTH+2] = (byte)stripeId;
-    return iv;
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -85,7 +85,7 @@ public final class OrcCodecPool {
         }
       }
       // We didn't add the codec to the list.
-      codec.close();
+      codec.destroy();
     } catch (Exception ex) {
       LOG.error("Ignoring codec cleanup error", ex);
     }

--- a/java/core/src/java/org/apache/orc/impl/SnappyCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/SnappyCodec.java
@@ -81,8 +81,8 @@ public class SnappyCodec extends AircompressorCodec
   }
 
   @Override
-  public void close() {
-    super.close();
+  public void destroy() {
+    super.destroy();
     if (decompressShim != null) {
       decompressShim.end();
     }

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -21,7 +21,6 @@ package org.apache.orc.impl;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -83,8 +82,7 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
   private final Path path;
   private long adjustedStripeSize;
   private final int rowIndexStride;
-  private final CompressionKind compress;
-  private int bufferSize;
+  private final StreamOptions compress;
   private final TypeDescription schema;
   private final PhysicalWriter physicalWriter;
   private final OrcFile.WriterVersion writerVersion;
@@ -148,17 +146,24 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     this.version = opts.getVersion();
     this.encodingStrategy = opts.getEncodingStrategy();
     this.compressionStrategy = opts.getCompressionStrategy();
-    this.compress = opts.getCompress();
     this.rowIndexStride = opts.getRowIndexStride();
     this.memoryManager = opts.getMemoryManager();
     buildIndex = rowIndexStride > 0;
     int numColumns = schema.getMaximumId() + 1;
     if (opts.isEnforceBufferSize()) {
       OutStream.assertBufferSizeValid(opts.getBufferSize());
-      this.bufferSize = opts.getBufferSize();
+      compress = new StreamOptions(opts.getBufferSize());
     } else {
-      this.bufferSize = getEstimatedBufferSize(adjustedStripeSize,
-          numColumns, opts.getBufferSize());
+      compress = new StreamOptions(getEstimatedBufferSize(adjustedStripeSize,
+          numColumns, opts.getBufferSize()));
+    }
+    this.physicalWriter = opts.getPhysicalWriter() == null
+                              ? new PhysicalFsWriter(fs, path, opts)
+                              : opts.getPhysicalWriter();
+    physicalWriter.writeHeader();
+    CompressionCodec codec = physicalWriter.getCompressionCodec();
+    if (codec != null) {
+      compress.withCodec(codec, codec.getDefaultOptions());
     }
     if (version == OrcFile.Version.FUTURE) {
       throw new IllegalArgumentException("Can not write in a unknown version.");
@@ -175,9 +180,6 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
           OrcUtils.includeColumns(opts.getBloomFilterColumns(), schema);
     }
     this.bloomFilterFpp = opts.getBloomFilterFpp();
-    this.physicalWriter = opts.getPhysicalWriter() == null ?
-        new PhysicalFsWriter(fs, path, opts) : opts.getPhysicalWriter();
-    physicalWriter.writeHeader();
     treeWriter = TreeWriter.Factory.create(schema, new StreamFactory(), false);
     if (buildIndex && rowIndexStride < MIN_ROW_INDEX_STRIDE) {
       throw new IllegalArgumentException("Row stride must be at least " +
@@ -187,8 +189,8 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     // ensure that we are able to handle callbacks before we register ourselves
     memoryManager.addWriter(path, opts.getStripeSize(), this);
     LOG.info("ORC writer created for path: {} with stripeSize: {} blockSize: {}" +
-        " compression: {} bufferSize: {}", path, adjustedStripeSize, opts.getBlockSize(),
-        compress, bufferSize);
+        " compression: {}", path, adjustedStripeSize, opts.getBlockSize(),
+        compress);
   }
 
   //@VisibleForTesting
@@ -205,8 +207,8 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
 
   @Override
   public void increaseCompressionSize(int newSize) {
-    if (newSize > bufferSize) {
-      bufferSize = newSize;
+    if (newSize > compress.getBufferSize()) {
+      compress.bufferSize(newSize);
     }
   }
 
@@ -270,40 +272,6 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     return false;
   }
 
-
-  public static
-  CompressionCodec.Options getCustomizedCodec(CompressionCodec codec,
-                                              OrcFile.CompressionStrategy strategy,
-                                              OrcProto.Stream.Kind kind) {
-    CompressionCodec.Options result = codec.createOptions();
-    switch (kind) {
-      case BLOOM_FILTER:
-      case DATA:
-      case DICTIONARY_DATA:
-      case BLOOM_FILTER_UTF8:
-        result.setData(CompressionCodec.DataKind.TEXT);
-        if (strategy == OrcFile.CompressionStrategy.SPEED) {
-          result.setSpeed(CompressionCodec.SpeedModifier.FAST);
-        } else {
-          result.setSpeed(CompressionCodec.SpeedModifier.DEFAULT);
-        }
-        break;
-      case LENGTH:
-      case DICTIONARY_COUNT:
-      case PRESENT:
-      case ROW_INDEX:
-      case SECONDARY:
-        // easily compressed using the fastest modes
-        result.setSpeed(CompressionCodec.SpeedModifier.FASTEST)
-            .setData(CompressionCodec.DataKind.BINARY);
-        break;
-      default:
-        LOG.info("Missing ORC compression modifiers for " + kind);
-        break;
-    }
-    return result;
-  }
-
   /**
    * Interface from the Writer to the TreeWriters. This limits the visibility
    * that the TreeWriters have into the Writer.
@@ -319,14 +287,9 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
                                   OrcProto.Stream.Kind kind
                                   ) throws IOException {
       final StreamName name = new StreamName(column, kind);
-      CompressionCodec codec = physicalWriter.getCompressionCodec();
-      StreamOptions options = new StreamOptions(bufferSize);
-      if (codec != null) {
-        options.withCodec(codec, getCustomizedCodec(codec, compressionStrategy,
-            kind));
-      }
       return new OutStream(physicalWriter.toString(),
-          options, physicalWriter.createDataStream(name));
+          SerializationUtils.getCustomizedCodec(compress, compressionStrategy, kind),
+          physicalWriter.createDataStream(name));
     }
 
     /**
@@ -500,15 +463,18 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
   }
 
   private long writePostScript() throws IOException {
+    CompressionCodec codec = compress.getCodec();
     OrcProto.PostScript.Builder builder =
         OrcProto.PostScript.newBuilder()
-            .setCompression(writeCompressionKind(compress))
+            .setCompression(writeCompressionKind(codec == null
+                                                     ? CompressionKind.NONE
+                                                     : codec.getKind()))
             .setMagic(OrcFile.MAGIC)
             .addVersion(version.getMajor())
             .addVersion(version.getMinor())
             .setWriterVersion(writerVersion.getId());
-    if (compress != CompressionKind.NONE) {
-      builder.setCompressionBlockSize(bufferSize);
+    if (compress.getCodec() != null) {
+      builder.setCompressionBlockSize(compress.getBufferSize());
     }
     return physicalWriter.writePostScript(builder);
   }

--- a/java/core/src/test/org/apache/orc/impl/TestBitFieldReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestBitFieldReader.java
@@ -32,7 +32,7 @@ public class TestBitFieldReader {
     final int COUNT = 16384;
     StreamOptions options = new StreamOptions(500);
     if (codec != null) {
-      options.withCodec(codec, codec.createOptions());
+      options.withCodec(codec, codec.getDefaultOptions());
     }
     BitFieldWriter out = new BitFieldWriter(
         new OutStream("test", options, collect), 1);

--- a/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
@@ -31,9 +31,10 @@ public class TestCryptoUtils {
 
   @Test
   public void testCreateStreamIv() throws Exception {
-    byte[] iv = CryptoUtils.createIvForStream(EncryptionAlgorithm.AES_CTR_128,
-        new StreamName(0x234567,
-        OrcProto.Stream.Kind.BLOOM_FILTER_UTF8), 0x123456);
+    EncryptionAlgorithm aes128 = EncryptionAlgorithm.AES_CTR_128;
+    byte[] iv = new byte[aes128.getIvLength()];
+    CryptoUtils.modifyIvForStream(0x234567, OrcProto.Stream.Kind.BLOOM_FILTER_UTF8,
+        0x123456).accept(iv);
     assertEquals(16, iv.length);
     assertEquals(0x23, iv[0]);
     assertEquals(0x45, iv[1]);

--- a/java/core/src/test/org/apache/orc/impl/TestIntegerCompressionReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestIntegerCompressionReader.java
@@ -17,8 +17,6 @@
  */
 package org.apache.orc.impl;
 
-import static junit.framework.Assert.assertEquals;
-
 import java.nio.ByteBuffer;
 import java.util.Random;
 
@@ -26,13 +24,15 @@ import org.apache.orc.CompressionCodec;
 import org.apache.orc.impl.writer.StreamOptions;
 import org.junit.Test;
 
+import static org.junit.Assert.assertEquals;
+
 public class TestIntegerCompressionReader {
 
   public void runSeekTest(CompressionCodec codec) throws Exception {
     TestInStream.OutputCollector collect = new TestInStream.OutputCollector();
     StreamOptions options = new StreamOptions(1000);
     if (codec != null) {
-      options.withCodec(codec, codec.createOptions());
+      options.withCodec(codec, codec.getDefaultOptions());
     }
     RunLengthIntegerWriterV2 out = new RunLengthIntegerWriterV2(
         new OutStream("test", options, collect), true);

--- a/java/core/src/test/org/apache/orc/impl/TestRunLengthByteReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRunLengthByteReader.java
@@ -72,7 +72,7 @@ public class TestRunLengthByteReader {
   public void testCompressedSeek() throws Exception {
     CompressionCodec codec = new SnappyCodec();
     StreamOptions options = new StreamOptions(500)
-                                .withCodec(codec, codec.createOptions());
+                                .withCodec(codec, codec.getDefaultOptions());
     TestInStream.OutputCollector collect = new TestInStream.OutputCollector();
     RunLengthByteWriter out = new RunLengthByteWriter(
         new OutStream("test", options, collect));

--- a/java/core/src/test/org/apache/orc/impl/TestRunLengthIntegerReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRunLengthIntegerReader.java
@@ -32,7 +32,7 @@ public class TestRunLengthIntegerReader {
     TestInStream.OutputCollector collect = new TestInStream.OutputCollector();
     StreamOptions options = new StreamOptions(1000);
     if (codec != null) {
-      options.withCodec(codec, codec.createOptions());
+      options.withCodec(codec, codec.getDefaultOptions());
     }
     RunLengthIntegerWriter out = new RunLengthIntegerWriter(
         new OutStream("test", options, collect), true);

--- a/java/core/src/test/org/apache/orc/impl/TestStreamName.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStreamName.java
@@ -38,7 +38,6 @@ public class TestStreamName {
     assertEquals(false, s1.equals(s2));
     assertEquals(false, s1.equals(s3));
     assertEquals(true, s1.equals(s1p));
-    assertEquals(true, s1.compareTo(null) < 0);
     assertEquals(false, s1.equals(null));
     assertEquals(true, s1.compareTo(s2) < 0);
     assertEquals(true, s2.compareTo(s3) < 0);

--- a/java/core/src/test/org/apache/orc/impl/TestZlib.java
+++ b/java/core/src/test/org/apache/orc/impl/TestZlib.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TestZlib {
 
@@ -37,7 +37,7 @@ public class TestZlib {
     in.flip();
     CompressionCodec codec = new ZlibCodec();
     assertEquals(false, codec.compress(in, out, null,
-        codec.createOptions()));
+        codec.getDefaultOptions()));
   }
 
   @Test


### PR DESCRIPTION
The writer's stream options should be cleaned up. There are a couple of related items:

* We end up changing the IV's for streams and we need to notify the stream when we do so, therefore it is better to make an explicit API to change them.
* CryptoUtils should match with functions to modify an IV rather than forcing an allocation.
* CompressionCodec.Options only needs to be copied when we have tuning options.
* CompressionCodec would be nice to have as Closeable where that returns it to the pool.

