### PR TITLE
Change calendar field to unused index

### DIFF
--- a/proto/orc_proto.proto
+++ b/proto/orc_proto.proto
@@ -368,7 +368,7 @@ message Footer {
 
   // information about the encryption in this file
   optional Encryption encryption = 10;
-  optional CalendarKind calendar = 11;
+  optional CalendarKind calendar = 12;
 }
 
 enum CompressionKind {


### PR DESCRIPTION
The calendar field is currently assigned to field 11, but this was previously used for stripeStatisticsLength and then removed with https://github.com/apache/orc/commit/548050271e5869bc6a5b4c8b735927d6d0721062#diff-f1e26f33ad210dfde6ab7123c7feb835L364
