### PR TITLE
ORC-513: [C++] Improve RowReaderImpl::seekToRow performance

### DIFF
--- a/c++/src/ColumnReader.hh
+++ b/c++/src/ColumnReader.hh
@@ -135,6 +135,13 @@ namespace orc {
       next(rowBatch, numValues, notNull);
     }
 
+    /**
+     * Seek to beginning of a row group in the current stripe
+     * @param positions a list of PositionProviders storing the positions
+     */
+    virtual void seekToRowGroup(
+      std::unordered_map<uint64_t, PositionProvider>& positions);
+
   };
 
   /**

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -140,6 +140,15 @@ namespace orc {
     // internal methods
     void startNextStripe();
 
+    // row index of current stripe with column id as the key
+    std::unordered_map<uint64_t, proto::RowIndex> rowIndexes;
+
+    /**
+     * Seek to the start of a row group in the current stripe
+     * @param rowGroupEntryId the row group id to seek to
+     */
+    void seekToRowGroup(uint32_t rowGroupEntryId);
+
   public:
    /**
     * Constructor that lets the user specify additional options.


### PR DESCRIPTION
Automatically levarage row group index to seek. Optimized for selected
columns only.