### PR TITLE
ORC-487. Implements column encryption for the row reader.

### DIFF
--- a/java/core/src/java/org/apache/orc/DataReader.java
+++ b/java/core/src/java/org/apache/orc/DataReader.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.apache.hadoop.hive.common.io.DiskRangeList;
+import org.apache.orc.impl.BufferChunkList;
 import org.apache.orc.impl.OrcIndex;
 
 /** An abstract data reader that IO formats can use to read bytes from underlying storage. */
@@ -30,32 +31,21 @@ public interface DataReader extends AutoCloseable, Cloneable {
   /** Opens the DataReader, making it ready to use. */
   void open() throws IOException;
 
-  OrcIndex readRowIndex(StripeInformation stripe,
-                        TypeDescription fileSchema,
-                        OrcProto.StripeFooter footer,
-                        boolean ignoreNonUtf8BloomFilter,
-                        boolean[] included,
-                        OrcProto.RowIndex[] indexes,
-                        boolean[] sargColumns,
-                        OrcFile.WriterVersion version,
-                        OrcProto.Stream.Kind[] bloomFilterKinds,
-                        OrcProto.BloomFilterIndex[] bloomFilterIndices
-                        ) throws IOException;
-
   OrcProto.StripeFooter readStripeFooter(StripeInformation stripe) throws IOException;
 
-  /** Reads the data.
+  /**
+   * Reads the data from the file.
    *
-   * Note that for the cases such as zero-copy read, caller must release the disk ranges
-   * produced after being done with them. Call isTrackingDiskRanges to find out if this is needed.
-   * @param range List if disk ranges to read. Ranges with data will be ignored.
-   * @param baseOffset Base offset from the start of the file of the ranges in disk range list.
+   * Note that for the cases such as zero-copy read, caller must release the disk
+   * ranges produced after being done with them. Call isTrackingDiskRanges to
+   * find out if this is needed.
+   *
+   * @param range List of disk ranges to read. Ranges with data will be ignored.
    * @param doForceDirect Whether the data should be read into direct buffers.
    * @return New or modified list of DiskRange-s, where all the ranges are filled with data.
    */
-  DiskRangeList readFileData(
-      DiskRangeList range, long baseOffset, boolean doForceDirect) throws IOException;
-
+  BufferChunkList readFileData(BufferChunkList range,
+                             boolean doForceDirect) throws IOException;
 
   /**
    * Whether the user should release buffers created by readFileData. See readFileData javadoc.
@@ -77,7 +67,7 @@ public interface DataReader extends AutoCloseable, Cloneable {
   DataReader clone();
 
   @Override
-  public void close() throws IOException;
+  void close() throws IOException;
 
   /**
    * Returns the compression codec used by this datareader.

--- a/java/core/src/java/org/apache/orc/OrcUtils.java
+++ b/java/core/src/java/org/apache/orc/OrcUtils.java
@@ -616,9 +616,17 @@ public class OrcUtils {
 
   public static List<StripeInformation> convertProtoStripesToStripes(
       List<OrcProto.StripeInformation> stripes) {
-    List<StripeInformation> result = new ArrayList<StripeInformation>(stripes.size());
-    for (OrcProto.StripeInformation info : stripes) {
-      result.add(new ReaderImpl.StripeInformationImpl(info));
+    List<StripeInformation> result = new ArrayList<>(stripes.size());
+    long previousStripeId = -1;
+    byte[][] previousKeys = null;
+    long stripeId = 0;
+    for (OrcProto.StripeInformation stripeProto: stripes) {
+      ReaderImpl.StripeInformationImpl stripe =
+          new ReaderImpl.StripeInformationImpl(stripeProto, stripeId++,
+              previousStripeId, previousKeys);
+      result.add(stripe);
+      previousStripeId = stripe.getEncryptionStripeId();
+      previousKeys = stripe.getEncryptedLocalKeys();
     }
     return result;
   }

--- a/java/core/src/java/org/apache/orc/StripeInformation.java
+++ b/java/core/src/java/org/apache/orc/StripeInformation.java
@@ -56,4 +56,25 @@ public interface StripeInformation {
    * @return a count of the number of rows
    */
   long getNumberOfRows();
+
+  /**
+   * Get the index of this stripe in the current file.
+   * @return 0 to number_of_stripes - 1
+   */
+  long getStripeId();
+
+  /**
+   * Get the original stripe id that was used when the stripe was originally
+   * written. This is only different that getStripeId in merged files.
+   * @return the original stripe id
+   */
+  long getEncryptionStripeId();
+
+  /**
+   * Get the encrypted keys starting from this stripe until overridden by
+   * a new set in a following stripe. The top level array is one for each
+   * encryption variant. Each element is an encrypted key.
+   * @return the array of encrypted keys
+   */
+  byte[][] getEncryptedLocalKeys();
 }

