### PR TITLE
ORC-640: [C++] Support consumption as CMake submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,9 @@
 # limitations under the License.
 
 cmake_minimum_required (VERSION 2.6)
+if (POLICY CMP0048)
+    cmake_policy(SET CMP0048 NEW)
+endif ()
 
 project(ORC C CXX)
 
@@ -19,7 +22,7 @@ SET(CPACK_PACKAGE_VERSION_MAJOR "1")
 SET(CPACK_PACKAGE_VERSION_MINOR "7")
 SET(CPACK_PACKAGE_VERSION_PATCH "0-SNAPSHOT")
 SET(ORC_VERSION "${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}")
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake_modules")
 
 option (BUILD_JAVA
     "Include ORC Java library in the build process"

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -184,9 +184,9 @@ include_directories (
 
 add_custom_command(OUTPUT orc_proto.pb.h orc_proto.pb.cc
    COMMAND ${PROTOBUF_EXECUTABLE}
-        -I ${CMAKE_SOURCE_DIR}/proto
+        -I ${PROJECT_SOURCE_DIR}/proto
         --cpp_out="${CMAKE_CURRENT_BINARY_DIR}"
-        "${CMAKE_SOURCE_DIR}/proto/orc_proto.proto"
+        "${PROJECT_SOURCE_DIR}/proto/orc_proto.proto"
 )
 
 set(SOURCE_FILES


### PR DESCRIPTION
Consuming Apache ORC in a C++ project as CMake submodule (via add_subdirectory) currently causes two issues:
* A warning about CMake policy CMP0048 not being set, which cannot be suppressed from the outside:
```
CMake Warning (dev) at third_party/orc/CMakeLists.txt:15 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
    PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```
* Errors about CMake modules not being found:
```
CMake Error at third_party/orc/CMakeLists.txt:116 (INCLUDE):
  INCLUDE could not find load file:

    CheckSourceCompiles


CMake Error at third_party/orc/CMakeLists.txt:117 (INCLUDE):
  INCLUDE could not find load file:

    ThirdpartyToolchain
```

This PR fixes the above.
