### PR TITLE
ORC-636: PPD Floating point stats with nonFinite numbers should be ignored

### DIFF
--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -494,12 +494,18 @@ namespace orc {
             colStats.doublestatistics().has_minimum() &&
             colStats.doublestatistics().has_maximum()) {
           const auto& stats = colStats.doublestatistics();
-          result = evaluatePredicateRange(
-            mOperator,
-            literal2Double(mLiterals),
-            stats.minimum(),
-            stats.maximum(),
-            colStats.hasnull());
+          if (!isfinite(stats.minimum()) || !isfinite(stats.maximum()) ||
+              !isfinite(stats.sum())) {
+              result = colStats.hasnull() ?
+                      TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+          } else {
+              result = evaluatePredicateRange(
+                      mOperator,
+                      literal2Double(mLiterals),
+                      stats.minimum(),
+                      stats.maximum(),
+                      colStats.hasnull());
+          }
         }
         break;
       }

--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -494,8 +494,8 @@ namespace orc {
             colStats.doublestatistics().has_minimum() &&
             colStats.doublestatistics().has_maximum()) {
           const auto& stats = colStats.doublestatistics();
-          if (!isfinite(stats.minimum()) || !isfinite(stats.maximum()) ||
-              !isfinite(stats.sum())) {
+          if (!std::isfinite(stats.minimum()) || !std::isfinite(stats.maximum()) ||
+              !std::isfinite(stats.sum())) {
               result = colStats.hasnull() ?
                       TruthValue::YES_NO_NULL : TruthValue::YES_NO;
           } else {

--- a/c++/test/TestPredicateLeaf.cc
+++ b/c++/test/TestPredicateLeaf.cc
@@ -348,7 +348,18 @@ namespace orc {
               evaluate(pred, createIntStats(10L, 15L, true)));
     EXPECT_EQ(TruthValue::YES_NULL,
               evaluate(pred, createIntStats(0L, 10L, true)));
-  }
+    // Edge case where stats contain NaN or Inf numbers
+    PredicateLeaf pred4(
+            PredicateLeaf::Operator::LESS_THAN,
+            PredicateDataType::FLOAT,
+            "x",
+            Literal(10.0));
+    const auto& dInf = static_cast<double>(INFINITY);
+    EXPECT_EQ(TruthValue::YES_NO,
+            evaluate(pred4, createDoubleStats(dInf, dInf)));
+    EXPECT_EQ(TruthValue::YES_NO_NULL,
+            evaluate(pred4, createDoubleStats(dInf, dInf, true)));
+    }
 
   TEST(TestPredicateLeaf, testIn) {
     PredicateLeaf pred(


### PR DESCRIPTION
Change-Id: Ib5859eeaef4123c363fb6a8fb5430ac9ef364611