--- a/java/core/src/java/org/apache/orc/impl/BitFieldWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/BitFieldWriter.java
@@ -18,6 +18,7 @@
 package org.apache.orc.impl;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 public class BitFieldWriter {
   private RunLengthByteWriter output;
@@ -69,5 +70,9 @@ public class BitFieldWriter {
 
   public long estimateMemory() {
     return output.estimateMemory();
+  }
+
+  public void changeIv(Consumer<byte[]> modifier) {
+    output.changeIv(modifier);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/BufferChunk.java
+++ b/java/core/src/java/org/apache/orc/impl/BufferChunk.java
@@ -1,6 +1,4 @@
-package org.apache.orc.impl;
-
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -18,6 +16,8 @@ package org.apache.orc.impl;
  * limitations under the License.
  */
 
+package org.apache.orc.impl;
+
 import org.apache.hadoop.hive.common.io.DiskRange;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
 import org.slf4j.Logger;
@@ -34,15 +34,20 @@ public class BufferChunk extends DiskRangeList {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(BufferChunk.class);
-  final ByteBuffer chunk;
+  private ByteBuffer chunk;
+
+  public BufferChunk(long offset, int length) {
+    super(offset, offset + length);
+    chunk = null;
+  }
 
   public BufferChunk(ByteBuffer chunk, long offset) {
     super(offset, offset + chunk.remaining());
     this.chunk = chunk;
   }
 
-  public ByteBuffer getChunk() {
-    return chunk;
+  public void setChunk(ByteBuffer chunk) {
+    this.chunk = chunk;
   }
 
   @Override
@@ -52,10 +57,14 @@ public class BufferChunk extends DiskRangeList {
 
   @Override
   public final String toString() {
-    boolean makesSense = chunk.remaining() == (end - offset);
-    return "data range [" + offset + ", " + end + "), size: " + chunk.remaining()
-        + (makesSense ? "" : "(!)") + " type: " +
-        (chunk.isDirect() ? "direct" : "array-backed");
+    if (chunk == null) {
+      return "data range[" + offset + ", " + end +")";
+    } else {
+      boolean makesSense = chunk.remaining() == (end - offset);
+      return "data range [" + offset + ", " + end + "), size: " + chunk.remaining()
+                 + (makesSense ? "" : "(!)") + " type: " +
+                 (chunk.isDirect() ? "direct" : "array-backed");
+    }
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/BufferChunkList.java
+++ b/java/core/src/java/org/apache/orc/impl/BufferChunkList.java
@@ -32,12 +32,26 @@ public class BufferChunkList {
     } else {
       tail.next = value;
       value.prev = tail;
+      value.next = null;
       tail = value;
     }
   }
 
   public BufferChunk get() {
     return head;
+  }
+
+  /**
+   * Get the nth element of the list
+   * @param chunk the element number to get from 0
+   * @return the given element number
+   */
+  public BufferChunk get(int chunk) {
+    BufferChunk ptr = head;
+    for(int i=0; i < chunk; ++i) {
+      ptr = ptr == null ? null : (BufferChunk) ptr.next;
+    }
+    return ptr;
   }
 
   public void clear() {

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -37,8 +37,10 @@ import org.apache.hadoop.hive.ql.util.TimestampUtils;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.TypeDescription.Category;
+import org.apache.orc.impl.reader.StripePlanner;
 
 /**
  * Convert ORC tree readers.
@@ -285,11 +287,9 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     }
 
     @Override
-    void startStripe(Map<StreamName, InStream> streams,
-        OrcProto.StripeFooter stripeFooter
-    ) throws IOException {
+    void startStripe(StripePlanner planner) throws IOException {
       // Pass-thru.
-      convertTreeReader.startStripe(streams, stripeFooter);
+      convertTreeReader.startStripe(planner);
     }
 
     @Override

--- a/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
+++ b/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,18 +20,14 @@ package org.apache.orc.impl;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.orc.CompressionKind;
-import org.apache.orc.OrcConf;
 
 public final class DataReaderProperties {
 
   private final FileSystem fileSystem;
   private final Path path;
   private final FSDataInputStream file;
-  private final CompressionKind compression;
+  private final InStream.StreamOptions compression;
   private final boolean zeroCopy;
-  private final int typeCount;
-  private final int bufferSize;
   private final int maxDiskRangeChunkLimit;
 
   private DataReaderProperties(Builder builder) {
@@ -40,8 +36,6 @@ public final class DataReaderProperties {
     this.file = builder.file;
     this.compression = builder.compression;
     this.zeroCopy = builder.zeroCopy;
-    this.typeCount = builder.typeCount;
-    this.bufferSize = builder.bufferSize;
     this.maxDiskRangeChunkLimit = builder.maxDiskRangeChunkLimit;
   }
 
@@ -57,20 +51,12 @@ public final class DataReaderProperties {
     return file;
   }
 
-  public CompressionKind getCompression() {
+  public InStream.StreamOptions getCompression() {
     return compression;
   }
 
   public boolean getZeroCopy() {
     return zeroCopy;
-  }
-
-  public int getTypeCount() {
-    return typeCount;
-  }
-
-  public int getBufferSize() {
-    return bufferSize;
   }
 
   public int getMaxDiskRangeChunkLimit() {
@@ -86,11 +72,9 @@ public final class DataReaderProperties {
     private FileSystem fileSystem;
     private Path path;
     private FSDataInputStream file;
-    private CompressionKind compression;
+    private InStream.StreamOptions compression;
     private boolean zeroCopy;
-    private int typeCount;
-    private int bufferSize;
-    private int maxDiskRangeChunkLimit = (int) OrcConf.ORC_MAX_DISK_RANGE_CHUNK_LIMIT.getDefaultValue();
+    private int maxDiskRangeChunkLimit;
 
     private Builder() {
 
@@ -111,7 +95,7 @@ public final class DataReaderProperties {
       return this;
     }
 
-    public Builder withCompression(CompressionKind value) {
+    public Builder withCompression(InStream.StreamOptions value) {
       this.compression = value;
       return this;
     }
@@ -121,18 +105,8 @@ public final class DataReaderProperties {
       return this;
     }
 
-    public Builder withTypeCount(int value) {
-      this.typeCount = value;
-      return this;
-    }
-
-    public Builder withBufferSize(int value) {
-      this.bufferSize = value;
-      return this;
-    }
-
     public Builder withMaxDiskRangeChunkLimit(int value) {
-      this.maxDiskRangeChunkLimit = value;
+      maxDiskRangeChunkLimit = value;
       return this;
     }
 

--- a/java/core/src/java/org/apache/orc/impl/IntegerWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/IntegerWriter.java
@@ -19,6 +19,7 @@
 package org.apache.orc.impl;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * Interface for writing integers.
@@ -50,4 +51,6 @@ public interface IntegerWriter {
    * @return number of bytes
    */
   long estimateMemory();
+
+  void changeIv(Consumer<byte[]> modifier);
 }

--- a/java/core/src/java/org/apache/orc/impl/OrcTail.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcTail.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -27,6 +27,7 @@ import org.apache.orc.CompressionCodec;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
 import org.apache.orc.OrcProto;
+import org.apache.orc.OrcUtils;
 import org.apache.orc.StripeInformation;
 import org.apache.orc.StripeStatistics;
 
@@ -77,11 +78,7 @@ public final class OrcTail {
   }
 
   public List<StripeInformation> getStripes() {
-    List<StripeInformation> result = new ArrayList<>(fileTail.getFooter().getStripesCount());
-    for (OrcProto.StripeInformation stripeProto : fileTail.getFooter().getStripesList()) {
-      result.add(new ReaderImpl.StripeInformationImpl(stripeProto));
-    }
-    return result;
+    return OrcUtils.convertProtoStripesToStripes(getFooter().getStripesList());
   }
 
   public CompressionKind getCompressionKind() {
@@ -92,9 +89,9 @@ public final class OrcTail {
     return (int) fileTail.getPostscript().getCompressionBlockSize();
   }
 
-  public List<StripeStatistics> getStripeStatistics() throws IOException {
+  public List<StripeStatistics> getStripeStatistics(InStream.StreamOptions options) throws IOException {
     List<StripeStatistics> result = new ArrayList<>();
-    List<OrcProto.StripeStatistics> ssProto = getStripeStatisticsProto();
+    List<OrcProto.StripeStatistics> ssProto = getStripeStatisticsProto(options);
     if (ssProto != null) {
       for (OrcProto.StripeStatistics ss : ssProto) {
         result.add(new StripeStatistics(ss.getColStatsList()));
@@ -103,17 +100,12 @@ public final class OrcTail {
     return result;
   }
 
-  public List<OrcProto.StripeStatistics> getStripeStatisticsProto() throws IOException {
+  public List<OrcProto.StripeStatistics> getStripeStatisticsProto(InStream.StreamOptions options) throws IOException {
     if (serializedTail == null) return null;
     if (metadata == null) {
-      CompressionCodec codec = OrcCodecPool.getCodec(getCompressionKind());
-      try {
-        metadata = extractMetadata(serializedTail, 0,
-            (int) fileTail.getPostscript().getMetadataLength(),
-            InStream.options().withCodec(codec).withBufferSize(getCompressionBufferSize()));
-      } finally {
-        OrcCodecPool.returnCodec(getCompressionKind(), codec);
-      }
+      metadata = extractMetadata(serializedTail, 0,
+          (int) fileTail.getPostscript().getMetadataLength(),
+          options);
       // clear does not clear the contents but sets position to 0 and limit = capacity
       serializedTail.clear();
     }
@@ -137,7 +129,6 @@ public final class OrcTail {
     OrcProto.Footer.Builder footerBuilder = OrcProto.Footer.newBuilder(fileTail.getFooter());
     footerBuilder.clearStatistics();
     fileTailBuilder.setFooter(footerBuilder.build());
-    OrcProto.FileTail result = fileTailBuilder.build();
-    return result;
+    return fileTailBuilder.build();
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/PhysicalFsWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/PhysicalFsWriter.java
@@ -22,19 +22,25 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedOutputStream;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.CompressionCodec;
+import org.apache.orc.EncryptionVariant;
 import org.apache.orc.OrcFile;
 import org.apache.orc.OrcProto;
 import org.apache.orc.PhysicalWriter;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.writer.WriterEncryptionKey;
+import org.apache.orc.impl.writer.WriterEncryptionVariant;
 import org.apache.orc.impl.writer.StreamOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,10 +52,12 @@ public class PhysicalFsWriter implements PhysicalWriter {
   private static final int HDFS_BUFFER_SIZE = 256 * 1024;
 
   private FSDataOutputStream rawWriter;
+  private final DirectStream rawStream;
+
   // the compressed metadata information outStream
-  private OutStream writer;
+  private OutStream compressStream;
   // a protobuf outStream around streamFactory
-  private CodedOutputStream protobufWriter;
+  private CodedOutputStream codedCompressStream;
 
   private final Path path;
   private final HadoopShims shims;
@@ -59,10 +67,7 @@ public class PhysicalFsWriter implements PhysicalWriter {
   private final OrcFile.CompressionStrategy compressionStrategy;
   private final boolean addBlockPadding;
   private final boolean writeVariableLengthBlocks;
-
-  // the streams that make up the current stripe
-  private final Map<StreamName, BufferedStream> streams =
-    new TreeMap<>();
+  private final VariantTracker unencrypted;
 
   private long headerLength;
   private long stripeStart;
@@ -70,11 +75,24 @@ public class PhysicalFsWriter implements PhysicalWriter {
   // natural blocks
   private long blockOffset;
   private int metadataLength;
+  private int stripeStatisticsLength = 0;
   private int footerLength;
+  private int stripeNumber = 0;
+
+  private final Map<WriterEncryptionVariant, VariantTracker> variants = new TreeMap<>();
 
   public PhysicalFsWriter(FileSystem fs,
                           Path path,
-                          OrcFile.WriterOptions opts) throws IOException {
+                          OrcFile.WriterOptions opts
+                          ) throws IOException {
+    this(fs, path, opts, new WriterEncryptionVariant[0]);
+  }
+
+  public PhysicalFsWriter(FileSystem fs,
+                          Path path,
+                          OrcFile.WriterOptions opts,
+                          WriterEncryptionVariant[] encryption
+                          ) throws IOException {
     this.path = path;
     long defaultStripeSize = opts.getStripeSize();
     this.addBlockPadding = opts.getBlockPadding();
@@ -98,16 +116,124 @@ public class PhysicalFsWriter implements PhysicalWriter {
     rawWriter = fs.create(path, opts.getOverwrite(), HDFS_BUFFER_SIZE,
         fs.getDefaultReplication(path), blockSize);
     blockOffset = 0;
-    writer = new OutStream("metadata", compress,
-        new DirectStream(rawWriter));
-    protobufWriter = CodedOutputStream.newInstance(writer);
+    unencrypted = new VariantTracker(opts.getSchema(), compress);
     writeVariableLengthBlocks = opts.getWriteVariableLengthBlocks();
     shims = opts.getHadoopShims();
+    rawStream = new DirectStream(rawWriter);
+    compressStream = new OutStream("stripe footer", compress, rawStream);
+    codedCompressStream = CodedOutputStream.newInstance(compressStream);
+    for(WriterEncryptionVariant variant: encryption) {
+      WriterEncryptionKey key = variant.getKeyDescription();
+      StreamOptions encryptOptions =
+          new StreamOptions(unencrypted.options)
+              .withEncryption(key.getAlgorithm(), variant.getFileFooterKey());
+      variants.put(variant, new VariantTracker(variant.getRoot(), encryptOptions));
+    }
   }
 
-  @Override
-  public CompressionCodec getCompressionCodec() {
-    return compress.getCodec();
+  /**
+   * Record the information about each column encryption variant.
+   * The unencrypted data and each encrypted column root are variants.
+   */
+  protected static class VariantTracker {
+    // the streams that make up the current stripe
+    protected final Map<StreamName, BufferedStream> streams = new TreeMap<>();
+    private final int rootColumn;
+    private final int lastColumn;
+    protected final StreamOptions options;
+    // a list for each column covered by this variant
+    // the elements in the list correspond to each stripe in the file
+    protected final List<OrcProto.ColumnStatistics>[] stripeStats;
+    protected final List<OrcProto.Stream> stripeStatsStreams = new ArrayList<>();
+    protected final OrcProto.ColumnStatistics[] fileStats;
+
+    VariantTracker(TypeDescription schema, StreamOptions options) {
+      rootColumn = schema.getId();
+      lastColumn = schema.getMaximumId();
+      this.options = options;
+      stripeStats = new List[schema.getMaximumId() - schema.getId() + 1];
+      for(int i=0; i < stripeStats.length; ++i) {
+        stripeStats[i] = new ArrayList<>();
+      }
+      fileStats = new OrcProto.ColumnStatistics[stripeStats.length];
+    }
+
+    public BufferedStream createStream(StreamName name) {
+      BufferedStream result = new BufferedStream();
+      streams.put(name, result);
+      return result;
+    }
+
+    /**
+     * Place the streams in the appropriate area while updating the sizes
+     * with the number of bytes in the area.
+     * @param area the area to write
+     * @param sizes the sizes of the areas
+     * @return the list of stream descriptions to add
+     */
+    public List<OrcProto.Stream> placeStreams(StreamName.Area area,
+                                              SizeCounters sizes) {
+      List<OrcProto.Stream> result = new ArrayList<>(streams.size());
+      for(Map.Entry<StreamName, BufferedStream> stream: streams.entrySet()) {
+        StreamName name = stream.getKey();
+        BufferedStream bytes = stream.getValue();
+        if (name.getArea() == area && !bytes.isSuppressed) {
+          OrcProto.Stream.Builder builder = OrcProto.Stream.newBuilder();
+          long size = bytes.getOutputSize();
+          if (area == StreamName.Area.INDEX) {
+            sizes.index += size;
+          } else {
+            sizes.data += size;
+          }
+          builder.setColumn(name.getColumn())
+              .setKind(name.getKind())
+              .setLength(size);
+            result.add(builder.build());
+        }
+      }
+      return result;
+    }
+
+    /**
+     * Write the streams in the appropriate area.
+     * @param area the area to write
+     * @param raw the raw stream to write to
+     */
+    public void writeStreams(StreamName.Area area,
+                             FSDataOutputStream raw) throws IOException {
+      for(Map.Entry<StreamName, BufferedStream> stream: streams.entrySet()) {
+        if (stream.getKey().getArea() == area) {
+          stream.getValue().spillToDiskAndClear(raw);
+        }
+      }
+    }
+
+    /**
+     * Computed the size of the given column on disk for this stripe.
+     * It excludes the index streams.
+     * @param column a column id
+     * @return the total number of bytes
+     */
+    public long getFileBytes(int column) {
+      long result = 0;
+      if (column >= rootColumn && column <= lastColumn) {
+        for(Map.Entry<StreamName, BufferedStream> entry: streams.entrySet()) {
+          StreamName name = entry.getKey();
+          if (name.getColumn() == column &&
+              name.getArea() != StreamName.Area.INDEX) {
+            result += entry.getValue().getOutputSize();
+          }
+        }
+      }
+      return result;
+    }
+  }
+
+  VariantTracker getVariant(EncryptionVariant column) {
+    if (column == null) {
+      return unencrypted;
+    }
+    return variants.get(column);
   }
 
   /**
@@ -120,20 +246,13 @@ public class PhysicalFsWriter implements PhysicalWriter {
    * @return number of bytes for the given column
    */
   @Override
-  public long getFileBytes(final int column) {
-    long size = 0;
-    for (final Map.Entry<StreamName, BufferedStream> pair: streams.entrySet()) {
-      final BufferedStream receiver = pair.getValue();
-      if(!receiver.isSuppressed) {
+  public long getFileBytes(int column, WriterEncryptionVariant variant) {
+    return getVariant(variant).getFileBytes(column);
+  }
 
-        final StreamName name = pair.getKey();
-        if(name.getColumn() == column && name.getArea() != StreamName.Area.INDEX ) {
-          size += receiver.getOutputSize();
-        }
-      }
-
-    }
-    return size;
+  @Override
+  public StreamOptions getStreamOptions() {
+    return unencrypted.options;
   }
 
   private static final byte[] ZEROS = new byte[64*1024];
@@ -198,36 +317,139 @@ public class PhysicalFsWriter implements PhysicalWriter {
   }
 
   private void writeStripeFooter(OrcProto.StripeFooter footer,
-                                 long dataSize,
-                                 long indexSize,
+                                 SizeCounters sizes,
                                  OrcProto.StripeInformation.Builder dirEntry) throws IOException {
-    footer.writeTo(protobufWriter);
-    protobufWriter.flush();
-    writer.flush();
+    footer.writeTo(codedCompressStream);
+    codedCompressStream.flush();
+    compressStream.flush();
     dirEntry.setOffset(stripeStart);
-    dirEntry.setFooterLength(rawWriter.getPos() - stripeStart - dataSize - indexSize);
+    dirEntry.setFooterLength(rawWriter.getPos() - stripeStart - sizes.total());
+  }
+
+  /**
+   * Write the saved encrypted stripe statistic in a variant out to the file.
+   * The streams that are written are added to the tracker.stripeStatsStreams.
+   * @param output the file we are writing to
+   * @param stripeNumber the number of stripes in the file
+   * @param tracker the variant to write out
+   */
+  static void writeEncryptedStripeStatistics(DirectStream output,
+                                             int stripeNumber,
+                                             VariantTracker tracker
+                                             ) throws IOException {
+    StreamOptions options = new StreamOptions(tracker.options);
+    tracker.stripeStatsStreams.clear();
+    for(int col = tracker.rootColumn;
+        col < tracker.rootColumn + tracker.stripeStats.length; ++col) {
+      options.modifyIv(CryptoUtils.modifyIvForStream(col,
+          OrcProto.Stream.Kind.STRIPE_STATISTICS, stripeNumber));
+      OutStream stream = new OutStream("stripe stats for " + col,
+          options, output);
+      OrcProto.ColumnarStripeStatistics stats =
+          OrcProto.ColumnarStripeStatistics.newBuilder()
+              .addAllColStats(tracker.stripeStats[col - tracker.rootColumn])
+              .build();
+      long start = output.output.getPos();
+      stats.writeTo(stream);
+      stream.flush();
+      OrcProto.Stream description = OrcProto.Stream.newBuilder()
+                                   .setColumn(col)
+                                   .setKind(OrcProto.Stream.Kind.STRIPE_STATISTICS)
+                                   .setLength(output.output.getPos() - start)
+                                   .build();
+      tracker.stripeStatsStreams.add(description);
+    }
+  }
+
+  /**
+   * Merge the saved unencrypted stripe statistics into the Metadata section
+   * of the footer.
+   * @param builder the Metadata section of the file
+   * @param stripeCount the number of stripes in the file
+   * @param stats the stripe statistics
+   */
+  static void setUnencryptedStripeStatistics(OrcProto.Metadata.Builder builder,
+                                             int stripeCount,
+                                             List<OrcProto.ColumnStatistics>[] stats) {
+    // Make the unencrypted stripe stats into lists of StripeStatistics.
+    builder.clearStripeStats();
+    for(int s=0; s < stripeCount; ++s) {
+      OrcProto.StripeStatistics.Builder stripeStats =
+          OrcProto.StripeStatistics.newBuilder();
+      for(List<OrcProto.ColumnStatistics> col: stats) {
+        stripeStats.addColStats(col.get(s));
+      }
+      builder.addStripeStats(stripeStats.build());
+    }
+  }
+
+  static void setEncryptionStatistics(OrcProto.Encryption.Builder encryption,
+                                      int stripeNumber,
+                                      Collection<VariantTracker> variants
+                                      ) throws IOException {
+    int v = 0;
+    for(VariantTracker variant: variants) {
+      OrcProto.EncryptionVariant.Builder variantBuilder =
+          encryption.getVariantsBuilder(v++);
+
+      // Add the stripe statistics streams to the variant description.
+      variantBuilder.clearStripeStatistics();
+      variantBuilder.addAllStripeStatistics(variant.stripeStatsStreams);
+
+      // Serialize and encrypt the file statistics.
+      OrcProto.FileStatistics.Builder file = OrcProto.FileStatistics.newBuilder();
+      for(OrcProto.ColumnStatistics col: variant.fileStats) {
+        file.addColumn(col);
+      }
+      StreamOptions options = new StreamOptions(variant.options);
+      options.modifyIv(CryptoUtils.modifyIvForStream(variant.rootColumn,
+          OrcProto.Stream.Kind.FILE_STATISTICS, stripeNumber));
+      BufferedStream buffer = new BufferedStream();
+      OutStream stream = new OutStream("stats for " + variant, options, buffer);
+      file.build().writeTo(stream);
+      stream.flush();
+      variantBuilder.setFileStatistics(buffer.getBytes());
+    }
   }
 
   @Override
   public void writeFileMetadata(OrcProto.Metadata.Builder builder) throws IOException {
-    long startPosn = rawWriter.getPos();
-    OrcProto.Metadata metadata = builder.build();
-    metadata.writeTo(protobufWriter);
-    protobufWriter.flush();
-    writer.flush();
-    this.metadataLength = (int) (rawWriter.getPos() - startPosn);
+    long stripeStatisticsStart = rawWriter.getPos();
+    for(VariantTracker variant: variants.values()) {
+      writeEncryptedStripeStatistics(rawStream, stripeNumber, variant);
+    }
+    setUnencryptedStripeStatistics(builder, stripeNumber, unencrypted.stripeStats);
+    long metadataStart = rawWriter.getPos();
+    builder.build().writeTo(codedCompressStream);
+    codedCompressStream.flush();
+    compressStream.flush();
+    this.stripeStatisticsLength = (int) (metadataStart - stripeStatisticsStart);
+    this.metadataLength = (int) (rawWriter.getPos() - metadataStart);
+  }
+
+  static void addUnencryptedStatistics(OrcProto.Footer.Builder builder,
+                                       OrcProto.ColumnStatistics[] stats) {
+    for(OrcProto.ColumnStatistics stat: stats) {
+      builder.addStatistics(stat);
+    }
   }
 
   @Override
   public void writeFileFooter(OrcProto.Footer.Builder builder) throws IOException {
-    long bodyLength = rawWriter.getPos() - metadataLength;
+    if (variants.size() > 0) {
+      OrcProto.Encryption.Builder encryption = builder.getEncryptionBuilder();
+      setEncryptionStatistics(encryption, stripeNumber, variants.values());
+      builder.setStripeStatisticsLength(stripeStatisticsLength);
+    }
+    addUnencryptedStatistics(builder, unencrypted.fileStats);
+    long bodyLength = rawWriter.getPos() - metadataLength - stripeStatisticsLength;
     builder.setContentLength(bodyLength);
     builder.setHeaderLength(headerLength);
     long startPosn = rawWriter.getPos();
     OrcProto.Footer footer = builder.build();
-    footer.writeTo(protobufWriter);
-    protobufWriter.flush();
-    writer.flush();
+    footer.writeTo(codedCompressStream);
+    codedCompressStream.flush();
+    compressStream.flush();
     this.footerLength = (int) (rawWriter.getPos() - startPosn);
   }
 
@@ -300,7 +522,7 @@ public class PhysicalFsWriter implements PhysicalWriter {
    * data as buffers fill up and stores them in the output list. When the
    * stripe is being written, the whole stream is written to the file.
    */
-  private static final class BufferedStream implements OutputReceiver {
+  static final class BufferedStream implements OutputReceiver {
     private boolean isSuppressed = false;
     private final List<ByteBuffer> output = new ArrayList<>();
 
@@ -319,17 +541,56 @@ public class PhysicalFsWriter implements PhysicalWriter {
     /**
      * Write any saved buffers to the OutputStream if needed, and clears all the
      * buffers.
+     * @return true if the stream was written
      */
-    void spillToDiskAndClear(FSDataOutputStream raw
-                                       ) throws IOException {
+    boolean spillToDiskAndClear(FSDataOutputStream raw) throws IOException {
       if (!isSuppressed) {
         for (ByteBuffer buffer: output) {
           raw.write(buffer.array(), buffer.arrayOffset() + buffer.position(),
             buffer.remaining());
         }
         output.clear();
+        return true;
       }
       isSuppressed = false;
+      return false;
+    }
+
+    /**
+     * Get the buffer as a protobuf ByteString and clears the BufferedStream.
+     * @return the bytes
+     */
+    ByteString getBytes() {
+      int len = output.size();
+      if (len == 0) {
+        return ByteString.EMPTY;
+      } else {
+        ByteString result = ByteString.copyFrom(output.get(0));
+        for (int i=1; i < output.size(); ++i) {
+          result = result.concat(ByteString.copyFrom(output.get(i)));
+        }
+        output.clear();
+        return result;
+      }
+    }
+
+    /**
+     * Get the stream as a ByteBuffer and clear it.
+     * @return a single ByteBuffer with the contents of the stream
+     */
+    ByteBuffer getByteBuffer() {
+      ByteBuffer result;
+      if (output.size() == 1) {
+        result = output.get(0);
+      } else {
+        result = ByteBuffer.allocate((int) getOutputSize());
+        for (ByteBuffer buffer : output) {
+          result.put(buffer);
+        }
+        output.clear();
+        result.flip();
+      }
+      return result;
     }
 
     /**
@@ -347,38 +608,86 @@ public class PhysicalFsWriter implements PhysicalWriter {
     }
   }
 
+  static class SizeCounters {
+    long index = 0;
+    long data = 0;
+
+    long total() {
+      return index + data;
+    }
+  }
+
+  void buildStreamList(OrcProto.StripeFooter.Builder footerBuilder,
+                       SizeCounters sizes
+                       ) throws IOException {
+    footerBuilder.addAllStreams(
+        unencrypted.placeStreams(StreamName.Area.INDEX, sizes));
+    final long unencryptedIndexSize = sizes.index;
+    int v = 0;
+    for (VariantTracker variant: variants.values()) {
+      OrcProto.StripeEncryptionVariant.Builder builder =
+          footerBuilder.getEncryptionBuilder(v++);
+      builder.addAllStreams(
+          variant.placeStreams(StreamName.Area.INDEX, sizes));
+    }
+    if (sizes.index != unencryptedIndexSize) {
+      // add a placeholder that covers the hole where the encrypted indexes are
+      footerBuilder.addStreams(OrcProto.Stream.newBuilder()
+                                   .setKind(OrcProto.Stream.Kind.ENCRYPTED_INDEX)
+                                   .setLength(sizes.index - unencryptedIndexSize));
+    }
+    footerBuilder.addAllStreams(
+        unencrypted.placeStreams(StreamName.Area.DATA, sizes));
+    final long unencryptedDataSize = sizes.data;
+    v = 0;
+    for (VariantTracker variant: variants.values()) {
+      OrcProto.StripeEncryptionVariant.Builder builder =
+          footerBuilder.getEncryptionBuilder(v++);
+      builder.addAllStreams(
+          variant.placeStreams(StreamName.Area.DATA, sizes));
+    }
+    if (sizes.data != unencryptedDataSize) {
+      // add a placeholder that covers the hole where the encrypted indexes are
+      footerBuilder.addStreams(OrcProto.Stream.newBuilder()
+                                   .setKind(OrcProto.Stream.Kind.ENCRYPTED_DATA)
+                                   .setLength(sizes.data - unencryptedDataSize));
+    }
+  }
+
   @Override
   public void finalizeStripe(OrcProto.StripeFooter.Builder footerBuilder,
                              OrcProto.StripeInformation.Builder dirEntry
                              ) throws IOException {
-    long indexSize = 0;
-    long dataSize = 0;
-    for (Map.Entry<StreamName, BufferedStream> pair: streams.entrySet()) {
-      BufferedStream receiver = pair.getValue();
-      if (!receiver.isSuppressed) {
-        long streamSize = receiver.getOutputSize();
-        StreamName name = pair.getKey();
-        footerBuilder.addStreams(OrcProto.Stream.newBuilder().setColumn(name.getColumn())
-            .setKind(name.getKind()).setLength(streamSize));
-        if (StreamName.Area.INDEX == name.getArea()) {
-          indexSize += streamSize;
-        } else {
-          dataSize += streamSize;
-        }
-      }
-    }
-    dirEntry.setIndexLength(indexSize).setDataLength(dataSize);
+    SizeCounters sizes = new SizeCounters();
+    buildStreamList(footerBuilder, sizes);
 
     OrcProto.StripeFooter footer = footerBuilder.build();
-    // Do we need to pad the file so the stripe doesn't straddle a block boundary?
-    padStripe(indexSize + dataSize + footer.getSerializedSize());
 
-    // write out the data streams
-    for (Map.Entry<StreamName, BufferedStream> pair : streams.entrySet()) {
-      pair.getValue().spillToDiskAndClear(rawWriter);
+    // Do we need to pad the file so the stripe doesn't straddle a block boundary?
+    padStripe(sizes.total() + footer.getSerializedSize());
+
+    // write the unencrypted index streams
+    unencrypted.writeStreams(StreamName.Area.INDEX, rawWriter);
+    // write the encrypted index streams
+    for (VariantTracker variant: variants.values()) {
+      variant.writeStreams(StreamName.Area.INDEX, rawWriter);
     }
+
+    // write the unencrypted data streams
+    unencrypted.writeStreams(StreamName.Area.DATA, rawWriter);
+    // write out the unencrypted data streams
+    for (VariantTracker variant: variants.values()) {
+      variant.writeStreams(StreamName.Area.DATA, rawWriter);
+    }
+
     // Write out the footer.
-    writeStripeFooter(footer, dataSize, indexSize, dirEntry);
+    writeStripeFooter(footer, sizes, dirEntry);
+
+    // fill in the data sizes
+    dirEntry.setDataLength(sizes.data);
+    dirEntry.setIndexLength(sizes.index);
+
+    stripeNumber += 1;
   }
 
   @Override
@@ -389,10 +698,11 @@ public class PhysicalFsWriter implements PhysicalWriter {
 
   @Override
   public BufferedStream createDataStream(StreamName name) {
-    BufferedStream result = streams.get(name);
+    VariantTracker variant = getVariant(name.getEncryption());
+    BufferedStream result = variant.streams.get(name);
     if (result == null) {
       result = new BufferedStream();
-      streams.put(name, result);
+      variant.streams.put(name, result);
     }
     return result;
   }
@@ -402,11 +712,26 @@ public class PhysicalFsWriter implements PhysicalWriter {
         kind);
   }
 
+  protected OutputStream createIndexStream(StreamName name) {
+    BufferedStream buffer = createDataStream(name);
+    VariantTracker tracker = getVariant(name.getEncryption());
+    StreamOptions options =
+        SerializationUtils.getCustomizedCodec(tracker.options,
+            compressionStrategy, name.getKind());
+    if (options.isEncrypted()) {
+      if (options == tracker.options) {
+        options = new StreamOptions(options);
+      }
+      options.modifyIv(CryptoUtils.modifyIvForStream(name, stripeNumber));
+    }
+    return new OutStream(name.toString(), options, buffer);
+  }
+
   @Override
   public void writeIndex(StreamName name,
-                         OrcProto.RowIndex.Builder index) throws IOException {
-    OutputStream stream = new OutStream(path.toString(),
-        getOptions(name.getKind()), createDataStream(name));
+                         OrcProto.RowIndex.Builder index
+                         ) throws IOException {
+    OutputStream stream = createIndexStream(name);
     index.build().writeTo(stream);
     stream.flush();
   }
@@ -415,10 +740,23 @@ public class PhysicalFsWriter implements PhysicalWriter {
   public void writeBloomFilter(StreamName name,
                                OrcProto.BloomFilterIndex.Builder bloom
                                ) throws IOException {
-    OutputStream stream = new OutStream(path.toString(),
-        getOptions(name.getKind()), createDataStream(name));
+    OutputStream stream = createIndexStream(name);
     bloom.build().writeTo(stream);
     stream.flush();
+  }
+
+  @Override
+  public void writeStatistics(StreamName name,
+                              OrcProto.ColumnStatistics.Builder statistics
+                              ) {
+    VariantTracker tracker = getVariant(name.getEncryption());
+    if (name.getKind() == OrcProto.Stream.Kind.FILE_STATISTICS) {
+      tracker.fileStats[name.getColumn() - tracker.rootColumn] =
+          statistics.build();
+    } else {
+      tracker.stripeStats[name.getColumn() - tracker.rootColumn]
+          .add(statistics.build());
+    }
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/PositionedOutputStream.java
+++ b/java/core/src/java/org/apache/orc/impl/PositionedOutputStream.java
@@ -19,6 +19,7 @@ package org.apache.orc.impl;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.function.Consumer;
 
 public abstract class PositionedOutputStream extends OutputStream {
 
@@ -36,4 +37,11 @@ public abstract class PositionedOutputStream extends OutputStream {
    * @return the number of bytes used by buffers.
    */
   public abstract long getBufferSize();
+
+  /**
+   * Change the current Initialization Vector (IV) for the encryption.
+   * Has no effect if the stream is not encrypted.
+   * @param modifier a function to modify the IV in place
+   */
+  public abstract void changeIv(Consumer<byte[]> modifier);
 }

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -412,7 +412,7 @@ public class ReaderImpl implements Reader {
     bb.position(footerAbsPos);
     bb.limit(footerAbsPos + footerSize);
     return OrcProto.Footer.parseFrom(InStream.createCodedInputStream(
-        InStream.create("footer", new BufferChunk(bb, 0), footerSize, options)));
+        InStream.create("footer", new BufferChunk(bb, 0), 0, footerSize, options)));
   }
 
   public static OrcProto.Metadata extractMetadata(ByteBuffer bb, int metadataAbsPos,
@@ -420,7 +420,7 @@ public class ReaderImpl implements Reader {
     bb.position(metadataAbsPos);
     bb.limit(metadataAbsPos + metadataSize);
     return OrcProto.Metadata.parseFrom(InStream.createCodedInputStream(
-        InStream.create("metadata", new BufferChunk(bb, 0), metadataSize, options)));
+        InStream.create("metadata", new BufferChunk(bb, 0), 0, metadataSize, options)));
   }
 
   private static OrcProto.PostScript extractPostScript(ByteBuffer bb, Path path,

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -1061,7 +1061,7 @@ public class RecordReaderImpl implements RecordReader {
           if (!(range instanceof BufferChunk)) {
             continue;
           }
-          dataReader.releaseBuffer(((BufferChunk) range).getChunk());
+          dataReader.releaseBuffer(range.getData());
         }
       }
     }
@@ -1213,7 +1213,7 @@ public class RecordReaderImpl implements RecordReader {
           ranges, streamOffset, streamDesc.getLength());
       StreamName name = new StreamName(column, streamDesc.getKind());
       streams.put(name, InStream.create(name.toString(), buffers,
-          streamDesc.getLength(), options));
+          0, streamDesc.getLength(), options));
       streamOffset += streamDesc.getLength();
     }
   }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -234,7 +234,7 @@ public class RecordReaderUtils {
                 indexes[column] = OrcProto.RowIndex.parseFrom(
                     InStream.createCodedInputStream(InStream.create("index",
                         new BufferChunk(bb, 0),
-                        stream.getLength(), options)));
+                        0, stream.getLength(), options)));
               }
               break;
             case BLOOM_FILTER:
@@ -246,7 +246,7 @@ public class RecordReaderUtils {
                 bloomFilterIndices[column] = OrcProto.BloomFilterIndex.parseFrom
                     (InStream.createCodedInputStream(InStream.create(
                         "bloom_filter", new BufferChunk(bb, 0),
-                        stream.getLength(), options)));
+                        0, stream.getLength(), options)));
               }
               break;
             default:
@@ -271,7 +271,7 @@ public class RecordReaderUtils {
       file.readFully(offset, tailBuf.array(), tailBuf.arrayOffset(), tailLength);
       return OrcProto.StripeFooter.parseFrom(
           InStream.createCodedInputStream(InStream.create("footer",
-              new BufferChunk(tailBuf, 0), tailLength, options)));
+              new BufferChunk(tailBuf, 0), 0, tailLength, options)));
     }
 
     @Override

--- a/java/core/src/java/org/apache/orc/impl/RunLengthByteWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthByteWriter.java
@@ -18,6 +18,7 @@
 package org.apache.orc.impl;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * A streamFactory that writes a sequence of bytes. A control byte is written before
@@ -106,5 +107,9 @@ public class RunLengthByteWriter {
 
   public long estimateMemory() {
     return output.getBufferSize() + MAX_LITERAL_SIZE;
+  }
+
+  public void changeIv(Consumer<byte[]> modifier) {
+    output.changeIv(modifier);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriter.java
@@ -18,6 +18,7 @@
 package org.apache.orc.impl;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * A streamFactory that writes a sequence of integers. A control byte is written before
@@ -143,5 +144,10 @@ public class RunLengthIntegerWriter implements IntegerWriter {
   @Override
   public long estimateMemory() {
     return output.getBufferSize();
+  }
+
+  @Override
+  public void changeIv(Consumer<byte[]> modifier) {
+    output.changeIv(modifier);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
@@ -18,6 +18,7 @@
 package org.apache.orc.impl;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 /**
  * <p>A writer that performs light weight compression over sequence of integers.
@@ -822,5 +823,10 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
   @Override
   public long estimateMemory() {
     return output.getBufferSize();
+  }
+
+  @Override
+  public void changeIv(Consumer<byte[]> modifier) {
+    output.changeIv(modifier);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
@@ -62,9 +62,9 @@ import java.util.Arrays;
  */
 public class SHA256MaskFactory extends MaskFactory {
 
-  final MessageDigest md;
+  private final MessageDigest md;
 
-  public SHA256MaskFactory(final String... params) {
+  SHA256MaskFactory() {
     super();
     try {
       md = MessageDigest.getInstance("SHA-256");
@@ -138,9 +138,9 @@ public class SHA256MaskFactory extends MaskFactory {
   /**
    * Helper function to mask binary data with it's SHA-256 hash.
    *
-   * @param source
-   * @param row
-   * @param target
+   * @param source the source data
+   * @param row the row that we are translating
+   * @param target the output data
    */
   void maskBinary(final BytesColumnVector source, final int row,
       final BytesColumnVector target) {
@@ -207,7 +207,7 @@ public class SHA256MaskFactory extends MaskFactory {
     final TypeDescription schema;
 
     /* create an instance */
-    public StringMask(TypeDescription schema) {
+    StringMask(TypeDescription schema) {
       super();
       this.schema = schema;
     }
@@ -254,7 +254,7 @@ public class SHA256MaskFactory extends MaskFactory {
   class BinaryMask implements DataMask {
 
     /* create an instance */
-    public BinaryMask() {
+    BinaryMask() {
       super();
     }
 

--- a/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryption.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryption.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.reader;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.HadoopShims;
+import org.apache.orc.impl.HadoopShimsFactory;
+import org.apache.orc.impl.MaskDescriptionImpl;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.List;
+
+public class ReaderEncryption {
+  private final HadoopShims.KeyProvider keyProvider;
+  private final ReaderEncryptionKey[] keys;
+  private final MaskDescriptionImpl[] masks;
+  private final ReaderEncryptionVariant[] variants;
+  // Mapping from each column to the next variant to try for that column.
+  // A value of variants.length means no encryption
+  private final ReaderEncryptionVariant[] columnVariants;
+
+  public ReaderEncryption() throws IOException {
+    this(null, null, null, null, null);
+  }
+
+  public ReaderEncryption(OrcProto.Footer footer,
+                          TypeDescription schema,
+                          List<StripeInformation> stripes,
+                          HadoopShims.KeyProvider provider,
+                          Configuration conf) throws IOException {
+    if (footer == null || !footer.hasEncryption()) {
+      keyProvider = null;
+      keys = new ReaderEncryptionKey[0];
+      masks = new MaskDescriptionImpl[0];
+      variants = new ReaderEncryptionVariant[0];
+      columnVariants = null;
+    } else {
+      keyProvider = provider != null ? provider :
+          HadoopShimsFactory.get().getKeyProvider(conf, new SecureRandom());
+      OrcProto.Encryption encrypt = footer.getEncryption();
+      masks = new MaskDescriptionImpl[encrypt.getMaskCount()];
+      for(int m=0; m < masks.length; ++m) {
+        masks[m] = new MaskDescriptionImpl(m, encrypt.getMask(m));
+      }
+      keys = new ReaderEncryptionKey[encrypt.getKeyCount()];
+      for(int k=0; k < keys.length; ++k) {
+        keys[k] = new ReaderEncryptionKey(encrypt.getKey(k));
+      }
+      variants = new ReaderEncryptionVariant[encrypt.getVariantsCount()];
+      for(int v=0; v < variants.length; ++v) {
+        OrcProto.EncryptionVariant variant = encrypt.getVariants(v);
+        variants[v] = new ReaderEncryptionVariant(keys[variant.getKey()], v,
+            variant, schema, stripes, keyProvider);
+      }
+      columnVariants = new ReaderEncryptionVariant[schema.getMaximumId() + 1];
+      for(int v = 0; v < variants.length; ++v) {
+        TypeDescription root = variants[v].getRoot();
+        for(int c = root.getId(); c <= root.getMaximumId(); ++c) {
+          if (columnVariants[c] == null) {
+            columnVariants[c] = variants[v];
+          }
+        }
+      }
+    }
+  }
+
+  public MaskDescriptionImpl[] getMasks() {
+    return masks;
+  }
+
+  public ReaderEncryptionKey[] getKeys() {
+    return keys;
+  }
+
+  public ReaderEncryptionVariant[] getVariants() {
+    return variants;
+  }
+
+  /**
+   * Find the next possible variant in this file for the given column.
+   * @param column the column to find a variant for
+   * @param lastVariant the previous variant that we looked at
+   * @return the next variant or null if there are none
+   */
+  private ReaderEncryptionVariant findNextVariant(int column,
+                                                  int lastVariant) {
+    for(int v = lastVariant + 1; v < variants.length; ++v) {
+      TypeDescription root = variants[v].getRoot();
+      if (root.getId() <= column && column <= root.getMaximumId()) {
+        return variants[v];
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Get the variant for a given column that the user has access to.
+   * If we haven't tried a given key, try to decrypt this variant's footer key
+   * to see if the KeyProvider will give it to us. If not, continue to the
+   * next variant.
+   * @param column the column id
+   * @return null for no encryption or the encryption variant
+   */
+  public ReaderEncryptionVariant getVariant(int column) throws IOException {
+    if (keyProvider != null) {
+      while (columnVariants[column] != null) {
+        ReaderEncryptionVariant result = columnVariants[column];
+        switch (result.getKeyDescription().getState()) {
+        case FAILURE:
+          break;
+        case SUCCESS:
+          return result;
+        case UNTRIED:
+          // try to get the footer key, to see if we have access
+          if (result.getFileFooterKey() != null) {
+            return result;
+          }
+        }
+        columnVariants[column] = findNextVariant(column, result.getVariantId());
+      }
+    }
+    return null;
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionKey.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionKey.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.reader;
+
+import org.apache.orc.EncryptionKey;
+import org.apache.orc.EncryptionAlgorithm;
+import org.apache.orc.OrcProto;
+import org.apache.orc.impl.HadoopShims;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This tracks the keys for reading encrypted columns.
+ */
+public class ReaderEncryptionKey implements EncryptionKey {
+  private final String name;
+  private final int version;
+  private final EncryptionAlgorithm algorithm;
+  private final List<ReaderEncryptionVariant> roots = new ArrayList<>();
+
+  /**
+   * Store the state of whether we've tried to decrypt a local key using this
+   * key or not. If it fails the first time, we assume the user doesn't have
+   * permission and move on. However, we don't want to retry the same failed
+   * key over and over again.
+   */
+  public enum State {
+    UNTRIED,
+    FAILURE,
+    SUCCESS
+  }
+
+  private State state = State.UNTRIED;
+
+  public ReaderEncryptionKey(OrcProto.EncryptionKey key) {
+    name = key.getKeyName();
+    version = key.getKeyVersion();
+    algorithm =
+        EncryptionAlgorithm.fromSerialization(key.getAlgorithm().getNumber());
+  }
+
+  @Override
+  public String getKeyName() {
+    return name;
+  }
+
+  @Override
+  public int getKeyVersion() {
+    return version;
+  }
+
+  @Override
+  public EncryptionAlgorithm getAlgorithm() {
+    return algorithm;
+  }
+
+  @Override
+  public ReaderEncryptionVariant[] getEncryptionRoots() {
+    return roots.toArray(new ReaderEncryptionVariant[roots.size()]);
+  }
+
+  public HadoopShims.KeyMetadata getMetadata() {
+    return new HadoopShims.KeyMetadata(name, version, algorithm);
+  }
+
+  public State getState() {
+    return state;
+  }
+
+  public void setFailure() {
+    state = State.FAILURE;
+  }
+
+  public void setSucess() {
+    if (state == State.FAILURE) {
+      throw new IllegalStateException("Key " + name + " had already failed.");
+    }
+    state = State.SUCCESS;
+  }
+
+  void addVariant(ReaderEncryptionVariant newVariant) {
+    roots.add(newVariant);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    } else if (other == this) {
+      return true;
+    } else {
+      return compareTo((EncryptionKey) other) == 0;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return name.hashCode() * 127 + version * 7 + algorithm.hashCode();
+  }
+
+  @Override
+  public int compareTo(@NotNull EncryptionKey other) {
+    int result = name.compareTo(other.getKeyName());
+    if (result == 0) {
+      result = Integer.compare(version, other.getKeyVersion());
+    }
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return name + "@" + version + " w/ " + algorithm;
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionVariant.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionVariant.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.reader;
+
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.orc.EncryptionAlgorithm;
+import org.apache.orc.EncryptionVariant;
+import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.HadoopShims;
+import org.apache.orc.impl.LocalKey;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.security.Key;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Information about an encrypted column.
+ */
+public class ReaderEncryptionVariant implements EncryptionVariant {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ReaderEncryptionVariant.class);
+  private final HadoopShims.KeyProvider provider;
+  private final ReaderEncryptionKey key;
+  private final TypeDescription column;
+  private final int variantId;
+  private final LocalKey[] localKeys;
+  private final LocalKey footerKey;
+
+  /**
+   * Create a reader's view of an encryption variant.
+   * @param key the encryption key description
+   * @param variantId the of of the variant (0..N-1)
+   * @param proto the serialized description of the variant
+   * @param schema the file schema
+   * @param stripes the stripe information
+   * @param provider the key provider
+   */
+  public ReaderEncryptionVariant(ReaderEncryptionKey key,
+                                 int variantId,
+                                 OrcProto.EncryptionVariant proto,
+                                 TypeDescription schema,
+                                 List<StripeInformation> stripes,
+                                 HadoopShims.KeyProvider provider) {
+    this.key = key;
+    this.variantId = variantId;
+    this.provider = provider;
+    this.column = proto.hasRoot() ? schema.findSubtype(proto.getRoot()) : null;
+    this.localKeys = new LocalKey[stripes.size()];
+    HashMap<BytesWritable, LocalKey> cache = new HashMap<>();
+    for(int s=0; s < localKeys.length; ++s) {
+      StripeInformation stripe = stripes.get(s);
+      localKeys[s] = getCachedKey(cache, key.getAlgorithm(),
+          stripe.getEncryptedLocalKeys()[variantId]);
+    }
+    if (proto.hasEncryptedKey()) {
+      footerKey = getCachedKey(cache, key.getAlgorithm(),
+          proto.getEncryptedKey().toByteArray());
+    } else {
+      footerKey = null;
+    }
+    key.addVariant(this);
+  }
+
+  @Override
+  public ReaderEncryptionKey getKeyDescription() {
+    return key;
+  }
+
+  @Override
+  public TypeDescription getRoot() {
+    return column;
+  }
+
+  @Override
+  public int getVariantId() {
+    return variantId;
+  }
+
+  /**
+   * Deduplicate the local keys so that we only decrypt each local key once.
+   * @param cache the cache to use
+   * @param encrypted the encrypted key
+   * @return the local key
+   */
+  private static LocalKey getCachedKey(Map<BytesWritable, LocalKey> cache,
+                                       EncryptionAlgorithm algorithm,
+                                       byte[] encrypted) {
+    // wrap byte array in BytesWritable to get equality and hash
+    BytesWritable wrap = new BytesWritable(encrypted);
+    LocalKey result = cache.get(wrap);
+    if (result == null) {
+      result = new LocalKey(algorithm, null, encrypted);
+      cache.put(wrap, result);
+    }
+    return result;
+  }
+
+  private Key getDecryptedKey(LocalKey localKey) throws IOException {
+    Key result = localKey.getDecryptedKey();
+    if (result == null) {
+      switch (this.key.getState()) {
+      case UNTRIED:
+        try {
+          result = provider.decryptLocalKey(key.getMetadata(),
+              localKey.getEncryptedKey());
+        } catch (IOException ioe) {
+          LOG.info("Can't decrypt using key {}", key);
+        }
+        if (result != null) {
+          localKey.setDecryptedKey(result);
+          key.setSucess();
+        } else {
+          key.setFailure();
+        }
+        break;
+      case SUCCESS:
+        result = provider.decryptLocalKey(key.getMetadata(),
+            localKey.getEncryptedKey());
+        if (result == null) {
+          throw new IOException("Can't decrypt local key " + key);
+        }
+        localKey.setDecryptedKey(result);
+        break;
+      case FAILURE:
+        return null;
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public Key getFileFooterKey() throws IOException {
+    return getDecryptedKey(footerKey);
+  }
+
+  @Override
+  public Key getStripeKey(long stripe) throws IOException {
+    return getDecryptedKey(localKeys[(int) stripe]);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == null || other.getClass() != getClass()) {
+      return false;
+    } else {
+      return compareTo((EncryptionVariant) other) == 0;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return key.hashCode() * 127 + column.getId();
+  }
+
+  @Override
+  public int compareTo(@NotNull EncryptionVariant other) {
+    if (other == this) {
+      return 0;
+    } else if (key == other.getKeyDescription()) {
+      return Integer.compare(column.getId(), other.getRoot().getId());
+    } else if (key == null) {
+      return -1;
+    } else {
+      return key.compareTo(other.getKeyDescription());
+    }
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -1,0 +1,529 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.reader;
+
+import com.google.protobuf.CodedInputStream;
+import org.apache.orc.DataReader;
+import org.apache.orc.EncryptionAlgorithm;
+import org.apache.orc.OrcFile;
+import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.BufferChunk;
+import org.apache.orc.impl.BufferChunkList;
+import org.apache.orc.impl.CryptoUtils;
+import org.apache.orc.impl.InStream;
+import org.apache.orc.impl.OrcIndex;
+import org.apache.orc.impl.RecordReaderUtils;
+import org.apache.orc.impl.StreamName;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This class handles parsing the stripe information and handling the necessary
+ * filtering and selection.
+ *
+ * It supports:
+ * <ul>
+ *   <li>column projection</li>
+ *   <li>row group selection</li>
+ *   <li>encryption</li>
+ * </ul>
+ */
+public class StripePlanner {
+  // global information
+  private final TypeDescription schema;
+  private final OrcFile.WriterVersion version;
+  private final OrcProto.ColumnEncoding[] encodings;
+  private final ReaderEncryption encryption;
+  private final DataReader dataReader;
+  private final InStream.StreamOptions compression;
+  private final boolean ignoreNonUtf8BloomFilter;
+  private final long maxBufferSize;
+
+  // specific to the current stripe
+  private String writerTimezone;
+  private long currentStripeId;
+  private long originalStripeId;
+  private Map<StreamName, StreamInformation> streams = new HashMap<>();
+  // the index streams sorted by offset
+  private final List<StreamInformation> indexStreams = new ArrayList<>();
+  // the data streams sorted by offset
+  private final List<StreamInformation> dataStreams = new ArrayList<>();
+  private final boolean[] usedVariants;
+  private final OrcProto.Stream.Kind[] bloomFilterKinds;
+  // does each column have a null stream?
+  private final boolean[] hasNull;
+
+  /**
+   * Create a stripe parser.
+   * @param schema the file schema
+   * @param encryption the encryption information
+   * @param compression the options to handle the compression
+   * @param dataReader the underlying data reader
+   * @param version the file writer version
+   * @param ignoreNonUtf8BloomFilter ignore old non-utf8 bloom filters
+   * @param maxBufferSize the largest single buffer to use
+   */
+  public StripePlanner(TypeDescription schema,
+                       ReaderEncryption encryption,
+                       InStream.StreamOptions compression,
+                       DataReader dataReader,
+                       OrcFile.WriterVersion version,
+                       boolean ignoreNonUtf8BloomFilter,
+                       long maxBufferSize) {
+    this.schema = schema;
+    this.version = version;
+    encodings = new OrcProto.ColumnEncoding[schema.getMaximumId()+1];
+    usedVariants = new boolean[encryption.getVariants().length];
+    this.encryption = encryption;
+    this.compression = compression;
+    this.dataReader = dataReader;
+    this.ignoreNonUtf8BloomFilter = ignoreNonUtf8BloomFilter;
+    bloomFilterKinds = new OrcProto.Stream.Kind[schema.getMaximumId() + 1];
+    hasNull = new boolean[schema.getMaximumId() + 1];
+    this.maxBufferSize = maxBufferSize;
+  }
+
+  public StripePlanner(StripePlanner old) {
+    this(old.schema, old.encryption, old.compression, old.dataReader,
+        old.version, old.ignoreNonUtf8BloomFilter, old.maxBufferSize);
+  }
+
+  /**
+   * Parse a new stripe. Resets the current stripe state.
+   * @param stripe the new stripe
+   * @param columnInclude an array with true for each column to read
+   * @return this for method chaining
+   */
+  public StripePlanner parseStripe(StripeInformation stripe,
+                                   boolean[] columnInclude) throws IOException {
+    OrcProto.StripeFooter footer = dataReader.readStripeFooter(stripe);
+    currentStripeId = stripe.getStripeId();
+    originalStripeId = stripe.getEncryptionStripeId();
+    writerTimezone = footer.getWriterTimezone();
+    streams.clear();
+    dataStreams.clear();
+    indexStreams.clear();
+    buildEncodings(footer, columnInclude);
+    findStreams(stripe.getOffset(), footer, columnInclude);
+    // figure out whether each column has null values in this stripe
+    Arrays.fill(hasNull, false);
+    for(StreamInformation stream: dataStreams) {
+      if (stream.kind == OrcProto.Stream.Kind.PRESENT) {
+        hasNull[stream.column] = true;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Read the stripe data from the file.
+   * @param index null for no row filters or the index for filtering
+   * @param rowGroupInclude null for all of the rows or an array with boolean
+   *                       for each row group in the current stripe.
+   * @param forceDirect should direct buffers be created?
+   * @return the buffers that were read
+   */
+  public BufferChunkList readData(OrcIndex index,
+                                boolean[] rowGroupInclude,
+                                boolean forceDirect) throws IOException {
+    BufferChunkList chunks = (index == null || rowGroupInclude == null)
+        ? planDataReading() : planPartialDataReading(index, rowGroupInclude);
+    dataReader.readFileData(chunks, forceDirect);
+    return chunks;
+  }
+
+  public String getWriterTimezone() {
+    return writerTimezone;
+  }
+
+  /**
+   * Get the stream for the given name.
+   * It is assumed that the name does <b>not</b> have the encryption set,
+   * because the TreeReader's don't know if they are reading encrypted data.
+   * Assumes that readData has already been called on this stripe.
+   * @param name the column/kind of the stream
+   * @return a new stream with the options set correctly
+   */
+  public InStream getStream(StreamName name) throws IOException {
+    StreamInformation stream = streams.get(name);
+    return stream == null ? null
+      : InStream.create(name, stream.firstChunk, stream.offset,
+          stream.length,  getStreamOptions(stream.column, stream.kind));
+  }
+
+  /**
+   * Release all of the buffers for the current stripe.
+   */
+  public void clearStreams() {
+    if (dataReader.isTrackingDiskRanges()) {
+      for (StreamInformation stream : indexStreams) {
+        stream.releaseBuffers(dataReader);
+      }
+      for (StreamInformation stream : dataStreams) {
+        stream.releaseBuffers(dataReader);
+      }
+    }
+    indexStreams.clear();
+    dataStreams.clear();
+    streams.clear();
+  }
+
+  /**
+   * Get the stream options for a stream in a stripe.
+   * @param column the column we are reading
+   * @param kind the stream kind we are reading
+   * @return a new stream options to read the given column
+   */
+  private InStream.StreamOptions getStreamOptions(int column,
+                                                  OrcProto.Stream.Kind kind
+                                                  ) throws IOException {
+    ReaderEncryptionVariant variant = encryption.getVariant(column);
+    if (variant == null) {
+      return compression;
+    } else {
+      EncryptionAlgorithm algorithm = variant.getKeyDescription().getAlgorithm();
+      byte[] iv = new byte[algorithm.getIvLength()];
+      Key key = variant.getStripeKey(currentStripeId);
+      CryptoUtils.modifyIvForStream(column, kind, originalStripeId).accept(iv);
+      return new InStream.StreamOptions(compression)
+                 .withEncryption(algorithm, key, iv);
+    }
+  }
+
+  public OrcProto.ColumnEncoding getEncoding(int column) {
+    return encodings[column];
+  }
+
+  private void buildEncodings(OrcProto.StripeFooter footer,
+                              boolean[] columnInclude) throws IOException {
+    for(int c=0; c < encodings.length; ++c) {
+      if (columnInclude == null || columnInclude[c]) {
+        ReaderEncryptionVariant variant = encryption.getVariant(c);
+        if (variant == null) {
+          encodings[c] = footer.getColumns(c);
+        } else {
+          usedVariants[variant.getVariantId()] = true;
+          int subColumn = c - variant.getRoot().getId();
+          encodings[c] = footer.getEncryption(variant.getVariantId())
+                             .getEncoding(subColumn);
+        }
+      }
+    }
+  }
+
+  /**
+   * For each stream, decide whether to include it in the list of streams.
+   * @param offset the position in the file for this stream
+   * @param columnInclude which columns are being read
+   * @param stream the stream to consider
+   * @param variant the variant being read
+   * @return the offset for the next stream
+   */
+  private long handleStream(long offset,
+                            boolean[] columnInclude,
+                            OrcProto.Stream stream,
+                            ReaderEncryptionVariant variant) throws IOException {
+    int column = stream.getColumn();
+    if (stream.hasKind()) {
+      OrcProto.Stream.Kind kind = stream.getKind();
+
+      if (kind == OrcProto.Stream.Kind.ENCRYPTED_INDEX ||
+              kind == OrcProto.Stream.Kind.ENCRYPTED_DATA) {
+        // Ignore the placeholders that shouldn't count toward moving the
+        // offsets.
+        return 0;
+      }
+
+      if (columnInclude[column] && encryption.getVariant(column) == variant) {
+        // Ignore any broken bloom filters unless the user forced us to use
+        // them.
+        if (kind != OrcProto.Stream.Kind.BLOOM_FILTER ||
+                !ignoreNonUtf8BloomFilter ||
+                !hadBadBloomFilters(schema.findSubtype(column).getCategory(),
+                    version)) {
+          // record what kind of bloom filters we are using
+          if (kind == OrcProto.Stream.Kind.BLOOM_FILTER_UTF8 ||
+              kind == OrcProto.Stream.Kind.BLOOM_FILTER) {
+            bloomFilterKinds[column] = kind;
+          }
+          StreamInformation info =
+              new StreamInformation(kind, column, offset, stream.getLength());
+          switch (StreamName.getArea(kind)) {
+          case DATA:
+            dataStreams.add(info);
+            break;
+          case INDEX:
+            indexStreams.add(info);
+            break;
+          default:
+          }
+          streams.put(new StreamName(column, kind), info);
+        }
+      }
+    }
+    return stream.getLength();
+  }
+
+  /**
+   * Find the complete list of streams.
+   * @param streamStart the starting offset of streams in the file
+   * @param footer the footer for the stripe
+   * @param columnInclude which columns are being read
+   */
+  private void findStreams(long streamStart,
+                           OrcProto.StripeFooter footer,
+                           boolean[] columnInclude) throws IOException {
+    long currentOffset = streamStart;
+    Arrays.fill(bloomFilterKinds, null);
+    for(OrcProto.Stream stream: footer.getStreamsList()) {
+      currentOffset += handleStream(currentOffset, columnInclude, stream, null);
+    }
+
+    // Add the encrypted streams that we are using
+    for(ReaderEncryptionVariant variant: encryption.getVariants()) {
+      int variantId = variant.getVariantId();
+      OrcProto.StripeEncryptionVariant stripeVariant =
+          footer.getEncryption(variantId);
+      for(OrcProto.Stream stream: stripeVariant.getStreamsList()) {
+        currentOffset += handleStream(currentOffset, columnInclude, stream, variant);
+      }
+    }
+  }
+
+  /**
+   * Read and parse the indexes for the current stripe.
+   * @param sargColumns the columns we can use bloom filters for
+   * @param output an OrcIndex to reuse
+   * @return the indexes for the required columns
+   */
+  public OrcIndex readRowIndex(boolean[] sargColumns,
+                               OrcIndex output) throws IOException {
+    int typeCount = schema.getMaximumId() + 1;
+    if (output == null) {
+      output = new OrcIndex(new OrcProto.RowIndex[typeCount],
+          new OrcProto.Stream.Kind[typeCount],
+          new OrcProto.BloomFilterIndex[typeCount]);
+    }
+    System.arraycopy(bloomFilterKinds, 0, output.getBloomFilterKinds(), 0,
+        bloomFilterKinds.length);
+    BufferChunkList ranges = planIndexReading(sargColumns);
+    dataReader.readFileData(ranges, false);
+    OrcProto.RowIndex[] indexes = output.getRowGroupIndex();
+    OrcProto.BloomFilterIndex[] blooms = output.getBloomFilterIndex();
+    for(StreamInformation stream: indexStreams) {
+      int column = stream.column;
+      if (stream.firstChunk != null) {
+        CodedInputStream data = InStream.createCodedInputStream(InStream.create(
+            "index", stream.firstChunk, stream.offset,
+            stream.length, getStreamOptions(column, stream.kind)));
+        switch (stream.kind) {
+        case ROW_INDEX:
+          indexes[column] = OrcProto.RowIndex.parseFrom(data);
+          break;
+        case BLOOM_FILTER:
+        case BLOOM_FILTER_UTF8:
+          if (sargColumns != null && sargColumns[column]) {
+            blooms[column] = OrcProto.BloomFilterIndex.parseFrom(data);
+          }
+          break;
+        default:
+          break;
+        }
+      }
+    }
+    return output;
+  }
+
+  private void addChunk(BufferChunkList list, StreamInformation stream,
+                        long offset, long length) {
+    while (length > 0) {
+      long thisLen = Math.min(length, maxBufferSize);
+      BufferChunk chunk = new BufferChunk(offset, (int) thisLen);
+      if (stream.firstChunk == null) {
+        stream.firstChunk = chunk;
+      }
+      list.add(chunk);
+      offset += thisLen;
+      length -= thisLen;
+    }
+  }
+
+  /**
+   * Plans the list of disk ranges that the given stripe needs to read the
+   * indexes. All of the positions are relative to the start of the stripe.
+   * @param bloomFilterColumns true for the columns (indexed by file columns) that
+   *                    we need bloom filters for
+   * @return a list of merged disk ranges to read
+   */
+  private BufferChunkList planIndexReading(boolean[] bloomFilterColumns) {
+    BufferChunkList result = new BufferChunkList();
+    for(StreamInformation stream: indexStreams) {
+      switch (stream.kind) {
+      case ROW_INDEX:
+        addChunk(result, stream, stream.offset, stream.length);
+        break;
+      case BLOOM_FILTER:
+      case BLOOM_FILTER_UTF8:
+        if (bloomFilterColumns[stream.column] &&
+                bloomFilterKinds[stream.column] == stream.kind) {
+          addChunk(result, stream, stream.offset, stream.length);
+        }
+        break;
+      default:
+        // PASS
+        break;
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Plans the list of disk ranges that the given stripe needs to read the
+   * data.
+   * @return a list of merged disk ranges to read
+   */
+  private BufferChunkList planDataReading() {
+    BufferChunkList result = new BufferChunkList();
+    for(StreamInformation stream: dataStreams) {
+      addChunk(result, stream, stream.offset, stream.length);
+    }
+    return result;
+  }
+
+  static boolean hadBadBloomFilters(TypeDescription.Category category,
+                                    OrcFile.WriterVersion version) {
+    switch(category) {
+    case STRING:
+    case CHAR:
+    case VARCHAR:
+      return !version.includes(OrcFile.WriterVersion.HIVE_12055);
+    case DECIMAL:
+      // fixed by ORC-101, but ORC-101 changed stream kind to BLOOM_FILTER_UTF8
+      return true;
+    case TIMESTAMP:
+      return !version.includes(OrcFile.WriterVersion.ORC_135);
+    default:
+      return false;
+    }
+  }
+
+  private static boolean hasSomeRowGroups(boolean[] includedRowGroups) {
+    for(boolean include: includedRowGroups) {
+      if (include) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Plan the ranges of the file that we need to read given the list of
+   * columns and row groups.
+   *
+   * @param index              the index to use for offsets
+   * @param includedRowGroups  which row groups are needed
+   * @return the list of disk  ranges that will be loaded
+   */
+  private BufferChunkList planPartialDataReading(OrcIndex index,
+                                                 @NotNull boolean[] includedRowGroups) {
+    BufferChunkList result = new BufferChunkList();
+    if (hasSomeRowGroups(includedRowGroups)) {
+      OrcProto.RowIndex[] rowIndex = index.getRowGroupIndex();
+      boolean isCompressed = compression.isCompressed();
+      for (StreamInformation stream : dataStreams) {
+        if (RecordReaderUtils.isDictionary(stream.kind, encodings[stream.column])) {
+          addChunk(result, stream, stream.offset, stream.length);
+        } else {
+          int column = stream.column;
+          OrcProto.RowIndex ri = rowIndex[column];
+          TypeDescription.Category kind = schema.findSubtype(column).getCategory();
+          long alreadyRead = 0;
+          for (int group = 0; group < includedRowGroups.length; ++group) {
+            if (includedRowGroups[group]) {
+              // find the last group that is selected
+              int endGroup = group;
+              while (endGroup < includedRowGroups.length - 1 &&
+                         includedRowGroups[endGroup + 1]) {
+                endGroup += 1;
+              }
+              int posn = RecordReaderUtils.getIndexPosition(
+                  encodings[stream.column].getKind(), kind, stream.kind,
+                  isCompressed, hasNull[column]);
+              long start = Math.max(alreadyRead,
+                  stream.offset + ri.getEntry(group).getPositions(posn));
+              long end = stream.offset;
+              if (endGroup == includedRowGroups.length - 1) {
+                end += stream.length;
+              } else {
+                long nextGroupOffset = ri.getEntry(endGroup + 1).getPositions(posn);
+                end += RecordReaderUtils.estimateRgEndOffset(
+                    compression, false, nextGroupOffset, stream.length);
+              }
+              if (alreadyRead < end) {
+                addChunk(result, stream, start, end - start);
+                alreadyRead = end;
+              }
+              group = endGroup;
+            }
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private static class StreamInformation {
+    final OrcProto.Stream.Kind kind;
+    final int column;
+    final long offset;
+    final long length;
+    BufferChunk firstChunk;
+
+    StreamInformation(OrcProto.Stream.Kind kind,
+                      int column, long offset, long length) {
+      this.kind = kind;
+      this.column = column;
+      this.offset = offset;
+      this.length = length;
+    }
+
+    void releaseBuffers(DataReader reader) {
+      long end = offset + length;
+      BufferChunk ptr = firstChunk;
+      while (ptr != null && ptr.getOffset() < end) {
+        ByteBuffer buffer = ptr.getData();
+        if (buffer != null) {
+          reader.releaseBuffer(buffer);
+          ptr.setChunk(null);
+        }
+        ptr = (BufferChunk) ptr.next;
+      }
+    }
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/writer/BooleanTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/BooleanTreeWriter.java
@@ -24,21 +24,23 @@ import org.apache.hadoop.hive.ql.util.JavaDataModel;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.BitFieldWriter;
+import org.apache.orc.impl.CryptoUtils;
 import org.apache.orc.impl.PositionRecorder;
 import org.apache.orc.impl.PositionedOutputStream;
+import org.apache.orc.impl.StreamName;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 public class BooleanTreeWriter extends TreeWriterBase {
   private final BitFieldWriter writer;
 
-  public BooleanTreeWriter(int columnId,
-                           TypeDescription schema,
-                           WriterContext writer,
-                           boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
-    PositionedOutputStream out = writer.createStream(id,
-        OrcProto.Stream.Kind.DATA);
+  public BooleanTreeWriter(TypeDescription schema,
+                           WriterEncryptionVariant encryption,
+                           WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
+    PositionedOutputStream out = writer.createStream(
+        new StreamName(id, OrcProto.Stream.Kind.DATA, encryption));
     this.writer = new BitFieldWriter(out, 1);
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
@@ -70,10 +72,8 @@ public class BooleanTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeStripe(OrcProto.StripeFooter.Builder builder,
-                          OrcProto.StripeStatistics.Builder stats,
-                          int requiredIndexEntries) throws IOException {
-    super.writeStripe(builder, stats, requiredIndexEntries);
+  public void writeStripe(int requiredIndexEntries) throws IOException {
+    super.writeStripe(requiredIndexEntries);
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
     }
@@ -100,5 +100,11 @@ public class BooleanTreeWriter extends TreeWriterBase {
   public void flushStreams() throws IOException {
     super.flushStreams();
     writer.flush();
+  }
+
+  @Override
+  public void prepareStripe(int stripeId) {
+    super.prepareStripe(stripeId);
+    writer.changeIv(CryptoUtils.modifyIvForStripe(stripeId));
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/ByteTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/ByteTreeWriter.java
@@ -23,21 +23,22 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.util.JavaDataModel;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.CryptoUtils;
 import org.apache.orc.impl.PositionRecorder;
 import org.apache.orc.impl.RunLengthByteWriter;
+import org.apache.orc.impl.StreamName;
 
 import java.io.IOException;
 
 public class ByteTreeWriter extends TreeWriterBase {
   private final RunLengthByteWriter writer;
 
-  public ByteTreeWriter(int columnId,
-                        TypeDescription schema,
-                        WriterContext writer,
-                        boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
-    this.writer = new RunLengthByteWriter(writer.createStream(id,
-        OrcProto.Stream.Kind.DATA));
+  public ByteTreeWriter(TypeDescription schema,
+                        WriterEncryptionVariant encryption,
+                        WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
+    this.writer = new RunLengthByteWriter(writer.createStream(
+        new StreamName(id, OrcProto.Stream.Kind.DATA, encryption)));
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
     }
@@ -80,10 +81,8 @@ public class ByteTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeStripe(OrcProto.StripeFooter.Builder builder,
-                          OrcProto.StripeStatistics.Builder stats,
-                          int requiredIndexEntries) throws IOException {
-    super.writeStripe(builder, stats, requiredIndexEntries);
+  public void writeStripe(int requiredIndexEntries) throws IOException {
+    super.writeStripe(requiredIndexEntries);
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
     }
@@ -110,5 +109,11 @@ public class ByteTreeWriter extends TreeWriterBase {
   public void flushStreams() throws IOException {
     super.flushStreams();
     writer.flush();
+  }
+
+  @Override
+  public void prepareStripe(int stripeId) {
+    super.prepareStripe(stripeId);
+    writer.changeIv(CryptoUtils.modifyIvForStripe(stripeId));
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/CharTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/CharTreeWriter.java
@@ -34,11 +34,10 @@ public class CharTreeWriter extends StringBaseTreeWriter {
   private final int maxLength;
   private final byte[] padding;
 
-  CharTreeWriter(int columnId,
-                 TypeDescription schema,
-                 WriterContext writer,
-                 boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
+  CharTreeWriter(TypeDescription schema,
+                 WriterEncryptionVariant encryption,
+                 WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
     maxLength = schema.getMaxLength();
     // utf-8 is currently 4 bytes long, but it could be upto 6
     padding = new byte[6*maxLength];

--- a/java/core/src/java/org/apache/orc/impl/writer/DateTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/DateTreeWriter.java
@@ -23,9 +23,11 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.util.JavaDataModel;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.CryptoUtils;
 import org.apache.orc.impl.IntegerWriter;
 import org.apache.orc.impl.OutStream;
 import org.apache.orc.impl.PositionRecorder;
+import org.apache.orc.impl.StreamName;
 
 import java.io.IOException;
 
@@ -33,13 +35,12 @@ public class DateTreeWriter extends TreeWriterBase {
   private final IntegerWriter writer;
   private final boolean isDirectV2;
 
-  public DateTreeWriter(int columnId,
-                        TypeDescription schema,
-                        WriterContext writer,
-                        boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
-    OutStream out = writer.createStream(id,
-        OrcProto.Stream.Kind.DATA);
+  public DateTreeWriter(TypeDescription schema,
+                        WriterEncryptionVariant encryption,
+                        WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
+    OutStream out = writer.createStream(
+        new StreamName(id, OrcProto.Stream.Kind.DATA, encryption));
     this.isDirectV2 = isNewWriteFormat(writer);
     this.writer = createIntegerWriter(out, true, isDirectV2, writer);
     if (rowIndexPosition != null) {
@@ -84,10 +85,8 @@ public class DateTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeStripe(OrcProto.StripeFooter.Builder builder,
-                          OrcProto.StripeStatistics.Builder stats,
-                          int requiredIndexEntries) throws IOException {
-    super.writeStripe(builder, stats, requiredIndexEntries);
+  public void writeStripe(int requiredIndexEntries) throws IOException {
+    super.writeStripe(requiredIndexEntries);
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
     }
@@ -127,4 +126,9 @@ public class DateTreeWriter extends TreeWriterBase {
     writer.flush();
   }
 
+  @Override
+  public void prepareStripe(int stripeId) {
+    super.prepareStripe(stripeId);
+    writer.changeIv(CryptoUtils.modifyIvForStripe(stripeId));
+  }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/DoubleTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/DoubleTreeWriter.java
@@ -23,9 +23,11 @@ import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
 import org.apache.hadoop.hive.ql.util.JavaDataModel;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.CryptoUtils;
 import org.apache.orc.impl.PositionRecorder;
 import org.apache.orc.impl.PositionedOutputStream;
 import org.apache.orc.impl.SerializationUtils;
+import org.apache.orc.impl.StreamName;
 
 import java.io.IOException;
 
@@ -33,13 +35,12 @@ public class DoubleTreeWriter extends TreeWriterBase {
   private final PositionedOutputStream stream;
   private final SerializationUtils utils;
 
-  public DoubleTreeWriter(int columnId,
-                          TypeDescription schema,
-                          WriterContext writer,
-                          boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
-    this.stream = writer.createStream(id,
-        OrcProto.Stream.Kind.DATA);
+  public DoubleTreeWriter(TypeDescription schema,
+                          WriterEncryptionVariant encryption,
+                          WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
+    this.stream = writer.createStream(
+        new StreamName(id, OrcProto.Stream.Kind.DATA, encryption));
     this.utils = new SerializationUtils();
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
@@ -83,10 +84,8 @@ public class DoubleTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeStripe(OrcProto.StripeFooter.Builder builder,
-                          OrcProto.StripeStatistics.Builder stats,
-                          int requiredIndexEntries) throws IOException {
-    super.writeStripe(builder, stats, requiredIndexEntries);
+  public void writeStripe(int requiredIndexEntries) throws IOException {
+    super.writeStripe(requiredIndexEntries);
     stream.flush();
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
@@ -114,5 +113,11 @@ public class DoubleTreeWriter extends TreeWriterBase {
   public void flushStreams() throws IOException {
     super.flushStreams();
     stream.flush();
+  }
+
+  @Override
+  public void prepareStripe(int stripeId) {
+    super.prepareStripe(stripeId);
+    stream.changeIv(CryptoUtils.modifyIvForStripe(stripeId));
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/EncryptionTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/EncryptionTreeWriter.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.writer;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.ColumnStatistics;
+import org.apache.orc.DataMask;
+import org.apache.orc.OrcProto;
+import org.apache.orc.TypeDescription;
+
+import java.io.IOException;
+
+/**
+ * TreeWriter that handles column encryption.
+ * We create a TreeWriter for each of the alternatives with an WriterContext
+ * that creates encrypted streams.
+ */
+public class EncryptionTreeWriter implements TreeWriter {
+  // the different writers
+  private final TreeWriter[] childrenWriters;
+  private final DataMask[] masks;
+  // a column vector that we use to apply the masks
+  private final VectorizedRowBatch scratch;
+
+  EncryptionTreeWriter(TypeDescription schema,
+                              WriterEncryptionVariant encryption,
+                              WriterContext context) throws IOException {
+    scratch = schema.createRowBatch();
+    childrenWriters = new TreeWriterBase[2];
+    masks = new DataMask[childrenWriters.length];
+
+    // no mask, encrypted data
+    masks[0] = null;
+    childrenWriters[0] = Factory.createSubtree(schema, encryption, context);
+
+    // masked unencrypted
+    masks[1] = context.getUnencryptedMask(schema.getId());
+    childrenWriters[1] = Factory.createSubtree(schema, null, context);
+  }
+
+  @Override
+  public void writeRootBatch(VectorizedRowBatch batch, int offset,
+                             int length) throws IOException {
+    scratch.ensureSize(length);
+    for(int alt=0; alt < childrenWriters.length; ++alt) {
+      // if there is a mask, apply it to each column
+      if (masks[alt] != null) {
+        for(int col=0; col < scratch.cols.length; ++col) {
+          masks[alt].maskData(batch.cols[col], scratch.cols[col], offset,
+              length);
+        }
+        childrenWriters[alt].writeRootBatch(scratch, offset, length);
+      } else {
+        childrenWriters[alt].writeRootBatch(batch, offset, length);
+      }
+    }
+  }
+
+  @Override
+  public void writeBatch(ColumnVector vector, int offset,
+                         int length) throws IOException {
+    for(int alt=0; alt < childrenWriters.length; ++alt) {
+      // if there is a mask, apply it to each column
+      if (masks[alt] != null) {
+        masks[alt].maskData(vector, scratch.cols[0], offset, length);
+        childrenWriters[alt].writeBatch(scratch.cols[0], offset, length);
+      } else {
+        childrenWriters[alt].writeBatch(vector, offset, length);
+      }
+    }
+  }
+
+  @Override
+  public void createRowIndexEntry() throws IOException {
+    for(TreeWriter child: childrenWriters) {
+      child.createRowIndexEntry();
+    }
+  }
+
+  @Override
+  public void flushStreams() throws IOException {
+    for(TreeWriter child: childrenWriters) {
+      child.flushStreams();
+    }
+  }
+
+  @Override
+  public void writeStripe(int requiredIndexEntries) throws IOException {
+    for(TreeWriter child: childrenWriters) {
+      child.writeStripe(requiredIndexEntries);
+    }
+  }
+
+  @Override
+  public void updateFileStatistics(OrcProto.StripeStatistics stats) {
+    for(TreeWriter child: childrenWriters) {
+      child.updateFileStatistics(stats);
+    }
+  }
+
+  @Override
+  public long estimateMemory() {
+    long result = 0;
+    for (TreeWriter writer : childrenWriters) {
+      result += writer.estimateMemory();
+    }
+    return result;
+  }
+
+  @Override
+  public long getRawDataSize() {
+    // return the size of the encrypted data
+    return childrenWriters[0].getRawDataSize();
+  }
+
+  @Override
+  public void prepareStripe(int stripeId) {
+    for (TreeWriter writer : childrenWriters) {
+      writer.prepareStripe(stripeId);
+    }
+  }
+
+  @Override
+  public void writeFileStatistics() throws IOException {
+    for (TreeWriter child : childrenWriters) {
+      child.writeFileStatistics();
+    }
+  }
+
+  @Override
+  public void getCurrentStatistics(ColumnStatistics[] output) {
+    childrenWriters[0].getCurrentStatistics(output);
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/writer/ListTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/ListTreeWriter.java
@@ -23,8 +23,10 @@ import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
 import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.CryptoUtils;
 import org.apache.orc.impl.IntegerWriter;
 import org.apache.orc.impl.PositionRecorder;
+import org.apache.orc.impl.StreamName;
 
 import java.io.IOException;
 
@@ -33,15 +35,15 @@ public class ListTreeWriter extends TreeWriterBase {
   private final boolean isDirectV2;
   private final TreeWriter childWriter;
 
-  ListTreeWriter(int columnId,
-                 TypeDescription schema,
-                 WriterContext writer,
-                 boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
+  ListTreeWriter(TypeDescription schema,
+                 WriterEncryptionVariant encryption,
+                 WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
     this.isDirectV2 = isNewWriteFormat(writer);
-    childWriter = Factory.create(schema.getChildren().get(0), writer, true);
-    lengths = createIntegerWriter(writer.createStream(columnId,
-        OrcProto.Stream.Kind.LENGTH), false, isDirectV2, writer);
+    childWriter = Factory.create(schema.getChildren().get(0), encryption, writer);
+    lengths = createIntegerWriter(writer.createStream(
+        new StreamName(id, OrcProto.Stream.Kind.LENGTH, encryption)),
+        false, isDirectV2, writer);
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
     }
@@ -120,11 +122,9 @@ public class ListTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeStripe(OrcProto.StripeFooter.Builder builder,
-                          OrcProto.StripeStatistics.Builder stats,
-                          int requiredIndexEntries) throws IOException {
-    super.writeStripe(builder, stats, requiredIndexEntries);
-    childWriter.writeStripe(builder, stats, requiredIndexEntries);
+  public void writeStripe(int requiredIndexEntries) throws IOException {
+    super.writeStripe(requiredIndexEntries);
+    childWriter.writeStripe(requiredIndexEntries);
     if (rowIndexPosition != null) {
       recordPosition(rowIndexPosition);
     }
@@ -170,5 +170,12 @@ public class ListTreeWriter extends TreeWriterBase {
   public void getCurrentStatistics(ColumnStatistics[] output) {
     super.getCurrentStatistics(output);
     childWriter.getCurrentStatistics(output);
+  }
+
+  @Override
+  public void prepareStripe(int stripeId) {
+    super.prepareStripe(stripeId);
+    lengths.changeIv(CryptoUtils.modifyIvForStripe(stripeId));
+    childWriter.prepareStripe(stripeId);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/ListTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/ListTreeWriter.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl.writer;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.IntegerWriter;
@@ -153,9 +154,9 @@ public class ListTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeFileStatistics(OrcProto.Footer.Builder footer) {
-    super.writeFileStatistics(footer);
-    childWriter.writeFileStatistics(footer);
+  public void writeFileStatistics() throws IOException {
+    super.writeFileStatistics();
+    childWriter.writeFileStatistics();
   }
 
   @Override
@@ -163,5 +164,11 @@ public class ListTreeWriter extends TreeWriterBase {
     super.flushStreams();
     lengths.flush();
     childWriter.flushStreams();
+  }
+
+  @Override
+  public void getCurrentStatistics(ColumnStatistics[] output) {
+    super.getCurrentStatistics(output);
+    childWriter.getCurrentStatistics(output);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/MapTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/MapTreeWriter.java
@@ -19,6 +19,7 @@ package org.apache.orc.impl.writer;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
+import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.IntegerWriter;
@@ -164,10 +165,10 @@ public class MapTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeFileStatistics(OrcProto.Footer.Builder footer) {
-    super.writeFileStatistics(footer);
-    keyWriter.writeFileStatistics(footer);
-    valueWriter.writeFileStatistics(footer);
+  public void writeFileStatistics() throws IOException {
+    super.writeFileStatistics();
+    keyWriter.writeFileStatistics();
+    valueWriter.writeFileStatistics();
   }
 
   @Override
@@ -176,5 +177,12 @@ public class MapTreeWriter extends TreeWriterBase {
     lengths.flush();
     keyWriter.flushStreams();
     valueWriter.flushStreams();
+  }
+
+  @Override
+  public void getCurrentStatistics(ColumnStatistics[] output) {
+    super.getCurrentStatistics(output);
+    keyWriter.getCurrentStatistics(output);
+    valueWriter.getCurrentStatistics(output);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/StringTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/StringTreeWriter.java
@@ -26,11 +26,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public class StringTreeWriter extends StringBaseTreeWriter {
-  StringTreeWriter(int columnId,
-                   TypeDescription schema,
-                   WriterContext writer,
-                   boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
+  StringTreeWriter(TypeDescription schema,
+                   WriterEncryptionVariant encryption,
+                   WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/writer/StructTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/StructTreeWriter.java
@@ -21,6 +21,7 @@ package org.apache.orc.impl.writer;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 
@@ -147,10 +148,10 @@ public class StructTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeFileStatistics(OrcProto.Footer.Builder footer) {
-    super.writeFileStatistics(footer);
+  public void writeFileStatistics() throws IOException {
+    super.writeFileStatistics();
     for (TreeWriter child : childrenWriters) {
-      child.writeFileStatistics(footer);
+      child.writeFileStatistics();
     }
   }
 
@@ -160,6 +161,13 @@ public class StructTreeWriter extends TreeWriterBase {
     for (TreeWriter child : childrenWriters) {
       child.flushStreams();
     }
+  }
 
+  @Override
+  public void getCurrentStatistics(ColumnStatistics[] output) {
+    super.getCurrentStatistics(output);
+    for (TreeWriter child: childrenWriters) {
+      child.getCurrentStatistics(output);
+    }
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/TreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/TreeWriter.java
@@ -47,6 +47,12 @@ public interface TreeWriter {
   long getRawDataSize();
 
   /**
+   * Set up for the next stripe.
+   * @param stripeId the next stripe id
+   */
+  void prepareStripe(int stripeId);
+
+  /**
    * Write a VectorizedRowBath to the file. This is called by the WriterImplV2
    * at the top level.
    * @param batch the list of all of the columns
@@ -79,17 +85,11 @@ public interface TreeWriter {
 
   /**
    * Write the stripe out to the file.
-   * @param stripeFooter the stripe footer that contains the information about the
-   *                layout of the stripe. The TreeWriterBase is required to update
-   *                the footer with its information.
-   * @param stats the stripe statistics information
    * @param requiredIndexEntries the number of index entries that are
    *                             required. this is to check to make sure the
    *                             row index is well formed.
    */
-  void writeStripe(OrcProto.StripeFooter.Builder stripeFooter,
-                   OrcProto.StripeStatistics.Builder stats,
-                   int requiredIndexEntries) throws IOException;
+  void writeStripe(int requiredIndexEntries) throws IOException;
 
   /**
    * During a stripe append, we need to update the file statistics.
@@ -98,7 +98,7 @@ public interface TreeWriter {
   void updateFileStatistics(OrcProto.StripeStatistics stripeStatistics);
 
   /**
-   * Add the file statistics to the file footer.
+   * Write the FileStatistics for each column in each encryption variant.
    */
   void writeFileStatistics() throws IOException;
 
@@ -110,71 +110,81 @@ public interface TreeWriter {
   void getCurrentStatistics(ColumnStatistics[] output);
 
   class Factory {
+    /**
+     * Create a new tree writer for the given types and insert encryption if
+     * required.
+     * @param schema the type to build a writer for
+     * @param encryption the encryption status
+     * @param streamFactory the writer context
+     * @return a new tree writer
+     */
     public static TreeWriter create(TypeDescription schema,
-                                    WriterContext streamFactory,
-                                    boolean nullable) throws IOException {
-      OrcFile.Version version = streamFactory.getVersion();
-      switch (schema.getCategory()) {
-        case BOOLEAN:
-          return new BooleanTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case BYTE:
-          return new ByteTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case SHORT:
-        case INT:
-        case LONG:
-          return new IntegerTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case FLOAT:
-          return new FloatTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case DOUBLE:
-          return new DoubleTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case STRING:
-          return new StringTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case CHAR:
-          return new CharTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case VARCHAR:
-          return new VarcharTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case BINARY:
-          return new BinaryTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case TIMESTAMP:
-          return new TimestampTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case DATE:
-          return new DateTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case DECIMAL:
-          if (version == OrcFile.Version.UNSTABLE_PRE_2_0 &&
-              schema.getPrecision() <= TypeDescription.MAX_DECIMAL64_PRECISION) {
-            return new Decimal64TreeWriter(schema.getId(),
-                schema, streamFactory, nullable);
-          }
-          return new DecimalTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case STRUCT:
-          return new StructTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case MAP:
-          return new MapTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case LIST:
-          return new ListTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        case UNION:
-          return new UnionTreeWriter(schema.getId(),
-              schema, streamFactory, nullable);
-        default:
-          throw new IllegalArgumentException("Bad category: " +
-              schema.getCategory());
+                                    WriterEncryptionVariant encryption,
+                                    WriterContext streamFactory) throws IOException {
+      if (encryption == null) {
+        // If we are the root of an encryption variant, create a special writer.
+        encryption = streamFactory.getEncryption(schema.getId());
+        if (encryption != null) {
+          return new EncryptionTreeWriter(schema, encryption, streamFactory);
+        }
       }
+      return createSubtree(schema, encryption, streamFactory);
     }
 
+    /**
+     * Create a subtree without inserting encryption nodes
+     * @param schema the schema to create
+     * @param encryption the encryption variant
+     * @param streamFactory the writer context
+     * @return a new tree writer
+     */
+    static TreeWriter createSubtree(TypeDescription schema,
+                                    WriterEncryptionVariant encryption,
+                                    WriterContext streamFactory) throws IOException {
+      OrcFile.Version version = streamFactory.getVersion();
+      switch (schema.getCategory()) {
+      case BOOLEAN:
+        return new BooleanTreeWriter(schema, encryption, streamFactory);
+      case BYTE:
+        return new ByteTreeWriter(schema, encryption, streamFactory);
+      case SHORT:
+      case INT:
+      case LONG:
+        return new IntegerTreeWriter(schema, encryption, streamFactory);
+      case FLOAT:
+        return new FloatTreeWriter(schema, encryption, streamFactory);
+      case DOUBLE:
+        return new DoubleTreeWriter(schema, encryption, streamFactory);
+      case STRING:
+        return new StringTreeWriter(schema, encryption, streamFactory);
+      case CHAR:
+        return new CharTreeWriter(schema, encryption, streamFactory);
+      case VARCHAR:
+        return new VarcharTreeWriter(schema, encryption, streamFactory);
+      case BINARY:
+        return new BinaryTreeWriter(schema, encryption, streamFactory);
+      case TIMESTAMP:
+        return new TimestampTreeWriter(schema, encryption, streamFactory);
+      case DATE:
+        return new DateTreeWriter(schema, encryption, streamFactory);
+      case DECIMAL:
+        if (version == OrcFile.Version.UNSTABLE_PRE_2_0 &&
+                schema.getPrecision() <= TypeDescription.MAX_DECIMAL64_PRECISION) {
+          return new Decimal64TreeWriter(schema, encryption, streamFactory);
+        }
+        return new DecimalTreeWriter(schema, encryption, streamFactory);
+      case STRUCT:
+        return new StructTreeWriter(schema, encryption, streamFactory);
+      case MAP:
+        return new MapTreeWriter(schema, encryption, streamFactory);
+      case LIST:
+        return new ListTreeWriter(schema, encryption, streamFactory);
+      case UNION:
+        return new UnionTreeWriter(schema, encryption, streamFactory);
+      default:
+        throw new IllegalArgumentException("Bad category: " +
+                                               schema.getCategory());
+      }
+    }
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/TreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/TreeWriter.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl.writer;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcFile;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
@@ -98,9 +99,15 @@ public interface TreeWriter {
 
   /**
    * Add the file statistics to the file footer.
-   * @param footer the file footer builder
    */
-  void writeFileStatistics(OrcProto.Footer.Builder footer);
+  void writeFileStatistics() throws IOException;
+
+  /**
+   * Get the current file statistics for each column. If a column is encrypted,
+   * the encrypted variant statistics are used.
+   * @param output an array that is filled in with the results
+   */
+  void getCurrentStatistics(ColumnStatistics[] output);
 
   class Factory {
     public static TreeWriter create(TypeDescription schema,

--- a/java/core/src/java/org/apache/orc/impl/writer/UnionTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/UnionTreeWriter.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl.writer;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
+import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.PositionRecorder;
@@ -165,10 +166,10 @@ public class UnionTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeFileStatistics(OrcProto.Footer.Builder footer) {
-    super.writeFileStatistics(footer);
+  public void writeFileStatistics() throws IOException {
+    super.writeFileStatistics();
     for (TreeWriter child : childrenWriters) {
-      child.writeFileStatistics(footer);
+      child.writeFileStatistics();
     }
   }
 
@@ -178,6 +179,14 @@ public class UnionTreeWriter extends TreeWriterBase {
     tags.flush();
     for (TreeWriter child : childrenWriters) {
       child.flushStreams();
+    }
+  }
+
+  @Override
+  public void getCurrentStatistics(ColumnStatistics[] output) {
+    super.getCurrentStatistics(output);
+    for (TreeWriter child: childrenWriters) {
+      child.getCurrentStatistics(output);
     }
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/writer/VarcharTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/VarcharTreeWriter.java
@@ -32,11 +32,10 @@ import java.nio.charset.StandardCharsets;
 public class VarcharTreeWriter extends StringBaseTreeWriter {
   private final int maxLength;
 
-  VarcharTreeWriter(int columnId,
-                    TypeDescription schema,
-                    WriterContext writer,
-                    boolean nullable) throws IOException {
-    super(columnId, schema, writer, nullable);
+  VarcharTreeWriter(TypeDescription schema,
+                    WriterEncryptionVariant encryption,
+                    WriterContext writer) throws IOException {
+    super(schema, encryption, writer);
     maxLength = schema.getMaxLength();
   }
 

--- a/java/core/src/java/org/apache/orc/impl/writer/WriterContext.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/WriterContext.java
@@ -102,6 +102,15 @@ public interface WriterContext {
                           OrcProto.BloomFilterIndex.Builder bloom
                           ) throws IOException;
 
+    /**
+     * Set the column statistics for the stripe or file.
+     * @param name the name of the statistics stream
+     * @param stats the statistics for this column in this stripe
+     */
+    void writeStatistics(StreamName name,
+                         OrcProto.ColumnStatistics.Builder stats
+                         ) throws IOException;
+
     boolean getUseUTCTimestamp();
 
     double getDictionaryKeySizeThreshold(int column);

--- a/java/core/src/java/org/apache/orc/impl/writer/WriterEncryptionKey.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/WriterEncryptionKey.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.writer;
+
+import org.apache.orc.EncryptionAlgorithm;
+import org.apache.orc.EncryptionKey;
+import org.apache.orc.EncryptionVariant;
+import org.apache.orc.impl.HadoopShims;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class WriterEncryptionKey implements EncryptionKey {
+  private final HadoopShims.KeyMetadata metadata;
+  private final List<WriterEncryptionVariant> roots = new ArrayList<>();
+  private int id;
+
+  public WriterEncryptionKey(HadoopShims.KeyMetadata key) {
+    this.metadata = key;
+  }
+
+  public void addRoot(WriterEncryptionVariant root) {
+    roots.add(root);
+  }
+
+  public HadoopShims.KeyMetadata getMetadata() {
+    return metadata;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  @Override
+  public String getKeyName() {
+    return metadata.getKeyName();
+  }
+
+  @Override
+  public int getKeyVersion() {
+    return metadata.getVersion();
+  }
+
+  public EncryptionAlgorithm getAlgorithm() {
+    return metadata.getAlgorithm();
+  }
+
+  @Override
+  public WriterEncryptionVariant[] getEncryptionRoots() {
+    return roots.toArray(new WriterEncryptionVariant[roots.size()]);
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public void sortRoots() {
+    Collections.sort(roots);
+  }
+
+  @Override
+  public int hashCode() {
+    return id;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == null || getClass() != other.getClass()) {
+      return false;
+    }
+    return compareTo((EncryptionKey) other) == 0;
+  }
+
+  @Override
+  public int compareTo(@NotNull EncryptionKey other) {
+    int result = getKeyName().compareTo(other.getKeyName());
+    if (result == 0) {
+      result = Integer.compare(getKeyVersion(), other.getKeyVersion());
+    }
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return metadata.toString();
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/writer/WriterEncryptionVariant.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/WriterEncryptionVariant.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.writer;
+
+import org.apache.orc.EncryptionVariant;
+import org.apache.orc.OrcProto;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.LocalKey;
+import org.jetbrains.annotations.NotNull;
+
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.List;
+
+public class WriterEncryptionVariant implements EncryptionVariant {
+  private int id;
+  private final WriterEncryptionKey key;
+  private final TypeDescription root;
+  private final LocalKey material;
+  private final OrcProto.FileStatistics.Builder fileStats =
+      OrcProto.FileStatistics.newBuilder();
+  private final List<OrcProto.ColumnEncoding> encodings = new ArrayList<>();
+
+  public WriterEncryptionVariant(WriterEncryptionKey key,
+                                 TypeDescription root,
+                                 LocalKey columnKey) {
+    this.key = key;
+    this.root = root;
+    this.material = columnKey;
+  }
+
+  @Override
+  public WriterEncryptionKey getKeyDescription() {
+    return key;
+  }
+
+  public TypeDescription getRoot() {
+    return root;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  @Override
+  public int getVariantId() {
+    return id;
+  }
+
+  @Override
+  public Key getFileFooterKey() {
+    return material.getDecryptedKey();
+  }
+
+  @Override
+  public Key getStripeKey(long stripe) {
+    return material.getDecryptedKey();
+  }
+
+  public LocalKey getMaterial() {
+    return material;
+  }
+
+  public void clearFileStatistics() {
+    fileStats.clearColumn();
+  }
+
+  public void addFileStatistics(OrcProto.ColumnStatistics column) {
+    fileStats.addColumn(column);
+  }
+
+  public OrcProto.FileStatistics getFileStatistics() {
+    return fileStats.build();
+  }
+
+  public void addEncoding(OrcProto.ColumnEncoding encoding) {
+    encodings.add(encoding);
+  }
+
+  public List<OrcProto.ColumnEncoding> getEncodings() {
+    return encodings;
+  }
+
+  public void clearEncodings() {
+    encodings.clear();
+  }
+
+  @Override
+  public int hashCode() {
+    return key.hashCode() << 16 ^ root.getId();
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    } else if (other == null || other.getClass() != getClass()) {
+      return false;
+    }
+    return compareTo((WriterEncryptionVariant) other) == 0;
+  }
+
+  @Override
+  public int compareTo(@NotNull EncryptionVariant other) {
+    int result = key.compareTo(other.getKeyDescription());
+    if (result == 0) {
+      result = Integer.compare(root.getId(), other.getRoot().getId());
+    }
+    return result;
+  }
+}
+

--- a/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
+++ b/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
@@ -207,7 +207,7 @@ public class TestNewIntegerEncoding {
       }
     }
   }
-  
+
   @Test
   public void testBasicDelta1() throws Exception {
     TypeDescription schema = TypeDescription.createLong();
@@ -1276,8 +1276,9 @@ public class TestNewIntegerEncoding {
     tslist.add(Timestamp.valueOf("1974-01-01 00:00:00"));
     int idx = 0;
     for (Timestamp ts : tslist) {
-      ((TimestampColumnVector) batch.cols[0]).set(idx, ts);
+      ((TimestampColumnVector) batch.cols[0]).set(idx++, ts);
     }
+    batch.size = tslist.size();
     writer.addRowBatch(batch);
     writer.close();
 
@@ -1287,6 +1288,7 @@ public class TestNewIntegerEncoding {
     batch = reader.getSchema().createRowBatch();
     idx = 0;
     while (rows.nextBatch(batch)) {
+      assertEquals(tslist.size(), batch.size);
       for(int r=0; r < batch.size; ++r) {
         assertEquals(tslist.get(idx++),
             ((TimestampColumnVector) batch.cols[0]).asScratchTimestamp(r));

--- a/java/core/src/test/org/apache/orc/TestStringDictionary.java
+++ b/java/core/src/test/org/apache/orc/TestStringDictionary.java
@@ -240,6 +240,11 @@ public class TestStringDictionary {
     }
 
     @Override
+    public void writeStatistics(StreamName name, OrcProto.ColumnStatistics.Builder stats) throws IOException {
+
+    }
+
+    @Override
     public boolean getUseUTCTimestamp() {
       return true;
     }

--- a/java/core/src/test/org/apache/orc/TestStringDictionary.java
+++ b/java/core/src/test/org/apache/orc/TestStringDictionary.java
@@ -40,6 +40,7 @@ import org.apache.orc.impl.writer.StreamOptions;
 import org.apache.orc.impl.writer.StringTreeWriter;
 import org.apache.orc.impl.writer.TreeWriter;
 import org.apache.orc.impl.writer.WriterContext;
+import org.apache.orc.impl.writer.WriterEncryptionVariant;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -172,9 +173,9 @@ public class TestStringDictionary {
     }
 
     @Override
-    public OutStream createStream(int column, OrcProto.Stream.Kind kind) throws IOException {
+    public OutStream createStream(StreamName name) throws IOException {
       TestInStream.OutputCollector collect = new TestInStream.OutputCollector();
-      streams.put(new StreamName(column, kind), collect);
+      streams.put(name, collect);
       return new OutStream("test", new StreamOptions(1000), collect);
     }
 
@@ -224,6 +225,16 @@ public class TestStringDictionary {
     }
 
     @Override
+    public void setEncoding(int column, WriterEncryptionVariant variant, OrcProto.ColumnEncoding encoding) {
+
+    }
+
+    @Override
+    public void writeStatistics(StreamName name, OrcProto.ColumnStatistics.Builder stats) throws IOException {
+
+    }
+
+    @Override
     public OrcFile.BloomFilterVersion getBloomFilterVersion() {
       return OrcFile.BloomFilterVersion.UTF8;
     }
@@ -240,8 +251,13 @@ public class TestStringDictionary {
     }
 
     @Override
-    public void writeStatistics(StreamName name, OrcProto.ColumnStatistics.Builder stats) throws IOException {
+    public DataMask getUnencryptedMask(int columnId) {
+      return null;
+    }
 
+    @Override
+    public WriterEncryptionVariant getEncryption(int columnId) {
+      return null;
     }
 
     @Override
@@ -262,7 +278,7 @@ public class TestStringDictionary {
     conf.set(OrcConf.DICTIONARY_KEY_SIZE_THRESHOLD.getAttribute(), "0.0");
     WriterContextImpl writerContext = new WriterContextImpl(schema, conf);
     StringTreeWriter writer = (StringTreeWriter)
-        TreeWriter.Factory.create(schema, writerContext, true);
+        TreeWriter.Factory.create(schema, null, writerContext);
 
     VectorizedRowBatch batch = schema.createRowBatch();
     BytesColumnVector col = (BytesColumnVector) batch.cols[0];

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -2099,7 +2099,7 @@ public class TestVectorOrcFile {
                                                    ) throws IOException {
     fs.delete(testFilePath, false);
     PhysicalWriter physical = new PhysicalFsWriter(fs, testFilePath, opts);
-    CompressionCodec codec = physical.getCompressionCodec();
+    CompressionCodec codec = physical.getStreamOptions().getCodec();
     Writer writer = OrcFile.createWriter(testFilePath,
         opts.physicalWriter(physical));
     writeRandomIntBytesBatches(writer, batch, count, size);

--- a/java/core/src/test/org/apache/orc/impl/MockDataReader.java
+++ b/java/core/src/test/org/apache/orc/impl/MockDataReader.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.orc.CompressionCodec;
+import org.apache.orc.DataReader;
+import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
+import org.apache.orc.TypeDescription;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+
+public class MockDataReader implements DataReader {
+  private final List<MockStripe> stripes = new ArrayList<>();
+  private final int numColumns;
+  private long offset = 3;
+  private MockStripe next;
+  private Set<ByteBuffer> outBuffers =
+      Collections.newSetFromMap(new IdentityHashMap<>());
+
+  public MockDataReader(TypeDescription schema) {
+    numColumns = schema.getMaximumId() + 1;
+    next = new MockStripe(numColumns, stripes.size(), offset);
+  }
+
+  public MockDataReader addStream(int column, OrcProto.Stream.Kind kind,
+                                  ByteBuffer bytes) {
+    next.addStream(column, kind, offset, bytes);
+    offset += bytes.remaining();
+    return this;
+  }
+
+  public MockDataReader addEncoding(OrcProto.ColumnEncoding.Kind kind) {
+    next.addEncoding(kind);
+    return this;
+  }
+
+  public MockDataReader addStripeFooter(int rows, String timezone) {
+    next.close(rows, timezone);
+    stripes.add(next);
+    offset += next.getFooterLength();
+    next = new MockStripe(numColumns, stripes.size(), offset);
+    return this;
+  }
+
+  @Override
+  public void open() { }
+
+  @Override
+  public OrcProto.StripeFooter readStripeFooter(StripeInformation stripe) {
+    return stripes.get((int) stripe.getStripeId()).getFooter();
+  }
+
+  @Override
+  public BufferChunkList readFileData(BufferChunkList list,
+                                      boolean doForceDirect) {
+    for(BufferChunk buffer = list.get(); buffer != null;
+        buffer = (BufferChunk) buffer.next) {
+      if (!buffer.hasData()) {
+        MockStripe stripe = getStripeByOffset(buffer.getOffset());
+        ByteBuffer data = stripe.getData(buffer.getOffset(), buffer.getLength());
+        outBuffers.add(data);
+        buffer.setChunk(data);
+      }
+    }
+    return list;
+  }
+
+  @Override
+  public boolean isTrackingDiskRanges() {
+    return true;
+  }
+
+  @Override
+  public void releaseBuffer(ByteBuffer toRelease) {
+    outBuffers.remove(toRelease);
+  }
+
+  @Override
+  public DataReader clone() {
+    throw new UnsupportedOperationException("Clone not supported.");
+  }
+
+  @Override
+  public void close() { }
+
+  @Override
+  public CompressionCodec getCompressionCodec() {
+    return null;
+  }
+
+  public MockStripe getStripe(int id) {
+    return stripes.get(id);
+  }
+
+  private MockStripe getStripeByOffset(long offset) {
+    for(MockStripe stripe: stripes) {
+      if (stripe.getOffset() <= offset &&
+              (offset - stripe.getOffset() < stripe.getLength())) {
+        return stripe;
+      }
+    }
+    throw new IllegalArgumentException("Can't find stripe at " + offset);
+  }
+
+  void resetCounts() {
+    for(MockStripe stripe: stripes) {
+      stripe.resetCounts();
+    }
+  }
+}

--- a/java/core/src/test/org/apache/orc/impl/MockStream.java
+++ b/java/core/src/test/org/apache/orc/impl/MockStream.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.orc.OrcProto;
+
+import java.nio.ByteBuffer;
+
+class MockStream {
+  final int column;
+  final OrcProto.Stream.Kind kind;
+  private final ByteBuffer bytes;
+  final long offset;
+  final int length;
+  int readCount = 0;
+
+  MockStream(int column, OrcProto.Stream.Kind kind, long offset,
+             ByteBuffer bytes) {
+    this.column = column;
+    this.kind = kind;
+    this.bytes = bytes;
+    this.offset = offset;
+    this.length = bytes.remaining();
+  }
+
+  ByteBuffer getData(long offset, int length) {
+    if (offset < this.offset ||
+        offset + length > this.offset + this.length) {
+      throw new IllegalArgumentException("Bad getData [" + offset + ", " +
+                                             (offset + length) + ") from [" +
+                                            this.offset + ", " +
+                                             (this.offset + this.length) + ")");
+    }
+    ByteBuffer copy = bytes.duplicate();
+    int posn = (int) (offset - this.offset);
+    copy.position(posn);
+    copy.limit(posn + length);
+    return copy;
+  }
+}

--- a/java/core/src/test/org/apache/orc/impl/MockStripe.java
+++ b/java/core/src/test/org/apache/orc/impl/MockStripe.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+public class MockStripe implements StripeInformation {
+  private final int numColumns;
+  private final List<MockStream> streams = new ArrayList<>();
+  private final List<OrcProto.ColumnEncoding> encodings = new ArrayList<>();
+  private final long startOffset;
+  private final int stripeId;
+  private int indexLength = 0;
+  private int dataLength = 0;
+  private int footerLength = 0;
+  private OrcProto.StripeFooter footer;
+  private int rows = 0;
+
+  public MockStripe(int numColumns, int stripeId, long offset) {
+    this.numColumns = numColumns;
+    this.startOffset = offset;
+    this.stripeId = stripeId;
+  }
+
+  public MockStream addStream(int column, OrcProto.Stream.Kind kind,
+                              long offset, ByteBuffer bytes) {
+    MockStream result = new MockStream(column, kind, offset, bytes);
+    streams.add(result);
+    int length = bytes.remaining();
+    if (StreamName.getArea(kind) == StreamName.Area.INDEX) {
+      indexLength += length;
+    } else {
+      dataLength += length;
+    }
+    return result;
+  }
+
+  public void addEncoding(OrcProto.ColumnEncoding.Kind kind) {
+    OrcProto.ColumnEncoding.Builder result =
+        OrcProto.ColumnEncoding.newBuilder();
+    result.setKind(kind);
+    encodings.add(result.build());
+  }
+
+  public void close(int rows, String timezone) {
+    this.rows = rows;
+    // make sure we have enough encodings
+    while (encodings.size() < numColumns) {
+      addEncoding(OrcProto.ColumnEncoding.Kind.DIRECT);
+    }
+    OrcProto.StripeFooter.Builder foot = OrcProto.StripeFooter.newBuilder();
+    for(MockStream stream: streams) {
+      foot.addStreams(OrcProto.Stream.newBuilder()
+                          .setKind(stream.kind)
+                          .setLength(stream.length)
+                          .setColumn(stream.column).build());
+    }
+    for(OrcProto.ColumnEncoding encoding: encodings) {
+      foot.addColumns(encoding);
+    }
+    if (timezone != null) {
+      foot.setWriterTimezone(timezone);
+    }
+    footer = foot.build();
+    footerLength = footer.getSerializedSize();
+  }
+
+  @Override
+  public long getOffset() {
+    return startOffset;
+  }
+
+  @Override
+  public long getLength() {
+    return indexLength + dataLength + footerLength;
+  }
+
+  @Override
+  public long getIndexLength() {
+    return indexLength;
+  }
+
+  @Override
+  public long getDataLength() {
+    return dataLength;
+  }
+
+  @Override
+  public long getFooterLength() {
+    return footerLength;
+  }
+
+  @Override
+  public long getNumberOfRows() {
+    return rows;
+  }
+
+  @Override
+  public long getStripeId() {
+    return stripeId;
+  }
+
+  @Override
+  public long getEncryptionStripeId() {
+    return stripeId;
+  }
+
+  @Override
+  public byte[][] getEncryptedLocalKeys() {
+    return new byte[0][];
+  }
+
+  public MockStream getStream(int column, OrcProto.Stream.Kind kind) {
+    for (MockStream stream: streams) {
+      if (stream.column == column && stream.kind == kind) {
+        return stream;
+      }
+    }
+    throw new IllegalArgumentException("Can't find stream column " + column
+                                           + " kind " + kind);
+  }
+
+  private MockStream getStream(long offset) {
+    for (MockStream stream: streams) {
+      if (stream.offset <= offset && offset < stream.offset + stream.length) {
+        return stream;
+      }
+    }
+    throw new IllegalArgumentException("Can't find stream at offset " + offset);
+  }
+
+  public ByteBuffer getData(long offset, int length) {
+    MockStream stream = getStream(offset);
+    stream.readCount += 1;
+    return stream.getData(offset, length);
+  }
+
+  public void resetCounts() {
+    for(MockStream stream: streams) {
+      stream.readCount = 0;
+    }
+  }
+
+  public OrcProto.StripeFooter getFooter() {
+    return footer;
+  }
+}

--- a/java/core/src/test/org/apache/orc/impl/TestBitFieldReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestBitFieldReader.java
@@ -53,7 +53,7 @@ public class TestBitFieldReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     BitFieldReader in = new BitFieldReader(InStream.create("test",
-        new BufferChunk(inBuf, 0), inBuf.remaining(),
+        new BufferChunk(inBuf, 0), 0, inBuf.remaining(),
         InStream.options().withCodec(codec).withBufferSize(500)));
     for(int i=0; i < COUNT; ++i) {
       int x = in.next();
@@ -102,7 +102,7 @@ public class TestBitFieldReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     BitFieldReader in = new BitFieldReader(InStream.create("test",
-        new BufferChunk(inBuf, 0), inBuf.remaining()));
+        new BufferChunk(inBuf, 0), 0, inBuf.remaining()));
     for(int i=0; i < COUNT; i += 5) {
       int x = in.next();
       if (i < COUNT/2) {
@@ -139,7 +139,7 @@ public class TestBitFieldReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     BitFieldReader in = new BitFieldReader(InStream.create("test",
-        new BufferChunk(inBuf, 0), inBuf.remaining()));
+        new BufferChunk(inBuf, 0), 0, inBuf.remaining()));
     in.seek(posn);
     in.skip(10);
     for(int r = 210; r < COUNT; ++r) {

--- a/java/core/src/test/org/apache/orc/impl/TestBitPack.java
+++ b/java/core/src/test/org/apache/orc/impl/TestBitPack.java
@@ -110,7 +110,7 @@ public class TestBitPack {
     inBuf.flip();
     long[] buff = new long[SIZE];
     utils.readInts(buff, 0, SIZE, fixedWidth,
-        InStream.create("test", new BufferChunk(inBuf,0),
+        InStream.create("test", new BufferChunk(inBuf,0), 0,
         inBuf.remaining()));
     for (int i = 0; i < SIZE; i++) {
       buff[i] = utils.zigzagDecode(buff[i]);

--- a/java/core/src/test/org/apache/orc/impl/TestDataReaderProperties.java
+++ b/java/core/src/test/org/apache/orc/impl/TestDataReaderProperties.java
@@ -36,15 +36,18 @@ public class TestDataReaderProperties {
 
   @Test
   public void testCompleteBuild() {
+    InStream.StreamOptions options = InStream.options()
+        .withCodec(OrcCodecPool.getCodec(CompressionKind.ZLIB));
     DataReaderProperties properties = DataReaderProperties.builder()
       .withFileSystem(mockedFileSystem)
       .withPath(mockedPath)
-      .withCompression(CompressionKind.ZLIB)
+      .withCompression(options)
       .withZeroCopy(mockedZeroCopy)
       .build();
     assertEquals(mockedFileSystem, properties.getFileSystem());
     assertEquals(mockedPath, properties.getPath());
-    assertEquals(CompressionKind.ZLIB, properties.getCompression());
+    assertEquals(CompressionKind.ZLIB,
+        properties.getCompression().getCodec().getKind());
     assertEquals(mockedZeroCopy, properties.getZeroCopy());
   }
 
@@ -69,7 +72,7 @@ public class TestDataReaderProperties {
   public void testMissingPath() {
     DataReaderProperties.builder()
       .withFileSystem(mockedFileSystem)
-      .withCompression(CompressionKind.NONE)
+      .withCompression(InStream.options())
       .withZeroCopy(mockedZeroCopy)
       .build();
   }
@@ -78,7 +81,7 @@ public class TestDataReaderProperties {
   public void testMissingFileSystem() {
     DataReaderProperties.builder()
       .withPath(mockedPath)
-      .withCompression(CompressionKind.NONE)
+      .withCompression(InStream.options())
       .withZeroCopy(mockedZeroCopy)
       .build();
   }

--- a/java/core/src/test/org/apache/orc/impl/TestInStream.java
+++ b/java/core/src/test/org/apache/orc/impl/TestInStream.java
@@ -108,7 +108,7 @@ public class TestInStream {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     InStream in = InStream.create("test", new BufferChunk(inBuf, 0),
-        inBuf.remaining());
+        0, inBuf.remaining());
     assertEquals("uncompressed stream test position: 0 length: 1024" +
                  " range: 0 offset: 0 limit: 1024",
                  in.toString());
@@ -161,7 +161,7 @@ public class TestInStream {
       offset += size;
     }
 
-    InStream in = InStream.create("test", list.get(), collect.buffer.size(),
+    InStream in = InStream.create("test", list.get(), 0, collect.buffer.size(),
         InStream.options().withEncryption(algorithm, decryptKey,
             writerOptions.getIv()));
     assertEquals("encrypted uncompressed stream test position: 0 length: 8192" +
@@ -219,7 +219,7 @@ public class TestInStream {
       offset += size;
     }
 
-    InStream in = InStream.create("test", list.get(), collect.buffer.size(),
+    InStream in = InStream.create("test", list.get(), 0, collect.buffer.size(),
         InStream.options()
             .withCodec(new ZlibCodec()).withBufferSize(500)
             .withEncryption(algorithm, decryptKey, writerOptions.getIv()));
@@ -258,7 +258,7 @@ public class TestInStream {
     ByteBuffer inBuf = ByteBuffer.allocate(collect.buffer.size());
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
-    InStream in = InStream.create("test", new BufferChunk(inBuf, 0),
+    InStream in = InStream.create("test", new BufferChunk(inBuf, 0), 0,
         inBuf.remaining(),
         InStream.options().withCodec(codec).withBufferSize(300));
     assertEquals("compressed stream test position: 0 length: 961 range: 0" +
@@ -294,7 +294,7 @@ public class TestInStream {
     ByteBuffer inBuf = ByteBuffer.allocate(collect.buffer.size());
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
-    InStream in = InStream.create("test", new BufferChunk(inBuf, 0),
+    InStream in = InStream.create("test", new BufferChunk(inBuf, 0), 0,
         inBuf.remaining(),
         InStream.options().withCodec(codec).withBufferSize(100));
     byte[] contents = new byte[1024];
@@ -310,7 +310,7 @@ public class TestInStream {
     inBuf.put((byte) 32);
     inBuf.put((byte) 0);
     inBuf.flip();
-    in = InStream.create("test2", new BufferChunk(inBuf, 0),
+    in = InStream.create("test2", new BufferChunk(inBuf, 0), 0,
         inBuf.remaining(),
         InStream.options().withCodec(codec).withBufferSize(300));
     try {
@@ -354,7 +354,7 @@ public class TestInStream {
     }
     InStream.StreamOptions inOptions = InStream.options()
         .withCodec(codec).withBufferSize(400);
-    InStream in = InStream.create("test", buffers.get(), 1674, inOptions);
+    InStream in = InStream.create("test", buffers.get(), 0, 1674, inOptions);
     assertEquals("compressed stream test position: 0 length: 1674 range: 0" +
                  " offset: 0 limit: 483 range 0 = 0 to 483;" +
                  "  range 1 = 483 to 1625;  range 2 = 1625 to 1674",
@@ -373,7 +373,7 @@ public class TestInStream {
     buffers.clear();
     buffers.add(new BufferChunk(inBuf[1], 483));
     buffers.add(new BufferChunk(inBuf[2], 1625));
-    in = InStream.create("test", buffers.get(), 1674, inOptions);
+    in = InStream.create("test", buffers.get(), 0, 1674, inOptions);
     inStream = new DataInputStream(in);
     positions[303].reset();
     in.seek(positions[303]);
@@ -384,7 +384,7 @@ public class TestInStream {
     buffers.clear();
     buffers.add(new BufferChunk(inBuf[0], 0));
     buffers.add(new BufferChunk(inBuf[2], 1625));
-    in = InStream.create("test", buffers.get(), 1674, inOptions);
+    in = InStream.create("test", buffers.get(), 0, 1674, inOptions);
     inStream = new DataInputStream(in);
     positions[1001].reset();
     for(int i=0; i < 300; ++i) {
@@ -424,7 +424,7 @@ public class TestInStream {
     buffers.add(new BufferChunk(inBuf[0], 0));
     buffers.add(new BufferChunk(inBuf[1], 1024));
     buffers.add(new BufferChunk(inBuf[2], 3072));
-    InStream in = InStream.create("test", buffers.get(), 4096);
+    InStream in = InStream.create("test", buffers.get(), 0, 4096);
     assertEquals("uncompressed stream test position: 0 length: 4096" +
                  " range: 0 offset: 0 limit: 1024",
                  in.toString());
@@ -442,7 +442,7 @@ public class TestInStream {
     buffers.clear();
     buffers.add(new BufferChunk(inBuf[1], 1024));
     buffers.add(new BufferChunk(inBuf[2], 3072));
-    in = InStream.create("test", buffers.get(), 4096);
+    in = InStream.create("test", buffers.get(), 0, 4096);
     inStream = new DataInputStream(in);
     positions[256].reset();
     in.seek(positions[256]);
@@ -453,7 +453,7 @@ public class TestInStream {
     buffers.clear();
     buffers.add(new BufferChunk(inBuf[0], 0));
     buffers.add(new BufferChunk(inBuf[2], 3072));
-    in = InStream.create("test", buffers.get(), 4096);
+    in = InStream.create("test", buffers.get(), 0, 4096);
     inStream = new DataInputStream(in);
     positions[768].reset();
     for(int i=0; i < 256; ++i) {
@@ -468,7 +468,7 @@ public class TestInStream {
   @Test
   public void testEmptyDiskRange() throws IOException {
     DiskRangeList range = new BufferChunk(ByteBuffer.allocate(0), 0);
-    InStream stream = new InStream.UncompressedStream("test", range, 0);
+    InStream stream = new InStream.UncompressedStream("test", range, 0, 0);
     assertEquals(0, stream.available());
     stream.seek(new PositionProvider() {
       @Override

--- a/java/core/src/test/org/apache/orc/impl/TestIntegerCompressionReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestIntegerCompressionReader.java
@@ -61,7 +61,7 @@ public class TestIntegerCompressionReader {
     inBuf.flip();
     RunLengthIntegerReaderV2 in =
       new RunLengthIntegerReaderV2(InStream.create("test",
-          new BufferChunk(inBuf, 0), inBuf.remaining(),
+          new BufferChunk(inBuf, 0), 0, inBuf.remaining(),
           InStream.options().withCodec(codec).withBufferSize(1000)), true, false);
     for(int i=0; i < 2048; ++i) {
       int x = (int) in.next();
@@ -114,7 +114,7 @@ public class TestIntegerCompressionReader {
     inBuf.flip();
     RunLengthIntegerReaderV2 in =
       new RunLengthIntegerReaderV2(InStream.create("test",
-                                                   new BufferChunk(inBuf, 0),
+                                                   new BufferChunk(inBuf, 0), 0,
                                                    inBuf.remaining()), true, false);
     for(int i=0; i < 2048; i += 10) {
       int x = (int) in.next();

--- a/java/core/src/test/org/apache/orc/impl/TestOrcLargeStripe.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOrcLargeStripe.java
@@ -18,9 +18,14 @@ package org.apache.orc.impl;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -33,7 +38,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.common.io.DiskRangeList;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.CompressionKind;
@@ -43,7 +47,6 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,7 +58,6 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class TestOrcLargeStripe {
 
-  private static final long MB = 1024 * 1024;
   private Path workDir = new Path(System.getProperty("test.tmp.dir", "target" + File.separator + "test"
     + File.separator + "tmp"));
 
@@ -77,38 +79,62 @@ public class TestOrcLargeStripe {
   @Mock
   private FSDataInputStream mockDataInput;
 
-  private DiskRangeList createRangeList(long... stripeSizes) {
-    DiskRangeList.CreateHelper list = new DiskRangeList.CreateHelper();
-    long prev = 0;
-    for (long stripe : stripeSizes) {
-      list.addOrMerge(prev, stripe, true, true);
-      prev = stripe;
+  static class RangeBuilder {
+    BufferChunkList result = new BufferChunkList();
+
+    RangeBuilder range(long offset, int length) {
+      result.add(new BufferChunk(offset, length));
+      return this;
     }
-    return list.extract();
-  }
 
-  private void verifyDiskRanges(long stripeLength, int expectedChunks) throws Exception {
-
-    DiskRangeList rangeList = createRangeList(stripeLength);
-
-    DiskRangeList newList = RecordReaderUtils.readDiskRanges(mockDataInput, null, 0, rangeList, false, (int) (2 * MB));
-    assertEquals(expectedChunks, newList.listSize());
-
-    newList = RecordReaderUtils.readDiskRanges(mockDataInput, null, 0, rangeList, true, (int) (2 * MB));
-    assertEquals(expectedChunks, newList.listSize());
-
-    HadoopShims.ZeroCopyReaderShim mockZcr = mock(HadoopShims.ZeroCopyReaderShim.class);
-    when(mockZcr.readBuffer(anyInt(), anyBoolean())).thenReturn(ByteBuffer.allocate((int) (2 * MB)));
-    newList = RecordReaderUtils.readDiskRanges(mockDataInput, mockZcr, 0, rangeList, true, (int) (2 * MB));
-    assertEquals(expectedChunks, newList.listSize());
+    BufferChunkList build() {
+      return result;
+    }
   }
 
   @Test
-  public void testStripeSizesBelowAndGreaterThanLimit() throws Exception {
-    verifyDiskRanges(MB, 1);
-    verifyDiskRanges(5 * MB, 3);
+  public void testZeroCopy() throws Exception {
+    BufferChunkList ranges = new RangeBuilder().range(1000, 3000).build();
+    HadoopShims.ZeroCopyReaderShim mockZcr = mock(HadoopShims.ZeroCopyReaderShim.class);
+    when(mockZcr.readBuffer(anyInt(), anyBoolean()))
+        .thenAnswer(invocation -> ByteBuffer.allocate(1000));
+    RecordReaderUtils.readDiskRanges(mockDataInput, mockZcr, ranges, true);
+    verify(mockDataInput).seek(1000);
+    verify(mockZcr).readBuffer(3000, false);
+    verify(mockZcr).readBuffer(2000, false);
+    verify(mockZcr).readBuffer(1000, false);
   }
 
+  @Test
+  public void testRangeMerge() throws Exception {
+    BufferChunkList rangeList = new RangeBuilder()
+                                    .range(100, 1000)
+                                    .range(1000, 10000)
+                                    .range(3000, 30000).build();
+    RecordReaderUtils.readDiskRanges(mockDataInput, null, rangeList, false);
+    verify(mockDataInput).readFully(eq(100L), any(), eq(0), eq(32900));
+  }
+
+  @Test
+  public void testRangeSkip() throws Exception {
+    BufferChunkList rangeList = new RangeBuilder()
+                                    .range(1000, 1000)
+                                    .range(2000, 1000)
+                                    .range(4000, 1000)
+                                    .range(4100, 100)
+                                    .range(8000, 1000).build();
+    RecordReaderUtils.readDiskRanges(mockDataInput, null, rangeList, false);
+    verify(mockDataInput).readFully(eq(1000L), any(), eq(0), eq(2000));
+    verify(mockDataInput).readFully(eq(4000L), any(), eq(0), eq(1000));
+    verify(mockDataInput).readFully(eq(8000L), any(), eq(0), eq(1000));
+  }
+
+  @Test
+  public void testEmpty() throws Exception {
+    BufferChunkList rangeList = new RangeBuilder().build();
+    RecordReaderUtils.readDiskRanges(mockDataInput, null, rangeList, false);
+    verify(mockDataInput, never()).readFully(anyLong(), any(), anyInt(), anyInt());
+  }
 
   @Test
   public void testConfigMaxChunkLimit() throws IOException {
@@ -117,28 +143,25 @@ public class TestOrcLargeStripe {
     TypeDescription schema = TypeDescription.createTimestamp();
     testFilePath = new Path(workDir, "TestOrcLargeStripe." +
       testCaseName.getMethodName() + ".orc");
+    fs.delete(testFilePath, false);
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000).bufferSize(10000)
         .version(OrcFile.Version.V_0_11).fileSystem(fs));
     writer.close();
 
-    try {
-      OrcFile.ReaderOptions opts = OrcFile.readerOptions(conf);
-      Reader reader = OrcFile.createReader(testFilePath, opts);
-      RecordReader recordReader = reader.rows(new Reader.Options().range(0L, Long.MAX_VALUE));
-      assertTrue(recordReader instanceof RecordReaderImpl);
-      assertEquals(Integer.MAX_VALUE - 1024, ((RecordReaderImpl) recordReader).getMaxDiskRangeChunkLimit());
+    OrcFile.ReaderOptions opts = OrcFile.readerOptions(conf);
+    Reader reader = OrcFile.createReader(testFilePath, opts);
+    RecordReader recordReader = reader.rows(new Reader.Options().range(0L, Long.MAX_VALUE));
+    assertTrue(recordReader instanceof RecordReaderImpl);
+    assertEquals(Integer.MAX_VALUE - 1024, ((RecordReaderImpl) recordReader).getMaxDiskRangeChunkLimit());
 
-      conf = new Configuration();
-      conf.setInt(OrcConf.ORC_MAX_DISK_RANGE_CHUNK_LIMIT.getHiveConfName(), 1000);
-      opts = OrcFile.readerOptions(conf);
-      reader = OrcFile.createReader(testFilePath, opts);
-      recordReader = reader.rows(new Reader.Options().range(0L, Long.MAX_VALUE));
-      assertTrue(recordReader instanceof RecordReaderImpl);
-      assertEquals(1000, ((RecordReaderImpl) recordReader).getMaxDiskRangeChunkLimit());
-    } finally {
-      fs.delete(testFilePath, false);
-    }
+    conf = new Configuration();
+    conf.setInt(OrcConf.ORC_MAX_DISK_RANGE_CHUNK_LIMIT.getHiveConfName(), 1000);
+    opts = OrcFile.readerOptions(conf);
+    reader = OrcFile.createReader(testFilePath, opts);
+    recordReader = reader.rows(new Reader.Options().range(0L, Long.MAX_VALUE));
+    assertTrue(recordReader instanceof RecordReaderImpl);
+    assertEquals(1000, ((RecordReaderImpl) recordReader).getMaxDiskRangeChunkLimit());
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
@@ -57,7 +57,7 @@ public class TestPhysicalFsWriter {
     }
 
     @Override
-    public void write(int b) throws IOException {
+    public void write(int b) {
       contents.add(new byte[]{(byte) b});
     }
 
@@ -97,12 +97,12 @@ public class TestPhysicalFsWriter {
 
     @Override
     public FSDataOutputStream append(Path f, int bufferSize,
-                                     Progressable progress) throws IOException {
+                                     Progressable progress) {
       throw new UnsupportedOperationException("append not supported");
     }
 
     @Override
-    public boolean rename(Path src, Path dst) throws IOException {
+    public boolean rename(Path src, Path dst) {
       boolean result = fileContents.containsKey(src) &&
           !fileContents.containsKey(dst);
       if (result) {
@@ -113,14 +113,14 @@ public class TestPhysicalFsWriter {
     }
 
     @Override
-    public boolean delete(Path f, boolean recursive) throws IOException {
+    public boolean delete(Path f, boolean recursive) {
       boolean result = fileContents.containsKey(f);
       fileContents.remove(f);
       return result;
     }
 
     @Override
-    public FileStatus[] listStatus(Path f) throws IOException {
+    public FileStatus[] listStatus(Path f) {
       return new FileStatus[]{getFileStatus(f)};
     }
 
@@ -135,12 +135,12 @@ public class TestPhysicalFsWriter {
     }
 
     @Override
-    public boolean mkdirs(Path f, FsPermission permission) throws IOException {
+    public boolean mkdirs(Path f, FsPermission permission) {
       return false;
     }
 
     @Override
-    public FileStatus getFileStatus(Path f) throws IOException {
+    public FileStatus getFileStatus(Path f) {
       List<byte[]> contents = fileContents.get(f);
       if (contents != null) {
         long sum = 0;
@@ -262,7 +262,8 @@ public class TestPhysicalFsWriter {
     }
 
     @Override
-    public ZeroCopyReaderShim getZeroCopyReader(FSDataInputStream in, ByteBufferPoolShim pool) throws IOException {
+    public ZeroCopyReaderShim getZeroCopyReader(FSDataInputStream in,
+                                                ByteBufferPoolShim pool) {
       return null;
     }
 
@@ -276,7 +277,7 @@ public class TestPhysicalFsWriter {
     }
 
     @Override
-    public KeyProvider getKeyProvider(Configuration conf, Random random) throws IOException {
+    public KeyProvider getKeyProvider(Configuration conf, Random random) {
       return null;
     }
   }

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -2104,7 +2104,7 @@ public class TestRecordReaderImpl {
         .setKind(OrcProto.ColumnEncoding.Kind.DIRECT_V2).build());
     encodings.add(OrcProto.ColumnEncoding.newBuilder()
         .setKind(OrcProto.ColumnEncoding.Kind.DIRECT_V2).build());
-    boolean[] rows = applier.pickRowGroups(new ReaderImpl.StripeInformationImpl(stripe),
+    boolean[] rows = applier.pickRowGroups(new ReaderImpl.StripeInformationImpl(stripe, 0, 1, null),
         indexes, null, encodings, null, false);
     assertEquals(4, rows.length);
     assertEquals(false, rows[0]);
@@ -2150,7 +2150,7 @@ public class TestRecordReaderImpl {
         .setKind(OrcProto.ColumnEncoding.Kind.DIRECT_V2).build());
     encodings.add(OrcProto.ColumnEncoding.newBuilder()
         .setKind(OrcProto.ColumnEncoding.Kind.DIRECT_V2).build());
-    boolean[] rows = applier.pickRowGroups(new ReaderImpl.StripeInformationImpl(stripe),
+    boolean[] rows = applier.pickRowGroups(new ReaderImpl.StripeInformationImpl(stripe, 0, 1, null),
         indexes, null, encodings, null, false);
     assertEquals(3, rows.length);
     assertEquals(false, rows[0]);

--- a/java/core/src/test/org/apache/orc/impl/TestRunLengthByteReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRunLengthByteReader.java
@@ -48,7 +48,7 @@ public class TestRunLengthByteReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     RunLengthByteReader in = new RunLengthByteReader(InStream.create("test",
-        new BufferChunk(inBuf, 0), inBuf.remaining()));
+        new BufferChunk(inBuf, 0), 0, inBuf.remaining()));
     for(int i=0; i < 2048; ++i) {
       int x = in.next() & 0xff;
       if (i < 1024) {
@@ -92,7 +92,7 @@ public class TestRunLengthByteReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     RunLengthByteReader in = new RunLengthByteReader(InStream.create("test",
-        new BufferChunk(inBuf, 0), inBuf.remaining(),
+        new BufferChunk(inBuf, 0), 0, inBuf.remaining(),
         InStream.options().withCodec(codec).withBufferSize(500)));
     for(int i=0; i < 2048; ++i) {
       int x = in.next() & 0xff;
@@ -130,7 +130,7 @@ public class TestRunLengthByteReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     RunLengthByteReader in = new RunLengthByteReader(InStream.create("test",
-        new BufferChunk(inBuf, 0), inBuf.remaining()));
+        new BufferChunk(inBuf, 0), 0, inBuf.remaining()));
     for(int i=0; i < 2048; i += 10) {
       int x = in.next() & 0xff;
       if (i < 1024) {

--- a/java/core/src/test/org/apache/orc/impl/TestRunLengthIntegerReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRunLengthIntegerReader.java
@@ -17,14 +17,14 @@
  */
 package org.apache.orc.impl;
 
-import static junit.framework.Assert.assertEquals;
-
 import java.nio.ByteBuffer;
 import java.util.Random;
 
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.impl.writer.StreamOptions;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class TestRunLengthIntegerReader {
 
@@ -60,7 +60,7 @@ public class TestRunLengthIntegerReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     RunLengthIntegerReader in = new RunLengthIntegerReader(InStream.create
-        ("test", new BufferChunk(inBuf, 0), inBuf.remaining(),
+        ("test", new BufferChunk(inBuf, 0), 0, inBuf.remaining(),
             InStream.options().withCodec(codec).withBufferSize(1000)), true);
     for(int i=0; i < 2048; ++i) {
       int x = (int) in.next();
@@ -112,7 +112,7 @@ public class TestRunLengthIntegerReader {
     collect.buffer.setByteBuffer(inBuf, 0, collect.buffer.size());
     inBuf.flip();
     RunLengthIntegerReader in = new RunLengthIntegerReader(InStream.create
-        ("test", new BufferChunk(inBuf, 0), inBuf.remaining()), true);
+        ("test", new BufferChunk(inBuf, 0), 0, inBuf.remaining()), true);
     for(int i=0; i < 2048; i += 10) {
       int x = (int) in.next();
       if (i < 1024) {

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -23,10 +23,8 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
@@ -47,7 +45,6 @@ import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -1581,7 +1578,17 @@ public class TestSchemaEvolution {
       buffer[i] = (byte) values[i];
     }
     ranges.add(new BufferChunk(ByteBuffer.wrap(buffer), 0));
-    streams.put(name, InStream.create(name.toString(), ranges.get(), values.length));
+    streams.put(name, InStream.create(name.toString(), ranges.get(), 0,
+        values.length));
+  }
+
+  static ByteBuffer createBuffer(int... values) {
+    ByteBuffer result = ByteBuffer.allocate(values.length);
+    for(int v: values) {
+      result.put((byte) v);
+    }
+    result.flip();
+    return result;
   }
 
   @Test

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -380,8 +380,7 @@ public final class FileDump {
         for (int colIdx : rowIndexCols) {
           sargColumns[colIdx] = true;
         }
-        OrcIndex indices = rows
-            .readRowIndex(stripeIx, null, null, null, sargColumns);
+        OrcIndex indices = rows.readRowIndex(stripeIx, null, sargColumns);
         for (int col : rowIndexCols) {
           StringBuilder buf = new StringBuilder();
           String rowIdxString = getFormattedRowIndices(col,


### PR DESCRIPTION
* Refactors the stripe planning and reading to a new class StripePlanner.
* Move rowIndex reading out of the DataReader, because it is tied to encryption.
* TreeReader.startStripe gets a StripePlanner.
* Adds test cases to TestVectorOrcFile.
* Adds test classes for making mock files for testing details of the StripePlanner.