### PR TITLE
ORC-531. Refactor schema evolution including removing the float conversions.

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -328,7 +328,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testFloatToDoubleEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
         testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createFloat();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -349,13 +349,13 @@ public class TestSchemaEvolution {
     RecordReader rows = reader.rows(reader.options().schema(schemaOnRead));
     batch = schemaOnRead.createRowBatch();
     rows.nextBatch(batch);
-    assertEquals(74.72, ((DoubleColumnVector) batch.cols[0]).vector[0], 0.00000000001);
+    assertEquals(74.72, ((DoubleColumnVector) batch.cols[0]).vector[0], 0.00001);
     rows.close();
   }
 
   @Test
   public void testFloatToDecimalEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createFloat();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -382,7 +382,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testFloatToDecimal64Evolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createFloat();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -409,7 +409,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testDoubleToDecimalEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createDouble();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -436,7 +436,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testDoubleToDecimal64Evolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createDouble();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -463,7 +463,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testLongToDecimalEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createLong();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -490,7 +490,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testLongToDecimal64Evolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createLong();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -517,7 +517,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testDecimalToDecimalEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createDecimal().withPrecision(38).withScale(0);
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -544,7 +544,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testDecimalToDecimal64Evolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createDecimal().withPrecision(38).withScale(2);
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -571,7 +571,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testStringToDecimalEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createString();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -599,7 +599,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testStringToDecimal64Evolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createString();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -627,7 +627,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testTimestampToDecimalEvolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createTimestamp();
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -654,7 +654,7 @@ public class TestSchemaEvolution {
 
   @Test
   public void testTimestampToDecimal64Evolution() throws Exception {
-    testFilePath = new Path(workDir, "TestOrcFile." +
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createTimestamp();
     Writer writer = OrcFile.createWriter(testFilePath,


### PR DESCRIPTION
This PR removes about 700 lines from the schema evolution code:
* Removes most of the float conversions, which aren't needed now.
* Removes the duplicate reference to the underlying TreeReader in each subclass.
* Creates a new double->float conversion that casts it to a float instead of using strings.
* The test case float->double had to loosen the delta on the comparison since we don't get the implicit truncation from going through stringification.
* Moves the file names for TestSchemaEvolution to use that as the filename prefix on the written orc files.