### PR TITLE
ORC-538. Fix a few problems with the type attributes.

### DIFF
--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -345,6 +345,12 @@ public class TestTypeDescription {
     schema.findSubtype("address.street").setAttribute("mask", "nullify")
         .setAttribute("encrypt", "pii");
 
+    TypeDescription clone = schema.clone();
+    assertEquals("12", clone.findSubtype("name").getAttributeValue("iceberg.id"));
+    clone.findSubtype("name").removeAttribute("iceberg.id");
+    assertEquals(0, clone.findSubtype("name").getAttributeNames().size());
+    assertEquals(1, schema.findSubtype("name").getAttributeNames().size());
+
     // write a file with those attributes
     Path path = new Path(System.getProperty("test.tmp.dir",
         "target" + File.separator + "test" + File.separator + "tmp"), "attribute.orc");

--- a/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
@@ -396,6 +396,10 @@ public class TestFileDump {
   @Test
   public void testBloomFilter() throws Exception {
     TypeDescription schema = getMyRecordType();
+    schema.setAttribute("test1", "value1");
+    schema.findSubtype("s")
+        .setAttribute("test2", "value2")
+        .setAttribute("test3", "value3");
     conf.set(OrcConf.ENCODING_STRATEGY.getAttribute(), "COMPRESSION");
     OrcFile.WriterOptions options = OrcFile.writerOptions(conf)
         .fileSystem(fs)

--- a/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
@@ -85,10 +85,11 @@ public class TestJsonFileDump {
 
   @Test
   public void testJsonDump() throws Exception {
-    TypeDescription schema = TypeDescription.createStruct()
-        .addField("i", TypeDescription.createInt())
-        .addField("l", TypeDescription.createLong())
-        .addField("s", TypeDescription.createString());
+    TypeDescription schema =
+        TypeDescription.fromString("struct<i:int,l:bigint,s:string>");
+    schema.findSubtype("l")
+        .setAttribute("test1", "value1")
+        .setAttribute("test2","value2");
     conf.set(OrcConf.ENCODING_STRATEGY.getAttribute(), "COMPRESSION");
     OrcFile.WriterOptions options = OrcFile.writerOptions(conf)
         .fileSystem(fs)

--- a/java/tools/src/test/resources/orc-file-dump-bloomfilter.out
+++ b/java/tools/src/test/resources/orc-file-dump-bloomfilter.out
@@ -4,6 +4,11 @@ Rows: 21000
 Compression: ZLIB
 Compression size: 4096
 Type: struct<i:int,l:bigint,s:string>
+Attributes on root
+  test1: value1
+Attributes on root.s
+  test2: value2
+  test3: value3
 
 Stripe Statistics:
   Stripe 1:
@@ -172,7 +177,7 @@ Stripes:
       Entry 0: numHashFunctions: 4 bitCount: 6272 popCount: 138 loadFactor: 0.022 expectedFpp: 2.343647E-7
       Stripe level merge: numHashFunctions: 4 bitCount: 6272 popCount: 138 loadFactor: 0.022 expectedFpp: 2.343647E-7
 
-File length: 272503 bytes
+File length: 272533 bytes
 Padding length: 0 bytes
 Padding ratio: 0%
 ________________________________________________________________________________________________________________________

--- a/java/tools/src/test/resources/orc-file-dump.json
+++ b/java/tools/src/test/resources/orc-file-dump.json
@@ -6,34 +6,28 @@
   "compression": "ZLIB",
   "compressionBufferSize": 4096,
   "schemaString": "struct<i:int,l:bigint,s:string>",
-  "schema": [
-    {
-      "columnId": 0,
-      "columnType": "STRUCT",
-      "childColumnNames": [
-        "i",
-        "l",
-        "s"
-      ],
-      "childColumnIds": [
-        1,
-        2,
-        3
-      ]
-    },
-    {
-      "columnId": 1,
-      "columnType": "INT"
-    },
-    {
-      "columnId": 2,
-      "columnType": "LONG"
-    },
-    {
-      "columnId": 3,
-      "columnType": "STRING"
+  "schema": {
+    "columnId": 0,
+    "columnType": "STRUCT",
+    "children": {
+      "i": {
+        "columnId": 1,
+        "columnType": "INT"
+      },
+      "l": {
+        "columnId": 2,
+        "columnType": "LONG",
+        "attributes": {
+          "test1": "value1",
+          "test2": "value2"
+        }
+      },
+      "s": {
+        "columnId": 3,
+        "columnType": "STRING"
+      }
     }
-  ],
+  },
   "stripeStatistics": [
     {
       "stripeNumber": 1,
@@ -1366,7 +1360,7 @@
       }]
     }
   ],
-  "fileLength": 272486,
+  "fileLength": 272511,
   "paddingLength": 0,
   "paddingRatio": 0,
   "status": "OK"


### PR DESCRIPTION
Fix a few problems with type annotations:
* clone() needs to copy them.
* setAttribute with null should clear them.
* equals should compare them
* file dump should print them.
* json file dump should make them nicer
* add test cases for the file dump commands.
* change the json write schema to be tree-like rather than flat.