### PR TITLE
ORC-518: Ignore findbugs false positives from jdk11.

### DIFF
--- a/java/core/src/findbugs/exclude.xml
+++ b/java/core/src/findbugs/exclude.xml
@@ -31,4 +31,11 @@
     <Bug pattern="MS_PKGPROTECT"/>
     <Class name="org.apache.orc.impl.RecordReaderImpl$SargApplier"/>
   </Match>
+  <!-- Java's try with resources causes a false positive.
+       See https://github.com/SERG-Delft/jpacman/pull/27 . -->
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    <Class name="org.apache.orc.impl.OrcAcidUtils"/>
+    <Method name="getLastFlushLength"/>
+  </Match>
 </FindBugsFilter>

--- a/java/tools/src/findbugs/exclude.xml
+++ b/java/tools/src/findbugs/exclude.xml
@@ -16,4 +16,11 @@
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2,DM_EXIT"/>
   </Match>
+  <!-- Java's try with resources causes a false positive.
+       See https://github.com/SERG-Delft/jpacman/pull/27 . -->
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+    <Class name="org.apache.orc.tools.PrintVersion"/>
+    <Method name="main"/>
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
Adds exclusions to fix the false positives.