### PR TITLE
ORC-648: Add GitHub Action for Java8/11 test coverage

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,46 @@
+name: master
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: "Build with Java ${{ matrix.java }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - 1.8
+          - 11
+    env:
+      MAVEN_OPTS: -Xmx2g
+      MAVEN_SKIP_RC: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Cache Maven local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ matrix.java }}-maven-
+    - name: Install Java ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: "Test"
+      run: |
+        mkdir -p ~/.m2
+        mkdir build
+        cd build
+        cmake ..
+        make package test-out
+        cd ../java
+        mvn apache-rat:check

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,12 +1,12 @@
-name: master
+name: branch-1.6
 
 on:
   push:
     branches:
-    - master
+    - branch-1.6
   pull_request:
     branches:
-    - master
+    - branch-1.6
 
 jobs:
   build:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `GitHub Action` for explicit Java 8/11 test coverage. Since this is an independent CI setup, this will not interfere with the existing CIs.

### Why are the changes needed?

Apache ORC is currently using
- Travis CI for testing various `clang` versions on Trusty and Mac with JDK7.
- Appveyor CI for testing Visual Studio on Windows OS.

### How was this patch tested?

Check the Github Action result on this PR.

![Screen Shot 2020-08-06 at 4 17 57 PM](https://user-images.githubusercontent.com/9700541/89592000-6b4c8d00-d800-11ea-9540-477188bfcb7f.png)
