### PR TITLE
ORC-654: Fix build with clang-10 and ubuntu-20

### DIFF
--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -123,7 +123,7 @@ void RleEncoderV2::write(int64_t val) {
             numLiterals = MIN_REPEAT;
         }
 
-        if (fixedRunLength == MAX_LITERAL_SIZE) {;
+        if (fixedRunLength == MAX_LITERAL_SIZE) {
             determineEncoding(option);
             writeValues(option);
         }
@@ -696,7 +696,7 @@ void RleEncoderV2::writeInts(int64_t* input, uint32_t offset, size_t len, uint32
   if (getClosestAlignedFixedBits(bitSize) == bitSize) {
     uint32_t numBytes;
     uint32_t endOffSet = static_cast<uint32_t>(offset + len);
-    if (bitSize < 8 ) {;
+    if (bitSize < 8 ) {
       char bitMask = static_cast<char>((1 << bitSize) - 1);
       uint32_t numHops = 8 / bitSize;
       uint32_t remainder = static_cast<uint32_t>(len % numHops);

--- a/c++/test/TestBloomFilter.cc
+++ b/c++/test/TestBloomFilter.cc
@@ -152,9 +152,9 @@ namespace orc {
 
     // test strings
     bloomFilter.reset();
-    const char * emptyStr = u8"";
-    const char * enStr = u8"english";
-    const char * cnStr = u8"中国字";
+    const char * emptyStr = "";
+    const char * enStr = "english";
+    const char * cnStr = "中国字";
 
     EXPECT_FALSE(bloomFilter.testBytes(emptyStr,
                                        static_cast<int64_t>(strlen(emptyStr))));

--- a/c++/test/TestByteRle.cc
+++ b/c++/test/TestByteRle.cc
@@ -1107,7 +1107,7 @@ TEST(BooleanRle, skipTestWithNulls) {
       rle->skip(4);
     }
     rle->skip(0);
-    data.assign(data.size(), -1);;
+    data.assign(data.size(), -1);
     rle->next(data.data(), data.size(), allNull.data());
     for (size_t j = 0; j < data.size(); ++j) {
       EXPECT_EQ(0, data[j]) << "Output wrong at " << i << ", " << j;


### PR DESCRIPTION
### What changes were proposed in this pull request?

On Ubuntu 20 with Clang 10, build doesn't work https://gist.github.com/nikitamikhaylov/18e5f22e81a89f701520558a4c39f30d
Because every statement is separated by ; and ; after { means empty statement, which has no effect.

### Why are the changes needed?

Because I want the build to work on Ubuntu 20.

### How was this patch tested?

Build now works.

