### PR TITLE
ORC-613: Fix OrcMapredRecordReader when dealing with union of multiple structs with different schema

### DIFF
--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcMapredRecordReader.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcMapredRecordReader.java
@@ -394,10 +394,10 @@ public class OrcMapredRecordReader<V extends WritableComparable>
       OrcStruct result;
       List<TypeDescription> childrenTypes = schema.getChildren();
       int numChildren = childrenTypes.size();
-      if (previous == null || previous.getClass() != OrcStruct.class) {
-        result = new OrcStruct(schema);
-      } else {
+      if (isReusable(previous, schema)) {
         result = (OrcStruct) previous;
+      } else {
+        result = new OrcStruct(schema);
       }
       StructColumnVector struct = (StructColumnVector) vector;
       for(int f=0; f < numChildren; ++f) {
@@ -408,6 +408,17 @@ public class OrcMapredRecordReader<V extends WritableComparable>
     } else {
       return null;
     }
+  }
+
+  /**
+   * Determine if a OrcStruct object is reusable.
+   */
+  private static boolean isReusable(Object previous, TypeDescription schema) {
+    if (previous == null || previous.getClass() != OrcStruct.class) {
+      return false;
+    }
+
+    return ((OrcStruct) previous).getSchema().equals(schema);
   }
 
   static OrcUnion nextUnion(ColumnVector vector,


### PR DESCRIPTION
The bug is described in ORC-613 but briefly, in `OrcMapredRecordReader.java#nextStruct`, the determination of whether a previous object can be reused is buggy: It only checks top-level type (`OrcStruct`) but not the child schema under `OrcStruct`. So if dealing with following schema: 
`uniontype <struct<field0, field1>, struct<>>`

Let's say we have sequence of data like following : 
record0: {0: <field0, field1>}
record1: {1:<>}

Record1 will reuse the previous object's schema and results in incorrect output. 

Added a unit test that can reproduce the scenario. 
