### PR TITLE
ORC-630: Fix orc-tools uber jar by adding guava dependency back

### DIFF
--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -82,6 +82,12 @@
       <groupId>org.threeten</groupId>
       <artifactId>threetenbp</artifactId>
     </dependency>
+    <!-- orc-tools uber jar needs to include this -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>compile</scope>
+    </dependency>
 
     <!-- test inter-project -->
     <dependency>


### PR DESCRIPTION
After ORC-599 (Bumping up guava to 28.1-jre), `orc-tools` uber jar fails due to `ClassNotFoundException`. This PR aims to add it back to `orc-tools`.
```
$ mvn package -DskipTests
$ java -jar tools/target/orc-tools-1.7.0-SNAPSHOT-uber.jar meta /tmp/o
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/common/base/Preconditions
	at org.apache.hadoop.conf.Configuration$DeprecationDelta.<init>(Configuration.java:328)
	at org.apache.hadoop.conf.Configuration$DeprecationDelta.<init>(Configuration.java:341)
	at org.apache.hadoop.conf.Configuration.<clinit>(Configuration.java:423)
	at org.apache.orc.tools.Driver.main(Driver.java:100)
Caused by: java.lang.ClassNotFoundException: com.google.common.base.Preconditions
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
```