### PR TITLE
ORC-614: Implement efficient seek() in decompression streams

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -553,7 +553,7 @@ DIAGNOSTIC_POP
     remainingLength -= availSize;
     bytesReturned += static_cast<off_t>(*size);
     if (saveBufferPositions) {
-      uncompressedBufferLength = *size;
+      uncompressedBufferLength = static_cast<size_t>(*size);
       outputBufferStart = reinterpret_cast<const char*>(*data);
     }
     return true;

--- a/c++/src/io/InputStream.cc
+++ b/c++/src/io/InputStream.cc
@@ -52,6 +52,10 @@ namespace orc {
     return result;
   }
 
+  uint64_t PositionProvider::current() {
+    return *position;
+  }
+
   SeekableInputStream::~SeekableInputStream() {
     // PASS
   }

--- a/c++/src/io/InputStream.hh
+++ b/c++/src/io/InputStream.hh
@@ -41,6 +41,7 @@ namespace orc {
   public:
     PositionProvider(const std::list<uint64_t>& positions);
     uint64_t next();
+    uint64_t current();
   };
 
   /**


### PR DESCRIPTION
The current implementation of ZlibDecompressionStream::seek and
BlockDecompressionStream::seek resets the state of the decompressor
and the underlying file reader and throws away their buffers.

This commit introduces two optimizations which rely on reusing
the buffers that still contain useful data, and therefore reducing
the time spent reading/uncompressing the buffers again.

The first case is when the seeked position is already read
and decompressed into the output stream.

The second case is when the seeked position is already read from
the input stream, but has not been decompressed yet, ie. it's
not in the output stream.

Tests:
 - Run the ORC tests, and the Impala tests working on ORC tables.
 - The regression that #476 would cause is not present anymore.