### PR TITLE
ORC-648: Add GitHub Action for Java8/11 test coverage

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,46 @@
+name: master
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: "Build with Java ${{ matrix.java }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - 1.8
+          - 11
+    env:
+      MAVEN_OPTS: -Xmx2g
+      MAVEN_SKIP_RC: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Cache Maven local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ matrix.java }}-maven-
+    - name: Install Java ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: "Test"
+      run: |
+        mkdir -p ~/.m2
+        mkdir build
+        cd build
+        cmake ..
+        make package test-out
+        cd ../java
+        mvn apache-rat:check


### PR DESCRIPTION
This PR aims to add `GitHub Action` for explicit Java 8/11 test coverage. Since this is an independent CI setup, this will not interfere with the existing CIs.

Apache ORC is currently using
- Travis CI for testing various `clang` versions on Trusty and Mac with JDK7.
- Appveyor CI for testing Visual Studio on Windows OS.

This is tested here.
- https://github.com/dongjoon-hyun/orc/pull/3

![Screen Shot 2020-07-16 at 9 56 22 PM](https://user-images.githubusercontent.com/9700541/87750050-3aec7280-c7af-11ea-9e2e-adbdf5bb7a9c.png)

After this PR, it seems that we need to file Apache INFRA JIRA issue to enable `GitHub Action` on ORC project.