### PR TITLE
Memory leak on test

### DIFF
--- a/c++/test/TestByteRle.cc
+++ b/c++/test/TestByteRle.cc
@@ -1509,6 +1509,7 @@ TEST(BooleanRle, seekBoolAndByteRLE) {
                     << "Output wrong at " << i;
     }
 
+    delete [] data;
     delete [] decodedData;
   }
 }  // namespace orc


### PR DESCRIPTION
ASAN reports a memory leak in this tests. The "data" buffer is allocated using new but no deallocated at the end.