### PR TITLE
ORC-571. Fix ArrayIndexOutOfBoundsException in StripePlanner.readRowIndex

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -98,13 +98,10 @@ public class RecordReaderImpl implements RecordReader {
   static int findColumns(SchemaEvolution evolution,
                          String columnName) {
     try {
-      final TypeDescription targetSchema;
-      if (evolution.getPositionalColumns()) {
-        targetSchema = evolution.getReaderBaseSchema();
-      } else {
-        targetSchema = evolution.getFileSchema();
-      }
-      return targetSchema.findSubtype(columnName).getId();
+      TypeDescription readerColumn =
+          evolution.getReaderBaseSchema().findSubtype(columnName);
+      TypeDescription fileColumn = evolution.getFileType(readerColumn);
+      return fileColumn == null ? -1 : fileColumn.getId();
     } catch (IllegalArgumentException e) {
       if (LOG.isDebugEnabled()){
         LOG.debug("{}", e.getMessage());
@@ -230,7 +227,7 @@ public class RecordReaderImpl implements RecordReader {
     reader = TreeReaderFactory.createTreeReader(evolution.getReaderSchema(),
         readerContext);
 
-    int columns = schema.getMaximumId() + 1;
+    int columns = evolution.getFileSchema().getMaximumId() + 1;
     indexes = new OrcIndex(new OrcProto.RowIndex[columns],
         new OrcProto.Stream.Kind[columns],
         new OrcProto.BloomFilterIndex[columns]);


### PR DESCRIPTION
This patch fixes the places where the RecordReaderImpl is using the reader schema when it needs to use the file schema.

It also adds some test cases where we test with sargs combined with schema evolution.