### PR TITLE
ORC-522: Add user type annotations.

### DIFF
--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -35,7 +35,9 @@ import org.apache.orc.impl.SchemaEvolution;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 /**
@@ -448,6 +450,17 @@ public class TypeDescription
     return this;
   }
 
+  /**
+   * Set an attribute on this type
+   * @param key the attribute name
+   * @param value the attribute value
+   * @return this for method chaining
+   */
+  public TypeDescription setAttribute(String key, String value) {
+    attributes.put(key, value);
+    return this;
+  }
+
   public static TypeDescription createVarchar() {
     return new TypeDescription(Category.VARCHAR);
   }
@@ -773,6 +786,26 @@ public class TypeDescription
   }
 
   /**
+   * Get the list of attribute names defined on this type.
+   * @return a list of sorted attribute names
+   */
+  public List<String> getAttributeNames() {
+    List<String> result = new ArrayList<>(attributes.size());
+    result.addAll(attributes.keySet());
+    Collections.sort(result);
+    return result;
+  }
+
+  /**
+   * Get the value of a given attribute.
+   * @param attributeName the name of the attribute
+   * @return the value of the attribute or null if it isn't set
+   */
+  public String getAttributeValue(String attributeName) {
+    return attributes.get(attributeName);
+  }
+
+  /**
    * Get the subtypes of this type.
    * @return the list of children types
    */
@@ -816,6 +849,7 @@ public class TypeDescription
   private final Category category;
   private final List<TypeDescription> children;
   private final List<String> fieldNames;
+  private final Map<String,String> attributes = new HashMap<>();
   private int maxLength = DEFAULT_LENGTH;
   private int precision = DEFAULT_PRECISION;
   private int scale = DEFAULT_SCALE;

--- a/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
@@ -276,6 +276,14 @@ public class JsonFileDump {
       if (type.hasMaximumLength()) {
         writer.key("maxLength").value(type.getMaximumLength());
       }
+
+      if (type.getAttributesCount() > 0) {
+        writer.key("attributes").object();
+        for(OrcProto.StringPair pair: type.getAttributesList()) {
+          writer.key(pair.getKey()).value(pair.getValue());
+        }
+        writer.endObject();
+      }
       writer.endObject();
     }
   }

--- a/proto/orc_proto.proto
+++ b/proto/orc_proto.proto
@@ -179,6 +179,11 @@ message StripeFooter {
 //   postscript: PostScript
 //   psLen: byte
 
+message StringPair {
+  optional string key = 1;
+  optional string value = 2;
+}
+
 message Type {
   enum Kind {
     BOOLEAN = 0;
@@ -206,6 +211,7 @@ message Type {
   optional uint32 maximumLength = 4;
   optional uint32 precision = 5;
   optional uint32 scale = 6;
+  repeated StringPair attributes = 7;
 }
 
 message StripeInformation {


### PR DESCRIPTION
Add the ability to store type annotations in the ORC metadata. I expect this will mostly be used by frameworks like Iceberg that are building above ORC.