### PR TITLE
ORC-567: [C++] Fix integer overflow in RowReader::seekToRow

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -299,7 +299,7 @@ namespace orc {
         currentStripeInfo.indexlength() > 0) {
       uint32_t rowGroupId =
         static_cast<uint32_t>(currentRowInStripe / footer->rowindexstride());
-      rowsToSkip -= rowGroupId * footer->rowindexstride();
+      rowsToSkip -= static_cast<uint64_t>(rowGroupId) * footer->rowindexstride();
 
       if (rowGroupId != 0) {
         seekToRowGroup(rowGroupId);


### PR DESCRIPTION
Fixes uint32 overflow when calculating how many rows to skip by casting to uint64.