### PR TITLE
ORC-657: Remove com.netflix.iceberg dependency in java/bench module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -39,7 +39,6 @@
     <avro.version>1.8.2</avro.version>
     <hadoop.version>2.7.3</hadoop.version>
     <hive.version>2.3.3</hive.version>
-    <iceberg.version>0.1.3</iceberg.version>
     <jmh.version>1.20</jmh.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.8.3</parquet.version>
@@ -86,39 +85,6 @@
           <exclusion>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.netflix.iceberg</groupId>
-        <artifactId>iceberg-api</artifactId>
-        <version>${iceberg.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.orc</groupId>
-            <artifactId>orc-core</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.netflix.iceberg</groupId>
-        <artifactId>iceberg-core</artifactId>
-        <version>${iceberg.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.orc</groupId>
-            <artifactId>orc-core</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.netflix.iceberg</groupId>
-        <artifactId>iceberg-spark</artifactId>
-        <version>${iceberg.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.apache.orc</groupId>
-            <artifactId>orc-core</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `com.netflix.iceberg` dependency from `java/bench` module

### Why are the changes needed?

This is unused and `iceberg` became Apache Iceberg already.

### How was this patch tested?

Manually.
```
$ cd java/bench
$ mvn package
```