### PR TITLE
ORC-656: Use gharchive.org instead of githubarchive.org

### DIFF
--- a/java/bench/fetch-data.sh
+++ b/java/bench/fetch-data.sh
@@ -18,4 +18,4 @@ mkdir -p data/sources/taxi
 (cd data/sources/taxi; wget https://s3.amazonaws.com/nyc-tlc/trip+data/yellow_tripdata_2015-{11,12}.csv)
 (cd data/sources/taxi; gzip *.csv)
 mkdir -p data/sources/github
-(cd data/sources/github; wget http://data.githubarchive.org/2015-11-{01..15}-{0..23}.json.gz)
+(cd data/sources/github; wget http://data.gharchive.org/2015-11-{01..15}-{0..23}.json.gz)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use gharchive.org instead of githubarchive.org.

### Why are the changes needed?

The URL is permanently moved. 
```
--2020-08-08 23:14:16--  http://data.githubarchive.org/2015-11-01-1.json.gz
Connecting to data.githubarchive.org (data.githubarchive.org)|140.82.113.18|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://data.gharchive.org/2015-11-01-1.json.gz [following]
--2020-08-08 23:14:16--  https://data.gharchive.org/2015-11-01-1.json.gz
Connecting to data.gharchive.org (data.gharchive.org)|104.18.54.216|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 4708768 (4.5M) [application/gzip]
Saving to: '2015-11-01-1.json.gz.1'
```


### How was this patch tested?

```
cd java/bench/
fetch-data.sh 
```