### PR TITLE
Fix specification of float encoding in BloomFilter

### DIFF
--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -1271,10 +1271,9 @@ message BloomFilterIndex {
 Bloom filter internally uses two different hash functions to map a key
 to a position in the bit set. For tinyint, smallint, int, bigint, float
 and double types, Thomas Wang's 64-bit integer hash function is used.
-Floats are converted to IEEE-754 32 bit representation
-(using Java's Float.floatToIntBits(float)). Similary, Doubles are
-converted to IEEE-754 64 bit representation (using Java's
-Double.doubleToLongBits(double)). All these primitive types
+Doubles are converted to IEEE-754 64 bit representation (using Java's
+Double.doubleToLongBits(double)). Floats are as converted to double 
+(using Java's float to double cast).  All these primitive types
 are cast to long base type before being passed on to the hash function.
 For strings and binary types, Murmur3 64 bit hash algorithm is used.
 The 64 bit variant of Murmur3 considers only the most significant


### PR DESCRIPTION
Floats are converted to double and added to BloomFilter according to the double rules.

The relevant code in the Java ORC writer is here (note that `value` is type float, and the code calls `addDouble`)
https://github.com/apache/orc/blob/d81131b9d608779f48d7de6a3c11ece03a3bc0a0/java/core/src/java/org/apache/orc/impl/writer/FloatTreeWriter.java#L56-L66