### PR TITLE
ORC-647: Add macOS 10.15 test to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,15 @@ matrix:
     - cd build
     - cmake -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
     - make package test-out
+  - compiler: clang
+    os: osx
+    osx_image: xcode12
+    script:
+    - brew link --overwrite --force openssl
+    - mkdir build
+    - cd build
+    - cmake -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
+    - make package test-out
 
 jdk:
   - openjdk7


### PR DESCRIPTION
### What changes were proposed in this pull request?

In addition to the existing macOS `10.13` and `10.14` testing, this PR aims to support `macOS 10.15` testing by using `osx_image: xcode12` in `branch-1.5`.
- https://docs.travis-ci.com/user/reference/osx/#using-macos

### Why are the changes needed?

This will add clang 12.0.0 test coverage as we see the Travis CI log in this PR.
- https://travis-ci.org/github/apache/orc/jobs/708583066
```
$ clang --version
98Apple clang version 12.0.0 (clang-1200.0.22.8)
99Target: x86_64-apple-darwin19.5.0
```

### How was this patch tested?

Pass the Travis in this PR.
Please note that AppVeyor has been broken on branch-1.5 and is irrelevant to this PR.
- https://github.com/apache/orc/commits/branch-1.5