### PR TITLE
ORC-588: Static field or method should be directly referred by its class

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReader.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReader.java
@@ -61,9 +61,9 @@ public class RunLengthIntegerReader implements IntegerReader {
       // convert from 0 to 255 to -128 to 127 by converting to a signed byte
       delta = (byte) (0 + delta);
       if (signed) {
-        literals[0] = utils.readVslong(input);
+        literals[0] = SerializationUtils.readVslong(input);
       } else {
-        literals[0] = utils.readVulong(input);
+        literals[0] = SerializationUtils.readVulong(input);
       }
     } else {
       repeat = false;
@@ -71,9 +71,9 @@ public class RunLengthIntegerReader implements IntegerReader {
       used = 0;
       for(int i=0; i < numLiterals; ++i) {
         if (signed) {
-          literals[i] = utils.readVslong(input);
+          literals[i] = SerializationUtils.readVslong(input);
         } else {
-          literals[i] = utils.readVulong(input);
+          literals[i] = SerializationUtils.readVulong(input);
         }
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReader.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReader.java
@@ -34,12 +34,10 @@ public class RunLengthIntegerReader implements IntegerReader {
   private int delta = 0;
   private int used = 0;
   private boolean repeat = false;
-  private SerializationUtils utils;
 
   public RunLengthIntegerReader(InStream input, boolean signed) throws IOException {
     this.input = input;
     this.signed = signed;
-    this.utils = new SerializationUtils();
   }
 
   private void readValues(boolean ignoreEof) throws IOException {

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
@@ -88,9 +88,9 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
     // read the first value stored as vint
     long firstVal = 0;
     if (signed) {
-      firstVal = utils.readVslong(input);
+      firstVal = SerializationUtils.readVslong(input);
     } else {
-      firstVal = utils.readVulong(input);
+      firstVal = SerializationUtils.readVulong(input);
     }
 
     // store first value to result buffer
@@ -101,7 +101,7 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
     if (fb == 0) {
       // read the fixed delta value stored as vint (deltas can be negative even
       // if all number are positive)
-      long fd = utils.readVslong(input);
+      long fd = SerializationUtils.readVslong(input);
       if (fd == 0) {
         isRepeating = true;
         assert numLiterals == 1;
@@ -114,7 +114,7 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
         }
       }
     } else {
-      long deltaBase = utils.readVslong(input);
+      long deltaBase = SerializationUtils.readVslong(input);
       // add delta base and first value
       literals[numLiterals++] = firstVal + deltaBase;
       prevVal = literals[numLiterals - 1];


### PR DESCRIPTION
Static field or method should be directly referred by its class