### PR TITLE
fix error configuration of apache rat plugin

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -206,7 +206,7 @@
             </execution>
           </executions>
           <configuration>
-            <excludeSubProject>false</excludeSubProject>
+            <excludeSubProjects>false</excludeSubProjects>
             <excludes>
               <exclude>**/data/**</exclude>
               <exclude>**/*.json</exclude>


### PR DESCRIPTION
fix error configuration of apache rat plugin
- change `excludeSubProject` to `excludeSubProjects`