### PR TITLE
ORC-40: [C++] Support building SearchArgument

### DIFF
--- a/c++/include/orc/sargs/Literal.hh
+++ b/c++/include/orc/sargs/Literal.hh
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_LITERAL_HH
+#define ORC_LITERAL_HH
+
+#include "orc/Int128.hh"
+#include "orc/Vector.hh"
+
+namespace orc {
+
+  /**
+   * Possible types for predicates
+   */
+  enum class PredicateType {
+    LONG = 0, FLOAT, STRING, DATE, DECIMAL, TIMESTAMP, BOOLEAN
+  };
+
+  /**
+   * Represents a literal value in a predicate
+   */
+  class Literal {
+  public:
+    Literal(const Literal &r);
+    ~Literal();
+    Literal& operator=(const Literal& r);
+    bool operator==(const Literal& r) const;
+    bool operator!=(const Literal& r) const;
+
+    /**
+     * Create a literal of null value for a specific type
+     */
+    Literal(PredicateType type);
+
+    /**
+     * Create a literal of LONG type
+     */
+    Literal(int64_t val);
+
+    /**
+     * Create a literal of FLOAT type
+     */
+    Literal(double val);
+
+    /**
+     * Create a literal of BOOLEAN type
+     */
+    Literal(bool val);
+
+    /**
+     * Create a literal of Timestamp or DATE type
+     */
+    Literal(PredicateType type, int64_t val);
+
+    /**
+     * Create a literal of STRING type
+     */
+    Literal(const char * str, size_t size);
+
+    /**
+     * Create a literal of DECIMAL type
+     */
+    Literal(Int128 val, int32_t precision, int32_t scale);
+
+    /**
+     * Getters of a specific data type for not-null literals
+     */
+    int64_t getLong() const;
+    int64_t getDate() const;
+    int64_t getTimestamp() const;
+    double getFloat() const;
+    std::string getString() const;
+    bool getBool() const;
+    Decimal getDecimal() const;
+
+    /**
+     * Check if a literal is null
+     */
+    bool isNull() const { return mIsNull; }
+
+    PredicateType getType() const { return mType; }
+    std::string toString() const;
+    size_t getHashCode() const { return mHashCode; }
+
+  private:
+    size_t hashCode() const;
+
+    union LiteralVal {
+      int64_t IntVal;
+      double DoubleVal;
+      int64_t DateVal;
+      char * Buffer;
+      int64_t TimeStampVal;
+      Int128 DecimalVal;
+      bool BooleanVal;
+
+      // explicitly define default constructor
+      LiteralVal(): DecimalVal(0) {}
+    };
+
+  private:
+    LiteralVal mValue;     // data value for this literal if not null
+    PredicateType mType;   // data type of the literal
+    size_t mSize;          // size of mValue if it is Buffer
+    int32_t mPrecision;    // precision of decimal type
+    int32_t mScale;        // scale of decimal type
+    bool mIsNull;          // whether this literal is null
+    size_t mHashCode;      // precomputed hash code for the literal
+  };
+
+} // namespace orc
+
+#endif //ORC_LITERAL_HH

