### PR TITLE
ORC-509: Update KeyProvider to match the updated spec.

### DIFF
--- a/java/core/src/java/org/apache/orc/InMemoryKeystore.java
+++ b/java/core/src/java/org/apache/orc/InMemoryKeystore.java
@@ -18,11 +18,11 @@
 package org.apache.orc;
 
 import org.apache.orc.impl.HadoopShims;
+import org.apache.orc.impl.LocalKey;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
@@ -60,13 +60,11 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
 
   static {
     try {
-      SUPPORTS_AES_256 = Cipher.getMaxAllowedKeyLength("AES") > 128;
+      SUPPORTS_AES_256 = Cipher.getMaxAllowedKeyLength("AES") >= 256;
     } catch (final NoSuchAlgorithmException e) {
       throw new IllegalArgumentException("Unknown algorithm", e);
     }
   }
-
-  private static final String LOCAL_KEY_CIPHER = "/CBC/NoPadding";
 
   private final Random random;
 
@@ -85,7 +83,7 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
    * Create a new InMemoryKeystore.
    */
   public InMemoryKeystore() {
-    this.random = new SecureRandom();
+    this(new SecureRandom());
   }
 
   /**
@@ -104,7 +102,7 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
    * @param version the version of the key
    * @return the versionName of the key.
    */
