### PR TITLE
ORC-519: Correct encoding for Decimal columns in specification

### DIFF
--- a/site/specification/ORCv0.md
+++ b/site/specification/ORCv0.md
@@ -664,13 +664,13 @@ the precision to a maximum of 38 digits, which conveniently uses 127
 bits plus a sign bit. The current encoding of decimal columns stores
 the integer representation of the value as an unbounded length zigzag
 encoded base 128 varint. The scale is stored in the SECONDARY stream
-as an signed integer.
+as a signed integer.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------
 DIRECT        | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unbounded base 128 varints
-              | SECONDARY       | No       | Unsigned Integer RLE v1
+              | SECONDARY       | No       | Signed Integer RLE v1
 
 ## Date Columns
 

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -1097,16 +1097,16 @@ the precision to a maximum of 38 digits, which conveniently uses 127
 bits plus a sign bit. The current encoding of decimal columns stores
 the integer representation of the value as an unbounded length zigzag
 encoded base 128 varint. The scale is stored in the SECONDARY stream
-as an signed integer.
+as a signed integer.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------
 DIRECT        | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unbounded base 128 varints
-              | SECONDARY       | No       | Unsigned Integer RLE v1
+              | SECONDARY       | No       | Signed Integer RLE v1
 DIRECT_V2     | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unbounded base 128 varints
-              | SECONDARY       | No       | Unsigned Integer RLE v2
+              | SECONDARY       | No       | Signed Integer RLE v2
 
 ## Date Columns
 

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -1121,7 +1121,7 @@ DIRECT        | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Signed Integer RLE v2
 DIRECT_V2     | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unbounded base 128 varints
-              | SECONDARY       | No       | Unsigned Integer RLE v2
+              | SECONDARY       | No       | Signed Integer RLE v2
 
 
 ## Date Columns


### PR DESCRIPTION
Currently the ORC specifications state that the secondary stream of
decimal columns are Unsigned RLE, but according to the code (both
Java and C++), Signed RLE is used.