### PR TITLE
ORC-599 Bumping up guava to 28.1-jre

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestSerializationUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSerializationUtils.java
@@ -25,8 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 
 import org.junit.Test;
@@ -136,21 +134,21 @@ public class TestSerializationUtils {
       LongMath.checkedSubtract(22222222222L, Long.MIN_VALUE);
       fail("expected ArithmeticException for overflow");
     } catch (ArithmeticException ex) {
-      assertEquals(ex.getMessage(), "overflow");
+      assertEquals("overflow: checkedSubtract(22222222222, -9223372036854775808)", ex.getMessage());
     }
 
     try {
       LongMath.checkedSubtract(-22222222222L, Long.MAX_VALUE);
       fail("expected ArithmeticException for overflow");
     } catch (ArithmeticException ex) {
-      assertEquals(ex.getMessage(), "overflow");
+      assertEquals("overflow: checkedSubtract(-22222222222, 9223372036854775807)", ex.getMessage());
     }
 
     try {
       LongMath.checkedSubtract(Long.MIN_VALUE, Long.MAX_VALUE);
       fail("expected ArithmeticException for overflow");
     } catch (ArithmeticException ex) {
-      assertEquals(ex.getMessage(), "overflow");
+      assertEquals("overflow: checkedSubtract(-9223372036854775808, 9223372036854775807)", ex.getMessage());
     }
 
     assertEquals(-8106206116692740190L,

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -412,11 +412,6 @@
         <version>2.2.4</version>
       </dependency>
       <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>28.1-jre</version>
-      </dependency>
-      <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>2.5.0</version>
@@ -693,6 +688,12 @@
       </dependency>
 
       <!-- test inter-project -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>28.1-jre</version>
+        <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -414,7 +414,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>11.0.2</version>
+        <version>28.1-jre</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Even though guava dependency is used only by Test classes it make sense to upgrade due to known security vulnerabilities  https://nvd.nist.gov/vuln/detail/CVE-2018-10237 and to reduce the dependency footprint e.g. Apache Hive is upgrading to 28.1-jre https://issues.apache.org/jira/browse/HIVE-21569