### PR TITLE
ORC-601: Add more debug info to error messages in the scanner

### DIFF
--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -338,7 +338,7 @@ namespace orc {
     const void* bufferPointer;
     bool result = inputStream->Next(&bufferPointer, &bufferLength);
     if (!result) {
-      throw ParseError("bad read in nextBuffer");
+      inputStream->throwFrom("ByteRleDecoder");
     }
     bufferStart = static_cast<const char*>(bufferPointer);
     bufferEnd = bufferStart + bufferLength;

--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -338,7 +338,7 @@ namespace orc {
     const void* bufferPointer;
     bool result = inputStream->Next(&bufferPointer, &bufferLength);
     if (!result) {
-      inputStream->throwFrom("ByteRleDecoder");
+      inputStream->throwParseErrorFrom("ByteRleDecoder");
     }
     bufferStart = static_cast<const char*>(bufferPointer);
     bufferEnd = bufferStart + bufferLength;

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -405,7 +405,7 @@ namespace orc {
         int length;
         if (!inputStream->Next
             (reinterpret_cast<const void**>(&bufferPointer), &length)) {
-          inputStream->throwFrom("DoubleColumnReader");
+          inputStream->throwParseErrorFrom("DoubleColumnReader");
         }
         bufferEnd = bufferPointer + length;
       }
@@ -509,7 +509,7 @@ namespace orc {
       const void* chunk;
       int length;
       if (!stream->Next(&chunk, &length)) {
-        stream->throwFrom("StringDictionaryColumnReader");
+        stream->throwParseErrorFrom("StringDictionaryColumnReader");
       }
       if (posn + length > bufferSize) {
         std::stringstream msg;
@@ -790,7 +790,7 @@ namespace orc {
       const void* readBuffer;
       int readLength;
       if (!blobStream->Next(&readBuffer, &readLength)) {
-        blobStream->throwFrom("StringDirectColumnReader");
+        blobStream->throwParseErrorFrom("StringDirectColumnReader");
       }
       lastBuffer = static_cast<const char*>(readBuffer);
       lastBufferLength = static_cast<size_t>(readLength);
@@ -1381,7 +1381,7 @@ namespace orc {
         int length;
         if (!valueStream->Next(reinterpret_cast<const void**>(&buffer),
                                &length)) {
-          valueStream->throwFrom("Decimal64ColumnReader");
+          valueStream->throwParseErrorFrom("Decimal64ColumnReader");
         }
         bufferEnd = buffer + length;
       }

--- a/c++/src/ColumnReader.hh
+++ b/c++/src/ColumnReader.hh
@@ -58,6 +58,21 @@ namespace orc {
                               proto::Stream_Kind kind,
                               bool shouldStream) const = 0;
 
+    std::unique_ptr<SeekableInputStream>
+                    getStreamOrThrow(const Type& type,
+                                     proto::Stream_Kind kind,
+                                     bool shouldStream) const {
+      std::unique_ptr<SeekableInputStream> stream =
+          getStream(type.getColumnId(), kind, shouldStream);
+      if (stream == nullptr) {
+        std::stringstream buffer;
+        buffer << Stream_Kind_Name(kind) << " stream not found in column "
+          << type.getColumnId() << " of type " << type.toString();
+        throw ParseError(buffer.str());
+      }
+      return stream;
+    }
+
     /**
      * Get the memory pool for this reader.
      */

--- a/c++/src/RLEv1.cc
+++ b/c++/src/RLEv1.cc
@@ -142,7 +142,7 @@ signed char RleDecoderV1::readByte() {
     int bufferLength;
     const void* bufferPointer;
     if (!inputStream->Next(&bufferPointer, &bufferLength)) {
-      throw ParseError("bad read in readByte");
+      inputStream->throwFrom("RleDecoderV1");
     }
     bufferStart = static_cast<const char*>(bufferPointer);
     bufferEnd = bufferStart + bufferLength;

--- a/c++/src/RLEv1.cc
+++ b/c++/src/RLEv1.cc
@@ -142,7 +142,7 @@ signed char RleDecoderV1::readByte() {
     int bufferLength;
     const void* bufferPointer;
     if (!inputStream->Next(&bufferPointer, &bufferLength)) {
-      inputStream->throwFrom("RleDecoderV1");
+      inputStream->throwParseErrorFrom("RleDecoderV1");
     }
     bufferStart = static_cast<const char*>(bufferPointer);
     bufferEnd = bufferStart + bufferLength;

--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -165,7 +165,7 @@ private:
     int bufferLength;
     const void* bufferPointer;
     if (!inputStream->Next(&bufferPointer, &bufferLength)) {
-      inputStream->throwFrom("RleDecoderV2");
+      inputStream->throwParseErrorFrom("RleDecoderV2");
     }
     bufferStart = static_cast<const char*>(bufferPointer);
     bufferEnd = bufferStart + bufferLength;

--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -165,7 +165,7 @@ private:
     int bufferLength;
     const void* bufferPointer;
     if (!inputStream->Next(&bufferPointer, &bufferLength)) {
-      throw ParseError("bad read in RleDecoderV2::readByte");
+      inputStream->throwFrom("RleDecoderV2");
     }
     bufferStart = static_cast<const char*>(bufferPointer);
     bufferEnd = bufferStart + bufferLength;

--- a/c++/src/io/InputStream.cc
+++ b/c++/src/io/InputStream.cc
@@ -56,6 +56,13 @@ namespace orc {
     // PASS
   }
 
+  void SeekableInputStream::throwFrom(const char* class_name) {
+    std::stringstream msg;
+    msg << "Read past end of stream in " << class_name
+        << "or some errors occured: " << this->getName();
+    throw ParseError(msg.str());
+  }
+
   SeekableArrayInputStream::~SeekableArrayInputStream() {
     // PASS
   }

--- a/c++/src/io/InputStream.cc
+++ b/c++/src/io/InputStream.cc
@@ -56,7 +56,7 @@ namespace orc {
     // PASS
   }
 
-  void SeekableInputStream::throwFrom(const char* class_name) {
+  void SeekableInputStream::throwParseErrorFrom(const char* class_name) {
     std::stringstream msg;
     msg << "Read past end of stream in " << class_name
         << " or some errors occured: " << this->getName();

--- a/c++/src/io/InputStream.cc
+++ b/c++/src/io/InputStream.cc
@@ -59,7 +59,7 @@ namespace orc {
   void SeekableInputStream::throwFrom(const char* class_name) {
     std::stringstream msg;
     msg << "Read past end of stream in " << class_name
-        << "or some errors occured: " << this->getName();
+        << " or some errors occured: " << this->getName();
     throw ParseError(msg.str());
   }
 

--- a/c++/src/io/InputStream.hh
+++ b/c++/src/io/InputStream.hh
@@ -53,6 +53,7 @@ namespace orc {
     virtual ~SeekableInputStream();
     virtual void seek(PositionProvider& position) = 0;
     virtual std::string getName() const = 0;
+    void throwFrom(const char* class_name);
   };
 
   /**

--- a/c++/src/io/InputStream.hh
+++ b/c++/src/io/InputStream.hh
@@ -53,7 +53,7 @@ namespace orc {
     virtual ~SeekableInputStream();
     virtual void seek(PositionProvider& position) = 0;
     virtual std::string getName() const = 0;
-    void throwFrom(const char* class_name);
+    void throwParseErrorFrom(const char* class_name);
   };
 
   /**

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable (orc-test
   TestByteRLEEncoder.cc
   TestColumnPrinter.cc
   TestColumnReader.cc
+  TestColumnReaderInvalidStripes.cc
   TestColumnStatistics.cc
   TestCompression.cc
   TestDecompression.cc

--- a/c++/test/TestColumnReaderInvalidStripes.cc
+++ b/c++/test/TestColumnReaderInvalidStripes.cc
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include "Adaptor.hh"
 #include "ColumnReader.hh"
@@ -33,13 +50,14 @@ namespace orc {
                                                     proto::Stream_Kind kind,
                                                     bool stream)
                                                     const override {
-      return std::unique_ptr<SeekableInputStream>
-              (getStreamProxy(columnId, kind, stream));
-    }
+        return std::unique_ptr<SeekableInputStream>
+                (getStreamProxy(columnId, kind, stream));
+      }
 
       MOCK_CONST_METHOD0(getSelectedColumns, const std::vector<bool>());
       MOCK_CONST_METHOD1(getEncoding, proto::ColumnEncoding(uint64_t));
-      MOCK_CONST_METHOD3(getStreamProxy,
+      MOCK_CONST_METHOD3(
+          getStreamProxy,
           SeekableInputStream*(uint64_t, proto::Stream_Kind, bool));
       MOCK_CONST_METHOD0(getErrorStream, std::ostream*());
       MOCK_CONST_METHOD0(getThrowOnHive11DecimalOverflow, bool());
@@ -85,6 +103,7 @@ namespace orc {
       EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
           .WillRepeatedly(testing::Return(nullptr));
     }
+
     void SetUp() override {
       SetUp(proto::ColumnEncoding_Kind_DIRECT);
     }

--- a/c++/test/TestColumnReaderInvalidStripes.cc
+++ b/c++/test/TestColumnReaderInvalidStripes.cc
@@ -1,0 +1,207 @@
+
+#include "Adaptor.hh"
+#include "ColumnReader.hh"
+#include "orc/Exceptions.hh"
+#include "OrcTest.hh"
+
+#include "wrap/orc-proto-wrapper.hh"
+#include "wrap/gtest-wrapper.h"
+#include "wrap/gmock.h"
+
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+#ifdef __clang__
+  DIAGNOSTIC_IGNORE("-Winconsistent-missing-override")
+  DIAGNOSTIC_IGNORE("-Wmissing-variable-declarations")
+#endif
+#ifdef __GNUC__
+  DIAGNOSTIC_IGNORE("-Wparentheses")
+#endif
+
+namespace orc {
+  using ::testing::TestWithParam;
+  using ::testing::Values;
+
+  class TestColumnReaderInvalidStripes : public ::testing::Test {
+    class MockStripeStreams : public StripeStreams {
+    public:
+      virtual ~MockStripeStreams() override;
+
+      std::unique_ptr<SeekableInputStream> getStream(uint64_t columnId,
+                                                    proto::Stream_Kind kind,
+                                                    bool stream)
+                                                    const override {
+      return std::unique_ptr<SeekableInputStream>
+              (getStreamProxy(columnId, kind, stream));
+    }
+
+      MOCK_CONST_METHOD0(getSelectedColumns, const std::vector<bool>());
+      MOCK_CONST_METHOD1(getEncoding, proto::ColumnEncoding(uint64_t));
+      MOCK_CONST_METHOD3(getStreamProxy,
+          SeekableInputStream*(uint64_t, proto::Stream_Kind, bool));
+      MOCK_CONST_METHOD0(getErrorStream, std::ostream*());
+      MOCK_CONST_METHOD0(getThrowOnHive11DecimalOverflow, bool());
+      MOCK_CONST_METHOD0(getForcedScaleOnHive11Decimal, int32_t());
+
+      MemoryPool &getMemoryPool() const {
+        return *getDefaultPool();
+      }
+
+      const Timezone &getWriterTimezone() const override {
+        return getTimezoneByName("America/Los_Angeles");
+      }
+    };
+
+  public:
+    virtual ~TestColumnReaderInvalidStripes();
+    MockStripeStreams streams;
+  protected:
+    void SetUp() {
+      // set getSelectedColumns()
+      std::vector<bool> selectedColumns(2, true);
+      EXPECT_CALL(streams, getSelectedColumns())
+          .WillRepeatedly(testing::Return(selectedColumns));
+
+      // set getEncoding
+      proto::ColumnEncoding directEncoding;
+      directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+      EXPECT_CALL(streams, getEncoding(testing::_))
+          .WillRepeatedly(testing::Return(directEncoding));
+
+      // set getStream
+      EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, true))
+          .WillRepeatedly(testing::Return(nullptr));
+      const unsigned char buffer1[] = { 0x3d };
+      EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, true))
+          .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                          (buffer1, ARRAY_SIZE(buffer1))));
+      EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+          .WillRepeatedly(testing::Return(nullptr));
+    }
+
+    void TearDown() {
+      ::testing::Mock::VerifyAndClearExpectations(&streams);
+    }
+
+    void SetNullLengthExpect() {
+      EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+          .WillRepeatedly(testing::Return(nullptr));
+    }
+
+    void SetNonNullLengthExpect() {
+      const unsigned char buffer4[] =  { 0x02, 0x01, 0x03 };
+      EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_LENGTH, true))
+          .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                          (buffer4, ARRAY_SIZE(buffer4))));
+    }
+
+    void RunTest(std::unique_ptr<Type> type, const char* msg) {
+      // create the row type
+      std::unique_ptr<Type> rowType = createStructType();
+      rowType->addStructField("col0", std::move(type));
+
+      std::unique_ptr<ColumnReader> reader;
+      ASSERT_THROW(
+        try {
+          reader = buildReader(*rowType, streams);
+        } catch (ParseError e) {
+          EXPECT_STREQ(e.what(), msg);
+          throw;
+        }, ParseError);
+    }
+  };
+
+  TestColumnReaderInvalidStripes::MockStripeStreams::~MockStripeStreams() {
+    // PASS
+  }
+  TestColumnReaderInvalidStripes::~TestColumnReaderInvalidStripes(){
+    // PASS
+  }
+
+TEST_F(TestColumnReaderInvalidStripes, testBool) {
+  RunTest(createPrimitiveType(BOOLEAN),
+         "DATA stream not found in column 1 of type boolean");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testByte) {
+  RunTest(createPrimitiveType(BYTE),
+         "DATA stream not found in column 1 of type tinyint");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testInt) {
+  RunTest(createPrimitiveType(INT),
+         "DATA stream not found in column 1 of type int");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testTimestamp) {
+  RunTest(createPrimitiveType(TIMESTAMP),
+         "DATA stream not found in column 1 of type timestamp");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testTimestampSecondary) {
+  const unsigned char buffer1[] = { 0x3d };
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+          .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                          (buffer1, ARRAY_SIZE(buffer1))));
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_SECONDARY, true))
+          .WillRepeatedly(testing::Return(nullptr));
+  RunTest(createPrimitiveType(TIMESTAMP),
+         "SECONDARY stream not found in column 1 of type timestamp");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testDouble) {
+  RunTest(createPrimitiveType(DOUBLE),
+         "DATA stream not found in column 1 of type double");
+}
+
+// Length stream is called first.
+TEST_F(TestColumnReaderInvalidStripes, testStringLength) {
+  SetNullLengthExpect();
+  RunTest(createPrimitiveType(STRING),
+         "LENGTH stream not found in column 1 of type string");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testStringData) {
+  SetNonNullLengthExpect();
+  RunTest(createPrimitiveType(STRING),
+         "DATA stream not found in column 1 of type string");
+}
+
+// Lists have only length streams.
+TEST_F(TestColumnReaderInvalidStripes, testList) {
+  SetNullLengthExpect();
+  RunTest(createListType(createPrimitiveType(INT)),
+         "LENGTH stream not found in column 1 of type array<int>");
+}
+
+// Maps have only length streams.
+TEST_F(TestColumnReaderInvalidStripes, testMap) {
+  SetNullLengthExpect();
+  RunTest(createMapType(createPrimitiveType(INT), createPrimitiveType(INT)),
+         "LENGTH stream not found in column 1 of type map<int,int>");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testUnion) {
+  RunTest(createUnionType(),
+         "DATA stream not found in column 1 of type uniontype<>");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testDecimalData) {
+  RunTest(createDecimalType(4,2),
+         "DATA stream not found in column 1 of type decimal(4,2)");
+}
+
+TEST_F(TestColumnReaderInvalidStripes, testDecimalSecondary) {
+  const unsigned char buffer1[] = { 0x3d };
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+          .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                          (buffer1, ARRAY_SIZE(buffer1))));
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_SECONDARY, true))
+          .WillRepeatedly(testing::Return(nullptr));
+  RunTest(createDecimalType(4,2),
+         "SECONDARY stream not found in column 1 of type decimal(4,2)");
+}
+
+}  // namespace orc

--- a/c++/test/TestColumnReaderInvalidStripes.cc
+++ b/c++/test/TestColumnReaderInvalidStripes.cc
@@ -100,11 +100,11 @@ namespace orc {
     }
 
     void SetNonNullLengthExpect(bool shouldPage = true) {
-      const unsigned char buffer4[] =  { 0x02, 0x01, 0x03 };
+      const unsigned char buffer[] = { 0x02, 0x01, 0x03, 0x02, 0x01, 0x03 };
       EXPECT_CALL(streams,
-                  getStreamProxy(1,proto::Stream_Kind_LENGTH, shouldPage))
+                  getStreamProxy(1, proto::Stream_Kind_LENGTH, shouldPage))
           .WillRepeatedly(testing::Return(new SeekableArrayInputStream(
-                                              buffer4, ARRAY_SIZE(buffer4))));
+                                              buffer, ARRAY_SIZE(buffer))));
     }
 
     void RunTest(std::unique_ptr<Type> type, const char* msg) {
@@ -199,7 +199,7 @@ TEST_F(TestColumnReaderInvalidStripes, testStringDictionaryBlob) {
   SetUp(proto::ColumnEncoding_Kind_DICTIONARY);
 
   // Data should not return null now.
-  const unsigned char buffer1[] = { 0x3d };
+  const unsigned char buffer1[] = { 0x2f, 0x00, 0x00, 0x2f, 0x00, 0x01 };
   EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(testing::Return(new SeekableArrayInputStream
                                       (buffer1, ARRAY_SIZE(buffer1))));

--- a/c++/test/TestColumnReaderInvalidStripes.cc
+++ b/c++/test/TestColumnReaderInvalidStripes.cc
@@ -55,7 +55,7 @@ namespace orc {
     };
 
   public:
-    virtual ~TestColumnReaderInvalidStripes();
+    virtual ~TestColumnReaderInvalidStripes() override;
     MockStripeStreams streams;
   protected:
     void SetUp(proto::ColumnEncoding_Kind encoding_kind) {

--- a/tools/test/TestFileScan.cc
+++ b/tools/test/TestFileScan.cc
@@ -147,11 +147,11 @@ void checkForError(const std::string& filename, const std::string& error_msg) {
 
 TEST (TestFileScan, testErrorHandling) {
   checkForError(findExample("corrupt/stripe_footer_bad_column_encodings.orc"),
-      "bad number of ColumnEncodings in StripeFooter: expected=6, actual=0");
+      "Bad number of ColumnEncodings in StripeFooter: expected=6, actual=0");
   checkForError(findExample("corrupt/negative_dict_entry_lengths.orc"),
-      "Negative dictionary entry length");
+      "Negative dictionary entry length for column 9");
   checkForError(findExample("corrupt/missing_length_stream_in_string_dict.orc"),
-      "LENGTH stream not found in StringDictionaryColumn");
+      "LENGTH stream not found in column 9 of type string");
   checkForError(findExample("corrupt/missing_blob_stream_in_string_dict.orc"),
-      "DICTIONARY_DATA stream not found in StringDictionaryColumn");
+      "DICTIONARY_DATA stream not found in column 10 of type string");
 }


### PR DESCRIPTION
This commit adds more debug info and unifies error messages in
the readers and related classes.

Tests:
  - Added test file to check for valid error message related to
    streams.