### PR TITLE
ORC-548. Fix Java InStream to work with BufferChunks that don't start at 0

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -335,7 +335,7 @@ public class ReaderImpl implements Reader {
       InStream.StreamOptions options = new InStream.StreamOptions(compression)
                                            .withEncryption(algorithm, key, iv);
       InStream in = InStream.create("encrypted file stats", buffer,
-          bytes.length, 0, options);
+          0, bytes.length, options);
       OrcProto.FileStatistics decrypted = OrcProto.FileStatistics.parseFrom(in);
       ColumnStatistics[] result = new ColumnStatistics[decrypted.getColumnCount()];
       TypeDescription root = encryption.getRoot();


### PR DESCRIPTION
We've changed InStream so that the BufferChunks don't need to start at the stream 0. This change finishes that.