### PR TITLE
ORC-658: Fix NoClassDefFoundError during benchmark data generation

### DIFF
--- a/java/bench/core/pom.xml
+++ b/java/bench/core/pom.xml
@@ -71,6 +71,10 @@
       <artifactId>hadoop-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `hadoop-hdfs` dependency to `bench/core` module.

### Why are the changes needed?

This will fix `NoClassDefFoundError` error during data generation.
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data
[WARN ] Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/hadoop/hdfs/client/HdfsDataOutputStream$SyncFlag
```

### How was this patch tested?

```
cd java/bench
mvn package
./fetch-data.sh
java -jar core/target/orc-benchmarks-core-*-uber.jar generate data
```