### PR TITLE
ORC-570: Supply lazy filesystem to ReaderOptions & DataReaderProperties

### DIFF
--- a/java/core/src/java/org/apache/orc/FileSystemSuplier.java
+++ b/java/core/src/java/org/apache/orc/FileSystemSuplier.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.IOException;
+
+@FunctionalInterface
+public interface FileSystemSuplier {
+  FileSystem get() throws IOException;
+}

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -274,7 +274,7 @@ public class OrcFile {
 
   public static class ReaderOptions {
     private final Configuration conf;
-    private FileSystem filesystem;
+    private FileSystemSuplier fsSuplier;
     private long maxLength = Long.MAX_VALUE;
     private OrcTail orcTail;
     private KeyProvider keyProvider;
@@ -288,8 +288,17 @@ public class OrcFile {
       this.conf = conf;
     }
 
-    public ReaderOptions filesystem(FileSystem fs) {
-      this.filesystem = fs;
+    public ReaderOptions filesystem(final FileSystem fs) {
+      return filesystem(new FileSystemSuplier() {
+        @Override
+        public FileSystem get() throws IOException {
+          return fs;
+        }
+      });
+    }
+
+    public ReaderOptions filesystem(FileSystemSuplier fs) {
+      this.fsSuplier = fs;
       return this;
     }
 
@@ -317,8 +326,8 @@ public class OrcFile {
       return conf;
     }
 
-    public FileSystem getFilesystem() {
-      return filesystem;
+    public FileSystem getFilesystem() throws IOException {
+      return fsSuplier != null ? fsSuplier.get(): null;
     }
 
     public long getMaxLength() {

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.orc.impl;
 
+import org.apache.orc.FileSystemSuplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,14 +50,14 @@ public class RecordReaderUtils {
     private FSDataInputStream file;
     private ByteBufferAllocatorPool pool;
     private HadoopShims.ZeroCopyReaderShim zcr = null;
-    private final FileSystem fs;
+    private final FileSystemSuplier fsSuplier;
     private final Path path;
     private final boolean useZeroCopy;
     private InStream.StreamOptions options;
     private boolean isOpen = false;
 
     private DefaultDataReader(DataReaderProperties properties) {
-      this.fs = properties.getFileSystem();
+      this.fsSuplier = properties.getFileSystemSupplier();
       this.path = properties.getPath();
       this.file = properties.getFile();
       this.useZeroCopy = properties.getZeroCopy();
@@ -66,7 +67,7 @@ public class RecordReaderUtils {
     @Override
     public void open() throws IOException {
       if (file == null) {
-        this.file = fs.open(path);
+        this.file = getFileSystem().open(path);
       }
       if (useZeroCopy) {
         // ZCR only uses codec for boolean checks.
@@ -152,6 +153,10 @@ public class RecordReaderUtils {
     @Override
     public InStream.StreamOptions getCompressionOptions() {
       return options;
+    }
+
+    private FileSystem getFileSystem() throws IOException {
+      return fsSuplier != null ? fsSuplier.get(): null;
     }
   }
 


### PR DESCRIPTION
Although these carry filesystem, it may not be needed at all if a file is not actually open (due to caching). Creation of an actual filesystem object can be deferred until a file is actually opened.

Change-Id: I1e2cad8b934a14fd0413caae68cf20417213d2b8