### PR TITLE
ORC-648: Add GitHub Action for Java8/11 test coverage

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,46 @@
+name: branch-1.5
+
+on:
+  push:
+    branches:
+    - branch-1.5
+  pull_request:
+    branches:
+    - branch-1.5
+
+jobs:
+  build:
+    name: "Build with Java ${{ matrix.java }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - 1.8
+          - 11
+    env:
+      MAVEN_OPTS: -Xmx2g
+      MAVEN_SKIP_RC: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Cache Maven local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ matrix.java }}-maven-
+    - name: Install Java ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: "Test"
+      run: |
+        mkdir -p ~/.m2
+        mkdir build
+        cd build
+        cmake ..
+        make package test-out
+        cd ../java
+        mvn apache-rat:check


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `GitHub Action` for explicit Java 8/11 test coverage on `branch-1.5`. Since this is an independent CI setup, this will not interfere with the existing CIs.

### Why are the changes needed?

Apache ORC is currently using
- Travis CI for testing various `clang` versions on Trusty and Mac with JDK7.
- Appveyor CI for testing Visual Studio on Windows OS.

### How was this patch tested?

See the GitHub Action on this PR.