### PR TITLE
ORC-609: Upgrade aircompressor to 0.16

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -445,13 +445,7 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>0.15</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.airlift</groupId>
-            <artifactId>slice</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>0.16</version>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>


### PR DESCRIPTION
This PR aims to upgrade `io.airlift:aircompressor` from 0.15 to 0.16.

This will remove the dependency `io.airlift:slice` and make us ready for the latest LZO version support.