### PR TITLE
ORC-480: [C++] Add an option to succeed build despite warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,10 @@ option(INSTALL_VENDORED_LIBS
     "Install vendored thirdparty libraries along with liborc"
     ON)
 
+option(STOP_BUILD_ON_WARNING
+    "Fail the build on C++ warnings"
+    ON)
+
 # Make sure that a build type is selected
 if (NOT CMAKE_BUILD_TYPE)
   message(STATUS "No build type selected, default to ReleaseWithDebugInfo")
@@ -85,9 +89,14 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   if (CMAKE_HOST_APPLE AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER "11.0")
     set (WARN_FLAGS "${WARN_FLAGS} -Wno-c++2a-compat")
   endif ()
-  set (WARN_FLAGS "${WARN_FLAGS} -Werror")
+  if (STOP_BUILD_ON_WARNING)
+    set (WARN_FLAGS "${WARN_FLAGS} -Werror")
+  endif ()
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set (WARN_FLAGS "-Wall -Wno-unknown-pragmas -Wconversion -Werror")
+  set (WARN_FLAGS "-Wall -Wno-unknown-pragmas -Wconversion")
+  if (STOP_BUILD_ON_WARNING)
+    set (WARN_FLAGS "${WARN_FLAGS} -Werror")
+  endif ()
   if (CMAKE_CXX_COMPILER_VERSION STREQUAL "" OR
       CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.7")
     set (CXX11_FLAGS "-std=c++0x")


### PR DESCRIPTION
The extensive warnings that are set are useful for CI and development,
but a nuisance for external packagers and dependent projects which
can encounter failing builds because of warnings in ORC.