### PR TITLE
ORC-574: Use const references for string statistics min and max to avoid copy construction

### DIFF
--- a/c++/include/orc/Statistics.hh
+++ b/c++/include/orc/Statistics.hh
@@ -282,13 +282,13 @@ namespace orc {
      * Get the minimum value for the column.
      * @return minimum value
      */
-    virtual std::string getMinimum() const = 0;
+    virtual const std::string & getMinimum() const = 0;
 
     /**
      * Get the maximum value for the column.
      * @return maximum value
      */
-    virtual std::string getMaximum() const = 0;
+    virtual const std::string & getMaximum() const = 0;
 
     /**
      * Get the total length of all values.

--- a/c++/src/Statistics.hh
+++ b/c++/src/Statistics.hh
@@ -94,7 +94,7 @@ namespace orc {
     // GET / SET _maximum
     bool hasMaximum() const { return _hasMaximum; }
 
-    T getMaximum() const { return _maximum; }
+    const T & getMaximum() const { return _maximum; }
 
     void setHasMaximum(bool hasMax) { _hasMaximum = hasMax; }
 
@@ -105,7 +105,7 @@ namespace orc {
 
     void setHasMinimum(bool hasMin) { _hasMinimum = hasMin; }
 
-    T getMinimum() const { return _minimum; }
+    const T & getMinimum() const { return _minimum; }
 
     void setMinimum(T min) { _minimum = min; }
 
@@ -1077,7 +1077,7 @@ namespace orc {
       _stats.setHasNull(hasNull);
     }
 
-    std::string getMinimum() const override {
+    const std::string & getMinimum() const override {
       if(hasMinimum()){
         return _stats.getMinimum();
       }else{
@@ -1085,7 +1085,7 @@ namespace orc {
       }
     }
 
-    std::string getMaximum() const override {
+    const std::string & getMaximum() const override {
       if(hasMaximum()){
         return _stats.getMaximum();
       }else{


### PR DESCRIPTION
… std::string alloc/delete

due to the getMaximum/Minimum returning std:string copies.

Changing the getMaximum/getMinimum methods to return const vals will prevent these alloc/copy/deletes from occurring.

This results in about a 30% cpu boost to write.