### PR TITLE
ORC-556: Do not check for TypeDescription attribute equality during schema evolution check

### DIFF
--- a/java/core/src/findbugs/exclude.xml
+++ b/java/core/src/findbugs/exclude.xml
@@ -65,4 +65,9 @@
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
     <Class name="org.apache.orc.TestStringDictionary"/>
   </Match>
+  <Match>
+    <Bug pattern="EQ_UNUSUAL"/>
+    <Class name="org.apache.orc.TypeDescription"/>
+    <Method name="equals" />
+  </Match>
 </FindBugsFilter>

--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -405,6 +405,13 @@ public class TypeDescription
     return equals(other, true);
   }
 
+  /**
+   * Indicates whether a {@link TypeDescription} object is "equal to" this one.
+   * @param other the reference object with which to compare.
+   * @param checkAttributes whether to check equality of attributes of the objects being compared
+   * @return {@code true} if this object is the same as the other
+   *         argument; {@code false} otherwise.
+   */
   public boolean equals(Object other, boolean checkAttributes) {
     if (other == null || !(other instanceof TypeDescription)) {
       return false;
@@ -437,7 +444,7 @@ public class TypeDescription
         return false;
       }
       for (int i = 0; i < children.size(); ++i) {
-        if (!children.get(i).equals(castOther.children.get(i))) {
+        if (!children.get(i).equals(castOther.children.get(i), checkAttributes)) {
           return false;
         }
       }

--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -402,6 +402,10 @@ public class TypeDescription
 
   @Override
   public boolean equals(Object other) {
+    return equals(other, true);
+  }
+
+  public boolean equals(Object other, boolean checkAttributes) {
     if (other == null || !(other instanceof TypeDescription)) {
       return false;
     }
@@ -415,15 +419,16 @@ public class TypeDescription
         precision != castOther.precision) {
       return false;
     }
-    // make sure the attributes are the same
-    List<String> attributeNames = getAttributeNames();
-    if (castOther.getAttributeNames().size() != attributeNames.size()) {
-      return false;
-    }
-    for(String attribute: attributeNames) {
-      if (!getAttributeValue(attribute).equals(
-          castOther.getAttributeValue(attribute))) {
+    if (checkAttributes) {
+      // make sure the attributes are the same
+      List<String> attributeNames = getAttributeNames();
+      if (castOther.getAttributeNames().size() != attributeNames.size()) {
         return false;
+      }
+      for (String attribute : attributeNames) {
+        if (!getAttributeValue(attribute).equals(castOther.getAttributeValue(attribute))) {
+          return false;
+        }
       }
     }
     // check the children

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -2322,7 +2322,7 @@ public class TreeReaderFactory {
       return new NullTreeReader(0);
     }
     TypeDescription.Category readerTypeCategory = readerType.getCategory();
-    if (!fileType.equals(readerType) &&
+    if (!fileType.equals(readerType, false) &&
         (readerTypeCategory != TypeDescription.Category.STRUCT &&
          readerTypeCategory != TypeDescription.Category.MAP &&
          readerTypeCategory != TypeDescription.Category.LIST &&

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -2322,6 +2322,8 @@ public class TreeReaderFactory {
       return new NullTreeReader(0);
     }
     TypeDescription.Category readerTypeCategory = readerType.getCategory();
+    // We skip attribute checks when comparing types since they are not used to
+    // create the ConvertTreeReaders
     if (!fileType.equals(readerType, false) &&
         (readerTypeCategory != TypeDescription.Category.STRUCT &&
          readerTypeCategory != TypeDescription.Category.MAP &&

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -19,6 +19,7 @@ package org.apache.orc;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -375,6 +376,24 @@ public class TestTypeDescription {
     assertEquals("pii", street.getAttributeValue("context"));
     assertEquals("nullify", street.getAttributeValue("mask"));
     assertEquals(null, street.getAttributeValue("foobar"));
+  }
+
+  @Test
+  public void testAttributesEquality() {
+    TypeDescription schema = TypeDescription.fromString(
+        "struct<" +
+            "name:struct<first:string,last:string>," +
+            "address:struct<street:string,city:string,country:string,post_code:string>," +
+            "credit_cards:array<struct<card_number:string,expire:date,ccv:string>>>");
+    // set some attributes
+    schema.findSubtype("name").setAttribute("iceberg.id", "12");
+    schema.findSubtype("address.street").setAttribute("mask", "nullify")
+        .setAttribute("context", "pii");
+
+    TypeDescription clone = schema.clone();
+    assertEquals(3, clearAttributes(clone));
+    assertFalse(clone.equals(schema));
+    assertTrue(clone.equals(schema, false));
   }
 
   static int clearAttributes(TypeDescription schema) {


### PR DESCRIPTION
During schema evolution checks, for a field with the same category, if the read schema has some attributes but the file schema does not, then the code will try to use `ConvertTreeReaderFactory` to create a converter, but will eventually fail because it sees that the category is the same https://github.com/apache/orc/blob/master/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java#L1669. Since the `ConvertTreeReaderFactory` does not require/understand these attribute values, we should probably not be checking them when deciding whether conversion is required. 

@omalley Can you take a look?