--- a/c++/include/orc/sargs/Literal.hh
+++ b/c++/include/orc/sargs/Literal.hh
@@ -25,9 +25,9 @@
 namespace orc {
 
   /**
-   * Possible types for predicates
+   * Possible data types for predicates
    */
-  enum class PredicateType {
+  enum class PredicateDataType {
     LONG = 0, FLOAT, STRING, DATE, DECIMAL, TIMESTAMP, BOOLEAN
   };
 
@@ -45,7 +45,7 @@ namespace orc {
     /**
      * Create a literal of null value for a specific type
      */
-    Literal(PredicateType type);
+    Literal(PredicateDataType type);
 
     /**
      * Create a literal of LONG type
@@ -65,7 +65,7 @@ namespace orc {
     /**
      * Create a literal of Timestamp or DATE type
      */
-    Literal(PredicateType type, int64_t val);
+    Literal(PredicateDataType type, int64_t val);
 
     /**
      * Create a literal of STRING type
@@ -93,7 +93,7 @@ namespace orc {
      */
     bool isNull() const { return mIsNull; }
 
-    PredicateType getType() const { return mType; }
+    PredicateDataType getType() const { return mType; }
     std::string toString() const;
     size_t getHashCode() const { return mHashCode; }
 
@@ -114,13 +114,13 @@ namespace orc {
     };
 
   private:
-    LiteralVal mValue;     // data value for this literal if not null
-    PredicateType mType;   // data type of the literal
-    size_t mSize;          // size of mValue if it is Buffer
-    int32_t mPrecision;    // precision of decimal type
-    int32_t mScale;        // scale of decimal type
-    bool mIsNull;          // whether this literal is null
-    size_t mHashCode;      // precomputed hash code for the literal
+    LiteralVal mValue;       // data value for this literal if not null
+    PredicateDataType mType; // data type of the literal
+    size_t mSize;            // size of mValue if it is Buffer
+    int32_t mPrecision;      // precision of decimal type
+    int32_t mScale;          // scale of decimal type
+    bool mIsNull;            // whether this literal is null
+    size_t mHashCode;        // precomputed hash code for the literal
   };
 
 } // namespace orc

--- a/c++/include/orc/sargs/SearchArgument.hh
+++ b/c++/include/orc/sargs/SearchArgument.hh
@@ -88,7 +88,7 @@ namespace orc {
      * @return this
      */
     virtual SearchArgumentBuilder& lessThan(const std::string& column,
-                                            PredicateType type,
+                                            PredicateDataType type,
                                             Literal literal) = 0;
 
     /**
@@ -99,7 +99,7 @@ namespace orc {
      * @return this
      */
     virtual SearchArgumentBuilder& lessThanEquals(const std::string& column,
-                                                  PredicateType type,
+                                                  PredicateDataType type,
                                                   Literal literal) = 0;
 
     /**
@@ -110,7 +110,7 @@ namespace orc {
      * @return this
      */
     virtual SearchArgumentBuilder& equals(const std::string& column,
-                                          PredicateType type,
+                                          PredicateDataType type,
                                           Literal literal) = 0;
 
     /**
@@ -121,7 +121,7 @@ namespace orc {
      * @return this
      */
     virtual SearchArgumentBuilder& nullSafeEquals(const std::string& column,
-                                                  PredicateType type,
+                                                  PredicateDataType type,
                                                   Literal literal) = 0;
 
     /**
@@ -132,7 +132,7 @@ namespace orc {
      * @return this
      */
     virtual SearchArgumentBuilder& in(const std::string& column,
-                                      PredicateType type,
+                                      PredicateDataType type,
                                       const std::initializer_list<Literal>& literals) = 0;
 
     /**
@@ -142,7 +142,7 @@ namespace orc {
      * @return this
      */
     virtual SearchArgumentBuilder& isNull(const std::string& column,
-                                          PredicateType type) = 0;
+                                          PredicateDataType type) = 0;
 
     /**
      * Add a between leaf to the current item on the stack.
@@ -153,7 +153,7 @@ namespace orc {
      * @return this
      */
     virtual SearchArgumentBuilder& between(const std::string& column,
-                                           PredicateType type,
+                                           PredicateDataType type,
                                            Literal lower,
                                            Literal upper) = 0;
 

--- a/c++/include/orc/sargs/SearchArgument.hh
+++ b/c++/include/orc/sargs/SearchArgument.hh
@@ -1,0 +1,185 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_SEARCHARGUMENT_HH
+#define ORC_SEARCHARGUMENT_HH
+
+#include "orc/sargs/Literal.hh"
+#include "orc/sargs/TruthValue.hh"
+
+namespace orc {
+
+  /**
+   * Primary interface for a search argument, which are the subset of predicates
+   * that can be pushed down to the RowReader. Each SearchArgument consists
+   * of a series of search clauses that must each be true for the row to be
+   * accepted by the filter.
+   *
+   * This requires that the filter be normalized into conjunctive normal form
+   * (<a href="http://en.wikipedia.org/wiki/Conjunctive_normal_form">CNF</a>).
+   */
+  class SearchArgument {
+  public:
+    virtual ~SearchArgument();
+
+    /**
+     * Evaluate the entire predicate based on the values for the leaf predicates.
+     * @param leaves the value of each leaf predicate
+     * @return the value of hte entire predicate
+     */
+    virtual TruthValue evaluate(const std::vector<TruthValue>& leaves) const = 0;
+
+    virtual std::string toString() const = 0;
+  };
+
+  /**
+   * A builder object to create a SearchArgument from expressions. The user
+   * must call startOr, startAnd, or startNot before adding any leaves.
+   */
+  class SearchArgumentBuilder {
+  public:
+    virtual ~SearchArgumentBuilder();
+
+    /**
+     * Start building an or operation and push it on the stack.
+     * @return this
+     */
+    virtual SearchArgumentBuilder& startOr() = 0;
+
+    /**
+     * Start building an and operation and push it on the stack.
+     * @return this
+     */
+    virtual SearchArgumentBuilder& startAnd() = 0;
+
+    /**
+     * Start building a not operation and push it on the stack.
+     * @return this
+     */
+    virtual SearchArgumentBuilder& startNot() = 0;
+
+    /**
+     * Finish the current operation and pop it off of the stack. Each start
+     * call must have a matching end.
+     * @return this
+     */
+    virtual SearchArgumentBuilder& end() = 0;
+
+    /**
+     * Add a less than leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    virtual SearchArgumentBuilder& lessThan(const std::string& column,
+                                            PredicateType type,
+                                            Literal literal) = 0;
+
+    /**
+     * Add a less than equals leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    virtual SearchArgumentBuilder& lessThanEquals(const std::string& column,
+                                                  PredicateType type,
+                                                  Literal literal) = 0;
+
+    /**
+     * Add an equals leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    virtual SearchArgumentBuilder& equals(const std::string& column,
+                                          PredicateType type,
+                                          Literal literal) = 0;
+
+    /**
+     * Add a null safe equals leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    virtual SearchArgumentBuilder& nullSafeEquals(const std::string& column,
+                                                  PredicateType type,
+                                                  Literal literal) = 0;
+
+    /**
+     * Add an in leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literals the literals
+     * @return this
+     */
+    virtual SearchArgumentBuilder& in(const std::string& column,
+                                      PredicateType type,
+                                      const std::initializer_list<Literal>& literals) = 0;
+
+    /**
+     * Add an is null leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @return this
+     */
+    virtual SearchArgumentBuilder& isNull(const std::string& column,
+                                          PredicateType type) = 0;
+
+    /**
+     * Add a between leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param lower the literal
+     * @param upper the literal
+     * @return this
+     */
+    virtual SearchArgumentBuilder& between(const std::string& column,
+                                           PredicateType type,
+                                           Literal lower,
+                                           Literal upper) = 0;
+
+    /**
+     * Add a truth value to the expression.
+     * @param truth truth value
+     * @return this
+     */
+    virtual SearchArgumentBuilder& literal(TruthValue truth) = 0;
+
+    /**
+     * Build and return the SearchArgument that has been defined. All of the
+     * starts must have been ended before this call.
+     * @return the new SearchArgument
+     */
+    virtual std::unique_ptr<SearchArgument> build() = 0;
+  };
+
+  /**
+   * Factory to create SearchArgumentBuilder which builds SearchArgument
+   */
+  class SearchArgumentFactory {
+  public:
+    static std::unique_ptr<SearchArgumentBuilder> newBuilder();
+  };
+
+} // namespace orc
+
+#endif //ORC_SEARCHARGUMENT_HH

--- a/c++/include/orc/sargs/TruthValue.hh
+++ b/c++/include/orc/sargs/TruthValue.hh
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_TRUTHVALUE_HH
+#define ORC_TRUTHVALUE_HH
+
+namespace orc {
+
+  enum class TruthValue {
+    YES, NO, IS_NULL, YES_NULL, NO_NULL, YES_NO, YES_NO_NULL
+  };
+
+  // Compute logical or between the two values.
+  TruthValue operator||(TruthValue left, TruthValue right);
+
+  // Compute logical AND between the two values.
+  TruthValue operator&&(TruthValue left, TruthValue right);
+
+  // Compute logical NOT for one value.
+  TruthValue operator!(TruthValue val);
+
+  // Do we need to read the data based on the TruthValue?
+  bool isNeeded(TruthValue val);
+
+} // namespace orc
+
+#endif //ORC_TRUTHVALUE_HH

--- a/c++/include/orc/sargs/TruthValue.hh
+++ b/c++/include/orc/sargs/TruthValue.hh
@@ -21,8 +21,17 @@
 
 namespace orc {
 
+  /**
+   * The potential result sets of logical operations.
+   */
   enum class TruthValue {
-    YES, NO, IS_NULL, YES_NULL, NO_NULL, YES_NO, YES_NO_NULL
+      YES,        // all rows satisfy the predicate
+      NO,         // all rows dissatisfy the predicate
+      IS_NULL,    // all rows are null value
+      YES_NULL,   // null values exist, not-null rows satisfy the predicate
+      NO_NULL,    // null values exist, not-null rows dissatisfy the predicate
+      YES_NO,     // some rows satisfy the predicate and the others not
+      YES_NO_NULL // null values exist, some rows satisfy predicate and some not
   };
 
   // Compute logical or between the two values.

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -194,6 +194,12 @@ set(SOURCE_FILES
   orc_proto.pb.h
   io/InputStream.cc
   io/OutputStream.cc
+  sargs/ExpressionTree.cc
+  sargs/Literal.cc
+  sargs/PredicateLeaf.cc
+  sargs/SargsApplier.cc
+  sargs/SearchArgument.cc
+  sargs/TruthValue.cc
   wrap/orc-proto-wrapper.cc
   Adaptor.cc
   BloomFilter.cc

--- a/c++/src/sargs/ExpressionTree.cc
+++ b/c++/src/sargs/ExpressionTree.cc
@@ -1,0 +1,192 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ExpressionTree.hh"
+
+#include <cassert>
+#include <sstream>
+
+namespace orc {
+
+  ExpressionTree::ExpressionTree(Operator op)
+                                : mOperator(op)
+                                , mLeaf(UNUSED_LEAF)
+                                , mConstant(TruthValue::YES_NO_NULL) {
+  }
+
+
+  ExpressionTree::ExpressionTree(Operator op,
+                                 std::initializer_list<TreeNode> children)
+                                : mOperator(op)
+                                , mChildren(children.begin(), children.end())
+                                , mLeaf(UNUSED_LEAF)
+                                , mConstant(TruthValue::YES_NO_NULL) {
+    // PASS
+  }
+
+  ExpressionTree::ExpressionTree(size_t leaf)
+                                : mOperator(Operator::LEAF)
+                                , mChildren()
+                                , mLeaf(leaf)
+                                , mConstant(TruthValue::YES_NO_NULL) {
+    // PASS
+  }
+
+  ExpressionTree::ExpressionTree(TruthValue constant)
+                                : mOperator(Operator::CONSTANT)
+                                , mChildren()
+                                , mLeaf(UNUSED_LEAF)
+                                , mConstant(constant) {
+    // PASS
+  }
+
+  ExpressionTree::ExpressionTree(const ExpressionTree& other)
+                                : mOperator(other.mOperator)
+                                , mLeaf(other.mLeaf)
+                                , mConstant(other.mConstant) {
+    for (TreeNode child : other.mChildren) {
+      mChildren.emplace_back(std::make_shared<ExpressionTree>(*child));
+    }
+  }
+
+  ExpressionTree::Operator ExpressionTree::getOperator() const {
+    return mOperator;
+  }
+
+  const std::vector<TreeNode>& ExpressionTree::getChildren() const {
+    return mChildren;
+  }
+
+  std::vector<TreeNode>& ExpressionTree::getChildren() {
+    return const_cast<std::vector<TreeNode>&>(
+      const_cast<const ExpressionTree *>(this)->getChildren());
+  }
+
+  const TreeNode ExpressionTree::getChild(size_t i) const {
+    return mChildren.at(i);
+  }
+
+  TreeNode ExpressionTree::getChild(size_t i) {
+    return std::const_pointer_cast<ExpressionTree>(
+      const_cast<const ExpressionTree *>(this)->getChild(i));
+  }
+
+  TruthValue ExpressionTree::getConstant() const {
+    assert(mOperator == Operator::CONSTANT);
+    return mConstant;
+  }
+
+  size_t ExpressionTree::getLeaf() const {
+    assert(mOperator == Operator::LEAF);
+    return mLeaf;
+  }
+
+  void ExpressionTree::setLeaf(size_t leaf) {
+    assert(mOperator == Operator::LEAF);
+    mLeaf = leaf;
+  }
+
+  void ExpressionTree::addChild(TreeNode child) {
+    mChildren.push_back(child);
+  }
+
+  TruthValue ExpressionTree::evaluate(
+                                 const std::vector<TruthValue>& leaves) const {
+    TruthValue result;
+    switch (mOperator) {
+      case Operator::OR:
+      {
+        result = mChildren.at(0)->evaluate(leaves);
+        for (size_t i = 1; i < mChildren.size(); ++i) {
+          result = mChildren.at(i)->evaluate(leaves) || result;
+        }
+        return result;
+      }
+      case Operator::AND:
+      {
+        result = mChildren.at(0)->evaluate(leaves);
+        for (size_t i = 1; i < mChildren.size(); ++i) {
+          result = mChildren.at(i)->evaluate(leaves) && result;
+        }
+        return result;
+      }
+      case Operator::NOT:
+        return !mChildren.at(0)->evaluate(leaves);
+      case Operator::LEAF:
+        return leaves[mLeaf];
+      case Operator::CONSTANT:
+        return mConstant;
+      default:
+        throw std::invalid_argument("Unknown operator!");
+    }
+  }
+
+  std::string to_string(TruthValue truthValue) {
+    switch (truthValue) {
+      case TruthValue::YES:
+        return "YES";
+      case TruthValue::NO:
+        return "NO";
+      case TruthValue::IS_NULL:
+        return "IS_NULL";
+      case TruthValue::YES_NULL:
+        return "YES_NULL";
+      case TruthValue::NO_NULL:
+        return "NO_NULL";
+      case TruthValue::YES_NO:
+        return "YES_NO";
+      case TruthValue::YES_NO_NULL:
+        return "YES_NO_NULL";
+      default:
+        throw std::invalid_argument("unknown TruthValue!");
+    }
+  }
+
+  std::string ExpressionTree::toString() const {
+    std::ostringstream sstream;
+    switch (mOperator) {
+      case Operator::OR:
+        sstream << "(or";
+        for (const auto& child : mChildren) {
+          sstream << ' ' << child->toString();
+        }
+        sstream << ')';
+        break;
+      case Operator::AND:
+        sstream << "(and";
+        for (const auto& child : mChildren) {
+          sstream << ' ' << child->toString();
+        }
+        sstream << ')';
+        break;
+      case Operator::NOT:
+        sstream << "(not " << mChildren.at(0)->toString() << ')';
+        break;
+      case Operator::LEAF:
+        sstream << "leaf-" << mLeaf;
+        break;
+      case Operator::CONSTANT:
+        sstream << to_string(mConstant);
+        break;
+      default:
+        throw std::invalid_argument("unknown operator!");
+    }
+    return sstream.str();
+  }
+
+} // namespace orc

--- a/c++/src/sargs/ExpressionTree.cc
+++ b/c++/src/sargs/ExpressionTree.cc
@@ -112,7 +112,7 @@ namespace orc {
       case Operator::OR:
       {
         result = mChildren.at(0)->evaluate(leaves);
-        for (size_t i = 1; i < mChildren.size(); ++i) {
+        for (size_t i = 1; i < mChildren.size() && !isNeeded(result); ++i) {
           result = mChildren.at(i)->evaluate(leaves) || result;
         }
         return result;
@@ -120,7 +120,7 @@ namespace orc {
       case Operator::AND:
       {
         result = mChildren.at(0)->evaluate(leaves);
-        for (size_t i = 1; i < mChildren.size(); ++i) {
+        for (size_t i = 1; i < mChildren.size() && isNeeded(result); ++i) {
           result = mChildren.at(i)->evaluate(leaves) && result;
         }
         return result;

--- a/c++/src/sargs/ExpressionTree.hh
+++ b/c++/src/sargs/ExpressionTree.hh
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_EXPRESSIONTREE_HH
+#define ORC_EXPRESSIONTREE_HH
+
+#include "orc/sargs/TruthValue.hh"
+
+#include <limits>
+#include <memory>
+#include <vector>
+
+static const size_t UNUSED_LEAF = std::numeric_limits<size_t>::max();
+
+namespace orc {
+
+  class ExpressionTree;
+  typedef std::shared_ptr<ExpressionTree> TreeNode;
+  typedef std::initializer_list<TreeNode> NodeList;
+
+  /**
+   * The inner representation of the SearchArgument. Most users should not
+   * need this interface, it is only for file formats that need to translate
+   * the SearchArgument into an internal form.
+   */
+  class ExpressionTree {
+  public:
+    enum class Operator { OR, AND, NOT, LEAF, CONSTANT };
+
+    ExpressionTree(Operator op);
+    ExpressionTree(Operator op, std::initializer_list<TreeNode> children);
+    ExpressionTree(size_t leaf);
+    ExpressionTree(TruthValue constant);
+
+    ExpressionTree(const ExpressionTree& other);
+    ExpressionTree& operator=(const ExpressionTree&) = delete;
+
+    Operator getOperator() const;
+
+    const std::vector<TreeNode>& getChildren() const;
+
+    std::vector<TreeNode>& getChildren();
+
+    const TreeNode getChild(size_t i) const;
+
+    TreeNode getChild(size_t i);
+
+    TruthValue getConstant() const;
+
+    size_t getLeaf() const;
+
+    void setLeaf(size_t leaf);
+
+    void addChild(TreeNode child);
+
+    std::string toString() const;
+
+    TruthValue evaluate(const std::vector<TruthValue>& leaves) const;
+
+  private:
+    Operator mOperator;
+    std::vector<TreeNode> mChildren;
+    size_t mLeaf;
+    TruthValue mConstant;
+  };
+
+} // namespace orc
+
+#endif //ORC_EXPRESSIONTREE_HH

--- a/c++/src/sargs/Literal.cc
+++ b/c++/src/sargs/Literal.cc
@@ -1,0 +1,321 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "orc/sargs/Literal.hh"
+
+#include <cmath>
+#include <functional>
+#include <limits>
+#include <sstream>
+
+namespace orc {
+
+  Literal::Literal(PredicateType type) {
+    mType = type;
+    mValue.DecimalVal = 0;
+    mSize = 0;
+    mIsNull = true;
+    mPrecision = 0;
+    mScale = 0;
+    mHashCode = 0;
+  }
+
+  Literal::Literal(int64_t val) {
+    mType = PredicateType::LONG;
+    mValue.IntVal = val;
+    mSize = sizeof(val);
+    mIsNull = false;
+    mPrecision = 0;
+    mScale = 0;
+    mHashCode = hashCode();
+  }
+
+  Literal::Literal(double val) {
+    mType = PredicateType::FLOAT;
+    mValue.DoubleVal = val;
+    mSize = sizeof(val);
+    mIsNull = false;
+    mPrecision = 0;
+    mScale = 0;
+    mHashCode = hashCode();
+  }
+
+  Literal::Literal(bool val) {
+    mType = PredicateType::BOOLEAN;
+    mValue.BooleanVal = val;
+    mSize = sizeof(val);
+    mIsNull = false;
+    mPrecision = 0;
+    mScale = 0;
+    mHashCode = hashCode();
+  }
+
+  Literal::Literal(PredicateType type, int64_t val) {
+    if (type != PredicateType::DATE && type != PredicateType::TIMESTAMP) {
+      throw std::invalid_argument("only DATE & TIMESTAMP are supported here!");
+    }
+    mType = type;
+    mValue.IntVal = val;
+    mSize = sizeof(val);
+    mIsNull = false;
+    mPrecision = 0;
+    mScale = 0;
+    mHashCode = hashCode();
+  }
+
+  Literal::Literal(const char * str, size_t size) {
+    mType = PredicateType::STRING;
+    mValue.Buffer = new char[size];
+    memcpy(mValue.Buffer, str, size);
+    mSize = size;
+    mIsNull = false;
+    mPrecision = 0;
+    mScale = 0;
+    mHashCode = hashCode();
+  }
+
+  Literal::Literal(Int128 val, int32_t precision, int32_t scale) {
+    mType = PredicateType::DECIMAL;
+    mValue.DecimalVal = val;
+    mPrecision = precision;
+    mScale = scale;
+    mSize = sizeof(Int128);
+    mIsNull = false;
+    mHashCode = hashCode();
+  }
+
+  Literal::Literal(const Literal& r): mType(r.mType)
+                                    , mSize(r.mSize)
+                                    , mIsNull(r.mIsNull)
+                                    , mHashCode(r.mHashCode) {
+    if (mType == PredicateType::STRING) {
+      mValue.Buffer = new char[r.mSize];
+      memcpy(mValue.Buffer, r.mValue.Buffer, r.mSize);
+      mPrecision = 0;
+      mScale = 0;
+    } else if (mType == PredicateType::DECIMAL) {
+      mPrecision = r.mPrecision;
+      mScale = r.mScale;
+      mValue = r.mValue;
+    } else {
+      mValue = r.mValue;
+      mPrecision = 0;
+      mScale = 0;
+    }
+  }
+
+  Literal::~Literal() {
+    if (mType == PredicateType::STRING && mValue.Buffer) {
+      delete [] mValue.Buffer;
+      mValue.Buffer = nullptr;
+    }
+  }
+
+  Literal& Literal::operator=(const Literal& r) {
+    if (this != &r) {
+      if (mType == PredicateType::STRING && mValue.Buffer) {
+        delete [] mValue.Buffer;
+        mValue.Buffer = nullptr;
+      }
+
+      mType = r.mType;
+      mSize = r.mSize;
+      mIsNull = r.mIsNull;
+      mPrecision = r.mPrecision;
+      mScale = r.mScale;
+      if (mType == PredicateType::STRING) {
+        mValue.Buffer = new char[r.mSize];
+        memcpy(mValue.Buffer, r.mValue.Buffer, r.mSize);
+      } else {
+        mValue = r.mValue;
+      }
+      mHashCode = r.mHashCode;
+    }
+    return *this;
+  }
+
+  std::string Literal::toString() const {
+    if (mIsNull) {
+      return "null";
+    }
+
+    std::ostringstream sstream;
+    std::string str;
+    switch (mType) {
+      case PredicateType::LONG:
+        sstream << mValue.IntVal;
+        break;
+      case PredicateType::DATE:
+        sstream << mValue.DateVal;
+        break;
+      case PredicateType::TIMESTAMP:
+        sstream << mValue.TimeStampVal;
+        break;
+      case PredicateType::FLOAT:
+        sstream << mValue.DoubleVal;
+        break;
+      case PredicateType::BOOLEAN:
+        sstream << (mValue.BooleanVal ? "true" : "false");
+        break;
+      case PredicateType::STRING:
+        str.assign(mValue.Buffer, mSize);
+        sstream << str;
+        break;
+      case PredicateType::DECIMAL:
+        sstream << mValue.DecimalVal.toDecimalString(mScale);
+        break;
+    }
+    return sstream.str();
+  }
+
+  size_t Literal::hashCode() const {
+    if (mIsNull) {
+      return 0;
+    }
+
+    switch (mType) {
+      case PredicateType::LONG:
+        return std::hash<int64_t>{}(mValue.IntVal);
+      case PredicateType::DATE:
+        return std::hash<int64_t>{}(mValue.DateVal);
+      case PredicateType::TIMESTAMP:
+        return std::hash<int64_t>{}(mValue.TimeStampVal);
+      case PredicateType::FLOAT:
+        return std::hash<double>{}(mValue.DoubleVal);
+      case PredicateType::BOOLEAN:
+        return std::hash<bool>{}(mValue.BooleanVal);
+      case PredicateType::STRING:
+        return std::hash<std::string>{}(
+          std::string(mValue.Buffer, mSize));
+      case PredicateType::DECIMAL:
+        // current glibc does not support hash<int128_t>
+        return std::hash<int64_t>{}(mValue.IntVal);
+      default:
+        return 0;
+    }
+  }
+
+  bool Literal::operator==(const Literal& r) const {
+    if (this == &r) {
+      return true;
+    }
+    if (mHashCode != r.mHashCode || mType != r.mType || mIsNull != r.mIsNull) {
+      return false;
+    }
+
+    if (mIsNull) {
+      return true;
+    }
+
+    switch (mType) {
+      case PredicateType::LONG:
+        return mValue.IntVal == r.mValue.IntVal;
+      case PredicateType::DATE:
+        return mValue.DateVal == r.mValue.DateVal;
+      case PredicateType::TIMESTAMP:
+        return mValue.TimeStampVal == r.mValue.TimeStampVal;
+      case PredicateType::FLOAT:
+        return std::fabs(mValue.DoubleVal - r.mValue.DoubleVal) <
+          std::numeric_limits<double>::epsilon();
+      case PredicateType::BOOLEAN:
+        return mValue.BooleanVal == r.mValue.BooleanVal;
+      case PredicateType::STRING:
+        return mSize == r.mSize && memcmp(
+          mValue.Buffer, r.mValue.Buffer, mSize) == 0;
+      case PredicateType::DECIMAL:
+        return mValue.DecimalVal == r.mValue.DecimalVal;
+      default:
+        return true;
+    }
+  }
+
+  bool Literal::operator!=(const Literal& r) const {
+    return !(*this == r);
+  }
+
+  int64_t Literal::getLong() const {
+    if (mIsNull) {
+      throw std::logic_error("cannot call getLong for null!");
+    }
+    if (mType != PredicateType::LONG) {
+      throw std::logic_error("cannot call getLong for " + toString());
+    }
+    return mValue.IntVal;
+  }
+
+  int64_t Literal::getDate() const {
+    if (mIsNull) {
+      throw std::logic_error("cannot call getLong for null!");
+    }
+    if (mType != PredicateType::DATE) {
+      throw std::logic_error("cannot call getDate for " + toString());
+    }
+    return mValue.DateVal;
+  }
+
+  int64_t Literal::getTimestamp() const {
+    if (mIsNull) {
+      throw std::logic_error("cannot call getLong for null!");
+    }
+    if (mType != PredicateType::TIMESTAMP) {
+      throw std::logic_error("cannot call getTimestamp for " + toString());
+    }
+    return mValue.TimeStampVal;
+  }
+
+  double Literal::getFloat() const {
+    if (mIsNull) {
+      throw std::logic_error("cannot call getLong for null!");
+    }
+    if (mType != PredicateType::FLOAT) {
+      throw std::logic_error("cannot call getFloat for " + toString());
+    }
+    return mValue.DoubleVal;
+  }
+
+  std::string Literal::getString() const {
+    if (mIsNull) {
+      throw std::logic_error("cannot call getLong for null!");
+    }
+    if (mType != PredicateType::STRING) {
+      throw std::logic_error("cannot call getString for " + toString());
+    }
+    return std::string(mValue.Buffer, mSize);
+  }
+
+  bool Literal::getBool() const {
+    if (mIsNull) {
+      throw std::logic_error("cannot call getLong for null!");
+    }
+    if (mType != PredicateType::BOOLEAN) {
+      throw std::logic_error("cannot call getBool for " + toString());
+    }
+    return mValue.BooleanVal;
+  }
+
+  Decimal Literal::getDecimal() const {
+    if (mIsNull) {
+      throw std::logic_error("cannot call getLong for null!");
+    }
+    if (mType != PredicateType::DECIMAL) {
+      throw std::logic_error("cannot call getDecimal for " + toString());
+    }
+    return Decimal(mValue.DecimalVal, mScale);
+  }
+
+}

--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -1,0 +1,698 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "orc/BloomFilter.hh"
+#include "orc/Common.hh"
+#include "PredicateLeaf.hh"
+#include "orc/Type.hh"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <type_traits>
+
+namespace orc {
+
+  PredicateLeaf::PredicateLeaf(Operator op,
+                               PredicateType type,
+                               const std::string& colName,
+                               Literal literal)
+                              : mOperator(op)
+                              , mType(type)
+                              , mColumnName(colName) {
+    mLiterals.emplace_back(literal);
+    mHashCode = hashCode();
+    validate();
+  }
+
+  PredicateLeaf::PredicateLeaf(Operator op,
+                               PredicateType type,
+                               const std::string& colName,
+                               const std::initializer_list<Literal>& literals)
+                              : mOperator(op)
+                              , mType(type)
+                              , mColumnName(colName)
+                              , mLiterals(literals.begin(), literals.end()) {
+    mHashCode = hashCode();
+    validate();
+  }
+
+  void PredicateLeaf::validate() const {
+    switch (mOperator) {
+      case Operator ::IS_NULL:
+        if (mColumnName.empty()) {
+          throw std::invalid_argument("column name should not be empty");
+        }
+        if (!mLiterals.empty()) {
+          throw std::invalid_argument("No literal is required!");
+        }
+        break;
+      case Operator::EQUALS:
+      case Operator::NULL_SAFE_EQUALS:
+      case Operator::LESS_THAN:
+      case Operator::LESS_THAN_EQUALS:
+        if (mColumnName.empty()) {
+          throw std::invalid_argument("column name should not be empty");
+        }
+        if (mLiterals.size() != 1) {
+          throw std::invalid_argument("One literal is required!");
+        }
+        if (static_cast<int>(mLiterals.at(0).getType()) !=
+            static_cast<int>(mType)) {
+          throw std::invalid_argument("leaf and literal types do not match!");
+        }
+        break;
+      case Operator::IN:
+        if (mColumnName.empty()) {
+          throw std::invalid_argument("column name should not be empty");
+        }
+        if (mLiterals.size() < 2) {
+          throw std::invalid_argument("At least two literals are required!");
+        }
+        for (auto literal : mLiterals) {
+          if (static_cast<int>(literal.getType()) != static_cast<int>(mType)) {
+            throw std::invalid_argument("leaf and literal types do not match!");
+          }
+        }
+        break;
+      case Operator::BETWEEN:
+        if (mColumnName.empty()) {
+          throw std::invalid_argument("column name should not be empty");
+        }
+        for (auto literal : mLiterals) {
+          if (static_cast<int>(literal.getType()) != static_cast<int>(mType)) {
+            throw std::invalid_argument("leaf and literal types do not match!");
+          }
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+  PredicateLeaf::Operator PredicateLeaf::getOperator() const {
+    return mOperator;
+  }
+
+  PredicateType PredicateLeaf::getType() const {
+    return mType;
+  }
+
+  /**
+   * Get the simple column name.
+   */
+  const std::string& PredicateLeaf::getColumnName() const {
+    return mColumnName;
+  }
+
+  /**
+   * Get the literal half of the predicate leaf.
+   */
+  Literal PredicateLeaf::getLiteral() const {
+    return mLiterals.at(0);
+  }
+
+  /**
+   * For operators with multiple literals (IN and BETWEEN), get the literals.
+   */
+  const std::vector<Literal>& PredicateLeaf::getLiteralList() const {
+    return mLiterals;
+  }
+
+  static std::string getLiteralString(const std::vector<Literal>& literals) {
+    return literals.at(0).toString();
+  }
+
+  static std::string getLiteralsString(const std::vector<Literal>& literals) {
+    std::ostringstream sstream;
+    sstream << "[";
+    for (size_t i = 0; i != literals.size(); ++i) {
+      sstream << literals[i].toString();
+      if (i + 1 != literals.size()) {
+        sstream << ", ";
+      }
+    }
+    sstream << "]";
+    return sstream.str();
+  }
+
+  std::string PredicateLeaf::toString() const {
+    std::ostringstream sstream;
+    sstream << '(';
+    switch (mOperator) {
+      case Operator ::IS_NULL:
+        sstream << mColumnName << " is null";
+        break;
+      case Operator::EQUALS:
+        sstream << mColumnName << " = " << getLiteralString(mLiterals);
+        break;
+      case Operator::NULL_SAFE_EQUALS:
+        sstream << mColumnName << " null_safe_= "
+                << getLiteralString(mLiterals);
+        break;
+      case Operator::LESS_THAN:
+        sstream << mColumnName << " < " << getLiteralString(mLiterals);
+        break;
+      case Operator::LESS_THAN_EQUALS:
+        sstream << mColumnName << " <= " << getLiteralString(mLiterals);
+        break;
+      case Operator::IN:
+        sstream << mColumnName << " in " << getLiteralsString(mLiterals);
+        break;
+      case Operator::BETWEEN:
+        sstream << mColumnName << " between " << getLiteralsString(mLiterals);
+        break;
+      default:
+        sstream << "unknown operator, colName: "
+                << mColumnName << ", literals: "
+                << getLiteralsString(mLiterals);
+    }
+    sstream << ')';
+    return sstream.str();
+  }
+
+  size_t PredicateLeaf::hashCode() const {
+    size_t value = 0;
+    std::for_each(mLiterals.cbegin(), mLiterals.cend(),
+      [&](const Literal& literal) {
+      value = value * 17 + literal.getHashCode();
+    });
+    return value * 103 * 101 * 3 * 17 +
+      std::hash<int>{}(static_cast<int>(mOperator)) +
+      std::hash<int>{}(static_cast<int>(mType)) * 17 +
+      std::hash<std::string>{}(mColumnName) * 3 * 17 +
+      std::hash<uint64_t>{}(mColumnId) * 3 * 17 * 17;
+  }
+
+  bool PredicateLeaf::operator==(const PredicateLeaf& r) const {
+    if (this == &r) {
+      return true;
+    }
+    if (mHashCode != r.mHashCode || mType != r.mType ||
+        mOperator != r.mOperator || mColumnName != r.mColumnName ||
+        mColumnId != r.mColumnId || mLiterals.size() != r.mLiterals.size()) {
+      return false;
+    }
+    for (size_t i = 0; i != mLiterals.size(); ++i) {
+      if (mLiterals[i] != r.mLiterals[i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // enum to mark the position of predicate in the range
+  enum class Location {
+    BEFORE, MIN, MIDDLE, MAX, AFTER
+  };
+
+  DIAGNOSTIC_PUSH
+  DIAGNOSTIC_IGNORE("-Wfloat-equal")
+
+  /**
+   * Given a point and min and max, determine if the point is before, at the
+   * min, in the middle, at the max, or after the range.
+   * @param point the point to test
+   * @param min the minimum point
+   * @param max the maximum point
+   * @return the location of the point
+   */
+  template <typename T>
+  Location compareToRange(const T& point, const T& min, const T& max) {
+    if (point < min) {
+      return Location::BEFORE;
+    } else if (point == min) {
+      return Location::MIN;
+    }
+
+    if (point > max) {
+      return Location::AFTER;
+    } else if (point == max) {
+      return Location::MAX;
+    }
+
+    return Location::MIDDLE;
+  }
+
+  /**
+   * Evaluate a predicate leaf according to min/max values
+   * @param op operator of the predicate
+   * @param values the value to test
+   * @param minValue the minimum value
+   * @param maxValue the maximum value
+   * @param hasNull whether the statistics contain null
+   * @return the TruthValue result of the test
+   */
+  template <typename T>
+  TruthValue evaluatePredicateRange(const PredicateLeaf::Operator op,
+                                    const std::vector<T>& values,
+                                    const T& minValue,
+                                    const T& maxValue,
+                                    bool hasNull) {
+    Location loc;
+    switch (op) {
+      case PredicateLeaf::Operator::NULL_SAFE_EQUALS:
+        loc = compareToRange(values.at(0), minValue, maxValue);
+        if (loc == Location::BEFORE || loc == Location::AFTER) {
+          return TruthValue::NO;
+        } else {
+          return TruthValue::YES_NO;
+        }
+      case PredicateLeaf::Operator::EQUALS:
+        loc = compareToRange(values.at(0), minValue, maxValue);
+        if (minValue == maxValue && loc == Location::MIN) {
+          return hasNull ? TruthValue::YES_NULL : TruthValue::YES;
+        } else if (loc == Location::BEFORE || loc == Location::AFTER) {
+          return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+        } else {
+          return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+        }
+      case PredicateLeaf::Operator::LESS_THAN:
+        loc = compareToRange(values.at(0), minValue, maxValue);
+        if (loc == Location::AFTER) {
+          return hasNull ? TruthValue::YES_NULL : TruthValue::YES;
+        } else if (loc == Location::BEFORE || loc == Location::MIN) {
+          return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+        } else {
+          return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+        }
+      case PredicateLeaf::Operator::LESS_THAN_EQUALS:
+        loc = compareToRange(values.at(0), minValue, maxValue);
+        if (loc == Location::AFTER || loc == Location::MAX) {
+          return hasNull ? TruthValue::YES_NULL : TruthValue::YES;
+        } else if (loc == Location::BEFORE) {
+          return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+        } else {
+          return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+        }
+      case PredicateLeaf::Operator::IN:
+        if (minValue == maxValue) {
+          // for a single value, look through to see if that value is in the set
+          for (auto& value : values) {
+            loc = compareToRange(value, minValue, maxValue);
+            if (loc == Location::MIN) {
+              return hasNull ? TruthValue::YES_NULL : TruthValue::YES;
+            }
+          }
+          return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+        } else {
+          // are all of the values outside of the range?
+          for (auto& value : values) {
+            loc = compareToRange(value, minValue, maxValue);
+            if (loc == Location::MIN || loc == Location::MIDDLE ||
+                loc == Location::MAX) {
+              return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+            }
+          }
+          return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+        }
+      case PredicateLeaf::Operator::BETWEEN:
+        if (values.empty()) {
+          return TruthValue::YES_NO;
+        }
+        loc = compareToRange(values.at(0), minValue, maxValue);
+        if (loc == Location::BEFORE || loc == Location::MIN) {
+          Location loc2 = compareToRange(values.at(1), minValue, maxValue);
+          if (loc2 == Location::AFTER || loc2 == Location::MAX) {
+            return hasNull ? TruthValue::YES_NULL : TruthValue::YES;
+          } else if (loc2 == Location::BEFORE) {
+            return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+          } else {
+            return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+          }
+        } else if (loc == Location::AFTER) {
+          return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+        } else {
+          return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+        }
+      case PredicateLeaf::Operator::IS_NULL:
+        // min = null condition above handles the all-nulls YES case
+        return hasNull ? TruthValue::YES_NO : TruthValue::NO;
+      default:
+        return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+    }
+  }
+
+  DIAGNOSTIC_POP
+
+  static TruthValue evaluateBoolPredicate(
+                                        const PredicateLeaf::Operator op,
+                                        const std::vector<Literal>& literals,
+                                        const proto::ColumnStatistics& stats) {
+    bool hasNull = stats.hasnull();
+    if (!stats.has_bucketstatistics() ||
+        stats.bucketstatistics().count_size() == 0) {
+      // does not have bool stats
+      return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+    }
+
+    auto trueCount = stats.bucketstatistics().count(0);
+    auto falseCount = stats.numberofvalues() - trueCount;
+    switch (op) {
+      case PredicateLeaf::Operator::IS_NULL:
+        return hasNull ? TruthValue::YES_NO : TruthValue::NO;
+      case PredicateLeaf::Operator::NULL_SAFE_EQUALS: {
+        if (literals.at(0).getBool()) {
+           return trueCount == 0 ?
+                  TruthValue::NO : TruthValue::YES_NO;
+        } else {
+          return falseCount == 0 ?
+                 TruthValue::NO : TruthValue::YES_NO;
+        }
+      }
+      case PredicateLeaf::Operator::EQUALS: {
+        if (literals.at(0).getBool()) {
+          if (trueCount == 0) {
+            return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+          } else {
+            return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+          }
+        } else {
+          if (falseCount == 0) {
+            return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+          } else {
+            return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+          }
+        }
+      }
+      case PredicateLeaf::Operator::LESS_THAN:
+      case PredicateLeaf::Operator::LESS_THAN_EQUALS:
+      case PredicateLeaf::Operator::IN:
+      case PredicateLeaf::Operator::BETWEEN:
+      default:
+        return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+    }
+  }
+
+  static std::vector<int64_t> literal2Long(const std::vector<Literal>& values) {
+    std::vector<int64_t> result;
+    std::for_each(values.cbegin(), values.cend(), [&](const Literal& val) {
+      if (!val.isNull()) {
+        result.emplace_back(val.getLong());
+      }
+    });
+    return result;
+  }
+
+  static std::vector<int32_t> literal2Date(const std::vector<Literal>& values) {
+    std::vector<int32_t> result;
+    std::for_each(values.cbegin(), values.cend(), [&](const Literal& val) {
+      if (!val.isNull()) {
+        result.emplace_back(val.getDate());
+      }
+    });
+    return result;
+  }
+
+  static std::vector<int64_t> literal2Timestamp(
+                                           const std::vector<Literal>& values) {
+    std::vector<int64_t> result;
+    std::for_each(values.cbegin(), values.cend(), [&](const Literal& val) {
+      if (!val.isNull()) {
+        result.emplace_back(val.getTimestamp());
+      }
+    });
+    return result;
+  }
+
+  static std::vector<Decimal> literal2Decimal(
+                                           const std::vector<Literal>& values) {
+    std::vector<Decimal> result;
+    std::for_each(values.cbegin(), values.cend(), [&](const Literal& val) {
+      if (!val.isNull()) {
+        result.emplace_back(val.getDecimal());
+      }
+    });
+    return result;
+  }
+
+  static std::vector<double> literal2Double(
+                                           const std::vector<Literal>& values) {
+    std::vector<double> result;
+    std::for_each(values.cbegin(), values.cend(), [&](const Literal& val) {
+      if (!val.isNull()) {
+        result.emplace_back(val.getFloat());
+      }
+    });
+    return result;
+  }
+
+  static std::vector<std::string> literal2String(
+                                           const std::vector<Literal>& values) {
+    std::vector<std::string> result;
+    std::for_each(values.cbegin(), values.cend(), [&](const Literal& val) {
+      if (!val.isNull()) {
+        result.emplace_back(val.getString());
+      }
+    });
+    return result;
+  }
+
+  TruthValue PredicateLeaf::evaluatePredicateMinMax(
+                                const proto::ColumnStatistics& colStats) const {
+    TruthValue result = TruthValue::YES_NO_NULL;
+    switch (mType) {
+      case PredicateType::LONG: {
+        if (colStats.has_intstatistics() &&
+            colStats.intstatistics().has_minimum() &&
+            colStats.intstatistics().has_maximum()) {
+          const auto& stats = colStats.intstatistics();
+          result = evaluatePredicateRange(
+            mOperator,
+            literal2Long(mLiterals),
+            stats.minimum(),
+            stats.maximum(),
+            colStats.hasnull());
+        }
+        break;
+      }
+      case PredicateType::FLOAT: {
+        if (colStats.has_doublestatistics() &&
+            colStats.doublestatistics().has_minimum() &&
+            colStats.doublestatistics().has_maximum()) {
+          const auto& stats = colStats.doublestatistics();
+          result = evaluatePredicateRange(
+            mOperator,
+            literal2Double(mLiterals),
+            stats.minimum(),
+            stats.maximum(),
+            colStats.hasnull());
+        }
+        break;
+      }
+      case PredicateType::STRING: {
+        if (colStats.has_stringstatistics() &&
+            colStats.stringstatistics().has_minimum() &&
+            colStats.stringstatistics().has_maximum()) {
+          const auto& stats = colStats.stringstatistics();
+          result = evaluatePredicateRange(
+            mOperator,
+            literal2String(mLiterals),
+            stats.minimum(),
+            stats.maximum(),
+            colStats.hasnull());
+        }
+        break;
+      }
+      case PredicateType::DATE: {
+        if (colStats.has_datestatistics() &&
+            colStats.datestatistics().has_minimum() &&
+            colStats.datestatistics().has_maximum()) {
+          const auto& stats = colStats.datestatistics();
+          result = evaluatePredicateRange(
+            mOperator,
+            literal2Date(mLiterals),
+            stats.minimum(),
+            stats.maximum(),
+            colStats.hasnull());
+        }
+        break;
+      }
+      case PredicateType::TIMESTAMP: {
+        if (colStats.has_timestampstatistics() &&
+            colStats.timestampstatistics().has_minimumutc() &&
+            colStats.timestampstatistics().has_maximumutc()) {
+          const auto& stats = colStats.timestampstatistics();
+          result = evaluatePredicateRange(
+            mOperator,
+            literal2Timestamp(mLiterals),
+            stats.minimumutc(),
+            stats.maximumutc(),
+            colStats.hasnull());
+        }
+        break;
+      }
+      case PredicateType::DECIMAL: {
+        if (colStats.has_decimalstatistics() &&
+            colStats.decimalstatistics().has_minimum() &&
+            colStats.decimalstatistics().has_maximum()) {
+          const auto& stats = colStats.decimalstatistics();
+          result = evaluatePredicateRange(
+            mOperator,
+            literal2Decimal(mLiterals),
+            Decimal(stats.minimum()),
+            Decimal(stats.maximum()),
+            colStats.hasnull());
+        }
+        break;
+      }
+      case PredicateType::BOOLEAN:  {
+        if (colStats.has_bucketstatistics()) {
+          result = evaluateBoolPredicate(mOperator, mLiterals, colStats);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    // make sure null literal is respected for IN operator
+    if (mOperator == Operator::IN && colStats.hasnull()) {
+      for (const auto& literal : mLiterals) {
+        if (literal.isNull()) {
+          result = TruthValue::YES_NO_NULL;
+          break;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  static bool shouldEvaluateBloomFilter(PredicateLeaf::Operator op,
+                                        TruthValue result,
+                                        const BloomFilter * bloomFilter) {
+    // evaluate bloom filter only when
+    // 1) Bloom filter is available
+    // 2) Min/Max evaluation yield YES or MAYBE
+    // 3) Predicate is EQUALS or IN list
+    // 4) Decimal type stores its string representation
+    //    but has inconsistency in trailing zeros
+    if (bloomFilter != nullptr
+        && result != TruthValue::NO_NULL && result != TruthValue::NO
+        && (op == PredicateLeaf::Operator::EQUALS
+            || op == PredicateLeaf::Operator::NULL_SAFE_EQUALS
+            || op == PredicateLeaf::Operator::IN)) {
+      return true;
+    }
+    return false;
+  }
+
+  static TruthValue checkInBloomFilter(PredicateLeaf::Operator,
+                                       PredicateType type,
+                                       const Literal& literal,
+                                       const BloomFilter * bf,
+                                       bool hasNull) {
+    TruthValue result = hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+    if (literal.isNull()) {
+      result = hasNull ? TruthValue::YES_NO_NULL : TruthValue::NO;
+    } else if (type == PredicateType::LONG) {
+      if (bf->testLong(literal.getLong())) {
+        result = TruthValue::YES_NO_NULL;
+      }
+    } else if (type == PredicateType::FLOAT) {
+      if (bf->testDouble(literal.getFloat())) {
+        result = TruthValue::YES_NO_NULL;
+      }
+    } else if (type == PredicateType::STRING) {
+      std::string str = literal.getString();
+      if (bf->testBytes(str.c_str(), static_cast<int64_t>(str.size()))) {
+        result = TruthValue::YES_NO_NULL;
+      }
+    } else if (type == PredicateType::DECIMAL) {
+      std::string decimal = literal.getDecimal().toString(true);
+      if (bf->testBytes(decimal.c_str(),  static_cast<int64_t>(decimal.size()))) {
+        result = TruthValue::YES_NO_NULL;
+      }
+    } else if (type == PredicateType::TIMESTAMP) {
+      if (bf->testLong(literal.getTimestamp())) {
+        result = TruthValue::YES_NO_NULL;
+      }
+    } else if (type == PredicateType::DATE) {
+      if (bf->testLong(literal.getDate())) {
+        result = TruthValue::YES_NO_NULL;
+      }
+    } else {
+      result = TruthValue::YES_NO_NULL;
+    }
+
+    if (result == TruthValue::YES_NO_NULL && !hasNull) {
+      result = TruthValue::YES_NO;
+    }
+
+    return result;
+  }
+
+  TruthValue PredicateLeaf::evaluatePredicateBloomFiter(const BloomFilter * bf,
+                                                        bool hasNull) const {
+    switch (mOperator) {
+      case Operator::NULL_SAFE_EQUALS:
+        // null safe equals does not return *_NULL variant.
+        // So set hasNull to false
+        return checkInBloomFilter(
+          mOperator, mType, mLiterals.front(), bf, false);
+      case Operator::EQUALS:
+        return checkInBloomFilter(
+          mOperator, mType, mLiterals.front(), bf, hasNull);
+      case Operator::IN:
+        for (const auto &literal : mLiterals) {
+          // if at least one value in IN list exist in bloom filter,
+          // qualify the row group/stripe
+          TruthValue result = checkInBloomFilter(
+            mOperator, mType, literal, bf, hasNull);
+          if (result == TruthValue::YES_NO_NULL ||
+              result == TruthValue::YES_NO) {
+            return result;
+          }
+        }
+        return hasNull ? TruthValue::NO_NULL : TruthValue::NO;
+      case Operator::LESS_THAN:
+      case Operator::LESS_THAN_EQUALS:
+      case Operator::BETWEEN:
+      case Operator::IS_NULL:
+      default:
+        return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+    }
+  }
+
+  TruthValue PredicateLeaf::evaluate(const WriterVersion writerVersion,
+                                     const proto::ColumnStatistics& colStats,
+                                     const BloomFilter * bloomFilter) const {
+    // files written before ORC-135 stores timestamp wrt to local timezone
+    // causing issues with PPD. disable PPD for timestamp for all old files
+    if (mType == PredicateType::TIMESTAMP) {
+      if (writerVersion < WriterVersion::WriterVersion_ORC_135) {
+        return TruthValue::YES_NO_NULL;
+      }
+    }
+
+    // if we didn't have any values, everything must have been null
+    if (colStats.hasnull() && colStats.numberofvalues() == 0) {
+      return mOperator == Operator::IS_NULL ?
+        TruthValue::YES : TruthValue::IS_NULL;
+    }
+
+    TruthValue result = evaluatePredicateMinMax(colStats);
+    if (shouldEvaluateBloomFilter(mOperator, result, bloomFilter)) {
+      return evaluatePredicateBloomFiter(bloomFilter, colStats.hasnull());
+    } else {
+      return result;
+    }
+  }
+
+} // namespace orc

--- a/c++/src/sargs/PredicateLeaf.hh
+++ b/c++/src/sargs/PredicateLeaf.hh
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_PREDICATELEAF_HH
+#define ORC_PREDICATELEAF_HH
+
+#include "wrap/orc-proto-wrapper.hh"
+#include "orc/Common.hh"
+#include "orc/sargs/Literal.hh"
+#include "orc/sargs/TruthValue.hh"
+
+#include <string>
+#include <vector>
+
+namespace orc {
+
+  static constexpr uint64_t INVALID_COLUMN_ID =
+    std::numeric_limits<uint64_t>::max();
+
+  class BloomFilter;
+
+  /**
+   * The primitive predicates that form a SearchArgument.
+   */
+  class PredicateLeaf {
+  public:
+    /**
+     * The possible operators for predicates. To get the opposites, construct
+     * an expression with a not operator.
+     */
+    enum class Operator {
+      EQUALS = 0,
+      NULL_SAFE_EQUALS,
+      LESS_THAN,
+      LESS_THAN_EQUALS,
+      IN,
+      BETWEEN,
+      IS_NULL
+    };
+
+    // The possible types for sargs.
+    enum class Type {
+      LONG = 0,     // all of the integer types
+      FLOAT,        // float and double
+      STRING,       // string, char, varchar
+      DATE,
+      DECIMAL,
+      TIMESTAMP,
+      BOOLEAN
+    };
+
+    PredicateLeaf() = default;
+
+    PredicateLeaf(Operator op,
+                  PredicateType type,
+                  const std::string& colName,
+                  Literal literal);
+
+    PredicateLeaf(Operator op,
+                  PredicateType type,
+                  const std::string& colName,
+                  const std::initializer_list<Literal>& literalList);
+
+    /**
+     * Get the operator for the leaf.
+     */
+    Operator getOperator() const;
+
+    /**
+     * Get the type of the column and literal by the file format.
+     */
+    PredicateType getType() const;
+
+    /**
+     * Get the simple column name.
+     */
+    const std::string& getColumnName() const;
+
+    /**
+     * Get the literal half of the predicate leaf.
+     */
+    Literal getLiteral() const;
+
+    /**
+     * For operators with multiple literals (IN and BETWEEN), get the literals.
+     */
+    const std::vector<Literal>& getLiteralList() const;
+
+    /**
+     * Evaluate current PredicateLeaf based on ColumnStatistics and BloomFilter
+     */
+    TruthValue evaluate(const WriterVersion writerVersion,
+                        const proto::ColumnStatistics& colStats,
+                        const BloomFilter * bloomFilter) const;
+
+    std::string toString() const;
+
+    bool operator==(const PredicateLeaf& r) const;
+
+    size_t getHashCode() const { return mHashCode; }
+
+  private:
+    size_t hashCode() const;
+
+    void validate() const;
+
+    TruthValue evaluatePredicateMinMax(
+                                 const proto::ColumnStatistics& colStats) const;
+
+    TruthValue evaluatePredicateBloomFiter(const BloomFilter * bloomFilter,
+                                           bool hasNull) const;
+
+  private:
+    Operator mOperator;
+    PredicateType mType;
+    std::string mColumnName;
+    uint64_t mColumnId;
+    std::vector<Literal> mLiterals;
+    size_t mHashCode;
+  };
+
+  struct PredicateLeafHash {
+    size_t operator()(const PredicateLeaf& leaf) const {
+      return leaf.getHashCode();
+    }
+  };
+
+  struct PredicateLeafComparator {
+    bool operator()(const PredicateLeaf& lhs, const PredicateLeaf& rhs) const {
+      return lhs == rhs;
+    }
+  };
+
+} // namespace orc
+
+#endif //ORC_PREDICATELEAF_HH

--- a/c++/src/sargs/PredicateLeaf.hh
+++ b/c++/src/sargs/PredicateLeaf.hh
@@ -67,12 +67,12 @@ namespace orc {
     PredicateLeaf() = default;
 
     PredicateLeaf(Operator op,
-                  PredicateType type,
+                  PredicateDataType type,
                   const std::string& colName,
                   Literal literal);
 
     PredicateLeaf(Operator op,
-                  PredicateType type,
+                  PredicateDataType type,
                   const std::string& colName,
                   const std::initializer_list<Literal>& literalList);
 
@@ -84,7 +84,7 @@ namespace orc {
     /**
      * Get the type of the column and literal by the file format.
      */
-    PredicateType getType() const;
+    PredicateDataType getType() const;
 
     /**
      * Get the simple column name.
@@ -127,7 +127,7 @@ namespace orc {
 
   private:
     Operator mOperator;
-    PredicateType mType;
+    PredicateDataType mType;
     std::string mColumnName;
     uint64_t mColumnId;
     std::vector<Literal> mLiterals;

--- a/c++/src/sargs/SargsApplier.cc
+++ b/c++/src/sargs/SargsApplier.cc
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "SargsApplier.hh"
+
+namespace orc {
+
+  // find column id from column name
+  uint64_t SargsApplier::findColumn(const Type& type,
+                                    const std::string& colName) {
+    for (uint64_t i = 0; i != type.getSubtypeCount(); ++i) {
+      if (type.getFieldName(i) == colName) {
+        return type.getSubtype(i)->getColumnId();
+      } else {
+        uint64_t ret = findColumn(*type.getSubtype(i), colName);
+        if (ret != INVALID_COLUMN_ID) {
+          return ret;
+        }
+      }
+    }
+    return INVALID_COLUMN_ID;
+  }
+
+  SargsApplier::SargsApplier(const Type& type,
+                             const SearchArgument * searchArgument,
+                             uint64_t rowIndexStride,
+                             WriterVersion writerVersion)
+                             : mType(type)
+                             , mSearchArgument(searchArgument)
+                             , mRowIndexStride(rowIndexStride)
+                             , mWriterVersion(writerVersion) {
+    const SearchArgumentImpl * sargs =
+      dynamic_cast<const SearchArgumentImpl *>(mSearchArgument);
+
+    // find the mapping from predicate leaves to columns
+    const std::vector<PredicateLeaf>& leaves = sargs->getLeaves();
+    mFilterColumns.resize(leaves.size(), INVALID_COLUMN_ID);
+    for (size_t i = 0; i != mFilterColumns.size(); ++i) {
+      mFilterColumns[i] = findColumn(type, leaves[i].getColumnName());
+    }
+  }
+
+  bool SargsApplier::pickRowGroups(
+               uint64_t rowsInStripe,
+               const std::unordered_map<uint64_t, proto::RowIndex>& rowIndexes,
+               const std::map<uint32_t, BloomFilterIndex>& bloomFilters) {
+    // init state of each row group
+    uint64_t groupsInStripe =
+      (rowsInStripe + mRowIndexStride - 1) / mRowIndexStride;
+    mRowGroups.resize(groupsInStripe, true);
+    mTotalRowsInStripe = rowsInStripe;
+
+    // row indexes do not exist, simply read all rows
+    if (rowIndexes.empty()) {
+      return true;
+    }
+
+    const auto& leaves =
+      dynamic_cast<const SearchArgumentImpl *>(mSearchArgument)->getLeaves();
+    std::vector<TruthValue> leafValues(
+      leaves.size(), TruthValue::YES_NO_NULL);
+    mHasSelected = false;
+    mHasSkipped = false;
+    for (size_t rowGroup = 0; rowGroup != groupsInStripe; ++rowGroup) {
+      for (size_t pred = 0; pred != leaves.size(); ++pred) {
+        uint64_t columnIdx = mFilterColumns[pred];
+        auto rowIndexIter = rowIndexes.find(columnIdx);
+        if (columnIdx == INVALID_COLUMN_ID || rowIndexIter == rowIndexes.cend()) {
+          // this column does not exist in current file
+          leafValues[pred] = TruthValue::YES_NO_NULL;
+        } else {
+          // get column statistics
+          const proto::ColumnStatistics& statistics =
+            rowIndexIter->second.entry(static_cast<int>(rowGroup)).statistics();
+
+          // get bloom filter
+          std::shared_ptr<BloomFilter> bloomFilter;
+          auto iter = bloomFilters.find(static_cast<uint32_t>(columnIdx));
+          if (iter != bloomFilters.cend()) {
+            bloomFilter = iter->second.entries.at(rowGroup);
+          }
+
+          leafValues[pred] = leaves[pred].evaluate(mWriterVersion,
+                                                   statistics,
+                                                   bloomFilter.get());
+        }
+      }
+
+      mRowGroups[rowGroup] = isNeeded(mSearchArgument->evaluate(leafValues));
+      mHasSelected = mHasSelected || mRowGroups[rowGroup];
+      mHasSkipped = mHasSkipped || (!mRowGroups[rowGroup]);
+    }
+
+    return mHasSelected;
+  }
+
+}

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_SARGSAPPLIER_HH
+#define ORC_SARGSAPPLIER_HH
+
+#include "wrap/orc-proto-wrapper.hh"
+#include <orc/Common.hh>
+#include "orc/BloomFilter.hh"
+#include "orc/Type.hh"
+
+#include "sargs/SearchArgument.hh"
+
+#include <unordered_map>
+
+namespace orc {
+
+  class SargsApplier {
+  public:
+    SargsApplier(const Type& type,
+                 const SearchArgument * searchArgument,
+                 uint64_t rowIndexStride,
+                 WriterVersion writerVersion);
+
+    /**
+     * TODO: use proto::RowIndex and proto::BloomFilter to do the evaluation
+     * Pick the row groups that we need to load from the current stripe.
+     * @return true if any row group is selected
+     */
+    bool pickRowGroups(
+                      uint64_t rowsInStripe,
+                      const std::unordered_map<uint64_t, proto::RowIndex>& rowIndexes,
+                      const std::map<uint32_t, BloomFilterIndex>& bloomFilters);
+
+    /**
+     * Return a vector of bool for each row group for their selection
+     * in the last evaluation
+     */
+    const std::vector<bool>& getRowGroups() const { return mRowGroups; }
+
+    /**
+     * Indicate whether any row group is selected in the last evaluation
+     */
+    bool hasSelected() const { return mHasSelected; }
+
+    /**
+     * Indicate whether any row group is skipped in the last evaluation
+     */
+    bool hasSkipped() const { return mHasSkipped; }
+
+    /**
+     * Whether any row group from current row in the stripe matches PPD.
+     */
+    bool hasSelectedFrom(uint64_t currentRowInStripe) const {
+      uint64_t rg = currentRowInStripe / mRowIndexStride;
+      for (; rg < mRowGroups.size(); ++rg) {
+        if (mRowGroups[rg]) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+  private:
+    friend class TestSargsApplier_findColumnTest_Test;
+    static uint64_t findColumn(const Type& type, const std::string& colName);
+
+  private:
+    const Type& mType;
+    const SearchArgument * mSearchArgument;
+    uint64_t mRowIndexStride;
+    WriterVersion mWriterVersion;
+    // column ids for each predicate leaf in the search argument
+    std::vector<uint64_t> mFilterColumns;
+
+    // store results of last call of pickRowGroups
+    std::vector<bool> mRowGroups;
+    uint64_t mTotalRowsInStripe;
+    bool mHasSelected;
+    bool mHasSkipped;
+  };
+
+}
+
+#endif //ORC_SARGSAPPLIER_HH

--- a/c++/src/sargs/SearchArgument.cc
+++ b/c++/src/sargs/SearchArgument.cc
@@ -105,7 +105,7 @@ namespace orc {
   SearchArgumentBuilder&
   SearchArgumentBuilderImpl::compareOperator(PredicateLeaf::Operator op,
                                              const std::string& column,
-                                             PredicateType type,
+                                             PredicateDataType type,
                                              Literal literal) {
     TreeNode parent = mCurrTree.front();
     if (column.empty()) {
@@ -118,26 +118,23 @@ namespace orc {
     return *this;
   }
 
-  SearchArgumentBuilder& SearchArgumentBuilderImpl::lessThan(
-                                                    const std::string& column,
-                                                    PredicateType type,
-                                                    Literal literal) {
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::lessThan(const std::string& column,
+                                                             PredicateDataType type,
+                                                             Literal literal) {
     return compareOperator(
       PredicateLeaf::Operator::LESS_THAN, column, type, literal);
   }
 
-  SearchArgumentBuilder& SearchArgumentBuilderImpl::lessThanEquals(
-                                                    const std::string& column,
-                                                    PredicateType type,
-                                                    Literal literal) {
+    SearchArgumentBuilder& SearchArgumentBuilderImpl::lessThanEquals(const std::string& column,
+                                                                     PredicateDataType type,
+                                                                     Literal literal) {
     return compareOperator(
       PredicateLeaf::Operator::LESS_THAN_EQUALS, column, type, literal);
   }
 
-  SearchArgumentBuilder& SearchArgumentBuilderImpl::equals(
-                                                    const std::string& column,
-                                                    PredicateType type,
-                                                    Literal literal) {
+    SearchArgumentBuilder& SearchArgumentBuilderImpl::equals(const std::string& column,
+                                                             PredicateDataType type,
+                                                             Literal literal) {
     if (literal.isNull()) {
       return isNull(column, type);
     } else {
@@ -146,18 +143,16 @@ namespace orc {
     }
   }
 
-  SearchArgumentBuilder& SearchArgumentBuilderImpl::nullSafeEquals(
-                                                    const std::string& column,
-                                                    PredicateType type,
-                                                    Literal literal) {
+    SearchArgumentBuilder& SearchArgumentBuilderImpl::nullSafeEquals(const std::string& column,
+                                                                     PredicateDataType type,
+                                                                     Literal literal) {
     return compareOperator(
       PredicateLeaf::Operator::NULL_SAFE_EQUALS, column, type, literal);
   }
 
-  SearchArgumentBuilder& SearchArgumentBuilderImpl::in(
-                               const std::string& column,
-                               PredicateType type,
-                               const std::initializer_list<Literal>& literals) {
+    SearchArgumentBuilder& SearchArgumentBuilderImpl::in(const std::string& column,
+                                                         PredicateDataType type,
+                                                         const std::initializer_list<Literal>& literals) {
     TreeNode& parent = mCurrTree.front();
     if (column.empty()) {
       parent->addChild(
@@ -174,9 +169,8 @@ namespace orc {
     return *this;
   }
 
-  SearchArgumentBuilder& SearchArgumentBuilderImpl::isNull(
-                                                     const std::string& column,
-                                                     PredicateType type) {
+    SearchArgumentBuilder& SearchArgumentBuilderImpl::isNull(const std::string& column,
+                                                             PredicateDataType type) {
     TreeNode& parent = mCurrTree.front();
     if (column.empty()) {
       parent->addChild(
@@ -191,11 +185,10 @@ namespace orc {
     return *this;
   }
 
-  SearchArgumentBuilder& SearchArgumentBuilderImpl::between(
-                                                      const std::string& column,
-                                                      PredicateType type,
-                                                      Literal lower,
-                                                      Literal upper) {
+    SearchArgumentBuilder& SearchArgumentBuilderImpl::between(const std::string& column,
+                                                              PredicateDataType type,
+                                                              Literal lower,
+                                                              Literal upper) {
     TreeNode& parent = mCurrTree.front();
     if (column.empty()) {
       parent->addChild(
@@ -225,8 +218,8 @@ namespace orc {
    * @return the next available leaf id
    */
   static size_t compactLeaves(const TreeNode& tree,
-                           size_t next,
-                           size_t leafReorder[]) {
+                              size_t next,
+                              size_t leafReorder[]) {
     if (tree->getOperator() == ExpressionTree::Operator::LEAF) {
       size_t oldLeaf = tree->getLeaf();
       if (leafReorder[oldLeaf] == UNUSED_LEAF) {

--- a/c++/src/sargs/SearchArgument.cc
+++ b/c++/src/sargs/SearchArgument.cc
@@ -1,0 +1,546 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sargs/SearchArgument.hh"
+
+#include <algorithm>
+#include <functional>
+#include <sstream>
+#include <unordered_set>
+
+namespace orc {
+
+  SearchArgument::~SearchArgument() {
+    // PASS
+  }
+
+  const std::vector<PredicateLeaf>& SearchArgumentImpl::getLeaves() const {
+    return mLeaves;
+  }
+
+  const ExpressionTree * SearchArgumentImpl::getExpression() const {
+    return mExpressionTree.get();
+  }
+
+  TruthValue SearchArgumentImpl::evaluate(
+                                  const std::vector<TruthValue>& leaves) const {
+    return mExpressionTree == nullptr ?
+      TruthValue::YES : mExpressionTree->evaluate(leaves);
+  }
+
+  std::string SearchArgumentImpl::toString() const {
+    std::ostringstream sstream;
+    for (size_t i = 0; i != mLeaves.size(); ++i) {
+      sstream << "leaf-" << i << " = " << mLeaves.at(i).toString() << ", ";
+    }
+    sstream << "expr = " << mExpressionTree->toString();
+    return sstream.str();
+  }
+
+  SearchArgumentBuilder::~SearchArgumentBuilder() {
+    // PASS
+  }
+
+  SearchArgumentBuilderImpl::SearchArgumentBuilderImpl() {
+    mRoot.reset(new ExpressionTree(ExpressionTree::Operator::AND));
+    mCurrTree.push_back(mRoot);
+  }
+
+  SearchArgumentBuilder&
+  SearchArgumentBuilderImpl::start(ExpressionTree::Operator op) {
+    TreeNode node = std::make_shared<ExpressionTree>(op);
+    mCurrTree.front()->addChild(node);
+    mCurrTree.push_front(node);
+    return *this;
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::startOr() {
+    return start(ExpressionTree::Operator::OR);
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::startAnd() {
+    return start(ExpressionTree::Operator::AND);
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::startNot() {
+    return start(ExpressionTree::Operator::NOT);
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::end() {
+    TreeNode& current = mCurrTree.front();
+    mCurrTree.pop_front();
+    if (current->getChildren().empty()) {
+      throw std::invalid_argument("Cannot create expression " +
+        mRoot->toString() + " with no children.");
+    }
+    if (current->getOperator() == ExpressionTree::Operator::NOT &&
+        current->getChildren().size() != 1) {
+      throw std::invalid_argument("Can't create NOT expression " +
+        current->toString() + " with more than 1 child.");
+    }
+    return *this;
+  }
+
+  size_t SearchArgumentBuilderImpl::addLeaf(PredicateLeaf leaf) {
+    size_t id = mLeaves.size();
+    const auto& result = mLeaves.insert(std::make_pair(leaf, id));
+    return result.first->second;
+  }
+
+  SearchArgumentBuilder&
+  SearchArgumentBuilderImpl::compareOperator(PredicateLeaf::Operator op,
+                                             const std::string& column,
+                                             PredicateType type,
+                                             Literal literal) {
+    TreeNode parent = mCurrTree.front();
+    if (column.empty()) {
+      parent->addChild(
+        std::make_shared<ExpressionTree>(TruthValue::YES_NO_NULL));
+    } else {
+      PredicateLeaf leaf(op, type, column, literal);
+      parent->addChild(std::make_shared<ExpressionTree>(addLeaf(leaf)));
+    }
+    return *this;
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::lessThan(
+                                                    const std::string& column,
+                                                    PredicateType type,
+                                                    Literal literal) {
+    return compareOperator(
+      PredicateLeaf::Operator::LESS_THAN, column, type, literal);
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::lessThanEquals(
+                                                    const std::string& column,
+                                                    PredicateType type,
+                                                    Literal literal) {
+    return compareOperator(
+      PredicateLeaf::Operator::LESS_THAN_EQUALS, column, type, literal);
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::equals(
+                                                    const std::string& column,
+                                                    PredicateType type,
+                                                    Literal literal) {
+    if (literal.isNull()) {
+      return isNull(column, type);
+    } else {
+      return compareOperator(
+        PredicateLeaf::Operator::EQUALS, column, type, literal);
+    }
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::nullSafeEquals(
+                                                    const std::string& column,
+                                                    PredicateType type,
+                                                    Literal literal) {
+    return compareOperator(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS, column, type, literal);
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::in(
+                               const std::string& column,
+                               PredicateType type,
+                               const std::initializer_list<Literal>& literals) {
+    TreeNode& parent = mCurrTree.front();
+    if (column.empty()) {
+      parent->addChild(
+        std::make_shared<ExpressionTree>((TruthValue::YES_NO_NULL)));
+    } else {
+      if (literals.size() == 0) {
+        throw std::invalid_argument(
+          "Can't create in expression with no arguments");
+      }
+      PredicateLeaf leaf(
+        PredicateLeaf::Operator::IN, type, column, literals);
+      parent->addChild(std::make_shared<ExpressionTree>(addLeaf(leaf)));
+    }
+    return *this;
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::isNull(
+                                                     const std::string& column,
+                                                     PredicateType type) {
+    TreeNode& parent = mCurrTree.front();
+    if (column.empty()) {
+      parent->addChild(
+        std::make_shared<ExpressionTree>(TruthValue::YES_NO_NULL));
+    } else {
+      PredicateLeaf leaf(PredicateLeaf::Operator::IS_NULL,
+                         type,
+                         column,
+                         {});
+      parent->addChild(std::make_shared<ExpressionTree>(addLeaf(leaf)));
+    }
+    return *this;
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::between(
+                                                      const std::string& column,
+                                                      PredicateType type,
+                                                      Literal lower,
+                                                      Literal upper) {
+    TreeNode& parent = mCurrTree.front();
+    if (column.empty()) {
+      parent->addChild(
+        std::make_shared<ExpressionTree>(TruthValue::YES_NO_NULL));
+    } else {
+      PredicateLeaf leaf(PredicateLeaf::Operator::BETWEEN,
+                         type,
+                         column,
+                         { lower, upper });
+      parent->addChild(std::make_shared<ExpressionTree>(addLeaf(leaf)));
+    }
+    return *this;
+  }
+
+  SearchArgumentBuilder& SearchArgumentBuilderImpl::literal(TruthValue truth) {
+    TreeNode& parent = mCurrTree.front();
+    parent->addChild(std::make_shared<ExpressionTree>(truth));
+    return *this;
+  }
+
+  /**
+   * Recursively explore the tree to find the leaves that are still reachable
+   * after optimizations.
+   * @param tree the node to check next
+   * @param next the next available leaf id
+   * @param leafReorder buffer for leaf reorder
+   * @return the next available leaf id
+   */
+  static size_t compactLeaves(const TreeNode& tree,
+                           size_t next,
+                           size_t leafReorder[]) {
+    if (tree->getOperator() == ExpressionTree::Operator::LEAF) {
+      size_t oldLeaf = tree->getLeaf();
+      if (leafReorder[oldLeaf] == UNUSED_LEAF) {
+        leafReorder[oldLeaf] = next++;
+      }
+    } else {
+      for (const TreeNode& child : tree->getChildren()) {
+        next = compactLeaves(child, next, leafReorder);
+      }
+    }
+    return next;
+  }
+
+  /**
+   * Rewrite expression tree to update the leaves.
+   * @param root the root of the tree to fix
+   * @param leafReorder a map from old leaf ids to new leaf ids
+   * @return the fixed root
+   */
+  static TreeNode rewriteLeaves(TreeNode root, size_t leafReorder[]) {
+    // The leaves could be shared in the tree. Use Set to remove the duplicates.
+    std::unordered_set<TreeNode> leaves;
+    std::deque<TreeNode> nodes;
+    nodes.push_back(root);
+
+    // Perform BFS
+    while (!nodes.empty()) {
+      TreeNode& node = nodes.front();
+      nodes.pop_front();
+
+      if (node->getOperator() == ExpressionTree::Operator::LEAF) {
+        leaves.insert(node);
+      } else {
+        for (auto& child : node->getChildren()) {
+          nodes.push_back(child);
+        }
+      }
+    }
+
+    // Update the leaf in place
+    for (auto& leaf : leaves) {
+      leaf->setLeaf(leafReorder[leaf->getLeaf()]);
+    }
+
+    return root;
+  }
+
+  /**
+   * Push the negations all the way to just before the leaves. Also remove
+   * double negatives.
+   *
+   * @param root the expression to normalize
+   * @return the normalized expression, which may share some or all of the
+   * nodes of the original expression.
+   */
+  TreeNode SearchArgumentBuilderImpl::pushDownNot(TreeNode root) {
+    if (root->getOperator() == ExpressionTree::Operator::NOT) {
+      TreeNode child = root->getChild(0);
+      switch (child->getOperator()) {
+        case ExpressionTree::Operator::NOT: {
+          return pushDownNot(child->getChild(0));
+        }
+        case ExpressionTree::Operator::CONSTANT: {
+          return std::make_shared<ExpressionTree>(!child->getConstant());
+        }
+        case ExpressionTree::Operator::AND: {
+          TreeNode result(new ExpressionTree(ExpressionTree::Operator::OR));
+          for (auto& kid : child->getChildren()) {
+            result->addChild(pushDownNot(std::make_shared<ExpressionTree>(
+                ExpressionTree::Operator::NOT, NodeList{ kid })
+            ));
+          }
+          return result;
+        }
+        case ExpressionTree::Operator::OR: {
+          TreeNode result(new ExpressionTree(ExpressionTree::Operator::AND));
+          for (auto& kid : child->getChildren()) {
+            result->addChild(pushDownNot(std::make_shared<ExpressionTree>(
+                ExpressionTree::Operator::NOT, NodeList{ kid })
+            ));
+          }
+          return result;
+        }
+        // for leaf, we don't do anything
+        case ExpressionTree::Operator::LEAF:
+        default:
+          break;
+      }
+    } else {
+      // iterate through children and push down not for each one
+      for (size_t i = 0; i != root->getChildren().size(); ++i) {
+        root->getChildren()[i] = pushDownNot(root->getChild(i));
+      }
+    }
+    return root;
+  }
+
+  /**
+   * Remove MAYBE values from the expression. If they are in an AND operator,
+   * they are dropped. If they are in an OR operator, they kill their parent.
+   * This assumes that pushDownNot has already been called.
+   *
+   * @param expr The expression to clean up
+   * @return The cleaned up expression
+   */
+  TreeNode SearchArgumentBuilderImpl::foldMaybe(TreeNode expr) {
+    if (expr) {
+      for (size_t i = 0; i != expr->getChildren().size(); ++i) {
+        TreeNode child = foldMaybe(expr->getChild(i));
+        if (child->getOperator() == ExpressionTree::Operator::CONSTANT &&
+            child->getConstant() == TruthValue::YES_NO_NULL) {
+          switch (expr->getOperator()) {
+            case ExpressionTree::Operator::AND:
+              expr->getChildren()[i] = nullptr;
+              break;
+            case ExpressionTree::Operator::OR:
+              // a maybe will kill the or condition
+              return child;
+            case ExpressionTree::Operator::NOT:
+            case ExpressionTree::Operator::LEAF:
+            case ExpressionTree::Operator::CONSTANT:
+            default:
+              throw std::invalid_argument(
+                "Got a maybe as child of " + expr->toString());
+          }
+        } else {
+          expr->getChildren()[i] = child;
+        }
+      }
+
+      auto& children = expr->getChildren();
+      if (!children.empty()) {
+        // eliminate removed maybe nodes from expr
+        std::vector<TreeNode> nodes;
+        std::for_each(children.begin(), children.end(),
+          [&](const TreeNode& node){ if (node) nodes.emplace_back(node); });
+        std::swap(children, nodes);
+        if (children.empty()) {
+          return std::make_shared<ExpressionTree>(TruthValue::YES_NO_NULL);
+        }
+      }
+    }
+    return expr;
+  }
+
+  /**
+   * Converts multi-level ands and ors into single level ones.
+   *
+   * @param root the expression to flatten
+   * @return the flattened expression, which will always be root with
+   *   potentially modified children.
+   */
+   TreeNode SearchArgumentBuilderImpl::flatten(TreeNode root) {
+    if (root) {
+      std::vector<TreeNode> nodes;
+      for (size_t i = 0; i != root->getChildren().size(); ++i) {
+        TreeNode child = flatten(root->getChild(i));
+        // do we need to flatten?
+        if (child->getOperator() == root->getOperator() &&
+            child->getOperator() != ExpressionTree::Operator::NOT) {
+          for (auto& grandkid : child->getChildren()) {
+            nodes.emplace_back(grandkid);
+          }
+        } else {
+          nodes.emplace_back(child);
+        }
+      }
+      std::swap(root->getChildren(), nodes);
+
+      // if we have a single AND or OR, just return the child
+      if ((root->getOperator() == ExpressionTree::Operator::OR ||
+           root->getOperator() == ExpressionTree::Operator::AND) &&
+          root->getChildren().size() == 1) {
+        return root->getChild(0);
+      }
+    }
+    return root;
+  }
+
+  /**
+   * Generate all combinations of items on the andList. For each item on the
+   * andList, it generates all combinations of one child from each and
+   * expression. Thus, (and a b) (and c d) will be expanded to: (or a c)
+   * (or a d) (or b c) (or b d). If there are items on the nonAndList, they
+   * are added to each or expression.
+   * @param result a list to put the results onto
+   * @param andList a list of and expressions
+   * @param nonAndList a list of non-and expressions
+   */
+  static void generateAllCombinations(std::vector<TreeNode>& result,
+                                      const std::vector<TreeNode>& andList,
+                                      const std::vector<TreeNode>& nonAndList) {
+    std::vector<TreeNode>& kids = andList.front()->getChildren();
+    if (result.empty()) {
+      for (TreeNode& kid : kids) {
+        TreeNode root(new ExpressionTree(ExpressionTree::Operator::OR));
+        result.emplace_back(root);
+        for (const TreeNode& node : nonAndList) {
+          root->addChild(std::make_shared<ExpressionTree>(*node));
+        }
+        root->addChild(kid);
+      }
+    } else {
+      std::vector<TreeNode> work(result.begin(), result.end());
+      result.clear();
+      for (TreeNode& kid : kids) {
+        for (TreeNode node : work) {
+          TreeNode copy = std::make_shared<ExpressionTree>(*node);
+          copy->addChild(kid);
+          result.emplace_back(copy);
+        }
+      }
+    }
+    if (andList.size() > 1) {
+      generateAllCombinations(
+        result,
+        std::vector<TreeNode>(andList.cbegin() + 1, andList.cend()),
+        nonAndList);
+    }
+  }
+
+  static const size_t CNF_COMBINATIONS_THRESHOLD = 256;
+  static bool checkCombinationsThreshold(const std::vector<TreeNode>& andList) {
+    size_t numComb = 1;
+    for (const TreeNode& tree : andList) {
+      numComb *= tree->getChildren().size();
+      if (numComb > CNF_COMBINATIONS_THRESHOLD) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Convert an expression so that the top level operator is AND with OR
+   * operators under it. This routine assumes that all of the NOT operators
+   * have been pushed to the leaves via pushdDownNot.
+   * @param root the expression
+   * @return the normalized expression
+   */
+  TreeNode SearchArgumentBuilderImpl::convertToCNF(TreeNode root) {
+    if (root) {
+      // convert all of the children to CNF
+      size_t size = root->getChildren().size();
+      for (size_t i = 0; i != size; ++i) {
+        root->getChildren()[i] = convertToCNF(root->getChild(i));
+      }
+      if (root->getOperator() == ExpressionTree::Operator::OR) {
+        // a list of leaves that weren't under AND expressions
+        std::vector<TreeNode> nonAndList;
+        // a list of AND expressions that we need to distribute
+        std::vector<TreeNode> andList;
+        for (TreeNode& child : root->getChildren()) {
+          if (child->getOperator() == ExpressionTree::Operator::AND) {
+            andList.emplace_back(child);
+          } else if (child->getOperator() == ExpressionTree::Operator::OR) {
+            // pull apart the kids of the OR expression
+            for (TreeNode& grandkid : child->getChildren()) {
+              nonAndList.emplace_back(grandkid);
+            }
+          } else {
+            nonAndList.emplace_back(child);
+          }
+        }
+        if (!andList.empty()) {
+          if (checkCombinationsThreshold(andList)) {
+            root = std::make_shared<ExpressionTree>(
+              ExpressionTree::Operator::AND);
+            generateAllCombinations(root->getChildren(), andList, nonAndList);
+          } else {
+            root = std::make_shared<ExpressionTree>(TruthValue::YES_NO_NULL);
+          }
+        }
+      }
+    }
+    return root;
+  }
+
+  SearchArgumentImpl::SearchArgumentImpl(TreeNode root,
+                                         const std::vector<PredicateLeaf>& leaves)
+                                        : mExpressionTree(root)
+                                        , mLeaves(leaves) {
+    // PASS
+  }
+
+  std::unique_ptr<SearchArgument> SearchArgumentBuilderImpl::build() {
+    if (mCurrTree.size() != 1) {
+      throw std::invalid_argument("Failed to end " +
+        std::to_string(mCurrTree.size()) + " operations.");
+    }
+    mRoot = pushDownNot(mRoot);
+    mRoot = foldMaybe(mRoot);
+    mRoot = flatten(mRoot);
+    mRoot = convertToCNF(mRoot);
+    mRoot = flatten(mRoot);
+    std::vector<size_t> leafReorder(mLeaves.size(), UNUSED_LEAF);
+    size_t newLeafCount = compactLeaves(mRoot, 0, leafReorder.data());
+    mRoot = rewriteLeaves(mRoot, leafReorder.data());
+
+    std::vector<PredicateLeaf> leafList(newLeafCount, PredicateLeaf());
+
+    // build the new list
+    for (auto & leaf : mLeaves) {
+      size_t newLoc = leafReorder[leaf.second];
+      if (newLoc != UNUSED_LEAF) {
+        leafList[newLoc] = leaf.first;
+      }
+    }
+    return std::unique_ptr<SearchArgument>(
+      new SearchArgumentImpl(mRoot, leafList));
+  }
+
+  std::unique_ptr<SearchArgumentBuilder> SearchArgumentFactory::newBuilder() {
+    return std::unique_ptr<SearchArgumentBuilder>(new SearchArgumentBuilderImpl());
+  }
+
+} // namespace orc

--- a/c++/src/sargs/SearchArgument.hh
+++ b/c++/src/sargs/SearchArgument.hh
@@ -1,0 +1,222 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_SRC_SEARCHARGUMENT_HH
+#define ORC_SRC_SEARCHARGUMENT_HH
+
+#include "wrap/orc-proto-wrapper.hh"
+#include "ExpressionTree.hh"
+#include "orc/sargs/SearchArgument.hh"
+#include "sargs/PredicateLeaf.hh"
+
+#include <deque>
+#include <stdexcept>
+#include <unordered_map>
+
+namespace orc {
+
+  /**
+   * Primary interface for a search argument, which are the subset of predicates
+   * that can be pushed down to the RowReader. Each SearchArgument consists
+   * of a series of search clauses that must each be true for the row to be
+   * accepted by the filter.
+   *
+   * This requires that the filter be normalized into conjunctive normal form
+   * (<a href="http://en.wikipedia.org/wiki/Conjunctive_normal_form">CNF</a>).
+   */
+  class SearchArgumentImpl : public SearchArgument {
+  public:
+    SearchArgumentImpl(TreeNode root, const std::vector<PredicateLeaf>& leaves);
+
+    /**
+     * Get the leaf predicates that are required to evaluate the predicate. The
+     * list will have the duplicates removed.
+     * @return the list of leaf predicates
+     */
+    const std::vector<PredicateLeaf>& getLeaves() const;
+
+    /**
+     * Get the expression tree. This should only needed for file formats that
+     * need to translate the expression to an internal form.
+     */
+    const ExpressionTree * getExpression() const;
+
+    /**
+     * Evaluate the entire predicate based on the values for the leaf predicates.
+     * @param leaves the value of each leaf predicate
+     * @return the value of hte entire predicate
+     */
+    TruthValue evaluate(const std::vector<TruthValue>& leaves) const override;
+
+    std::string toString() const override;
+
+  private:
+    std::shared_ptr<ExpressionTree> mExpressionTree;
+    std::vector<PredicateLeaf> mLeaves;
+  };
+
+  /**
+   * A builder object to create a SearchArgument from expressions. The user
+   * must call startOr, startAnd, or startNot before adding any leaves.
+   */
+  class SearchArgumentBuilderImpl : public SearchArgumentBuilder {
+  public:
+    SearchArgumentBuilderImpl();
+
+    /**
+     * Start building an or operation and push it on the stack.
+     * @return this
+     */
+    SearchArgumentBuilder& startOr() override;
+
+    /**
+     * Start building an and operation and push it on the stack.
+     * @return this
+     */
+    SearchArgumentBuilder& startAnd() override;
+
+    /**
+     * Start building a not operation and push it on the stack.
+     * @return this
+     */
+    SearchArgumentBuilder& startNot() override;
+
+    /**
+     * Finish the current operation and pop it off of the stack. Each start
+     * call must have a matching end.
+     * @return this
+     */
+    SearchArgumentBuilder& end() override;
+
+    /**
+     * Add a less than leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    SearchArgumentBuilder& lessThan(const std::string& column,
+                                    PredicateType type,
+                                    Literal literal) override;
+
+    /**
+     * Add a less than equals leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    SearchArgumentBuilder& lessThanEquals(const std::string& column,
+                                          PredicateType type,
+                                          Literal literal) override;
+
+    /**
+     * Add an equals leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    SearchArgumentBuilder& equals(const std::string& column,
+                                  PredicateType type,
+                                  Literal literal) override;
+
+    /**
+     * Add a null safe equals leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literal the literal
+     * @return this
+     */
+    SearchArgumentBuilder& nullSafeEquals(const std::string& column,
+                                          PredicateType type,
+                                          Literal literal) override;
+
+    /**
+     * Add an in leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param literals the literals
+     * @return this
+     */
+    SearchArgumentBuilder& in(const std::string& column,
+                              PredicateType type,
+                              const std::initializer_list<Literal>& literals) override;
+
+    /**
+     * Add an is null leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @return this
+     */
+    SearchArgumentBuilder& isNull(const std::string& column,
+                                  PredicateType type) override;
+
+    /**
+     * Add a between leaf to the current item on the stack.
+     * @param column the name of the column
+     * @param type the type of the expression
+     * @param lower the literal
+     * @param upper the literal
+     * @return this
+     */
+    SearchArgumentBuilder& between(const std::string& column,
+                                   PredicateType type,
+                                   Literal lower,
+                                   Literal upper) override;
+
+    /**
+     * Add a truth value to the expression.
+     * @param truth truth value
+     * @return this
+     */
+    SearchArgumentBuilder& literal(TruthValue truth) override;
+
+    /**
+     * Build and return the SearchArgument that has been defined. All of the
+     * starts must have been ended before this call.
+     * @return the new SearchArgument
+     */
+    std::unique_ptr<SearchArgument> build() override;
+
+  private:
+    SearchArgumentBuilder& start(ExpressionTree::Operator op);
+    size_t addLeaf(PredicateLeaf leaf);
+    SearchArgumentBuilder& compareOperator(PredicateLeaf::Operator op,
+                                           const std::string& column,
+                                           PredicateType type,
+                                           Literal literal);
+
+  public:
+    static TreeNode pushDownNot(TreeNode root);
+    static TreeNode foldMaybe(TreeNode expr);
+    static TreeNode flatten(TreeNode root);
+    static TreeNode convertToCNF(TreeNode root);
+
+  private:
+    std::deque<TreeNode> mCurrTree;
+    std::unordered_map<PredicateLeaf,
+                       size_t,
+                       PredicateLeafHash,
+                       PredicateLeafComparator> mLeaves;
+    std::shared_ptr<ExpressionTree> mRoot;
+  };
+
+} // namespace orc
+
+#endif //ORC_SRC_SEARCHARGUMENT_HH

--- a/c++/src/sargs/SearchArgument.hh
+++ b/c++/src/sargs/SearchArgument.hh
@@ -59,7 +59,7 @@ namespace orc {
     /**
      * Evaluate the entire predicate based on the values for the leaf predicates.
      * @param leaves the value of each leaf predicate
-     * @return the value of hte entire predicate
+     * @return the value of the entire predicate
      */
     TruthValue evaluate(const std::vector<TruthValue>& leaves) const override;
 
@@ -111,7 +111,7 @@ namespace orc {
      * @return this
      */
     SearchArgumentBuilder& lessThan(const std::string& column,
-                                    PredicateType type,
+                                    PredicateDataType type,
                                     Literal literal) override;
 
     /**
@@ -122,7 +122,7 @@ namespace orc {
      * @return this
      */
     SearchArgumentBuilder& lessThanEquals(const std::string& column,
-                                          PredicateType type,
+                                          PredicateDataType type,
                                           Literal literal) override;
 
     /**
@@ -133,7 +133,7 @@ namespace orc {
      * @return this
      */
     SearchArgumentBuilder& equals(const std::string& column,
-                                  PredicateType type,
+                                  PredicateDataType type,
                                   Literal literal) override;
 
     /**
@@ -144,7 +144,7 @@ namespace orc {
      * @return this
      */
     SearchArgumentBuilder& nullSafeEquals(const std::string& column,
-                                          PredicateType type,
+                                          PredicateDataType type,
                                           Literal literal) override;
 
     /**
@@ -155,7 +155,7 @@ namespace orc {
      * @return this
      */
     SearchArgumentBuilder& in(const std::string& column,
-                              PredicateType type,
+                              PredicateDataType type,
                               const std::initializer_list<Literal>& literals) override;
 
     /**
@@ -165,7 +165,7 @@ namespace orc {
      * @return this
      */
     SearchArgumentBuilder& isNull(const std::string& column,
-                                  PredicateType type) override;
+                                  PredicateDataType type) override;
 
     /**
      * Add a between leaf to the current item on the stack.
@@ -176,7 +176,7 @@ namespace orc {
      * @return this
      */
     SearchArgumentBuilder& between(const std::string& column,
-                                   PredicateType type,
+                                   PredicateDataType type,
                                    Literal lower,
                                    Literal upper) override;
 
@@ -199,7 +199,7 @@ namespace orc {
     size_t addLeaf(PredicateLeaf leaf);
     SearchArgumentBuilder& compareOperator(PredicateLeaf::Operator op,
                                            const std::string& column,
-                                           PredicateType type,
+                                           PredicateDataType type,
                                            Literal literal);
 
   public:

--- a/c++/src/sargs/TruthValue.cc
+++ b/c++/src/sargs/TruthValue.cc
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "orc/sargs/TruthValue.hh"
+
+#include <stdexcept>
+
+namespace orc {
+
+  TruthValue operator||(TruthValue left, TruthValue right) {
+    if (right == TruthValue::YES || left == TruthValue::YES) {
+      return TruthValue::YES;
+    }
+    if (right == TruthValue::YES_NULL || left == TruthValue::YES_NULL) {
+      return TruthValue::YES_NULL;
+    }
+    if (right == TruthValue::NO) {
+      return left;
+    }
+    if (left == TruthValue::NO) {
+      return right;
+    }
+    if (left == TruthValue::IS_NULL) {
+      if (right == TruthValue::NO_NULL || right == TruthValue::IS_NULL) {
+        return TruthValue::IS_NULL;
+      } else {
+        return TruthValue::YES_NULL;
+      }
+    }
+    if (right == TruthValue::IS_NULL) {
+      if (left == TruthValue::NO_NULL) {
+        return TruthValue::IS_NULL;
+      } else {
+        return TruthValue::YES_NULL;
+      }
+    }
+    if (left == TruthValue::NO_NULL && right == TruthValue::NO_NULL) {
+      return TruthValue::NO_NULL;
+    }
+    return TruthValue::YES_NO_NULL;
+  }
+
+  TruthValue operator&&(TruthValue left, TruthValue right) {
+    if (right == TruthValue::NO || left == TruthValue::NO) {
+      return TruthValue::NO;
+    }
+    if (right == TruthValue::NO_NULL || left == TruthValue::NO_NULL) {
+      return TruthValue::NO_NULL;
+    }
+    if (right == TruthValue::YES) {
+      return left;
+    }
+    if (left == TruthValue::YES) {
+      return right;
+    }
+    if (left == TruthValue::IS_NULL) {
+      if (right == TruthValue::YES_NULL || right == TruthValue::IS_NULL) {
+        return TruthValue::IS_NULL;
+      } else {
+        return TruthValue::NO_NULL;
+      }
+    }
+    if (right == TruthValue::IS_NULL) {
+      if (left == TruthValue::YES_NULL) {
+        return TruthValue::IS_NULL;
+      } else {
+        return TruthValue::NO_NULL;
+      }
+    }
+    if (left == TruthValue::YES_NULL && right == TruthValue::YES_NULL) {
+      return TruthValue::YES_NULL;
+    }
+    return TruthValue::YES_NO_NULL;
+  }
+
+  TruthValue operator!(TruthValue val) {
+    switch (val) {
+      case TruthValue::NO:
+        return TruthValue::YES;
+      case TruthValue::YES:
+        return TruthValue::NO;
+      case TruthValue::IS_NULL:
+      case TruthValue::YES_NO:
+      case TruthValue::YES_NO_NULL:
+        return val;
+      case TruthValue::NO_NULL:
+        return TruthValue::YES_NULL;
+      case TruthValue::YES_NULL:
+        return TruthValue::NO_NULL;
+      default:
+        throw std::invalid_argument("Unknown TruthValue");
+    }
+  }
+
+  bool isNeeded(TruthValue val) {
+    switch (val) {
+      case TruthValue::NO:
+      case TruthValue::IS_NULL:
+      case TruthValue::NO_NULL:
+        return false;
+      case TruthValue::YES:
+      case TruthValue::YES_NO:
+      case TruthValue::YES_NULL:
+      case TruthValue::YES_NO_NULL:
+      default:
+        return true;
+    }
+  }
+
+}

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -38,10 +38,13 @@ add_executable (orc-test
   TestDictionaryEncoding.cc
   TestDriver.cc
   TestInt128.cc
+  TestPredicateLeaf.cc
   TestReader.cc
   TestRleDecoder.cc
   TestRleEncoder.cc
   TestRLEV2Util.cc
+  TestSargsApplier.cc
+  TestSearchArgument.cc
   TestStripeIndexStatistics.cc
   TestTimestampStatistics.cc
   TestTimezone.cc

--- a/c++/test/TestPredicateLeaf.cc
+++ b/c++/test/TestPredicateLeaf.cc
@@ -252,6 +252,14 @@ namespace orc {
             Literal(1500, 4, 2));
     EXPECT_EQ(TruthValue::YES_NO, evaluate(pred9,
       createDecimalStats(Decimal("10.0"), Decimal("100.0"))));
+
+    PredicateLeaf pred10(
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::LONG,
+            "x",
+            Literal(PredicateDataType::LONG));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred2, createIntStats(50, 100)));
   }
 
   TEST(TestPredicateLeaf, testEquals) {

--- a/c++/test/TestPredicateLeaf.cc
+++ b/c++/test/TestPredicateLeaf.cc
@@ -165,30 +165,30 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testPredEvalWithColStats) {
     PredicateLeaf pred0(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::BOOLEAN,
-      "x",
-      Literal(true));
-    EXPECT_EQ(TruthValue::YES_NO,
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::BOOLEAN,
+            "x",
+            Literal(true));
+    EXPECT_EQ(TruthValue::YES,
               evaluate(pred0, createBooleanStats(10, 10)));
     EXPECT_EQ(TruthValue::NO,
               evaluate(pred0, createBooleanStats(10, 0)));
 
     PredicateLeaf pred1(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::BOOLEAN,
-      "x",
-      Literal(false));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::BOOLEAN,
+            "x",
+            Literal(false));
     EXPECT_EQ(TruthValue::NO,
               evaluate(pred1, createBooleanStats(10, 10)));
-    EXPECT_EQ(TruthValue::YES_NO,
+    EXPECT_EQ(TruthValue::YES,
               evaluate(pred1, createBooleanStats(10, 0)));
 
     PredicateLeaf pred2(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::LONG,
-      "x",
-      Literal(static_cast<int64_t>(15)));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::LONG,
+            "x",
+            Literal(static_cast<int64_t>(15)));
     EXPECT_EQ(TruthValue::YES_NO,
               evaluate(pred2, createIntStats(10, 100)));
     EXPECT_EQ(TruthValue::NO,
@@ -196,70 +196,70 @@ namespace orc {
 
     // delibrately pass column statistics of float type
     PredicateLeaf pred3(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::FLOAT,
-      "x",
-      Literal(1.0));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::FLOAT,
+            "x",
+            Literal(1.0));
     EXPECT_EQ(TruthValue::YES_NO_NULL,
               evaluate(pred3, createIntStats(10, 100)));
 
     PredicateLeaf pred4(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::FLOAT,
-      "x",
-      Literal(15.0));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::FLOAT,
+            "x",
+            Literal(15.0));
     EXPECT_EQ(TruthValue::YES_NO,
               evaluate(pred4, createDoubleStats(10.0, 100.0)));
     EXPECT_EQ(TruthValue::NO,
               evaluate(pred4, createDoubleStats(50.0, 100.0)));
 
     PredicateLeaf pred5(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::STRING,
-      "x",
-      Literal("100", 3));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::STRING,
+            "x",
+            Literal("100", 3));
     EXPECT_EQ(TruthValue::YES_NO,
               evaluate(pred5, createStringStats("10", "1000")));
 
     PredicateLeaf pred6(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::DATE,
-      "x",
-      Literal(PredicateType::DATE, 15));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::DATE,
+            "x",
+            Literal(PredicateDataType::DATE, 15));
     EXPECT_EQ(TruthValue::YES_NO,
               evaluate(pred6, createDateStats(10, 100)));
 
     PredicateLeaf pred7(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::DATE,
-      "x",
-      Literal(PredicateType::DATE, 150));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::DATE,
+            "x",
+            Literal(PredicateDataType::DATE, 150));
     EXPECT_EQ(TruthValue::NO,
               evaluate(pred7, createDateStats(10, 100)));
 
     PredicateLeaf pred8(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::TIMESTAMP,
-      "x",
-      Literal(PredicateType::TIMESTAMP, 500L));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::TIMESTAMP,
+            "x",
+            Literal(PredicateDataType::TIMESTAMP, 500L));
     EXPECT_EQ(TruthValue::NO,
               evaluate(pred8, createTimestampStats(450LL, 490L)));
 
     PredicateLeaf pred9(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::DECIMAL,
-      "x",
-      Literal(1500, 4, 2));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::DECIMAL,
+            "x",
+            Literal(1500, 4, 2));
     EXPECT_EQ(TruthValue::YES_NO, evaluate(pred9,
       createDecimalStats(Decimal("10.0"), Decimal("100.0"))));
   }
 
   TEST(TestPredicateLeaf, testEquals) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::LONG,
-      "x",
-      Literal(static_cast<int64_t>(15)));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::LONG,
+            "x",
+            Literal(static_cast<int64_t>(15)));
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createIntStats(20L, 30L, true)));
     EXPECT_EQ(TruthValue::YES_NO_NULL,
@@ -288,10 +288,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testNullSafeEquals) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::LONG,
-      "x",
-      Literal(static_cast<int64_t>(15)));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::LONG,
+            "x",
+            Literal(static_cast<int64_t>(15)));
     EXPECT_EQ(TruthValue::NO,
               evaluate(pred, createIntStats(20L, 30L, true)));
     EXPECT_EQ(TruthValue::YES_NO,
@@ -308,10 +308,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testLessThan) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::LESS_THAN,
-      PredicateType::LONG,
-      "x",
-      Literal(static_cast<int64_t>(15)));
+            PredicateLeaf::Operator::LESS_THAN,
+            PredicateDataType::LONG,
+            "x",
+            Literal(static_cast<int64_t>(15)));
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createIntStats(20L, 30L, true)));
     EXPECT_EQ(TruthValue::NO_NULL,
@@ -326,10 +326,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testLessThanEquals) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::LESS_THAN_EQUALS,
-      PredicateType::LONG,
-      "x",
-      Literal(static_cast<int64_t>(15)));
+            PredicateLeaf::Operator::LESS_THAN_EQUALS,
+            PredicateDataType::LONG,
+            "x",
+            Literal(static_cast<int64_t>(15)));
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createIntStats(20L, 30L, true)));
     EXPECT_EQ(TruthValue::YES_NO_NULL,
@@ -344,10 +344,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testIn) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::LONG,
-      "x",
-      {Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20))});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::LONG,
+            "x",
+            {Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20))});
     EXPECT_EQ(TruthValue::YES_NULL,
               evaluate(pred, createIntStats(20L, 20L, true)));
     EXPECT_EQ(TruthValue::NO_NULL,
@@ -360,10 +360,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testBetween) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::BETWEEN,
-      PredicateType::LONG,
-      "x",
-      {Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20))});
+            PredicateLeaf::Operator::BETWEEN,
+            PredicateDataType::LONG,
+            "x",
+            {Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20))});
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createIntStats(0L, 5L, true)));
     EXPECT_EQ(TruthValue::NO_NULL,
@@ -381,10 +381,10 @@ namespace orc {
 
     // check with empty predicate list
     PredicateLeaf pred1(
-      PredicateLeaf::Operator::BETWEEN,
-      PredicateType::LONG,
-      "x",
-      {});
+            PredicateLeaf::Operator::BETWEEN,
+            PredicateDataType::LONG,
+            "x",
+            {});
     EXPECT_EQ(TruthValue::YES_NO,
               evaluate(pred1, createIntStats(0L, 5L, true)));
     EXPECT_EQ(TruthValue::YES_NO,
@@ -397,20 +397,20 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testIsNull) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IS_NULL,
-      PredicateType::LONG,
-      "x",
-      {});
+            PredicateLeaf::Operator::IS_NULL,
+            PredicateDataType::LONG,
+            "x",
+            {});
     EXPECT_EQ(TruthValue::YES_NO,
               evaluate(pred, createIntStats(20L, 30L, true)));
   }
 
   TEST(TestPredicateLeaf, testEqualsWithNullInStats) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::STRING,
-      "x",
-      Literal("c", 1));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::STRING,
+            "x",
+            Literal("c", 1));
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createStringStats("d", "e", true)));
     EXPECT_EQ(TruthValue::NO_NULL,
@@ -427,10 +427,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testNullSafeEqualsWithNullInStats) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::STRING,
-      "x",
-      Literal("c", 1));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::STRING,
+            "x",
+            Literal("c", 1));
     EXPECT_EQ(TruthValue::NO,
               evaluate(pred, createStringStats("d", "e", true)));
     EXPECT_EQ(TruthValue::NO,
@@ -447,10 +447,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testLessThanWithNullInStats) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::LESS_THAN,
-      PredicateType::STRING,
-      "x",
-      Literal("c", 1));
+            PredicateLeaf::Operator::LESS_THAN,
+            PredicateDataType::STRING,
+            "x",
+            Literal("c", 1));
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createStringStats("d", "e", true)));
     EXPECT_EQ(TruthValue::YES_NULL,
@@ -467,10 +467,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testLessThanEqualsWithNullInStats) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::LESS_THAN_EQUALS,
-      PredicateType::STRING,
-      "x",
-      Literal("c", 1));
+            PredicateLeaf::Operator::LESS_THAN_EQUALS,
+            PredicateDataType::STRING,
+            "x",
+            Literal("c", 1));
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createStringStats("d", "e", true)));
     EXPECT_EQ(TruthValue::YES_NULL,
@@ -487,10 +487,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testInWithNullInStats) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::STRING,
-      "x",
-      {Literal("c", 1), Literal("f", 1)});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::STRING,
+            "x",
+            {Literal("c", 1), Literal("f", 1)});
     EXPECT_EQ(TruthValue::NO_NULL,
               evaluate(pred, createStringStats("d", "e", true)));
     EXPECT_EQ(TruthValue::NO_NULL,
@@ -507,10 +507,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testBetweenWithNullInStats) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::BETWEEN,
-      PredicateType::STRING,
-      "x",
-      {Literal("c", 1), Literal("f", 1)});
+            PredicateLeaf::Operator::BETWEEN,
+            PredicateDataType::STRING,
+            "x",
+            {Literal("c", 1), Literal("f", 1)});
     EXPECT_EQ(TruthValue::YES_NULL,
               evaluate(pred, createStringStats("d", "e", true)));
     EXPECT_EQ(TruthValue::YES_NULL,
@@ -541,10 +541,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testIsNullWithNullInStats) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IS_NULL,
-      PredicateType::STRING,
-      "x",
-      {});
+            PredicateLeaf::Operator::IS_NULL,
+            PredicateDataType::STRING,
+            "x",
+            {});
     EXPECT_EQ(TruthValue::YES_NO,
               evaluate(pred, createStringStats("c", "d", true)));
     EXPECT_EQ(TruthValue::NO,
@@ -553,10 +553,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testIntNullSafeEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::LONG,
-      "x",
-      Literal(static_cast<int64_t>(15)));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::LONG,
+            "x",
+            Literal(static_cast<int64_t>(15)));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addLong(i);
@@ -570,10 +570,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testIntEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::LONG,
-      "x",
-      Literal(static_cast<int64_t>(15)));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::LONG,
+            "x",
+            Literal(static_cast<int64_t>(15)));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addLong(i);
@@ -587,10 +587,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testIntInBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::LONG,
-      "x",
-      {Literal(static_cast<int64_t>(15)), Literal(static_cast<int64_t>(19))});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::LONG,
+            "x",
+            {Literal(static_cast<int64_t>(15)), Literal(static_cast<int64_t>(19))});
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addLong(i);
@@ -605,10 +605,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDoubleNullSafeEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::FLOAT,
-      "x",
-      Literal(15.0));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::FLOAT,
+            "x",
+            Literal(15.0));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addDouble(static_cast<double>(i));
@@ -622,10 +622,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDoubleEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::FLOAT,
-      "x",
-      Literal(15.0));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::FLOAT,
+            "x",
+            Literal(15.0));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addDouble(static_cast<double>(i));
@@ -639,10 +639,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDoubleInBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::FLOAT,
-      "x",
-      {Literal(15.0), Literal(19.0)});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::FLOAT,
+            "x",
+            {Literal(15.0), Literal(19.0)});
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addDouble(static_cast<double>(i));
@@ -657,10 +657,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testStringEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::STRING,
-      "x",
-      Literal("str_15", 6));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::STRING,
+            "x",
+            Literal("str_15", 6));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       std::string str = "str_" + std::to_string(i);
@@ -675,10 +675,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testStringInBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::STRING,
-      "x",
-      {Literal("str_15", 6), Literal("str_19", 6)});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::STRING,
+            "x",
+            {Literal("str_15", 6), Literal("str_19", 6)});
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       std::string str = "str_" + std::to_string(i);
@@ -696,10 +696,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDateNullSafeEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
-      PredicateType::DATE,
-      "x",
-      Literal(PredicateType::DATE, 15));
+            PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+            PredicateDataType::DATE,
+            "x",
+            Literal(PredicateDataType::DATE, 15));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addLong(i);
@@ -713,10 +713,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDateEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::DATE,
-      "x",
-      Literal(PredicateType::DATE, 15));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::DATE,
+            "x",
+            Literal(PredicateDataType::DATE, 15));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addLong(i);
@@ -730,10 +730,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDateInBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::DATE,
-      "x",
-      {Literal(PredicateType::DATE, 15), Literal(PredicateType::DATE, 19)});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::DATE,
+            "x",
+            {Literal(PredicateDataType::DATE, 15), Literal(PredicateDataType::DATE, 19)});
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       bf.addLong(i);
@@ -750,10 +750,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDecimalEqualsBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::DECIMAL,
-      "x",
-      Literal(15, 2, 0));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::DECIMAL,
+            "x",
+            Literal(15, 2, 0));
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       std::string str = Decimal(i, 0).toString(true);
@@ -770,10 +770,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testDecimalInBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::DECIMAL,
-      "x",
-      {Literal(15, 2, 0), Literal(19, 2, 0)});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::DECIMAL,
+            "x",
+            {Literal(15, 2, 0), Literal(19, 2, 0)});
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       std::string str = Decimal(i, 0).toString(true);
@@ -795,10 +795,10 @@ namespace orc {
 
   TEST(TestPredicateLeaf, testNullsInBloomFilter) {
     PredicateLeaf pred(
-      PredicateLeaf::Operator::IN,
-      PredicateType::DECIMAL,
-      "x",
-      {Literal(15, 2, 0), Literal(19, 2, 0), Literal(PredicateType::DECIMAL)});
+            PredicateLeaf::Operator::IN,
+            PredicateDataType::DECIMAL,
+            "x",
+            {Literal(15, 2, 0), Literal(19, 2, 0), Literal(PredicateDataType::DECIMAL)});
     BloomFilterImpl bf(10000);
     for (int64_t i = 20; i < 1000; i++) {
       std::string str = Decimal(i, 0).toString(true);

--- a/c++/test/TestPredicateLeaf.cc
+++ b/c++/test/TestPredicateLeaf.cc
@@ -1,0 +1,827 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BloomFilter.hh"
+#include "orc/BloomFilter.hh"
+#include "orc/sargs/Literal.hh"
+#include "sargs/PredicateLeaf.cc"
+#include "Statistics.hh"
+#include "wrap/gtest-wrapper.h"
+
+namespace orc {
+
+  TEST(TestPredicateLeaf, testCompareToRangeInt) {
+    EXPECT_EQ(Location::BEFORE, compareToRange(19L, 20L, 40L));
+    EXPECT_EQ(Location::AFTER, compareToRange(41L, 20L, 40L));
+    EXPECT_EQ(Location::MIN, compareToRange(20L, 20L, 40L));
+    EXPECT_EQ(Location::MIDDLE, compareToRange(21L, 20L, 40L));
+    EXPECT_EQ(Location::MAX, compareToRange(40L, 20L, 40L));
+    EXPECT_EQ(Location::BEFORE, compareToRange(0L, 1L, 1L));
+    EXPECT_EQ(Location::MIN, compareToRange(1L, 1L, 1L));
+    EXPECT_EQ(Location::AFTER, compareToRange(2L, 1L, 1L));
+  }
+
+  TEST(TestPredicateLeaf, testCompareToRangeString) {
+    EXPECT_EQ(Location::BEFORE, compareToRange(
+      std::string("a"), std::string("b"), std::string("c")));
+    EXPECT_EQ(Location::AFTER,compareToRange(
+      std::string("d"), std::string("b"), std::string("c")));
+    EXPECT_EQ(Location::MIN,compareToRange(
+      std::string("b"), std::string("b"), std::string("c")));
+    EXPECT_EQ(Location::MIDDLE,compareToRange(
+      std::string("bb"), std::string("b"), std::string("c")));
+    EXPECT_EQ(Location::MAX,compareToRange(
+      std::string("c"), std::string("b"), std::string("c")));
+    EXPECT_EQ(Location::BEFORE,compareToRange(
+      std::string("a"), std::string("b"), std::string("b")));
+    EXPECT_EQ(Location::MIN,compareToRange(
+      std::string("b"), std::string("b"), std::string("b")));
+    EXPECT_EQ(Location::AFTER,compareToRange(
+      std::string("c"), std::string("b"), std::string("b")));
+  }
+
+  TEST(TestPredicateLeaf, testCompareToCharNeedConvert) {
+    EXPECT_EQ(Location::BEFORE, compareToRange(
+      std::string("apple"), std::string("hello"), std::string("world")));
+    EXPECT_EQ(Location::AFTER,compareToRange(
+      std::string("zombie"), std::string("hello"), std::string("world")));
+    EXPECT_EQ(Location::MIN,compareToRange(
+      std::string("hello"), std::string("hello"), std::string("world")));
+    EXPECT_EQ(Location::MIDDLE,compareToRange(
+      std::string("pilot"), std::string("hello"), std::string("world")));
+    EXPECT_EQ(Location::MAX,compareToRange(
+      std::string("world"), std::string("hello"), std::string("world")));
+    EXPECT_EQ(Location::BEFORE,compareToRange(
+      std::string("apple"), std::string("hello"), std::string("hello")));
+    EXPECT_EQ(Location::MIN,compareToRange(
+      std::string("hello"), std::string("hello"), std::string("hello")));
+    EXPECT_EQ(Location::AFTER,compareToRange(
+      std::string("zombie"), std::string("hello"), std::string("hello")));
+  }
+
+  static proto::ColumnStatistics createBooleanStats(
+    uint64_t n, uint64_t trueCount, bool hasNull = false) {
+    proto::ColumnStatistics colStats;
+    colStats.set_hasnull(hasNull);
+    colStats.set_numberofvalues(n);
+
+    proto::BucketStatistics * boolStats = colStats.mutable_bucketstatistics();
+    boolStats->add_count(trueCount);
+    return colStats;
+  }
+
+  static proto::ColumnStatistics createIntStats(
+    int64_t min, int64_t max, bool hasNull = false) {
+    proto::ColumnStatistics colStats;
+    colStats.set_hasnull(hasNull);
+    colStats.set_numberofvalues(10);
+
+    proto::IntegerStatistics * intStats = colStats.mutable_intstatistics();
+    intStats->set_minimum(min);
+    intStats->set_maximum(max);
+    return colStats;
+  }
+
+  static proto::ColumnStatistics createDoubleStats(
+    double min, double max, bool hasNull = false) {
+    proto::ColumnStatistics colStats;
+    colStats.set_hasnull(hasNull);
+    colStats.set_numberofvalues(10);
+
+    proto::DoubleStatistics * doubleStats = colStats.mutable_doublestatistics();
+    doubleStats->set_minimum(min);
+    doubleStats->set_maximum(max);
+    return colStats;
+  }
+
+  static proto::ColumnStatistics createDecimalStats(
+    Decimal min, Decimal max, bool hasNull = false) {
+    proto::ColumnStatistics colStats;
+    colStats.set_hasnull(hasNull);
+    colStats.set_numberofvalues(10);
+
+    proto::DecimalStatistics * decimalStats = colStats.mutable_decimalstatistics();
+    decimalStats->set_minimum(min.toString(true));
+    decimalStats->set_maximum(max.toString(true));
+    return colStats;
+  }
+
+  static proto::ColumnStatistics createDateStats(
+    int32_t min, int32_t max, bool hasNull = false) {
+    proto::ColumnStatistics colStats;
+    colStats.set_hasnull(hasNull);
+    colStats.set_numberofvalues(10);
+
+    proto::DateStatistics * dateStats = colStats.mutable_datestatistics();
+    dateStats->set_minimum(min);
+    dateStats->set_maximum(max);
+    return colStats;
+  }
+
+  static proto::ColumnStatistics createTimestampStats(
+    int64_t min, int64_t max, bool hasNull = false) {
+    proto::ColumnStatistics colStats;
+    colStats.set_hasnull(hasNull);
+    colStats.set_numberofvalues(10);
+
+    proto::TimestampStatistics * tsStats = colStats.mutable_timestampstatistics();
+    tsStats->set_minimumutc(min);
+    tsStats->set_maximumutc(max);
+    return colStats;
+  }
+
+  static proto::ColumnStatistics createStringStats(
+    std::string min, std::string max, bool hasNull = false) {
+    proto::ColumnStatistics colStats;
+    colStats.set_hasnull(hasNull);
+    colStats.set_numberofvalues(10);
+
+    proto::StringStatistics * strStats = colStats.mutable_stringstatistics();
+    strStats->set_minimum(min);
+    strStats->set_maximum(max);
+    return colStats;
+  }
+
+  static TruthValue evaluate(const PredicateLeaf& pred,
+                             const proto::ColumnStatistics& pbStats,
+                             const BloomFilter * bf = nullptr) {
+    return pred.evaluate(WriterVersion_ORC_135, pbStats, bf);
+  }
+
+  TEST(TestPredicateLeaf, testPredEvalWithColStats) {
+    PredicateLeaf pred0(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::BOOLEAN,
+      "x",
+      Literal(true));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred0, createBooleanStats(10, 10)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred0, createBooleanStats(10, 0)));
+
+    PredicateLeaf pred1(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::BOOLEAN,
+      "x",
+      Literal(false));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred1, createBooleanStats(10, 10)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred1, createBooleanStats(10, 0)));
+
+    PredicateLeaf pred2(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::LONG,
+      "x",
+      Literal(static_cast<int64_t>(15)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred2, createIntStats(10, 100)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred2, createIntStats(50, 100)));
+
+    // delibrately pass column statistics of float type
+    PredicateLeaf pred3(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::FLOAT,
+      "x",
+      Literal(1.0));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred3, createIntStats(10, 100)));
+
+    PredicateLeaf pred4(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::FLOAT,
+      "x",
+      Literal(15.0));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred4, createDoubleStats(10.0, 100.0)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred4, createDoubleStats(50.0, 100.0)));
+
+    PredicateLeaf pred5(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::STRING,
+      "x",
+      Literal("100", 3));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred5, createStringStats("10", "1000")));
+
+    PredicateLeaf pred6(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::DATE,
+      "x",
+      Literal(PredicateType::DATE, 15));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred6, createDateStats(10, 100)));
+
+    PredicateLeaf pred7(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::DATE,
+      "x",
+      Literal(PredicateType::DATE, 150));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred7, createDateStats(10, 100)));
+
+    PredicateLeaf pred8(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::TIMESTAMP,
+      "x",
+      Literal(PredicateType::TIMESTAMP, 500L));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred8, createTimestampStats(450LL, 490L)));
+
+    PredicateLeaf pred9(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::DECIMAL,
+      "x",
+      Literal(1500, 4, 2));
+    EXPECT_EQ(TruthValue::YES_NO, evaluate(pred9,
+      createDecimalStats(Decimal("10.0"), Decimal("100.0"))));
+  }
+
+  TEST(TestPredicateLeaf, testEquals) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::LONG,
+      "x",
+      Literal(static_cast<int64_t>(15)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(20L, 30L, true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(15L, 30L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10L, 30L, true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10L, 15L, true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(0L, 10L, true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(15L, 15L, true)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createIntStats(20L, 30L)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(15L, 30L))) ;
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(10L, 30L)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(10L, 15L)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createIntStats(0L, 10L)));
+    EXPECT_EQ(TruthValue::YES,
+              evaluate(pred, createIntStats(15L, 15L)));
+  }
+
+  TEST(TestPredicateLeaf, testNullSafeEquals) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::LONG,
+      "x",
+      Literal(static_cast<int64_t>(15)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createIntStats(20L, 30L, true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(15L, 30L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(10L, 30L, true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(10L, 15L, true)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createIntStats(0L, 10L, true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(15L, 15L, true)));
+  }
+
+  TEST(TestPredicateLeaf, testLessThan) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::LESS_THAN,
+      PredicateType::LONG,
+      "x",
+      Literal(static_cast<int64_t>(15)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(20L, 30L, true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(15L, 30L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10L, 30L, true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10L, 15L, true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(0L, 10L, true)));
+  }
+
+  TEST(TestPredicateLeaf, testLessThanEquals) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::LESS_THAN_EQUALS,
+      PredicateType::LONG,
+      "x",
+      Literal(static_cast<int64_t>(15)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(20L, 30L, true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(15L, 30L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10L, 30L, true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(10L, 15L, true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(0L, 10L, true)));
+  }
+
+  TEST(TestPredicateLeaf, testIn) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::LONG,
+      "x",
+      {Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20))});
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(20L, 20L, true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(30L, 30L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10L, 30L, true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(12L, 18L, true)));
+  }
+
+  TEST(TestPredicateLeaf, testBetween) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::BETWEEN,
+      PredicateType::LONG,
+      "x",
+      {Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20))});
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(0L, 5L, true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(30L, 40L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(5L, 15L, true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(15L, 25L, true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(5L, 25L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(10L, 20L, true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(12L, 18L, true)));
+
+    // check with empty predicate list
+    PredicateLeaf pred1(
+      PredicateLeaf::Operator::BETWEEN,
+      PredicateType::LONG,
+      "x",
+      {});
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred1, createIntStats(0L, 5L, true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred1, createIntStats(30L, 40L, true))) ;
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred1, createIntStats(5L, 15L, true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred1, createIntStats(10L, 20L, true)));
+  }
+
+  TEST(TestPredicateLeaf, testIsNull) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IS_NULL,
+      PredicateType::LONG,
+      "x",
+      {});
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(20L, 30L, true)));
+  }
+
+  TEST(TestPredicateLeaf, testEqualsWithNullInStats) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::STRING,
+      "x",
+      Literal("c", 1));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("d", "e", true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("a", "b", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("b", "c", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("c", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("b", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("c", "c", true)));
+  }
+
+  TEST(TestPredicateLeaf, testNullSafeEqualsWithNullInStats) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::STRING,
+      "x",
+      Literal("c", 1));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createStringStats("d", "e", true)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createStringStats("a", "b", true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createStringStats("b", "c", true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createStringStats("c", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createStringStats("b", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createStringStats("c", "c", true)));
+  }
+
+  TEST(TestPredicateLeaf, testLessThanWithNullInStats) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::LESS_THAN,
+      PredicateType::STRING,
+      "x",
+      Literal("c", 1));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("d", "e", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("a", "b", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("b", "c", true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("c", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("b", "d", true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("c", "c", true)));
+  }
+
+  TEST(TestPredicateLeaf, testLessThanEqualsWithNullInStats) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::LESS_THAN_EQUALS,
+      PredicateType::STRING,
+      "x",
+      Literal("c", 1));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("d", "e", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("a", "b", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("b", "c", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("c", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("b", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("c", "c", true)));
+  }
+
+  TEST(TestPredicateLeaf, testInWithNullInStats) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::STRING,
+      "x",
+      {Literal("c", 1), Literal("f", 1)});
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("d", "e", true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("a", "b", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("e", "f", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("c", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("b", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("c", "c", true)));
+  }
+
+  TEST(TestPredicateLeaf, testBetweenWithNullInStats) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::BETWEEN,
+      PredicateType::STRING,
+      "x",
+      {Literal("c", 1), Literal("f", 1)});
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("d", "e", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("e", "f", true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("h", "g", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("f", "g", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("e", "g", true)));
+
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("c", "e", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("c", "f", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("c", "g", true)));
+
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("a", "b", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("a", "c", true)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("b", "d", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("c", "c", true)));
+  }
+
+  TEST(TestPredicateLeaf, testIsNullWithNullInStats) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IS_NULL,
+      PredicateType::STRING,
+      "x",
+      {});
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createStringStats("c", "d", true)));
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createStringStats("c", "d", false)));
+  }
+
+  TEST(TestPredicateLeaf, testIntNullSafeEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::LONG,
+      "x",
+      Literal(static_cast<int64_t>(15)));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addLong(i);
+    }
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createIntStats(10, 100), &bf));
+    bf.addLong(15);
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(10, 100), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testIntEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::LONG,
+      "x",
+      Literal(static_cast<int64_t>(15)));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addLong(i);
+    }
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(10, 100, true), &bf));
+    bf.addLong(15);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10, 100, true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testIntInBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::LONG,
+      "x",
+      {Literal(static_cast<int64_t>(15)), Literal(static_cast<int64_t>(19))});
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addLong(i);
+    }
+    bf.addLong(19);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10, 100, true), &bf));
+    bf.addLong(15);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10, 100, true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDoubleNullSafeEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::FLOAT,
+      "x",
+      Literal(15.0));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addDouble(static_cast<double>(i));
+    }
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createIntStats(10.0, 100.0, true), &bf));
+    bf.addDouble(15.0);
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createIntStats(10.0, 100.0, true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDoubleEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::FLOAT,
+      "x",
+      Literal(15.0));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addDouble(static_cast<double>(i));
+    }
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(10.0, 100.0, true), &bf));
+    bf.addDouble(15.0);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10.0, 100.0, true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDoubleInBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::FLOAT,
+      "x",
+      {Literal(15.0), Literal(19.0)});
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addDouble(static_cast<double>(i));
+    }
+    bf.addDouble(19.0);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10.0, 100.0, true), &bf));
+    bf.addDouble(15.0);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createIntStats(10.0, 100.0, true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testStringEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::STRING,
+      "x",
+      Literal("str_15", 6));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      std::string str = "str_" + std::to_string(i);
+      bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    }
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("str_10", "str_200", true), &bf));
+    bf.addBytes("str_15", 6);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createStringStats("str_10", "str_200", true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testStringInBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::STRING,
+      "x",
+      {Literal("str_15", 6), Literal("str_19", 6)});
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      std::string str = "str_" + std::to_string(i);
+      bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    }
+    EXPECT_EQ(TruthValue::NO_NULL, evaluate(pred,
+      createStringStats("str_10", "str_200", true), &bf));
+    bf.addBytes("str_19", 6);
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createStringStats("str_10", "str_200", true), &bf));
+    bf.addBytes("str_15", 6);
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createStringStats("str_10", "str_200", true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDateNullSafeEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::NULL_SAFE_EQUALS,
+      PredicateType::DATE,
+      "x",
+      Literal(PredicateType::DATE, 15));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addLong(i);
+    }
+    EXPECT_EQ(TruthValue::NO,
+              evaluate(pred, createDateStats(10, 100), &bf));
+    bf.addLong(15);
+    EXPECT_EQ(TruthValue::YES_NO,
+              evaluate(pred, createDateStats(10.0, 100.0), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDateEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::DATE,
+      "x",
+      Literal(PredicateType::DATE, 15));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addLong(i);
+    }
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createDateStats(10, 100, true), &bf));
+    bf.addLong(15);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createDateStats(10.0, 100.0, true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDateInBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::DATE,
+      "x",
+      {Literal(PredicateType::DATE, 15), Literal(PredicateType::DATE, 19)});
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      bf.addLong(i);
+    }
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createDateStats(10, 100, true), &bf));
+    bf.addLong(19);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createDateStats(10.0, 100.0, true), &bf));
+    bf.addLong(15);
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+              evaluate(pred, createDateStats(10.0, 100.0, true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDecimalEqualsBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::DECIMAL,
+      "x",
+      Literal(15, 2, 0));
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      std::string str = Decimal(i, 0).toString(true);
+      bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    }
+    EXPECT_EQ(TruthValue::NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("100"), true), &bf));
+
+    std::string str = Decimal(15, 0).toString();
+    bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("100"), true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testDecimalInBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::DECIMAL,
+      "x",
+      {Literal(15, 2, 0), Literal(19, 2, 0)});
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      std::string str = Decimal(i, 0).toString(true);
+      bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    }
+    EXPECT_EQ(TruthValue::NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("100"), true), &bf));
+
+    std::string str = Decimal(15, 0).toString();
+    bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("100"), true), &bf));
+
+    str = Decimal(19, 0).toString();
+    bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("100"), true), &bf));
+  }
+
+  TEST(TestPredicateLeaf, testNullsInBloomFilter) {
+    PredicateLeaf pred(
+      PredicateLeaf::Operator::IN,
+      PredicateType::DECIMAL,
+      "x",
+      {Literal(15, 2, 0), Literal(19, 2, 0), Literal(PredicateType::DECIMAL)});
+    BloomFilterImpl bf(10000);
+    for (int64_t i = 20; i < 1000; i++) {
+      std::string str = Decimal(i, 0).toString(true);
+      bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    }
+
+    // hasNull is false, so bloom filter should return NO
+    EXPECT_EQ(TruthValue::NO, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("200"), false), &bf));
+
+    // hasNull is true, so bloom filter should return YES_NO_NULL
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("200"), true), &bf));
+
+    std::string str = Decimal(19, 0).toString();
+    bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("200"), true), &bf));
+
+    str = Decimal(15, 0).toString();
+    bf.addBytes(str.c_str(), static_cast<int64_t>(str.size()));
+    EXPECT_EQ(TruthValue::YES_NO_NULL, evaluate(
+      pred, createDecimalStats(Decimal("10"), Decimal("200"), true), &bf));
+  }
+
+}  // namespace orc

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sargs/SargsApplier.hh"
+#include "wrap/gtest-wrapper.h"
+
+namespace orc {
+
+  TEST(TestSargsApplier, findColumnTest) {
+    auto type = std::unique_ptr<Type>(Type::buildTypeFromString(
+      "struct<a:int,c:string,e:struct<f:bigint,g:double>>"));
+    EXPECT_EQ(1, SargsApplier::findColumn(*type, "a"));
+    EXPECT_EQ(2, SargsApplier::findColumn(*type, "c"));
+    EXPECT_EQ(3, SargsApplier::findColumn(*type, "e"));
+    EXPECT_EQ(4, SargsApplier::findColumn(*type, "f"));
+    EXPECT_EQ(5, SargsApplier::findColumn(*type, "g"));
+    EXPECT_EQ(std::numeric_limits<uint64_t>::max(),
+      SargsApplier::findColumn(*type, "b"));
+  }
+
+  static proto::ColumnStatistics createIntStats(
+    int64_t min, int64_t max, bool hasNull = false) {
+    proto::ColumnStatistics statistics;
+    statistics.set_hasnull(hasNull);
+    auto intStats = statistics.mutable_intstatistics();
+    intStats->set_minimum(min);
+    intStats->set_maximum(max);
+    return statistics;
+  }
+
+  TEST(TestSargsApplier, testPickRowGroups) {
+    auto type = std::unique_ptr<Type>(
+      Type::buildTypeFromString("struct<x:int,y:int>"));
+    auto sarg = SearchArgumentFactory::newBuilder()
+      ->startAnd()
+      .equals(
+        "x",
+        PredicateType::LONG,
+        Literal(static_cast<int64_t>(100)))
+      .equals(
+        "y",
+        PredicateType::LONG,
+        Literal(static_cast<int64_t>(10)))
+      .end()
+      .build();
+
+    // prepare row group column statistics
+    std::unordered_map<uint64_t, proto::RowIndex> rowIndexes;
+    // col 1
+    proto::RowIndex rowIndex1;
+    *rowIndex1.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(0L, 10L);
+    *rowIndex1.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(100L, 200L);
+    *rowIndex1.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(300L, 500L);
+    *rowIndex1.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(100L, 100L);
+    rowIndexes[1] = rowIndex1;
+
+    // col 2
+    proto::RowIndex rowIndex2;
+    *rowIndex2.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(0L, 9L);
+    *rowIndex2.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(11L, 20L);
+    *rowIndex2.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(10L, 10L);
+    *rowIndex2.mutable_entry()->Add()->mutable_statistics() =
+      createIntStats(0L, 100LL);
+    rowIndexes[2] = rowIndex2;
+
+    // evaluate row group index
+    SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
+    EXPECT_TRUE(applier.pickRowGroups(4000, rowIndexes, {}));
+    std::vector<bool> rowgroups = applier.getRowGroups();
+    EXPECT_EQ(4, rowgroups.size());
+    EXPECT_EQ(false, rowgroups[0]);
+    EXPECT_EQ(false, rowgroups[1]);
+    EXPECT_EQ(false, rowgroups[2]);
+    EXPECT_EQ(true, rowgroups[3]);
+  }
+
+}  // namespace orc

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -49,13 +49,13 @@ namespace orc {
     auto sarg = SearchArgumentFactory::newBuilder()
       ->startAnd()
       .equals(
-        "x",
-        PredicateType::LONG,
-        Literal(static_cast<int64_t>(100)))
+              "x",
+              PredicateDataType::LONG,
+              Literal(static_cast<int64_t>(100)))
       .equals(
-        "y",
-        PredicateType::LONG,
-        Literal(static_cast<int64_t>(10)))
+              "y",
+              PredicateDataType::LONG,
+              Literal(static_cast<int64_t>(10)))
       .end()
       .build();
 

