### PR TITLE
ORC-517: Fix incorrect minimum and maximum statistics for decimal64 columns.

### DIFF
--- a/java/core/src/findbugs/exclude.xml
+++ b/java/core/src/findbugs/exclude.xml
@@ -31,4 +31,11 @@
     <Bug pattern="MS_PKGPROTECT"/>
     <Class name="org.apache.orc.impl.RecordReaderImpl$SargApplier"/>
   </Match>
+  <!-- Java's try with resources causes a false positive.
+       See https://github.com/SERG-Delft/jpacman/pull/27 . -->
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    <Class name="org.apache.orc.impl.OrcAcidUtils"/>
+    <Method name="getLastFlushLength"/>
+  </Match>
 </FindBugsFilter>

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -171,6 +171,7 @@ public class OrcFile {
     HIVE_13083(WriterImplementation.ORC_JAVA, 4), // decimals write present stream correctly
     ORC_101(WriterImplementation.ORC_JAVA, 5),   // bloom filters use utf8
     ORC_135(WriterImplementation.ORC_JAVA, 6),   // timestamp stats use utc
+    ORC_517(WriterImplementation.ORC_JAVA, 7),   // decimal64 min/max are fixed
 
     // C++ ORC Writer
     ORC_CPP_ORIGINAL(WriterImplementation.ORC_CPP, 6),
@@ -254,7 +255,7 @@ public class OrcFile {
   /**
    * The WriterVersion for this version of the software.
    */
-  public static final WriterVersion CURRENT_WRITER = WriterVersion.ORC_135;
+  public static final WriterVersion CURRENT_WRITER = WriterVersion.ORC_517;
 
   public enum EncodingStrategy {
     SPEED, COMPRESSION

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -959,8 +959,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       implements DecimalColumnStatistics {
 
     private final int scale;
-    private long minimum;
-    private long maximum;
+    private long minimum = Long.MAX_VALUE;
+    private long maximum = Long.MIN_VALUE;
     private boolean hasSum = true;
     private long sum = 0;
     private final HiveDecimalWritable scratch = new HiveDecimalWritable();
@@ -975,9 +975,13 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       OrcProto.DecimalStatistics dec = stats.getDecimalStatistics();
       if (dec.hasMaximum()) {
         maximum = new HiveDecimalWritable(dec.getMaximum()).serialize64(scale);
+      } else {
+        maximum = Long.MIN_VALUE;
       }
       if (dec.hasMinimum()) {
         minimum = new HiveDecimalWritable(dec.getMinimum()).serialize64(scale);
+      } else {
+        minimum = Long.MAX_VALUE;
       }
       if (dec.hasSum()) {
         hasSum = true;
@@ -995,8 +999,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     @Override
     public void reset() {
       super.reset();
-      minimum = 0;
-      maximum = 0;
+      minimum = Long.MAX_VALUE;
+      maximum = Long.MIN_VALUE;
       hasSum = true;
       sum = 0;
     }
@@ -1022,12 +1026,10 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           value > TypeDescription.MAX_DECIMAL64) {
         throw new IllegalArgumentException("Out of bounds decimal64 " + value);
       }
-      if (getNumberOfValues() == 0) {
+      if (minimum > value) {
         minimum = value;
-        maximum = value;
-      } else if (minimum > value) {
-        minimum = value;
-      } else if (maximum < value) {
+      }
+      if (maximum < value) {
         maximum = value;
       }
       if (hasSum) {
@@ -1061,7 +1063,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        if (getNumberOfValues() != 0) {
+        if (other.getNumberOfValues() != 0) {
           throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
         }
       }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -451,7 +451,7 @@ public class RecordReaderImpl implements RecordReader {
                                            OrcProto.ColumnEncoding encoding,
                                            OrcProto.BloomFilter bloomFilter,
                                            OrcFile.WriterVersion writerVersion,
-                                           TypeDescription.Category type) {
+                                           TypeDescription type) {
     return evaluatePredicateProto(statsProto, predicate, kind, encoding, bloomFilter,
         writerVersion, type, false);
   }
@@ -476,14 +476,15 @@ public class RecordReaderImpl implements RecordReader {
                                            OrcProto.ColumnEncoding encoding,
                                            OrcProto.BloomFilter bloomFilter,
                                            OrcFile.WriterVersion writerVersion,
-                                           TypeDescription.Category type,
+                                           TypeDescription type,
                                            boolean useUTCTimestamp) {
     ColumnStatistics cs = ColumnStatisticsImpl.deserialize(null, statsProto);
     Object minValue = getMin(cs, useUTCTimestamp);
     Object maxValue = getMax(cs, useUTCTimestamp);
     // files written before ORC-135 stores timestamp wrt to local timezone causing issues with PPD.
     // disable PPD for timestamp for all old files
-    if (type.equals(TypeDescription.Category.TIMESTAMP)) {
+    TypeDescription.Category category = type.getCategory();
+    if (category == TypeDescription.Category.TIMESTAMP) {
       if (!writerVersion.includes(OrcFile.WriterVersion.ORC_135)) {
         LOG.debug("Not using predication pushdown on {} because it doesn't " +
                   "include ORC-135. Writer version: {}",
@@ -495,10 +496,19 @@ public class RecordReaderImpl implements RecordReader {
           predicate.getType() != PredicateLeaf.Type.STRING) {
         return TruthValue.YES_NO_NULL;
       }
+    } else if (writerVersion == OrcFile.WriterVersion.ORC_135 &&
+               category == TypeDescription.Category.DECIMAL &&
+               type.getPrecision() <= TypeDescription.MAX_DECIMAL64_PRECISION) {
+      // ORC 1.5.0 to 1.5.5, which use WriterVersion.ORC_135, have broken
+      // min and max values for decimal64. See ORC-517.
+      LOG.debug("Not using predicate push down on {}, because the file doesn't"+
+                   " include ORC-517. Writer version: {}",
+          predicate.getColumnName(), writerVersion);
+      return TruthValue.YES_NO_NULL;
     }
     return evaluatePredicateRange(predicate, minValue, maxValue, cs.hasNull(),
-        BloomFilterIO.deserialize(kind, encoding, writerVersion, type, bloomFilter),
-        useUTCTimestamp);
+        BloomFilterIO.deserialize(kind, encoding, writerVersion, type.getCategory(),
+            bloomFilter), useUTCTimestamp);
   }
 
   /**
@@ -953,7 +963,7 @@ public class RecordReaderImpl implements RecordReader {
                 leafValues[pred] = evaluatePredicateProto(stats,
                     predicate, bfk, encodings.get(columnIx), bf,
                     writerVersion, evolution.getFileSchema().
-                    findSubtype(columnIx).getCategory(),
+                    findSubtype(columnIx),
                     useUTCTimestamp);
               } catch (Exception e) {
                 exceptionCount[pred] += 1;

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -41,7 +41,6 @@ import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -420,7 +419,7 @@ public class TestRecordReaderImpl {
             .build();
     return RecordReaderImpl.evaluatePredicateProto(stats, predicate, null,
         encoding, null,
-        OrcFile.WriterVersion.ORC_135, TypeDescription.Category.BOOLEAN);
+        OrcFile.WriterVersion.ORC_135, TypeDescription.createBoolean());
   }
 
   static TruthValue evaluateInteger(OrcProto.ColumnStatistics stats,
@@ -431,7 +430,7 @@ public class TestRecordReaderImpl {
             .build();
     return RecordReaderImpl.evaluatePredicateProto(stats, predicate, null,
         encoding, null,
-        OrcFile.WriterVersion.ORC_135, TypeDescription.Category.LONG);
+        OrcFile.WriterVersion.ORC_135, TypeDescription.createLong());
   }
 
   static TruthValue evaluateDouble(OrcProto.ColumnStatistics stats,
@@ -442,7 +441,7 @@ public class TestRecordReaderImpl {
             .build();
     return RecordReaderImpl.evaluatePredicateProto(stats, predicate, null,
         encoding, null,
-        OrcFile.WriterVersion.ORC_135, TypeDescription.Category.DOUBLE);
+        OrcFile.WriterVersion.ORC_135, TypeDescription.createDouble());
   }
 
   static TruthValue evaluateTimestamp(OrcProto.ColumnStatistics stats,
@@ -456,7 +455,7 @@ public class TestRecordReaderImpl {
     return RecordReaderImpl.evaluatePredicateProto(stats, predicate, null,
         encoding, null,
         include135 ? OrcFile.WriterVersion.ORC_135: OrcFile.WriterVersion.ORC_101,
-        TypeDescription.Category.TIMESTAMP, useUTCTimestamp);
+        TypeDescription.createTimestamp(), useUTCTimestamp);
   }
 
   static TruthValue evaluateTimestampBloomfilter(OrcProto.ColumnStatistics stats,
@@ -479,7 +478,7 @@ public class TestRecordReaderImpl {
     BloomFilterIO.serialize(builder, bloom);
     return RecordReaderImpl.evaluatePredicateProto(stats, predicate, kind,
         encoding.build(), builder.build(), version,
-        TypeDescription.Category.TIMESTAMP, useUTCTimestamp);
+        TypeDescription.createTimestamp(), useUTCTimestamp);
   }
 
   @Test

--- a/java/tools/src/findbugs/exclude.xml
+++ b/java/tools/src/findbugs/exclude.xml
@@ -16,4 +16,11 @@
   <Match>
     <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2,DM_EXIT"/>
   </Match>
+  <!-- Java's try with resources causes a false positive.
+       See https://github.com/SERG-Delft/jpacman/pull/27 . -->
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
+    <Class name="org.apache.orc.tools.PrintVersion"/>
+    <Method name="main"/>
+  </Match>
 </FindBugsFilter>

--- a/java/tools/src/test/resources/orc-file-dump-bloomfilter.out
+++ b/java/tools/src/test/resources/orc-file-dump-bloomfilter.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_135
+File Version: 0.12 with ORC_517
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-dump-bloomfilter2.out
+++ b/java/tools/src/test/resources/orc-file-dump-bloomfilter2.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_135
+File Version: 0.12 with ORC_517
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-dump-dictionary-threshold.out
+++ b/java/tools/src/test/resources/orc-file-dump-dictionary-threshold.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_135
+File Version: 0.12 with ORC_517
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-dump.json
+++ b/java/tools/src/test/resources/orc-file-dump.json
@@ -1,7 +1,7 @@
 {
   "fileName": "TestFileDump.testDump.orc",
   "fileVersion": "0.12",
-  "writerVersion": "ORC_135",
+  "writerVersion": "ORC_517",
   "numberOfRows": 21000,
   "compression": "ZLIB",
   "compressionBufferSize": 4096,

--- a/java/tools/src/test/resources/orc-file-dump.out
+++ b/java/tools/src/test/resources/orc-file-dump.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_135
+File Version: 0.12 with ORC_517
 Rows: 21000
 Compression: ZLIB
 Compression size: 4096

--- a/java/tools/src/test/resources/orc-file-has-null.out
+++ b/java/tools/src/test/resources/orc-file-has-null.out
@@ -1,5 +1,5 @@
 Structure for TestFileDump.testDump.orc
-File Version: 0.12 with ORC_135
+File Version: 0.12 with ORC_517
 Rows: 20000
 Compression: ZLIB
 Compression size: 4096

--- a/proto/orc_proto.proto
+++ b/proto/orc_proto.proto
@@ -249,6 +249,7 @@ message PostScript {
   //   4 = HIVE-13083 fixed (decimals write present stream correctly)
   //   5 = ORC-101 fixed (bloom filters use utf8 consistently)
   //   6 = ORC-135 fixed (timestamp statistics use utc)
+  //   7 = ORC-517 fixed (decimal64 min/max incorrect)
   //
   // Version of the ORC C++ writer:
   //   6 = original


### PR DESCRIPTION
The new decimal64 implementation was using the item count to determine whether there were any values already loaded. Unfortunately, the writer was updating the item count before updating the decimal min/max. This led to using 0 as the minimum and maximum.