### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/docker/debian10/Dockerfile
+++ b/docker/debian10/Dockerfile
@@ -21,7 +21,7 @@ FROM debian:buster
 MAINTAINER Owen O'Malley <omalley@apache.org>
 
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   cmake \
   gcc \
   g++ \

--- a/docker/debian8/Dockerfile
+++ b/docker/debian8/Dockerfile
@@ -23,7 +23,7 @@ MAINTAINER Owen O'Malley <owen@hortonworks.com>
 ADD sources.list apt.conf /etc/apt/
 
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   autoconf \
   cmake \
   gcc \

--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -21,7 +21,7 @@ FROM debian:9
 MAINTAINER Owen O'Malley <owen@hortonworks.com>
 
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   cmake \
   gcc \
   g++ \

--- a/docker/ubuntu14/Dockerfile
+++ b/docker/ubuntu14/Dockerfile
@@ -21,10 +21,10 @@ FROM ubuntu:14.04
 MAINTAINER Owen O'Malley <owen@hortonworks.com>
 
 RUN apt-get update
-RUN apt-get install -y software-properties-common
+RUN apt-get --no-install-recommends install -y software-properties-common
 RUN add-apt-repository -y ppa:openjdk-r/ppa
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   autoconf \
   cmake \
   gcc \

--- a/docker/ubuntu16-clang5/Dockerfile
+++ b/docker/ubuntu16-clang5/Dockerfile
@@ -21,11 +21,11 @@ FROM ubuntu:16.04
 MAINTAINER Owen O'Malley <owen@hortonworks.com>
 
 RUN apt-get update
-RUN apt-get install -y wget software-properties-common
+RUN apt-get --no-install-recommends install -y wget software-properties-common
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main"
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   cmake \
   default-jdk \
   clang-5.0 \

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -21,7 +21,7 @@ FROM ubuntu:16.04
 MAINTAINER Owen O'Malley <owen@hortonworks.com>
 
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   cmake \
   default-jdk \
   gcc \

--- a/docker/ubuntu18/Dockerfile
+++ b/docker/ubuntu18/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER Owen O'Malley <owen@hortonworks.com>
 
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   cmake \
   gcc \
   g++ \

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER ORC team <dev@orc.apache.org>
 
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update
-RUN apt-get install -y \
+RUN apt-get --no-install-recommends install -y \
   g++ \
   gcc \
   git \

--- a/snap/README.md
+++ b/snap/README.md
@@ -13,7 +13,7 @@ If you don't use VM, you'll need to install snapcraft, which is the tool to buil
 snaps.
 
 ```bash
-% sudo apt-get install snapcraft
+% sudo apt-get --no-install-recommends install snapcraft
 ```
 
 In both cases, go into the snap directory and build the snap:

--- a/snap/vagrant-provision.sh
+++ b/snap/vagrant-provision.sh
@@ -14,6 +14,6 @@
 
 apt-get update
 DEBIAN_FRONTEND=noninteractive apt-get upgrade -y
-apt-get install -y \
+apt-get --no-install-recommends install -y \
    emacs-nox \
    snapcraft


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>