--- a/c++/test/TestSearchArgument.cc
+++ b/c++/test/TestSearchArgument.cc
@@ -1,0 +1,524 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sargs/SearchArgument.hh"
+#include "wrap/gtest-wrapper.h"
+
+#include <unordered_set>
+
+namespace orc {
+
+  TEST(TestSearchArgument, literalTest) {
+    Literal literal0(static_cast<int64_t>(1234));
+    EXPECT_EQ(PredicateType::LONG, literal0.getType());
+    EXPECT_TRUE("1234" == literal0.toString());
+    EXPECT_EQ(1234, literal0.getHashCode());
+
+    Literal literal1(0.1234);
+    EXPECT_EQ(PredicateType::FLOAT, literal1.getType());
+    EXPECT_TRUE("0.1234" == literal1.toString());
+
+    Literal literal2(false);
+    EXPECT_EQ(PredicateType::BOOLEAN, literal2.getType());
+    EXPECT_TRUE("false" == literal2.toString());
+
+    Literal literal3(PredicateType::TIMESTAMP, 123456L);
+    EXPECT_EQ(PredicateType::TIMESTAMP, literal3.getType());
+    EXPECT_TRUE("123456" == literal3.toString());
+
+    Literal literal4(Int128(54321), 6, 2);
+    EXPECT_EQ(PredicateType::DECIMAL, literal4.getType());
+    EXPECT_TRUE("543.21" == literal4.toString());
+
+    Literal literal5("test", 4);
+    EXPECT_EQ(PredicateType::STRING, literal5.getType());
+    EXPECT_TRUE("test" == literal5.toString());
+
+    Literal left(static_cast<int64_t>(123)), right(static_cast<int64_t>(123));
+    EXPECT_TRUE(left == right);
+    EXPECT_FALSE(left != right);
+    Literal left2(static_cast<int64_t>(321));
+    EXPECT_TRUE(left2 != right);
+    EXPECT_FALSE(left2 == right);
+  }
+
+  TEST(TestSearchArgument, predicateLeafTest) {
+    PredicateLeaf leaf1(
+      PredicateLeaf::Operator::EQUALS,
+      PredicateType::LONG,
+      "id",
+      Literal(static_cast<int64_t>(1234)));
+    EXPECT_EQ(PredicateLeaf::Operator::EQUALS, leaf1.getOperator());
+    EXPECT_EQ(PredicateType::LONG, leaf1.getType());
+    EXPECT_EQ("id", leaf1.getColumnName());
+    EXPECT_EQ("(id = 1234)", leaf1.toString());
+
+    const char * str1 = "aaa", * str2 = "zzz";
+    PredicateLeaf leaf2(
+      PredicateLeaf::Operator::BETWEEN,
+      PredicateType::STRING,
+      "name",
+      { Literal(str1, 3), Literal(str2, 3)});
+    EXPECT_EQ(PredicateLeaf::Operator::BETWEEN, leaf2.getOperator());
+    EXPECT_EQ(PredicateType::STRING, leaf2.getType());
+    EXPECT_EQ("name", leaf2.getColumnName());
+    EXPECT_EQ("(name between [aaa, zzz])", leaf2.toString());
+
+    PredicateLeaf leaf3(leaf2);
+    EXPECT_TRUE(leaf2 == leaf3);
+    EXPECT_FALSE(leaf1 == leaf3);
+
+    PredicateLeaf leaf4(
+      PredicateLeaf::Operator::LESS_THAN_EQUALS,
+      PredicateType::DECIMAL,
+      "sales",
+      { Literal(111222, 6, 3) });
+    EXPECT_EQ(PredicateLeaf::Operator::LESS_THAN_EQUALS, leaf4.getOperator());
+    EXPECT_EQ(PredicateType::DECIMAL, leaf4.getType());
+    EXPECT_EQ("(sales <= 111.222)", leaf4.toString());
+  }
+
+  TEST(TestSearchArgument, truthValueTest) {
+    EXPECT_EQ(TruthValue::YES, TruthValue::YES && TruthValue::YES);
+    EXPECT_EQ(TruthValue::NO, TruthValue::YES && TruthValue::NO);
+    EXPECT_EQ(TruthValue::IS_NULL, TruthValue::YES && TruthValue::IS_NULL);
+    EXPECT_EQ(TruthValue::YES_NULL, TruthValue::YES && TruthValue::YES_NULL);
+
+    EXPECT_EQ(TruthValue::NO, TruthValue::NO || TruthValue::NO);
+    EXPECT_EQ(TruthValue::YES, TruthValue::YES || TruthValue::NO);
+
+    EXPECT_EQ(TruthValue::YES, !TruthValue::NO);
+  }
+
+  static TreeNode _not(TreeNode arg) {
+    return std::make_shared<ExpressionTree>(ExpressionTree::Operator::NOT,
+      NodeList{arg});
+  }
+
+  static TreeNode _and(NodeList args) {
+    return std::make_shared<ExpressionTree>(ExpressionTree::Operator::AND, args);
+  }
+
+  static TreeNode _and(TreeNode l, TreeNode r) {
+    return std::make_shared<ExpressionTree>(
+      ExpressionTree::Operator::AND, NodeList{l, r});
+  }
+
+  static TreeNode _or(NodeList args) {
+    return std::make_shared<ExpressionTree>(ExpressionTree::Operator::OR, args);
+  }
+
+  static TreeNode _or(TreeNode l, TreeNode r) {
+    return std::make_shared<ExpressionTree>(
+      ExpressionTree::Operator::OR, NodeList{l, r});
+  }
+
+  static TreeNode _leaf(int leaf) {
+    return std::make_shared<ExpressionTree>(leaf);
+  }
+
+  static TreeNode _constant(TruthValue val) {
+    return std::make_shared<ExpressionTree>(val);
+  }
+
+  TEST(TestSearchArgument, testNotPushdown) {
+    EXPECT_EQ("leaf-1",
+              SearchArgumentBuilderImpl::pushDownNot(_leaf(1))->toString());
+    EXPECT_EQ("(not leaf-1)",
+              SearchArgumentBuilderImpl::pushDownNot(_not(_leaf(1)))->toString());
+    EXPECT_EQ("leaf-1",
+              SearchArgumentBuilderImpl::pushDownNot(_not(_not(_leaf(1))))
+                ->toString());
+    EXPECT_EQ("(not leaf-1)",
+              SearchArgumentBuilderImpl::pushDownNot(_not(_not(_not(_leaf(1)))))->
+                toString());
+    EXPECT_EQ("(or leaf-1 (not leaf-2))",
+              SearchArgumentBuilderImpl::pushDownNot(_not(_and(_not(_leaf(1)),
+                                                             _leaf(2))))->toString());
+    EXPECT_EQ("(and (not leaf-1) leaf-2)",
+              SearchArgumentBuilderImpl::pushDownNot(_not(_or(_leaf(1),
+                                                            _not(_leaf(2)))))->toString());
+    EXPECT_EQ("(or (or (not leaf-1) leaf-2) leaf-3)",
+              SearchArgumentBuilderImpl::pushDownNot(_or(_not(_and(_leaf(1),
+                                                                 _not(_leaf(2)))),
+                                                       _not(_not(_leaf(3)))))->toString());
+    EXPECT_EQ("NO", SearchArgumentBuilderImpl::pushDownNot(
+      _not(_constant(TruthValue::YES)))->toString());
+    EXPECT_EQ("YES", SearchArgumentBuilderImpl::pushDownNot(
+      _not(_constant(TruthValue::NO)))->toString());
+    EXPECT_EQ("IS_NULL", SearchArgumentBuilderImpl::pushDownNot(
+      _not(_constant(TruthValue::IS_NULL)))->toString());
+    EXPECT_EQ("YES_NO", SearchArgumentBuilderImpl::pushDownNot(
+      _not(_constant(TruthValue::YES_NO)))->toString());
+    EXPECT_EQ("YES_NULL", SearchArgumentBuilderImpl::pushDownNot(
+      _not(_constant(TruthValue::NO_NULL)))->toString());
+    EXPECT_EQ("NO_NULL", SearchArgumentBuilderImpl::pushDownNot(
+      _not(_constant(TruthValue::YES_NULL)))->toString());
+    EXPECT_EQ("YES_NO_NULL", SearchArgumentBuilderImpl::pushDownNot(
+      _not(_constant(TruthValue::YES_NO_NULL)))->toString());
+  }
+
+  TEST(TestSearchArgument, testFlatten) {
+    EXPECT_EQ("leaf-1",
+              SearchArgumentBuilderImpl::flatten(_leaf(1))->toString());
+    EXPECT_EQ("NO",
+              SearchArgumentBuilderImpl::flatten(_constant(TruthValue::NO))->toString());
+    EXPECT_EQ("(not (not leaf-1))",
+              SearchArgumentBuilderImpl::flatten(_not(_not(_leaf(1))))->toString());
+    EXPECT_EQ("(and leaf-1 leaf-2)",
+              SearchArgumentBuilderImpl::flatten(_and(_leaf(1), _leaf(2)))->toString());
+    EXPECT_EQ("(and (or leaf-1 leaf-2) leaf-3)",
+              SearchArgumentBuilderImpl::flatten(_and(_or(_leaf(1), _leaf(2)), _leaf(3))
+              )->toString());
+    EXPECT_EQ("(and leaf-1 leaf-2 leaf-3 leaf-4)",
+              SearchArgumentBuilderImpl::flatten(_and(_and(_leaf(1), _leaf(2)),
+                                                    _and(_leaf(3), _leaf(4))))->toString());
+    EXPECT_EQ("(or leaf-1 leaf-2 leaf-3 leaf-4)",
+              SearchArgumentBuilderImpl::flatten(
+                _or(_leaf(1), _or(_leaf(2), _or(_leaf(3), _leaf(4)))))->toString());
+    EXPECT_EQ("(or leaf-1 leaf-2 leaf-3 leaf-4)",
+              SearchArgumentBuilderImpl::flatten(
+                _or(_or(_or(_leaf(1), _leaf(2)), _leaf(3)), _leaf(4)))->toString());
+    EXPECT_EQ("(or leaf-1 leaf-2 leaf-3 leaf-4 leaf-5 leaf-6)",
+              SearchArgumentBuilderImpl::flatten(
+                _or(_or(_leaf(1), _or(_leaf(2), _leaf(3))), _or(_or(_leaf(4), _leaf(5)), _leaf(6))))->toString());
+    EXPECT_EQ("(and (not leaf-1) leaf-2 (not leaf-3) leaf-4 (not leaf-5) leaf-6)",
+              SearchArgumentBuilderImpl::flatten(_and(_and(_not(_leaf(1)),
+                _and(_leaf(2), _not(_leaf(3)))), _and(_and(_leaf(4), _not(_leaf(5))), _leaf(6)))
+              )->toString());
+    EXPECT_EQ("(not (and leaf-1 leaf-2 leaf-3))",
+              SearchArgumentBuilderImpl::flatten(_not(_and(_leaf(1), _and(_leaf(2), _leaf(3))))
+              )->toString());
+  }
+
+  TEST(TestSearchArgument, testFoldMaybe) {
+    EXPECT_EQ("(and leaf-1)",
+              SearchArgumentBuilderImpl::foldMaybe(
+                _and(_leaf(1), _constant(TruthValue::YES_NO_NULL)))->toString());
+    EXPECT_EQ("(and leaf-1 leaf-2)",
+              SearchArgumentBuilderImpl::foldMaybe(
+                _and(NodeList{_leaf(1),
+                              _constant(TruthValue::YES_NO_NULL),
+                              _leaf(2)
+                }))->toString());
+    EXPECT_EQ("(and leaf-1 leaf-2)",
+              SearchArgumentBuilderImpl::
+              foldMaybe(_and(NodeList {_constant(TruthValue::YES_NO_NULL),
+                             _leaf(1),
+                             _leaf(2),
+                             _constant(TruthValue::YES_NO_NULL)
+              }))->toString());
+    EXPECT_EQ("YES_NO_NULL",
+              SearchArgumentBuilderImpl::
+              foldMaybe(_and(_constant(TruthValue::YES_NO_NULL),
+                             _constant(TruthValue::YES_NO_NULL)))->toString());
+    EXPECT_EQ("YES_NO_NULL",
+              SearchArgumentBuilderImpl::
+              foldMaybe(_or(_leaf(1),
+                            _constant(TruthValue::YES_NO_NULL)))->toString());
+    EXPECT_EQ("(or leaf-1 (and leaf-2))",
+      SearchArgumentBuilderImpl::foldMaybe(
+        _or(_leaf(1),
+          _and(_leaf(2),
+            _constant(TruthValue::YES_NO_NULL))))->toString());
+    EXPECT_EQ("(and leaf-1)",SearchArgumentBuilderImpl::foldMaybe(
+      _and(_or(_leaf(2),
+        _constant(TruthValue::YES_NO_NULL)),
+          _leaf(1)))->toString());
+    EXPECT_EQ("(and leaf-100)",
+      SearchArgumentBuilderImpl::foldMaybe(
+        SearchArgumentBuilderImpl::convertToCNF(_and(_leaf(100),
+        _or(NodeList { _and(_leaf(0), _leaf(1)),
+                       _and(_leaf(2), _leaf(3)),
+                       _and(_leaf(4), _leaf(5)),
+                       _and(_leaf(6), _leaf(7)),
+                       _and(_leaf(8), _leaf(9)),
+                       _and(_leaf(10), _leaf(11)),
+                       _and(_leaf(12), _leaf(13)),
+                       _and(_leaf(14), _leaf(15)),
+                       _and(_leaf(16), _leaf(17))}))))->toString());
+  }
+
+  static void assertNoSharedNodes(TreeNode tree,
+                                  std::unordered_set<TreeNode>& seen)  {
+    if (seen.find(tree) != seen.end() &&
+        tree->getOperator() != ExpressionTree::Operator::LEAF) {
+      throw std::runtime_error(
+        "repeated node in expression " + tree->toString());
+    }
+    seen.insert(tree);
+    for (auto& child : tree->getChildren()) {
+      assertNoSharedNodes(child, seen);
+    }
+  }
+
+  TEST(TestSearchArgument, testCNF) {
+    EXPECT_EQ("leaf-1",
+      SearchArgumentBuilderImpl::convertToCNF(_leaf(1))->toString());
+    EXPECT_EQ("NO",SearchArgumentBuilderImpl::convertToCNF(
+      _constant(TruthValue::NO))->toString());
+    EXPECT_EQ("(not leaf-1)", SearchArgumentBuilderImpl::convertToCNF(
+      _not(_leaf(1)))->toString());
+    EXPECT_EQ("(and leaf-1 leaf-2)", SearchArgumentBuilderImpl::
+      convertToCNF(_and(_leaf(1), _leaf(2)))->toString());
+    EXPECT_EQ("(or (not leaf-1) leaf-2)",SearchArgumentBuilderImpl::
+      convertToCNF(_or(_not(_leaf(1)), _leaf(2)))->toString());
+    EXPECT_EQ("(and (or leaf-1 leaf-2) (not leaf-3))",
+                 SearchArgumentBuilderImpl::convertToCNF(
+                 _and(_or(_leaf(1), _leaf(2)), _not(_leaf(3))))->toString());
+    EXPECT_EQ("(and (or leaf-1 leaf-3) (or leaf-2 leaf-3)"
+                 " (or leaf-1 leaf-4) (or leaf-2 leaf-4))",
+                 SearchArgumentBuilderImpl::convertToCNF(_or(
+                     _and(_leaf(1), _leaf(2)),
+                     _and(_leaf(3), _leaf(4))))->toString());
+    EXPECT_EQ("(and"
+                 " (or leaf-1 leaf-5) (or leaf-2 leaf-5)"
+                 " (or leaf-3 leaf-5) (or leaf-4 leaf-5)"
+                 " (or leaf-1 leaf-6) (or leaf-2 leaf-6)"
+                 " (or leaf-3 leaf-6) (or leaf-4 leaf-6))",
+              SearchArgumentBuilderImpl::convertToCNF(
+                _or(_and(NodeList{_leaf(1), _leaf(2), _leaf(3), _leaf(4)}),
+                  _and(_leaf(5), _leaf(6)))
+              )->toString());
+    EXPECT_EQ("(and"
+                 " (or leaf-5 leaf-6 (not leaf-7) leaf-1 leaf-3)"
+                 " (or leaf-5 leaf-6 (not leaf-7) leaf-2 leaf-3)"
+                 " (or leaf-5 leaf-6 (not leaf-7) leaf-1 leaf-4)"
+                 " (or leaf-5 leaf-6 (not leaf-7) leaf-2 leaf-4))",
+                 SearchArgumentBuilderImpl::convertToCNF(
+                   _or(NodeList{_and(_leaf(1), _leaf(2)),
+                                _and(_leaf(3), _leaf(4)),
+                                _or(_leaf(5), _leaf(6)),
+                                _not(_leaf(7))
+                   }))->toString());
+    EXPECT_EQ("(and"
+                 " (or leaf-8 leaf-0 leaf-3 leaf-6)"
+                 " (or leaf-8 leaf-1 leaf-3 leaf-6)"
+                 " (or leaf-8 leaf-2 leaf-3 leaf-6)"
+                 " (or leaf-8 leaf-0 leaf-4 leaf-6)"
+                 " (or leaf-8 leaf-1 leaf-4 leaf-6)"
+                 " (or leaf-8 leaf-2 leaf-4 leaf-6)"
+                 " (or leaf-8 leaf-0 leaf-5 leaf-6)"
+                 " (or leaf-8 leaf-1 leaf-5 leaf-6)"
+                 " (or leaf-8 leaf-2 leaf-5 leaf-6)"
+                 " (or leaf-8 leaf-0 leaf-3 leaf-7)"
+                 " (or leaf-8 leaf-1 leaf-3 leaf-7)"
+                 " (or leaf-8 leaf-2 leaf-3 leaf-7)"
+                 " (or leaf-8 leaf-0 leaf-4 leaf-7)"
+                 " (or leaf-8 leaf-1 leaf-4 leaf-7)"
+                 " (or leaf-8 leaf-2 leaf-4 leaf-7)"
+                 " (or leaf-8 leaf-0 leaf-5 leaf-7)"
+                 " (or leaf-8 leaf-1 leaf-5 leaf-7)"
+                 " (or leaf-8 leaf-2 leaf-5 leaf-7))",
+                 SearchArgumentBuilderImpl::convertToCNF(_or(NodeList {
+                     _and(NodeList {_leaf(0), _leaf(1), _leaf(2)}),
+                     _and(NodeList {_leaf(3), _leaf(4), _leaf(5)}),
+                     _and(_leaf(6), _leaf(7)),
+                     _leaf(8)})
+                     )->toString());
+    EXPECT_EQ("YES_NO_NULL", SearchArgumentBuilderImpl::convertToCNF(
+      _or(NodeList {_and(_leaf(0), _leaf(1)),
+                    _and(_leaf(2), _leaf(3)),
+                    _and(_leaf(4), _leaf(5)),
+                    _and(_leaf(6), _leaf(7)),
+                    _and(_leaf(8), _leaf(9)),
+                    _and(_leaf(10), _leaf(11)),
+                    _and(_leaf(12), _leaf(13)),
+                    _and(_leaf(14), _leaf(15)),
+                    _and(_leaf(16), _leaf(17))}))->toString());
+    EXPECT_EQ("(and leaf-100 YES_NO_NULL)",
+              SearchArgumentBuilderImpl::convertToCNF(
+                _and(_leaf(100),
+                     _or(NodeList {
+                       _and(_leaf(0), _leaf(1)),
+                       _and(_leaf(2), _leaf(3)),
+                       _and(_leaf(4), _leaf(5)),
+                       _and(_leaf(6), _leaf(7)),
+                       _and(_leaf(8), _leaf(9)),
+                       _and(_leaf(10), _leaf(11)),
+                       _and(_leaf(12), _leaf(13)),
+                       _and(_leaf(14), _leaf(15)),
+                       _and(_leaf(16), _leaf(17))})))->toString());
+
+    std::unordered_set<TreeNode> seen;
+    EXPECT_NO_THROW(assertNoSharedNodes(
+      SearchArgumentBuilderImpl::convertToCNF(
+        _or(NodeList {_and(NodeList { _leaf(0), _leaf(1), _leaf(2) }),
+                      _and(NodeList { _leaf(3), _leaf(4), _leaf(5) }),
+                      _and(_leaf(6), _leaf(7)),
+                      _leaf(8)})), seen));
+  }
+
+  TEST(TestSearchArgument, testBuilder) {
+    auto sarg = SearchArgumentFactory::newBuilder()
+        ->startAnd()
+        .lessThan("x", PredicateType::LONG,
+          Literal(static_cast<int64_t>(10)))
+        .lessThanEquals("y", PredicateType::STRING, Literal("hi", 2))
+        .equals("z", PredicateType::FLOAT, Literal(1.1))
+        .end()
+        .build();
+    EXPECT_EQ("leaf-0 = (x < 10), "
+              "leaf-1 = (y <= hi), "
+              "leaf-2 = (z = 1.1), "
+              "expr = (and leaf-0 leaf-1 leaf-2)", sarg->toString());
+    sarg = SearchArgumentFactory::newBuilder()
+      ->startNot()
+      .startOr()
+      .isNull("x", PredicateType::LONG)
+      .between("y", PredicateType::LONG,
+        Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20)))
+      .in("z", PredicateType::LONG,
+          {Literal(static_cast<int64_t>(1)),
+           Literal(static_cast<int64_t>(2)), Literal(static_cast<int64_t>(3))})
+      .nullSafeEquals(
+        "a", PredicateType::STRING, Literal("stinger", 7))
+      .end()
+      .end()
+      .build();
+    EXPECT_EQ(
+      "leaf-0 = (x is null), "
+      "leaf-1 = (y between [10, 20]), "
+      "leaf-2 = (z in [1, 2, 3]), "
+      "leaf-3 = (a null_safe_= stinger), "
+      "expr = (and (not leaf-0) (not leaf-1) (not leaf-2) (not leaf-3))",
+      sarg->toString());
+  }
+
+  TEST(TestSearchArgument, testBuilderComplexTypes) {
+    auto sarg = SearchArgumentFactory::newBuilder()
+        ->startAnd()
+        .lessThan("x", PredicateType::DATE,  // 1970-01-11
+                  Literal(PredicateType::DATE, 123456L))
+        .lessThanEquals("y", PredicateType::STRING,
+                        Literal("hi        ", 10))
+        .equals("z", PredicateType::DECIMAL, Literal(10, 2, 1))
+        .end()
+        .build();
+    EXPECT_EQ("leaf-0 = (x < 123456), "
+              "leaf-1 = (y <= hi        ), "
+              "leaf-2 = (z = 1.0), "
+              "expr = (and leaf-0 leaf-1 leaf-2)", sarg->toString());
+
+    sarg = SearchArgumentFactory::newBuilder()
+      ->startNot()
+      .startOr()
+      .isNull("x", PredicateType::LONG)
+      .between("y", PredicateType::DECIMAL,
+               Literal(10, 3, 0), Literal(200, 3, 1))
+      .in("z", PredicateType::LONG,
+          { Literal(static_cast<int64_t>(1)),
+            Literal(static_cast<int64_t>(2)),
+            Literal(static_cast<int64_t>(3)) })
+      .nullSafeEquals("a", PredicateType::STRING,
+                      Literal("stinger", 7))
+      .end()
+      .end()
+      .build();
+    EXPECT_EQ("leaf-0 = (x is null), "
+              "leaf-1 = (y between [10, 20.0]), "
+              "leaf-2 = (z in [1, 2, 3]), "
+              "leaf-3 = (a null_safe_= stinger), "
+              "expr = (and (not leaf-0) (not leaf-1) (not leaf-2) (not leaf-3))",
+              sarg->toString());
+  }
+
+  TEST(TestSearchArgument, testBuilderComplexTypes2) {
+    auto sarg =
+      SearchArgumentFactory::newBuilder()
+        ->startAnd()
+        .lessThan("x", PredicateType::DATE,
+                  Literal(PredicateType::DATE, 11111L))  // "2005-3-12"
+        .lessThanEquals("y", PredicateType::STRING,
+                        Literal("hi        ", 10))
+        .equals("z", PredicateType::DECIMAL,
+                Literal(10, 2, 1))
+        .end()
+        .build();
+    EXPECT_EQ("leaf-0 = (x < 11111), "
+              "leaf-1 = (y <= hi        ), "
+              "leaf-2 = (z = 1.0), "
+              "expr = (and leaf-0 leaf-1 leaf-2)", sarg->toString());
+
+    sarg = SearchArgumentFactory::newBuilder()
+      ->startNot()
+      .startOr()
+      .isNull("x", PredicateType::LONG)
+      .between("y", PredicateType::DECIMAL,
+               Literal(10, 2, 0), Literal(200, 3, 1))
+      .in("z", PredicateType::LONG,
+          { Literal(static_cast<int64_t>(1)),
+            Literal(static_cast<int64_t>(2)),
+            Literal(static_cast<int64_t>(3)) })
+      .nullSafeEquals("a", PredicateType::STRING,
+                      Literal("stinger", 7))
+      .end()
+      .end()
+      .build();
+    EXPECT_EQ("leaf-0 = (x is null), "
+              "leaf-1 = (y between [10, 20.0]), "
+              "leaf-2 = (z in [1, 2, 3]), "
+              "leaf-3 = (a null_safe_= stinger), "
+              "expr = (and (not leaf-0) (not leaf-1) (not leaf-2) (not leaf-3))",
+              sarg->toString());
+  }
+
+  TEST(TestSearchArgument, testBuilderFloat) {
+    auto sarg = SearchArgumentFactory::newBuilder()
+      ->startAnd()
+      .lessThan("x", PredicateType::LONG,
+        Literal(static_cast<int64_t>(22)))
+      .lessThan("x1", PredicateType::LONG,
+        Literal(static_cast<int64_t>(22)))
+      .lessThanEquals("y", PredicateType::STRING,
+        Literal("hi        ", 10))
+      .equals("z", PredicateType::FLOAT, Literal(0.22))
+      .equals("z1", PredicateType::FLOAT, Literal(0.22))
+      .end()
+      .build();
+    EXPECT_EQ("leaf-0 = (x < 22), "
+                 "leaf-1 = (x1 < 22), "
+                 "leaf-2 = (y <= hi        ), "
+                 "leaf-3 = (z = 0.22), "
+                 "leaf-4 = (z1 = 0.22), "
+                 "expr = (and leaf-0 leaf-1 leaf-2 leaf-3 leaf-4)",
+                 sarg->toString());
+  }
+
+  TEST(TestSearchArgument, testBadLiteral) {
+    EXPECT_THROW(
+      SearchArgumentFactory::newBuilder()
+        ->startAnd()
+        .lessThan("x", PredicateType::LONG, Literal("hi", 2))
+        .end()
+        .build(),
+      std::invalid_argument);
+  }
+
+  TEST(TestSearchArgument, testBadLiteralList) {
+    EXPECT_THROW(
+      SearchArgumentFactory::newBuilder()
+        ->startAnd()
+        .in("x", PredicateType::STRING,
+            {Literal("hi                     ", 23)})
+        .end()
+        .build(),
+      std::invalid_argument);
+  }
+
+}  // namespace orc

