### PR TITLE
Int128: Undefined behaviour in left-shift

### DIFF
--- a/c++/include/orc/Int128.hh
+++ b/c++/include/orc/Int128.hh
@@ -196,11 +196,11 @@ namespace orc {
     Int128& operator<<=(uint32_t bits) {
       if (bits != 0) {
         if (bits < 64) {
-          highbits <<= bits;
+          highbits = static_cast<int64_t>(static_cast<uint64_t>(highbits) << bits);
           highbits |= (lowbits >> (64 - bits));
           lowbits <<= bits;
         } else if (bits < 128) {
-          highbits = static_cast<int64_t>(lowbits) << (bits - 64);
+          highbits = static_cast<int64_t>(lowbits << (bits - 64));
           lowbits = 0;
         } else {
           highbits = 0;
@@ -218,7 +218,7 @@ namespace orc {
       if (bits != 0) {
         if (bits < 64) {
           lowbits >>= bits;
-          lowbits |= static_cast<uint64_t>(highbits << (64 - bits));
+          lowbits |= static_cast<uint64_t>(highbits) << (64 - bits);
           highbits = static_cast<int64_t>
             (static_cast<uint64_t>(highbits) >> bits);
         } else if (bits < 128) {


### PR DESCRIPTION
Left-shifting into the sign bit is Undefined Behaviour and UBSAN reports it executing ORC tests. If shiftint into the sign it is desied, the workaround is doing the shift in unsigned types, and casting it to signed. Casting an unsigned type to signed when the value is not representable by the signed type is Implementation Defined, but nearly all implementations just maintain all bits.

With this patch, UBSAN errors from sign bit shifts are removed. But UBSAN still reports other errors like:
/Src/RLE.cc:80:22: runtime error: left shift of negative value -290
../Src/BloomFilter.cc:246:15: runtime error: signed integer overflow: -1628351410 + -814175404 cannot be represented in type 'int'