### PR TITLE
ORC-659: Initialize "next_in" before calling DeflateInit2

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -292,6 +292,7 @@ DIAGNOSTIC_PUSH
     strm.zalloc = nullptr;
     strm.zfree = nullptr;
     strm.opaque = nullptr;
+    strm.next_in = nullptr;
 
     if (deflateInit2(&strm, level, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY)
         != Z_OK) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to initialize `next_in` before calling DeflateInit2.

### Why are the changes needed?

According to zlib documentation of DeflateInit2:

_"This is another version of deflateInit with more compression options. The fields **next_in**, zalloc, zfree and opaque must be initialized before by the caller."_

In an alpine docker DeflateInit2 was returning an error that seems to be solved with the patch.

### How was this patch tested?

Pass UT.