### PR TITLE
ORC-650: Fix argument to find_package() for ZSTD

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -136,7 +136,7 @@ endif ()
 # Zstd
 
 if (NOT "${ZSTD_HOME}" STREQUAL "")
-  find_package (zstd REQUIRED)
+  find_package (ZSTD REQUIRED)
   set(ZSTD_VENDORED FALSE)
 else ()
   set(ZSTD_HOME "${THIRDPARTY_DIR}/zstd_ep-install")


### PR DESCRIPTION
The name of the module is FindZSTD.cmake and not Findzstd.cmake