### PR TITLE
ORC-639: Improve zstd performance

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -911,11 +911,15 @@ DIAGNOSTIC_POP
                                                    capacity,
                                                    blockSize,
                                                    pool) {
-      // PASS
+      this->init();
     }
 
     virtual std::string getName() const override {
       return "ZstdCompressionStream";
+    }
+    
+    virtual ~ZSTDCompressionStream() override {
+      this->end();
     }
 
   protected:
@@ -924,15 +928,43 @@ DIAGNOSTIC_POP
     virtual uint64_t estimateMaxCompressionSize() override {
       return ZSTD_compressBound(static_cast<size_t>(bufferSize));
     }
+    
+  private:
+    void init();
+    void end();
+    ZSTD_CCtx *cctx;
   };
 
   uint64_t ZSTDCompressionStream::doBlockCompression() {
-    return ZSTD_compress(compressorBuffer.data(),
-                         compressorBuffer.size(),
-                         rawInputBuffer.data(),
-                         static_cast<size_t>(bufferSize),
-                         level);
+    return ZSTD_compressCCtx(cctx,
+                             compressorBuffer.data(),
+                             compressorBuffer.size(),
+                             rawInputBuffer.data(),
+                             static_cast<size_t>(bufferSize),
+                             level);
   }
+  
+DIAGNOSTIC_PUSH
+
+#if defined(__GNUC__) || defined(__clang__)
+  DIAGNOSTIC_IGNORE("-Wold-style-cast")
+#endif
+
+  void ZSTDCompressionStream::init() {
+
+    cctx = ZSTD_createCCtx();
+    if (!cctx) {
+      throw std::runtime_error("Error while calling ZSTD_createCCtx() for zstd.");
+    }
+  }
+
+
+  void ZSTDCompressionStream::end() {
+    (void)ZSTD_freeCCtx(cctx);
+    cctx = nullptr;
+  }
+
+DIAGNOSTIC_PUSH
 
   /**
    * ZSTD block decompression
@@ -945,7 +977,11 @@ DIAGNOSTIC_POP
                             : BlockDecompressionStream(std::move(inStream),
                                                        blockSize,
                                                        _pool) {
-      // PASS
+      this->init();
+    }
+
+    virtual ~ZSTDDecompressionStream() override {
+      this->end();
     }
 
     std::string getName() const override {
@@ -959,17 +995,45 @@ DIAGNOSTIC_POP
                                 uint64_t length,
                                 char *output,
                                 size_t maxOutputLength) override;
+
+  private:
+    void init();
+    void end();
+    ZSTD_DCtx *dctx;
   };
 
   uint64_t ZSTDDecompressionStream::decompress(const char *inputPtr,
                                                uint64_t length,
                                                char *output,
                                                size_t maxOutputLength) {
-    return static_cast<uint64_t>(ZSTD_decompress(output,
-                                                 maxOutputLength,
-                                                 inputPtr,
-                                                 length));
+    return static_cast<uint64_t>(ZSTD_decompressDCtx(dctx,
+                                                     output,
+                                                     maxOutputLength,
+                                                     inputPtr,
+                                                     length));
   }
+
+DIAGNOSTIC_PUSH
+
+#if defined(__GNUC__) || defined(__clang__)
+  DIAGNOSTIC_IGNORE("-Wold-style-cast")
+#endif
+
+  void ZSTDDecompressionStream::init() {
+
+    dctx = ZSTD_createDCtx();
+    if (!dctx) {
+      throw std::runtime_error("Error while calling ZSTD_createDCtx() for zstd.");
+    }
+  }
+
+
+  void ZSTDDecompressionStream::end() {
+    (void)ZSTD_freeDCtx(dctx);
+    dctx = nullptr;
+  }
+
+DIAGNOSTIC_PUSH
 
   std::unique_ptr<BufferedOutputStream>
      createCompressor(


### PR DESCRIPTION
Issue described in [ORC-639](https://issues.apache.org/jira/browse/ORC-639):

In Compression.cc, classes ZSTDCompressionStream and ZSTDDecompressionStream employ Zstd's "Simple API", which initializes the compression/decompression context each time. This context initialization includes time to initialize all compression/decompression tables.

Using the "Explicit context" API improves the performance significantly as compression/decompression tables are constructed once and reused each time "decompress" or "doBlockCompression" is called.

We've noticed more than 15% time improvement in some applications with this change, so it seems that any ORC user using Zstd can benefit from this change.