-  protected static String buildVersionName(final String name,
+  private static String buildVersionName(final String name,
       final int version) {
     return name + "@" + version;
   }
@@ -143,28 +141,23 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
    * @return the local key's material
    */
   @Override
-  public HadoopShims.LocalKey createLocalKey(final HadoopShims.KeyMetadata key) {
+  public LocalKey createLocalKey(final HadoopShims.KeyMetadata key) {
     final String keyVersion = buildVersionName(key.getKeyName(), key.getVersion());
     if (!keys.containsKey(keyVersion)) {
       throw new IllegalArgumentException("Unknown key " + key);
     }
     final KeyVersion secret = keys.get(keyVersion);
     final EncryptionAlgorithm algorithm = secret.getAlgorithm();
-    byte[] unecryptedKey = new byte[algorithm.keyLength()];
-    random.nextBytes(unecryptedKey);
+    byte[] encryptedKey = new byte[algorithm.keyLength()];
+    random.nextBytes(encryptedKey);
     byte[] iv = new byte[algorithm.getIvLength()];
-    String cipherName = algorithm.getAlgorithm() + LOCAL_KEY_CIPHER;
-    Cipher localCipher;
+    System.arraycopy(encryptedKey, 0, iv, 0, iv.length);
+    Cipher localCipher = algorithm.createCipher();
 
     try {
-      localCipher = Cipher.getInstance(cipherName);
-      localCipher.init(Cipher.ENCRYPT_MODE,
+      localCipher.init(Cipher.DECRYPT_MODE,
           new SecretKeySpec(secret.getMaterial(),
           algorithm.getAlgorithm()), new IvParameterSpec(iv));
-    } catch (NoSuchPaddingException e) {
-      throw new IllegalStateException( "ORC bad padding for " + cipherName, e);
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException( "ORC bad algorithm for " + cipherName, e);
     } catch (final InvalidKeyException e) {
       throw new IllegalStateException(
           "ORC bad encryption key for " + keyVersion, e);
@@ -174,10 +167,8 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
     }
 
     try {
-      byte[] encryptedKey = localCipher.doFinal(unecryptedKey);
-      return new HadoopShims.LocalKey(new SecretKeySpec(unecryptedKey,
-          algorithm.getAlgorithm()),
-          encryptedKey);
+      byte[] decryptedKey = localCipher.doFinal(encryptedKey);
+      return new LocalKey(algorithm, decryptedKey, encryptedKey);
     } catch (final IllegalBlockSizeException e) {
       throw new IllegalStateException(
           "ORC bad block size for " + keyVersion, e);
@@ -211,18 +202,13 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
     final KeyVersion secret = keys.get(keyVersion);
     final EncryptionAlgorithm algorithm = secret.getAlgorithm();
     byte[] iv = new byte[algorithm.getIvLength()];
-    String cipherName = algorithm.getAlgorithm() + LOCAL_KEY_CIPHER;
-    Cipher localCipher;
+    System.arraycopy(encryptedKey, 0, iv, 0, iv.length);
+    Cipher localCipher = algorithm.createCipher();
 
     try {
-      localCipher = Cipher.getInstance(cipherName);
       localCipher.init(Cipher.DECRYPT_MODE,
           new SecretKeySpec(secret.getMaterial(),
           algorithm.getAlgorithm()), new IvParameterSpec(iv));
-    } catch (NoSuchPaddingException e) {
-      throw new IllegalStateException( "ORC bad padding for " + cipherName, e);
-    } catch (NoSuchAlgorithmException e) {
-      throw new IllegalStateException( "ORC bad algorithm for " + cipherName, e);
     } catch (final InvalidKeyException e) {
       throw new IllegalStateException(
           "ORC bad encryption key for " + keyVersion, e);
@@ -241,6 +227,11 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
       throw new IllegalStateException(
           "ORC bad padding for " + keyVersion, e);
     }
+  }
+
+  @Override
+  public HadoopShims.KeyProviderKind getKind() {
+    return HadoopShims.KeyProviderKind.HADOOP;
   }
 
   /**
@@ -331,7 +322,7 @@ public class InMemoryKeystore implements HadoopShims.KeyProvider {
      *
      * @return the material
      */
-    public byte[] getMaterial() {
+    private byte[] getMaterial() {
       return material;
     }
 

--- a/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
+++ b/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
@@ -19,6 +19,7 @@ package org.apache.orc;
 
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.orc.impl.HadoopShims;
+import org.apache.orc.impl.LocalKey;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,44 +88,44 @@ public class TestInMemoryKeystore {
     HadoopShims.KeyMetadata metadata128 = memoryKeystore
         .getCurrentKeyVersion("key128");
 
-    HadoopShims.LocalKey key128 = memoryKeystore.createLocalKey(metadata128);
+    LocalKey key128 = memoryKeystore.createLocalKey(metadata128);
     // we are sure the key is the same because of the random generator.
     Assert.assertEquals("39 72 2c bb f8 b9 1a 4b 90 45 c5 e6 17 5f 10 01",
-        stringify(key128.decryptedKey.getEncoded()));
+        stringify(key128.getEncryptedKey()));
+    Assert.assertEquals("46 33 66 fd 79 57 66 9a ba 4a 28 df bf 16 f2 88",
+        stringify(key128.getDecryptedKey().getEncoded()));
     // used online aes/cbc calculator to encrypt key
-    Assert.assertEquals("7f 41 4a 46 81 ee 7c d1 2a 0f ed 39 a8 49 e2 89",
-        stringify(key128.encryptedKey));
-    Assert.assertEquals("AES", key128.decryptedKey.getAlgorithm());
+    Assert.assertEquals("AES", key128.getDecryptedKey().getAlgorithm());
 
     // now decrypt the key again
     Key decryptKey = memoryKeystore.decryptLocalKey(metadata128,
-        key128.encryptedKey);
-    Assert.assertEquals(stringify(key128.decryptedKey.getEncoded()),
+        key128.getEncryptedKey());
+    Assert.assertEquals(stringify(key128.getDecryptedKey().getEncoded()),
         stringify(decryptKey.getEncoded()));
 
     HadoopShims.KeyMetadata metadata256 = memoryKeystore
         .getCurrentKeyVersion("key256");
-    HadoopShims.LocalKey key256 = memoryKeystore.createLocalKey(metadata256);
+    LocalKey key256 = memoryKeystore.createLocalKey(metadata256);
     // this is forced by the fixed Random in the keystore for this test
     if (InMemoryKeystore.SUPPORTS_AES_256) {
-      Assert.assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08 0f 7b" +
-              " 6c db 79 e5 51 ec 9c 9c c7 fc bd 60 ee 73",
-          stringify(key256.decryptedKey.getEncoded()));
-      // used online aes/cbc calculator to encrypt key
-      Assert.assertEquals("ea 73 33 5b 14 5d 70 d8 3f e9 d1 05 2b 2d 62 a0 86 16"+
-              " ad a0 2a d6 8a 20 46 1d 00 ce f9 2a 31 48",
-          stringify(key256.encryptedKey));
+      Assert.assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08 0f " +
+                              "7b 6c db 79 e5 51 ec 9c 9c c7 fc bd 60 ee 73",
+          stringify(key256.getEncryptedKey()));
+       // used online aes/cbc calculator to encrypt key
+      Assert.assertEquals("00 b0 1c 24 d9 03 bc 02 63 87 b3 f9 65 4e e7 a8 b8" +
+                              " 58 eb a0 81 06 b3 61 cf f8 06 ba 30 d4 c5 36",
+          stringify(key256.getDecryptedKey().getEncoded()));
     } else {
       Assert.assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08",
-          stringify(key256.decryptedKey.getEncoded()));
-      Assert.assertEquals("87 df d0 2a 68 1a b9 cb a7 88 ec f4 83 49 95 e0",
-          stringify(key256.encryptedKey));
+          stringify(key256.getEncryptedKey()));
+      Assert.assertEquals("6d 1c ff 55 a5 44 75 11 fb e6 8e 08 cd 2a 10 e8",
+          stringify(key256.getDecryptedKey().getEncoded()));
     }
-    Assert.assertEquals("AES", key256.decryptedKey.getAlgorithm());
+    Assert.assertEquals("AES", key256.getDecryptedKey().getAlgorithm());
 
     // now decrypt the key again
-    decryptKey = memoryKeystore.decryptLocalKey(metadata256, key256.encryptedKey);
-    Assert.assertEquals(stringify(key256.decryptedKey.getEncoded()),
+    decryptKey = memoryKeystore.decryptLocalKey(metadata256, key256.getEncryptedKey());
+    Assert.assertEquals(stringify(key256.getDecryptedKey().getEncoded()),
         stringify(decryptKey.getEncoded()));
   }
 

--- a/java/shims/src/java/org/apache/orc/EncryptionAlgorithm.java
+++ b/java/shims/src/java/org/apache/orc/EncryptionAlgorithm.java
@@ -93,4 +93,9 @@ public enum EncryptionAlgorithm {
     throw new IllegalArgumentException("Unknown code in encryption algorithm " +
         serialization);
   }
+
+  @Override
+  public String toString() {
+    return algorithm + (keyLength * 8);
+  }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
@@ -80,5 +80,10 @@ public class HadoopShimsPre2_3 implements HadoopShims {
     public Key decryptLocalKey(KeyMetadata key, byte[] encryptedKey) {
       return null;
     }
+
+    @Override
+    public KeyProviderKind getKind() {
+      return null;
+    }
   }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -106,11 +106,13 @@ public class HadoopShimsPre2_7 implements HadoopShims {
    *
    * So the flow looks like:
    * <pre>
-   *   encryptedKey = securely random 16 bytes
+   *   encryptedKey = securely random 16 or 32 bytes
+   *   iv = first 16 byte of encryptedKey
    *   --- on KMS ---
-   *   tmpKey0 = aes(masterKey, encryptedKey)
-   *   tmpKey1 = aes(masterKey, encryptedKey+1)
-   *   decryptedKey = xor(tmpKey0, 0) + xor(tmpKey1, 0)
+   *   tmpKey0 = aes(masterKey, iv)
+   *   tmpKey1 = aes(masterKey, iv+1)
+   *   decryptedKey0 = xor(tmpKey0, encryptedKey0)
+   *   decryptedKey1 = xor(tmpKey1, encryptedKey1)
    * </pre>
    *
    * In the long term, we should probably fix Hadoop's generateEncryptedKey
@@ -139,21 +141,34 @@ public class HadoopShimsPre2_7 implements HadoopShims {
           findAlgorithm(meta));
     }
 
+    /**
+     * The Ranger/Hadoop KMS mangles the IV by bit flipping it in a misguided
+     * attempt to improve security. By bit flipping it here, we undo the
+     * silliness so that we get
+     * @param input the input array to copy from
+     * @param output the output array to write to
+     */
+    private static void unmangleIv(byte[] input, byte[] output) {
+      for(int i=0; i < output.length && i < input.length; ++i) {
+        output[i] = (byte) (0xff ^ input[i]);
+      }
+    }
+
     @Override
     public LocalKey createLocalKey(KeyMetadata key) throws IOException {
       EncryptionAlgorithm algorithm = key.getAlgorithm();
-      byte[] encryptedKey = new byte[algorithm.getIvLength()];
+      byte[] encryptedKey = new byte[algorithm.keyLength()];
       random.nextBytes(encryptedKey);
+      byte[] iv = new byte[algorithm.getIvLength()];
+      unmangleIv(encryptedKey, iv);
       KeyProviderCryptoExtension.EncryptedKeyVersion param =
           KeyProviderCryptoExtension.EncryptedKeyVersion.createForDecryption(
-              key.getKeyName(), buildKeyVersionName(key), encryptedKey,
-              algorithm.getZeroKey());
+              key.getKeyName(), buildKeyVersionName(key), iv, encryptedKey);
       try {
         KeyProviderCryptoExtension.KeyVersion decryptedKey =
             ((KeyProviderCryptoExtension) provider)
                 .decryptEncryptedKey(param);
-        return new LocalKey(new SecretKeySpec(decryptedKey.getMaterial(),
-                                              algorithm.getAlgorithm()),
+        return new LocalKey(algorithm, decryptedKey.getMaterial(),
                             encryptedKey);
       } catch (GeneralSecurityException e) {
         throw new IOException("Can't create local encryption key for " + key, e);
@@ -164,10 +179,11 @@ public class HadoopShimsPre2_7 implements HadoopShims {
     public Key decryptLocalKey(KeyMetadata key,
                                byte[] encryptedKey) throws IOException {
       EncryptionAlgorithm algorithm = key.getAlgorithm();
+      byte[] iv = new byte[algorithm.getIvLength()];
+      unmangleIv(encryptedKey, iv);
       KeyProviderCryptoExtension.EncryptedKeyVersion param =
           KeyProviderCryptoExtension.EncryptedKeyVersion.createForDecryption(
-              key.getKeyName(), buildKeyVersionName(key), encryptedKey,
-              algorithm.getZeroKey());
+              key.getKeyName(), buildKeyVersionName(key), iv, encryptedKey);
       try {
         KeyProviderCryptoExtension.KeyVersion decrypted =
             ((KeyProviderCryptoExtension) provider)
@@ -177,6 +193,11 @@ public class HadoopShimsPre2_7 implements HadoopShims {
       } catch (GeneralSecurityException e) {
         return null;
       }
+    }
+
+    @Override
+    public HadoopShims.KeyProviderKind getKind() {
+      return HadoopShims.KeyProviderKind.HADOOP;
     }
   }
 

--- a/java/shims/src/java/org/apache/orc/impl/LocalKey.java
+++ b/java/shims/src/java/org/apache/orc/impl/LocalKey.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.orc.EncryptionAlgorithm;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.security.Key;
+
+/**
+ * Local keys are random keys that are generated for each file & column.
+ * The file's metadata includes the encryptedKey and the reader needs to
+ * use the KeyProvider to get the decryptedKey.
+ */
+public class LocalKey {
+  private final byte[] encryptedKey;
+  private Key decryptedKey;
+
+  public LocalKey(EncryptionAlgorithm algorithm,
+                  byte[] decryptedKey,
+                  byte[] encryptedKey) {
+    this.encryptedKey = encryptedKey;
+    if (decryptedKey != null) {
+      setDecryptedKey(new SecretKeySpec(decryptedKey, algorithm.getAlgorithm()));
+    }
+  }
+
+  public void setDecryptedKey(Key key) {
+    decryptedKey = key;
+  }
+
+  public Key getDecryptedKey() {
+    return decryptedKey;
+  }
+
+  public byte[] getEncryptedKey() {
+    return encryptedKey;
+  }
+}

--- a/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
+++ b/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
@@ -81,9 +81,16 @@ public class TestHadoopShimsPre2_7 {
     assertEquals(true, keyNames.contains("secret"));
     HadoopShims.KeyMetadata piiKey = provider.getCurrentKeyVersion("pii");
     assertEquals(1, piiKey.getVersion());
-    HadoopShims.LocalKey localKey = provider.createLocalKey(piiKey);
-    Key key = provider.decryptLocalKey(piiKey, localKey.encryptedKey);
-    assertEquals(new BytesWritable(localKey.decryptedKey.getEncoded()).toString(),
+    LocalKey localKey = provider.createLocalKey(piiKey);
+    byte[] encrypted = localKey.getEncryptedKey();
+    // make sure that we get exactly what we expect to test the encryption
+    assertEquals("c7 ab 4f bb 38 f4 de ad d0 b3 59 e2 21 2a 95 32",
+        new BytesWritable(encrypted).toString());
+    // now check to make sure that we get the expected bytes back
+    assertEquals("c7 a1 d0 41 7b 24 72 44 1a 58 c7 72 4a d4 be b3",
+        new BytesWritable(localKey.getDecryptedKey().getEncoded()).toString());
+    Key key = provider.decryptLocalKey(piiKey, encrypted);
+    assertEquals(new BytesWritable(localKey.getDecryptedKey().getEncoded()).toString(),
         new BytesWritable(key.getEncoded()).toString());
   }
 


### PR DESCRIPTION
The big things here are:
* Record how the keys were encrypted.
* Make the "Hadoop KMS" shim generate the encrypted key and use the prefix as the IV.
* Make the "Hadoop KMS" shim bit flip the IV to compensate for the bit flip in the KMS.
* Add test cases that check to make sure we get the results we expect for the encrypted key.
* Pull the LocalKey out of the HadoopShim class.