--- a/c++/test/TestSearchArgument.cc
+++ b/c++/test/TestSearchArgument.cc
@@ -25,28 +25,27 @@ namespace orc {
 
   TEST(TestSearchArgument, literalTest) {
     Literal literal0(static_cast<int64_t>(1234));
-    EXPECT_EQ(PredicateType::LONG, literal0.getType());
+    EXPECT_EQ(PredicateDataType::LONG, literal0.getType());
     EXPECT_TRUE("1234" == literal0.toString());
-    EXPECT_EQ(1234, literal0.getHashCode());
 
     Literal literal1(0.1234);
-    EXPECT_EQ(PredicateType::FLOAT, literal1.getType());
+    EXPECT_EQ(PredicateDataType::FLOAT, literal1.getType());
     EXPECT_TRUE("0.1234" == literal1.toString());
 
     Literal literal2(false);
-    EXPECT_EQ(PredicateType::BOOLEAN, literal2.getType());
+    EXPECT_EQ(PredicateDataType::BOOLEAN, literal2.getType());
     EXPECT_TRUE("false" == literal2.toString());
 
-    Literal literal3(PredicateType::TIMESTAMP, 123456L);
-    EXPECT_EQ(PredicateType::TIMESTAMP, literal3.getType());
+    Literal literal3(PredicateDataType::TIMESTAMP, 123456L);
+    EXPECT_EQ(PredicateDataType::TIMESTAMP, literal3.getType());
     EXPECT_TRUE("123456" == literal3.toString());
 
     Literal literal4(Int128(54321), 6, 2);
-    EXPECT_EQ(PredicateType::DECIMAL, literal4.getType());
+    EXPECT_EQ(PredicateDataType::DECIMAL, literal4.getType());
     EXPECT_TRUE("543.21" == literal4.toString());
 
     Literal literal5("test", 4);
-    EXPECT_EQ(PredicateType::STRING, literal5.getType());
+    EXPECT_EQ(PredicateDataType::STRING, literal5.getType());
     EXPECT_TRUE("test" == literal5.toString());
 
     Literal left(static_cast<int64_t>(123)), right(static_cast<int64_t>(123));
@@ -59,23 +58,23 @@ namespace orc {
 
   TEST(TestSearchArgument, predicateLeafTest) {
     PredicateLeaf leaf1(
-      PredicateLeaf::Operator::EQUALS,
-      PredicateType::LONG,
-      "id",
-      Literal(static_cast<int64_t>(1234)));
+            PredicateLeaf::Operator::EQUALS,
+            PredicateDataType::LONG,
+            "id",
+            Literal(static_cast<int64_t>(1234)));
     EXPECT_EQ(PredicateLeaf::Operator::EQUALS, leaf1.getOperator());
-    EXPECT_EQ(PredicateType::LONG, leaf1.getType());
+    EXPECT_EQ(PredicateDataType::LONG, leaf1.getType());
     EXPECT_EQ("id", leaf1.getColumnName());
     EXPECT_EQ("(id = 1234)", leaf1.toString());
 
     const char * str1 = "aaa", * str2 = "zzz";
     PredicateLeaf leaf2(
-      PredicateLeaf::Operator::BETWEEN,
-      PredicateType::STRING,
-      "name",
-      { Literal(str1, 3), Literal(str2, 3)});
+            PredicateLeaf::Operator::BETWEEN,
+            PredicateDataType::STRING,
+            "name",
+            { Literal(str1, 3), Literal(str2, 3)});
     EXPECT_EQ(PredicateLeaf::Operator::BETWEEN, leaf2.getOperator());
-    EXPECT_EQ(PredicateType::STRING, leaf2.getType());
+    EXPECT_EQ(PredicateDataType::STRING, leaf2.getType());
     EXPECT_EQ("name", leaf2.getColumnName());
     EXPECT_EQ("(name between [aaa, zzz])", leaf2.toString());
 
@@ -84,12 +83,12 @@ namespace orc {
     EXPECT_FALSE(leaf1 == leaf3);
 
     PredicateLeaf leaf4(
-      PredicateLeaf::Operator::LESS_THAN_EQUALS,
-      PredicateType::DECIMAL,
-      "sales",
-      { Literal(111222, 6, 3) });
+            PredicateLeaf::Operator::LESS_THAN_EQUALS,
+            PredicateDataType::DECIMAL,
+            "sales",
+            { Literal(111222, 6, 3) });
     EXPECT_EQ(PredicateLeaf::Operator::LESS_THAN_EQUALS, leaf4.getOperator());
-    EXPECT_EQ(PredicateType::DECIMAL, leaf4.getType());
+    EXPECT_EQ(PredicateDataType::DECIMAL, leaf4.getType());
     EXPECT_EQ("(sales <= 111.222)", leaf4.toString());
   }
 
@@ -367,10 +366,10 @@ namespace orc {
   TEST(TestSearchArgument, testBuilder) {
     auto sarg = SearchArgumentFactory::newBuilder()
         ->startAnd()
-        .lessThan("x", PredicateType::LONG,
-          Literal(static_cast<int64_t>(10)))
-        .lessThanEquals("y", PredicateType::STRING, Literal("hi", 2))
-        .equals("z", PredicateType::FLOAT, Literal(1.1))
+        .lessThan("x", PredicateDataType::LONG,
+                  Literal(static_cast<int64_t>(10)))
+        .lessThanEquals("y", PredicateDataType::STRING, Literal("hi", 2))
+        .equals("z", PredicateDataType::FLOAT, Literal(1.1))
         .end()
         .build();
     EXPECT_EQ("leaf-0 = (x < 10), "
@@ -380,14 +379,14 @@ namespace orc {
     sarg = SearchArgumentFactory::newBuilder()
       ->startNot()
       .startOr()
-      .isNull("x", PredicateType::LONG)
-      .between("y", PredicateType::LONG,
-        Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20)))
-      .in("z", PredicateType::LONG,
+      .isNull("x", PredicateDataType::LONG)
+      .between("y", PredicateDataType::LONG,
+               Literal(static_cast<int64_t>(10)), Literal(static_cast<int64_t>(20)))
+      .in("z", PredicateDataType::LONG,
           {Literal(static_cast<int64_t>(1)),
            Literal(static_cast<int64_t>(2)), Literal(static_cast<int64_t>(3))})
       .nullSafeEquals(
-        "a", PredicateType::STRING, Literal("stinger", 7))
+              "a", PredicateDataType::STRING, Literal("stinger", 7))
       .end()
       .end()
       .build();
@@ -403,11 +402,11 @@ namespace orc {
   TEST(TestSearchArgument, testBuilderComplexTypes) {
     auto sarg = SearchArgumentFactory::newBuilder()
         ->startAnd()
-        .lessThan("x", PredicateType::DATE,  // 1970-01-11
-                  Literal(PredicateType::DATE, 123456L))
-        .lessThanEquals("y", PredicateType::STRING,
+        .lessThan("x", PredicateDataType::DATE,  // 1970-01-11
+                  Literal(PredicateDataType::DATE, 123456L))
+        .lessThanEquals("y", PredicateDataType::STRING,
                         Literal("hi        ", 10))
-        .equals("z", PredicateType::DECIMAL, Literal(10, 2, 1))
+        .equals("z", PredicateDataType::DECIMAL, Literal(10, 2, 1))
         .end()
         .build();
     EXPECT_EQ("leaf-0 = (x < 123456), "
@@ -418,14 +417,14 @@ namespace orc {
     sarg = SearchArgumentFactory::newBuilder()
       ->startNot()
       .startOr()
-      .isNull("x", PredicateType::LONG)
-      .between("y", PredicateType::DECIMAL,
+      .isNull("x", PredicateDataType::LONG)
+      .between("y", PredicateDataType::DECIMAL,
                Literal(10, 3, 0), Literal(200, 3, 1))
-      .in("z", PredicateType::LONG,
+      .in("z", PredicateDataType::LONG,
           { Literal(static_cast<int64_t>(1)),
             Literal(static_cast<int64_t>(2)),
             Literal(static_cast<int64_t>(3)) })
-      .nullSafeEquals("a", PredicateType::STRING,
+      .nullSafeEquals("a", PredicateDataType::STRING,
                       Literal("stinger", 7))
       .end()
       .end()
@@ -442,11 +441,11 @@ namespace orc {
     auto sarg =
       SearchArgumentFactory::newBuilder()
         ->startAnd()
-        .lessThan("x", PredicateType::DATE,
-                  Literal(PredicateType::DATE, 11111L))  // "2005-3-12"
-        .lessThanEquals("y", PredicateType::STRING,
+        .lessThan("x", PredicateDataType::DATE,
+                  Literal(PredicateDataType::DATE, 11111L))  // "2005-3-12"
+        .lessThanEquals("y", PredicateDataType::STRING,
                         Literal("hi        ", 10))
-        .equals("z", PredicateType::DECIMAL,
+        .equals("z", PredicateDataType::DECIMAL,
                 Literal(10, 2, 1))
         .end()
         .build();
@@ -458,14 +457,14 @@ namespace orc {
     sarg = SearchArgumentFactory::newBuilder()
       ->startNot()
       .startOr()
-      .isNull("x", PredicateType::LONG)
-      .between("y", PredicateType::DECIMAL,
+      .isNull("x", PredicateDataType::LONG)
+      .between("y", PredicateDataType::DECIMAL,
                Literal(10, 2, 0), Literal(200, 3, 1))
-      .in("z", PredicateType::LONG,
+      .in("z", PredicateDataType::LONG,
           { Literal(static_cast<int64_t>(1)),
             Literal(static_cast<int64_t>(2)),
             Literal(static_cast<int64_t>(3)) })
-      .nullSafeEquals("a", PredicateType::STRING,
+      .nullSafeEquals("a", PredicateDataType::STRING,
                       Literal("stinger", 7))
       .end()
       .end()
@@ -481,14 +480,14 @@ namespace orc {
   TEST(TestSearchArgument, testBuilderFloat) {
     auto sarg = SearchArgumentFactory::newBuilder()
       ->startAnd()
-      .lessThan("x", PredicateType::LONG,
-        Literal(static_cast<int64_t>(22)))
-      .lessThan("x1", PredicateType::LONG,
-        Literal(static_cast<int64_t>(22)))
-      .lessThanEquals("y", PredicateType::STRING,
-        Literal("hi        ", 10))
-      .equals("z", PredicateType::FLOAT, Literal(0.22))
-      .equals("z1", PredicateType::FLOAT, Literal(0.22))
+      .lessThan("x", PredicateDataType::LONG,
+                Literal(static_cast<int64_t>(22)))
+      .lessThan("x1", PredicateDataType::LONG,
+                Literal(static_cast<int64_t>(22)))
+      .lessThanEquals("y", PredicateDataType::STRING,
+                      Literal("hi        ", 10))
+      .equals("z", PredicateDataType::FLOAT, Literal(0.22))
+      .equals("z1", PredicateDataType::FLOAT, Literal(0.22))
       .end()
       .build();
     EXPECT_EQ("leaf-0 = (x < 22), "
@@ -504,7 +503,7 @@ namespace orc {
     EXPECT_THROW(
       SearchArgumentFactory::newBuilder()
         ->startAnd()
-        .lessThan("x", PredicateType::LONG, Literal("hi", 2))
+        .lessThan("x", PredicateDataType::LONG, Literal("hi", 2))
         .end()
         .build(),
       std::invalid_argument);
@@ -514,7 +513,7 @@ namespace orc {
     EXPECT_THROW(
       SearchArgumentFactory::newBuilder()
         ->startAnd()
-        .in("x", PredicateType::STRING,
+        .in("x", PredicateDataType::STRING,
             {Literal("hi                     ", 23)})
         .end()
         .build(),


### PR DESCRIPTION
1. Implement Literal class to handle literal values in a predicate of different data types.
2. Port TruthValue, ExpressionTree, PredicateLeaf, and SearchArgument from Java hive-storage-api.
3. Port SargsApplier from Java ORC reader.