### PR TITLE
ORC-622: Added BatchReader and TypeReader

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -249,13 +249,13 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     }
 
     @Override
-    void checkEncoding(OrcProto.ColumnEncoding encoding) throws IOException {
+    public void checkEncoding(OrcProto.ColumnEncoding encoding) throws IOException {
       // Pass-thru.
       fromReader.checkEncoding(encoding);
     }
 
     @Override
-    void startStripe(StripePlanner planner) throws IOException {
+    public void startStripe(StripePlanner planner) throws IOException {
       // Pass-thru.
       fromReader.startStripe(planner);
     }
@@ -273,7 +273,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     }
 
     @Override
-    void skipRows(long items) throws IOException {
+    public void skipRows(long items) throws IOException {
       // Pass-thru.
       fromReader.skipRows(items);
     }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -48,6 +48,7 @@ import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
+import org.apache.orc.impl.reader.tree.BatchReader;
 import org.apache.orc.util.BloomFilter;
 import org.apache.orc.util.BloomFilterIO;
 import org.slf4j.Logger;
@@ -78,7 +79,7 @@ public class RecordReaderImpl implements RecordReader {
   private int currentStripe = -1;
   private long rowBaseInStripe = 0;
   private long rowCountInStripe = 0;
-  private final TreeReaderFactory.TreeReader reader;
+  private final BatchReader<?> reader;
   private final OrcIndex indexes;
   private final SargApplier sargApp;
   // an array about which row groups aren't skipped
@@ -227,8 +228,7 @@ public class RecordReaderImpl implements RecordReader {
           .setProlepticGregorian(fileReader.writerUsedProlepticGregorian(),
               fileReader.options.getConvertToProlepticGregorian())
           .setEncryption(encryption);
-    reader = TreeReaderFactory.createTreeReader(evolution.getReaderSchema(),
-        readerContext);
+    reader = TreeReaderFactory.createRootReader(evolution.getReaderSchema(), readerContext);
 
     int columns = evolution.getFileSchema().getMaximumId() + 1;
     indexes = new OrcIndex(new OrcProto.RowIndex[columns],
@@ -1109,7 +1109,7 @@ public class RecordReaderImpl implements RecordReader {
    * @throws IOException
    */
   private boolean advanceToNextRow(
-      TreeReaderFactory.TreeReader reader, long nextRow, boolean canAdvanceStripe)
+    BatchReader<?> reader, long nextRow, boolean canAdvanceStripe)
       throws IOException {
     long nextRowInStripe = nextRow - rowBaseInStripe;
     // check for row skipping
@@ -1166,8 +1166,6 @@ public class RecordReaderImpl implements RecordReader {
       rowInStripe += batchSize;
       reader.setVectorColumnCount(batch.getDataColumnCount());
       reader.nextBatch(batch, batchSize);
-      batch.selectedInUse = false;
-      batch.size = batchSize;
       advanceToNextRow(reader, rowInStripe + rowBaseInStripe, true);
       return batch.size  != 0;
     } catch (IOException e) {
@@ -1261,7 +1259,7 @@ public class RecordReaderImpl implements RecordReader {
     }
   }
 
-  private void seekToRowEntry(TreeReaderFactory.TreeReader reader, int rowEntry)
+  private void seekToRowEntry(BatchReader<?> reader, int rowEntry)
       throws IOException {
     OrcProto.RowIndex[] rowIndices = indexes.getRowGroupIndex();
     PositionProvider[] index = new PositionProvider[rowIndices.length];

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -166,7 +166,6 @@ public class TreeReaderFactory {
   public abstract static class TreeReader implements TypeReader {
     protected final int columnId;
     protected BitFieldReader present = null;
-    protected int vectorColumnCount;
     protected final Context context;
 
     static final long[] powerOfTenTable = {
@@ -203,7 +202,6 @@ public class TreeReaderFactory {
       } else {
         present = new BitFieldReader(in);
       }
-      vectorColumnCount = -1;
     }
 
     public void checkEncoding(OrcProto.ColumnEncoding encoding) throws IOException {

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -494,15 +494,14 @@ public class StripePlanner {
     return result;
   }
 
-  private static class StreamInformation {
-    final OrcProto.Stream.Kind kind;
-    final int column;
-    final long offset;
-    final long length;
-    BufferChunk firstChunk;
+  public static class StreamInformation {
+    public final OrcProto.Stream.Kind kind;
+    public final int column;
+    public final long offset;
+    public final long length;
+    public BufferChunk firstChunk;
 
-    StreamInformation(OrcProto.Stream.Kind kind,
-                      int column, long offset, long length) {
+    public StreamInformation(OrcProto.Stream.Kind kind, int column, long offset, long length) {
       this.kind = kind;
       this.column = column;
       this.offset = offset;

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
@@ -1,0 +1,54 @@
+package org.apache.orc.impl.reader.tree;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.impl.PositionProvider;
+import org.apache.orc.impl.reader.StripePlanner;
+
+import java.io.IOException;
+
+public class BatchReader<T extends TypeReader> {
+  // The row type reader
+  public final T rootType;
+
+  protected int vectorColumnCount = -1;
+
+  public BatchReader(T rootType) {
+    this.rootType = rootType;
+  }
+
+  public void startStripe(StripePlanner planner) throws IOException {
+    rootType.startStripe(planner);
+  }
+
+  public void setVectorColumnCount(int vectorColumnCount) {
+    this.vectorColumnCount = vectorColumnCount;
+  }
+
+  /**
+   * Handle an elementary type
+   *
+   * @param batch     the batch to read into
+   * @param batchSize the number of rows to read
+   * @throws IOException
+   */
+  public void nextBatch(VectorizedRowBatch batch,
+                        int batchSize) throws IOException {
+    batch.cols[0].reset();
+    batch.cols[0].ensureSize(batchSize, false);
+    rootType.nextVector(batch.cols[0], null, batchSize);
+    resetBatch(batch, batchSize);
+  }
+
+  protected void resetBatch(VectorizedRowBatch batch, int batchSize) {
+    batch.selectedInUse = false;
+    batch.size = batchSize;
+  }
+
+  public void skipRows(long rows) throws IOException {
+    rootType.skipRows(rows);
+  }
+
+  public void seek(PositionProvider[] index) throws IOException {
+    rootType.seek(index);
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.orc.impl.reader.tree;
 
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
@@ -1,0 +1,28 @@
+package org.apache.orc.impl.reader.tree;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.impl.TreeReaderFactory;
+
+import java.io.IOException;
+
+public class StructBatchReader extends BatchReader<TreeReaderFactory.StructTreeReader> {
+
+  public StructBatchReader(TreeReaderFactory.StructTreeReader rowReader) {
+    super(rowReader);
+  }
+
+  @Override
+  public void nextBatch(VectorizedRowBatch batch, int batchSize) throws IOException {
+    for (int i = 0; i < rootType.fields.length &&
+                    (vectorColumnCount == -1 || i < vectorColumnCount); ++i) {
+      ColumnVector colVector = batch.cols[i];
+      if (colVector != null) {
+        colVector.reset();
+        colVector.ensureSize(batchSize, false);
+        rootType.fields[i].nextVector(colVector, null, batchSize);
+      }
+    }
+    resetBatch(batch, batchSize);
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.orc.impl.reader.tree;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.orc.impl.reader.tree;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
@@ -1,0 +1,26 @@
+package org.apache.orc.impl.reader.tree;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.orc.OrcProto;
+import org.apache.orc.impl.PositionProvider;
+import org.apache.orc.impl.reader.StripePlanner;
+
+import java.io.IOException;
+
+public interface TypeReader {
+  void checkEncoding(OrcProto.ColumnEncoding encoding) throws IOException;
+
+  void startStripe(StripePlanner planner) throws IOException;
+
+  void seek(PositionProvider[] index) throws IOException;
+
+  void seek(PositionProvider index) throws IOException;
+
+  void skipRows(long rows) throws IOException;
+
+  void nextVector(ColumnVector previous,
+                  boolean[] isNull,
+                  int batchSize) throws IOException;
+
+  int getColumnId();
+}

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -53,6 +53,8 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
+import org.apache.orc.impl.reader.tree.BatchReader;
+import org.apache.orc.impl.reader.tree.StructBatchReader;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -1641,13 +1643,14 @@ public class TestSchemaEvolution {
 
     TreeReaderFactory.Context treeContext =
         new TreeReaderFactory.ReaderContext().setSchemaEvolution(evo);
-    TreeReaderFactory.TreeReader reader =
-        TreeReaderFactory.createTreeReader(readType, treeContext);
+    BatchReader<?> reader =
+        TreeReaderFactory.createRootReader(readType, treeContext);
 
     // check to make sure the tree reader is built right
-    assertEquals(TreeReaderFactory.StructTreeReader.class, reader.getClass());
+    assertEquals(StructBatchReader.class, reader.getClass());
+    assertEquals(TreeReaderFactory.StructTreeReader.class, reader.rootType.getClass());
     TreeReaderFactory.TreeReader[] children =
-        ((TreeReaderFactory.StructTreeReader) reader).getChildReaders();
+        ((TreeReaderFactory.StructTreeReader) reader.rootType).getChildReaders();
     assertEquals(3, children.length);
     assertEquals(TreeReaderFactory.NullTreeReader.class, children[0].getClass());
     assertEquals(TreeReaderFactory.StringTreeReader.class, children[1].getClass());


### PR DESCRIPTION
This is fix for [ORC-622](https://issues.apache.org/jira/browse/ORC-622)

Fixed the TreeReaderFactory and ConvertTreeReaderFactory
Made RecordReaderImpl use RootReader instead of TreeReader
removed nextBatch method from TreeReader
Rename RootReader -> BatchReader, rowReader -> rootType
Moved the batch commit logic into the BatchReader
StreamInformation public
Added getColumnId into TypeReader
commitBatch has been renamed to resetBatch in BatchReader