### PR TITLE
ORC-655: Update bench to use Spark 2.4.6

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -44,7 +44,7 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.8.3</parquet.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <spark.version>2.4.0</spark.version>
+    <spark.version>2.4.6</spark.version>
     <storage-api.version>2.7.2</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -100,11 +100,11 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_2.11</artifactId>
     </dependency>
-    <!-- Spark 2.4 uses Parquet 1.10.0 -->
+    <!-- Spark 2.4.6 uses Parquet 1.10.1 -->
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hadoop</artifactId>
-      <version>1.10.0</version>
+      <version>1.10.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
@@ -150,7 +150,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `bench` module to use Apache Spark 2.4.6.

### Why are the changes needed?

Apache Spark 2.4.6 is the latest version and we need to update `maven-shade-plugin` to use it.

### How was this patch tested?

This should be tested manually.
```
$ cd java/bench
$ mvn clean package
```