### PR TITLE
Change logging level of creating new codec in OrcCodecPool

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
@@ -53,7 +53,7 @@ public final class OrcCodecPool {
     }
     if (codec == null) {
       codec = WriterImpl.createCodec(kind);
-      LOG.info("Got brand-new codec " + kind);
+      LOG.debug("Got brand-new codec " + kind);
     } else {
       LOG.debug("Got recycled codec");
     }


### PR DESCRIPTION
When using Hive LLAP in a cloud environment, we observed a bunch of (>100000) non-useful logs: 

`impl.OrcCodecPool: Got brand-new codec ZLIB`

I think the log level here can be reduced to DEBUG.