### PR TITLE
ORC-624: Fix UBSan errors reported in the testsuite:

### DIFF
--- a/c++/include/orc/Int128.hh
+++ b/c++/include/orc/Int128.hh
@@ -196,11 +196,12 @@ namespace orc {
     Int128& operator<<=(uint32_t bits) {
       if (bits != 0) {
         if (bits < 64) {
-          highbits <<= bits;
+          // use unsigned type to avoid left-shift into the sign bit
+          highbits = static_cast<int64_t>(static_cast<uint64_t>(highbits) << bits);
           highbits |= (lowbits >> (64 - bits));
           lowbits <<= bits;
         } else if (bits < 128) {
-          highbits = static_cast<int64_t>(lowbits) << (bits - 64);
+          highbits = static_cast<int64_t>(lowbits << (bits - 64));
           lowbits = 0;
         } else {
           highbits = 0;
@@ -218,7 +219,8 @@ namespace orc {
       if (bits != 0) {
         if (bits < 64) {
           lowbits >>= bits;
-          lowbits |= static_cast<uint64_t>(highbits << (64 - bits));
+          // use unsigned type to avoid left-shift into the sign bit
+          lowbits |= static_cast<uint64_t>(highbits) << (64 - bits);
           highbits = static_cast<int64_t>
             (static_cast<uint64_t>(highbits) >> bits);
         } else if (bits < 128) {

--- a/c++/src/BloomFilter.cc
+++ b/c++/src/BloomFilter.cc
@@ -224,11 +224,12 @@ namespace orc {
   DIAGNOSTIC_POP
 
   void BloomFilterImpl::addHash(uint64_t hash64) {
-    int32_t hash1 = static_cast<int32_t>(hash64 & 0xffffffff);
-    int32_t hash2 = static_cast<int32_t>(hash64 >> 32);
+    // use unsigned type to obtain modulo behaviour without UB
+    uint32_t hash1 = static_cast<uint32_t>(hash64 & 0xffffffffU);
+    uint32_t hash2 = static_cast<uint32_t>(hash64 >> 32);
 
     for (int32_t i = 1; i <= mNumHashFunctions; ++i) {
-      int32_t combinedHash = hash1 + i * hash2;
+      uint32_t combinedHash = hash1 + i * hash2;
       // hashcode should be positive, flip all the bits if it's negative
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;
@@ -239,11 +240,12 @@ namespace orc {
   }
 
   bool BloomFilterImpl::testHash(uint64_t hash64) const{
-    int32_t hash1 = static_cast<int32_t>(hash64 & 0xffffffff);
-    int32_t hash2 = static_cast<int32_t>(hash64 >> 32);
+    // use unsigned type to obtain modulo behaviour without UB
+    uint32_t hash1 = static_cast<uint32_t>(hash64 & 0xffffffffU);
+    uint32_t hash2 = static_cast<uint32_t>(hash64 >> 32);
 
     for (int32_t i = 1; i <= mNumHashFunctions; ++i) {
-      int32_t combinedHash = hash1 + i * hash2;
+      uint32_t combinedHash = hash1 + i * hash2;
       // hashcode should be positive, flip all the bits if it's negative
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;

--- a/c++/src/BloomFilter.cc
+++ b/c++/src/BloomFilter.cc
@@ -229,7 +229,7 @@ namespace orc {
     uint32_t hash2 = static_cast<uint32_t>(hash64 >> 32);
 
     for (int32_t i = 1; i <= mNumHashFunctions; ++i) {
-      uint32_t combinedHash = hash1 + static_cast<uint32_t>(i) * hash2;
+      int32_t combinedHash = static_cast<int32_t>(hash1 + static_cast<uint32_t>(i) * hash2);
       // hashcode should be positive, flip all the bits if it's negative
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;
@@ -245,7 +245,7 @@ namespace orc {
     uint32_t hash2 = static_cast<uint32_t>(hash64 >> 32);
 
     for (int32_t i = 1; i <= mNumHashFunctions; ++i) {
-      uint32_t combinedHash = hash1 + static_cast<uint32_t>(i) * hash2;
+      int32_t combinedHash = static_cast<int32_t>(hash1 + static_cast<uint32_t>(i) * hash2);
       // hashcode should be positive, flip all the bits if it's negative
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;

--- a/c++/src/BloomFilter.cc
+++ b/c++/src/BloomFilter.cc
@@ -229,7 +229,7 @@ namespace orc {
     uint32_t hash2 = static_cast<uint32_t>(hash64 >> 32);
 
     for (int32_t i = 1; i <= mNumHashFunctions; ++i) {
-      uint32_t combinedHash = hash1 + i * hash2;
+      uint32_t combinedHash = hash1 + static_cast<uint32_t>(i) * hash2;
       // hashcode should be positive, flip all the bits if it's negative
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;
@@ -245,7 +245,7 @@ namespace orc {
     uint32_t hash2 = static_cast<uint32_t>(hash64 >> 32);
 
     for (int32_t i = 1; i <= mNumHashFunctions; ++i) {
-      uint32_t combinedHash = hash1 + i * hash2;
+      uint32_t combinedHash = hash1 + static_cast<uint32_t>(i) * hash2;
       // hashcode should be positive, flip all the bits if it's negative
       if (combinedHash < 0) {
         combinedHash = ~combinedHash;

--- a/c++/src/LzoDecompressor.cc
+++ b/c++/src/LzoDecompressor.cc
@@ -378,11 +378,15 @@ namespace orc {
         lastLiteralLength = literalLength;
       }
       
-      int16_t i16Temp;
-      if (input + SIZE_OF_SHORT > inputLimit &&
-          (memcpy(&i16Temp, input, sizeof(int16_t)), i16Temp) != 0) {
-        throw MalformedInputException(input - inputAddress);
+      if (input + SIZE_OF_SHORT > inputLimit) {
+         int16_t i16Temp;
+         memcpy(&i16Temp, input, sizeof(int16_t));
+
+        if(i16Temp != 0) {
+          throw MalformedInputException(input - inputAddress);
+        }
       }
+
       input += SIZE_OF_SHORT;
     }
 

--- a/c++/src/RLE.cc
+++ b/c++/src/RLE.cc
@@ -77,7 +77,7 @@ namespace orc {
   }
 
   void RleEncoder::writeVslong(int64_t val) {
-    writeVulong((val << 1) ^ (val >> 63));
+    writeVulong(static_cast<int64_t>(static_cast<uint64_t>(val) << 1) ^ (val >> 63));
   }
 
   void RleEncoder::writeVulong(int64_t val) {

--- a/c++/src/RLE.hh
+++ b/c++/src/RLE.hh
@@ -27,7 +27,8 @@
 namespace orc {
 
   inline int64_t zigZag(int64_t value) {
-    return (value << 1) ^ (value >> 63);
+    // avoid UB with left-shift casting to unsigned
+    return static_cast<int64_t>(static_cast<uint64_t>(value) << 1) ^ (value >> 63);
   }
 
   inline int64_t unZigZag(uint64_t value) {

--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -172,7 +172,11 @@ namespace orc {
 
     if (_stats.hasSum()) {
       bool wasPositive = _stats.getSum() >= 0;
-      _stats.setSum(value * repetitions + _stats.getSum());
+      // use unsigned types for modulo behaviour without UB
+      _stats.setSum
+        (static_cast<int64_t>
+          (static_cast<uint64_t>(value * repetitions) +
+             static_cast<uint64_t>(_stats.getSum())));
       if ((value >= 0) == wasPositive) {
         _stats.setHasSum((_stats.getSum() >= 0) == wasPositive);
       }

--- a/c++/src/Statistics.hh
+++ b/c++/src/Statistics.hh
@@ -975,7 +975,10 @@ namespace orc {
       _stats.setHasSum(_stats.hasSum() && intStats.hasSum());
       if (_stats.hasSum()) {
         bool wasPositive = _stats.getSum() >= 0;
-        _stats.setSum(_stats.getSum() + intStats.getSum());
+        // Use unsigned type to obtain modulo behaviour without UB
+        _stats.setSum(static_cast<int64_t>
+          (static_cast<uint64_t>
+            (_stats.getSum()) + static_cast<uint64_t>(intStats.getSum())));
         if ((intStats.getSum() >= 0) == wasPositive) {
           _stats.setHasSum((_stats.getSum() >= 0) == wasPositive);
         }


### PR DESCRIPTION
using gcc --version:
gcc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0

- Left-shift into sign-bit.
- Signed integer overflow when modulo behavior is intended
- Use memcpy (which modern compilers should optimize anyway) to avoid unaligned reads