### PR TITLE
ORC-661. Use LocalDate and day of epoch instead of java's Date for column statistics

### DIFF
--- a/java/core/src/java/org/apache/orc/DateColumnStatistics.java
+++ b/java/core/src/java/org/apache/orc/DateColumnStatistics.java
@@ -17,21 +17,50 @@
  */
 package org.apache.orc;
 
+import java.time.LocalDate;
+import java.time.chrono.ChronoLocalDate;
 import java.util.Date;
 
 /**
  * Statistics for DATE columns.
  */
 public interface DateColumnStatistics extends ColumnStatistics {
+
+  /**
+   * Get the minimum value for the column.
+   * @return minimum value as a LocalDate
+   */
+  ChronoLocalDate getMinimumLocalDate();
+
+  /**
+   * Get the minimum value for the column.
+   * @return minimum value as days since epoch (1 Jan 1970)
+   */
+  long getMinimumDayOfEpoch();
+
+  /**
+   * Get the maximum value for the column.
+   * @return maximum value as a LocalDate
+   */
+  ChronoLocalDate getMaximumLocalDate();
+
+  /**
+   * Get the maximum value for the column.
+   * @return maximum value as days since epoch (1 Jan 1970)
+   */
+  long getMaximumDayOfEpoch();
+
   /**
    * Get the minimum value for the column.
    * @return minimum value
+   * @deprecated Use #getMinimumLocalDate instead
    */
   Date getMinimum();
 
   /**
    * Get the maximum value for the column.
    * @return maximum value
+   * @deprecated Use #getMaximumLocalDate instead
    */
   Date getMaximum();
 }

--- a/java/core/src/java/org/apache/orc/impl/DateUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DateUtils.java
@@ -97,12 +97,12 @@ public class DateUtils {
    * @return day of epoch in the hybrid Julian/Gregorian
    */
   public static int convertDateToHybrid(int proleptic) {
-    int hyrbid = proleptic;
+    int hybrid = proleptic;
     if (proleptic < SWITCHOVER_DAYS) {
       String dateStr = PROLEPTIC_DATE_FORMAT.format(LocalDate.ofEpochDay(proleptic));
-      hyrbid = (int) LocalDate.from(HYBRID_DATE_FORMAT.parse(dateStr)).toEpochDay();
+      hybrid = (int) LocalDate.from(HYBRID_DATE_FORMAT.parse(dateStr)).toEpochDay();
     }
-    return hyrbid;
+    return hybrid;
   }
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -17,6 +17,13 @@
  */
 package org.apache.orc.impl;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.chrono.ChronoLocalDate;
+import java.time.format.DateTimeFormatter;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -25,7 +32,6 @@ import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument.TruthValue;
 import org.apache.hadoop.hive.ql.util.TimestampUtils;
-import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.orc.BooleanColumnStatistics;
@@ -49,6 +55,7 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
 import org.apache.orc.impl.reader.tree.BatchReader;
+import org.apache.orc.impl.writer.DateTreeWriter;
 import org.apache.orc.util.BloomFilter;
 import org.apache.orc.util.BloomFilterIO;
 import org.slf4j.Logger;
@@ -56,10 +63,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TimeZone;
@@ -418,8 +425,8 @@ public class RecordReaderImpl implements RecordReader {
           stats.getMaximum() == null);
     } else if (index instanceof DateColumnStatistics) {
       DateColumnStatistics stats = (DateColumnStatistics) index;
-      java.util.Date min = stats.getMinimum();
-      java.util.Date max = stats.getMaximum();
+      ChronoLocalDate min = stats.getMinimumLocalDate();
+      ChronoLocalDate max = stats.getMaximumLocalDate();
       return new ValueRange<>(predicate, min, max, stats.hasNull());
     } else if (index instanceof DecimalColumnStatistics) {
       DecimalColumnStatistics stats = (DecimalColumnStatistics) index;
@@ -752,8 +759,8 @@ public class RecordReaderImpl implements RecordReader {
           result = TruthValue.YES_NO_NULL;
         }
       }
-    } else if (predObj instanceof Date) {
-      if (bf.testLong(DateWritable.dateToDays((Date) predObj))) {
+    } else if (predObj instanceof ChronoLocalDate) {
+      if (bf.testLong(((ChronoLocalDate) predObj).toEpochDay())) {
         result = TruthValue.YES_NO_NULL;
       }
     } else {
@@ -801,12 +808,17 @@ public class RecordReaderImpl implements RecordReader {
           return Boolean.valueOf(obj.toString());
         }
       case DATE:
-        if (obj instanceof Date) {
+        if (obj instanceof ChronoLocalDate) {
           return obj;
+        } else if (obj instanceof java.sql.Date) {
+          return ((java.sql.Date) obj).toLocalDate();
+        } else if (obj instanceof Date) {
+          return LocalDateTime.ofInstant(((Date) obj).toInstant(),
+              ZoneOffset.UTC).toLocalDate();
         } else if (obj instanceof String) {
-          return Date.valueOf((String) obj);
+          return LocalDate.parse((String) obj);
         } else if (obj instanceof Timestamp) {
-          return DateWritable.timeToDate(((Timestamp) obj).getTime() / 1000L);
+          return ((Timestamp) obj).toLocalDateTime().toLocalDate();
         }
         // always string, but prevent the comparison to numbers (are they days/seconds/milliseconds?)
         break;
@@ -859,6 +871,11 @@ public class RecordReaderImpl implements RecordReader {
         }
         break;
       case STRING:
+        if (obj instanceof ChronoLocalDate) {
+          ChronoLocalDate date = (ChronoLocalDate) obj;
+          return date.format(DateTimeFormatter.ISO_LOCAL_DATE
+              .withChronology(date.getChronology()));
+        }
         return (obj.toString());
       case TIMESTAMP:
         if (obj instanceof Timestamp) {
@@ -875,6 +892,9 @@ public class RecordReaderImpl implements RecordReader {
           return TimestampUtils.decimalToTimestamp(((HiveDecimalWritable) obj).getHiveDecimal());
         } else if (obj instanceof Date) {
           return new Timestamp(((Date) obj).getTime());
+        } else if (obj instanceof ChronoLocalDate) {
+          return new Timestamp(((ChronoLocalDate) obj).atTime(LocalTime.MIDNIGHT)
+              .toInstant(ZoneOffset.UTC).getEpochSecond() * 1000L);
         }
         // float/double conversion to timestamp is interpreted as seconds whereas integer conversion
         // to timestamp is interpreted as milliseconds by default. The integer to timestamp casting

--- a/java/core/src/java/org/apache/orc/impl/writer/TreeWriterBase.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/TreeWriterBase.java
@@ -89,9 +89,10 @@ public abstract class TreeWriterBase implements TreeWriter {
     isPresent = new BitFieldWriter(isPresentOutStream, 1);
     this.foundNulls = false;
     createBloomFilter = context.getBloomFilterColumns()[id];
-    indexStatistics = ColumnStatisticsImpl.create(schema);
-    stripeColStatistics = ColumnStatisticsImpl.create(schema);
-    fileStatistics = ColumnStatisticsImpl.create(schema);
+    boolean proleptic = context.getProlepticGregorian();
+    indexStatistics = ColumnStatisticsImpl.create(schema, proleptic);
+    stripeColStatistics = ColumnStatisticsImpl.create(schema, proleptic);
+    fileStatistics = ColumnStatisticsImpl.create(schema, proleptic);
     if (context.buildIndex()) {
       rowIndex = OrcProto.RowIndex.newBuilder();
       rowIndexEntry = OrcProto.RowIndexEntry.newBuilder();

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -388,8 +388,10 @@ public class TestColumnStatistics {
     ColumnStatisticsImpl stats2 = ColumnStatisticsImpl.create(schema);
     stats1.updateDate(new DateWritable(1000));
     stats1.updateDate(new DateWritable(100));
+    stats1.increment(2);
     stats2.updateDate(new DateWritable(10));
     stats2.updateDate(new DateWritable(2000));
+    stats2.increment(2);
     stats1.merge(stats2);
     DateColumnStatistics typed = (DateColumnStatistics) stats1;
     assertEquals(new DateWritable(10).get(), typed.getMinimum());
@@ -397,9 +399,35 @@ public class TestColumnStatistics {
     stats1.reset();
     stats1.updateDate(new DateWritable(-10));
     stats1.updateDate(new DateWritable(10000));
+    stats1.increment(2);
     stats1.merge(stats2);
     assertEquals(new DateWritable(-10).get(), typed.getMinimum());
     assertEquals(new DateWritable(10000).get(), typed.getMaximum());
+  }
+
+  @Test
+  public void testLocalDateMerge() throws Exception {
+    TypeDescription schema = TypeDescription.createDate();
+
+    ColumnStatisticsImpl stats1 = ColumnStatisticsImpl.create(schema);
+    ColumnStatisticsImpl stats2 = ColumnStatisticsImpl.create(schema);
+    stats1.updateDate(1000);
+    stats1.updateDate(100);
+    stats1.increment(2);
+    stats2.updateDate(10);
+    stats2.updateDate(2000);
+    stats2.increment(2);
+    stats1.merge(stats2);
+    DateColumnStatistics typed = (DateColumnStatistics) stats1;
+    assertEquals(10, typed.getMinimumDayOfEpoch());
+    assertEquals(2000, typed.getMaximumDayOfEpoch());
+    stats1.reset();
+    stats1.updateDate(-10);
+    stats1.updateDate(10000);
+    stats1.increment(2);
+    stats1.merge(stats2);
+    assertEquals(-10, typed.getMinimumLocalDate().toEpochDay());
+    assertEquals(10000, typed.getMaximumLocalDate().toEpochDay());
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/TestProlepticConversions.java
+++ b/java/core/src/test/org/apache/orc/TestProlepticConversions.java
@@ -17,6 +17,9 @@
  */
 package org.apache.orc;
 
+import java.time.chrono.Chronology;
+import java.time.chrono.IsoChronology;
+import java.time.format.DateTimeFormatter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -45,6 +48,7 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import org.threeten.extra.chrono.HybridChronology;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -126,11 +130,12 @@ public class TestProlepticConversions {
       t.changeCalendar(writerProlepticGregorian, false);
       i.changeCalendar(writerProlepticGregorian, false);
       GregorianCalendar cal = writerProlepticGregorian ? PROLEPTIC : HYBRID;
-      SimpleDateFormat dateFormat = createParser("yyyy-MM-dd", cal);
       SimpleDateFormat timeFormat = createParser("yyyy-MM-dd HH:mm:ss", cal);
+      Chronology writerChronology = writerProlepticGregorian
+          ? IsoChronology.INSTANCE : HybridChronology.INSTANCE;
       for(int r=0; r < batch.size; ++r) {
-        d.vector[r] = TimeUnit.MILLISECONDS.toDays(
-            dateFormat.parse(String.format("%04d-01-23", r * 2 + 1)).getTime());
+        d.vector[r] = writerChronology.date(r * 2 + 1, 1, 23)
+            .toEpochDay();
         Date val = timeFormat.parse(
             String.format("%04d-03-21 %02d:12:34", 2 * r + 1, r % 24));
         t.time[r] = val.getTime();
@@ -151,16 +156,18 @@ public class TestProlepticConversions {
       TimestampColumnVector t = (TimestampColumnVector) batch.cols[1];
       TimestampColumnVector i = (TimestampColumnVector) batch.cols[2];
       GregorianCalendar cal = readerProlepticGregorian ? PROLEPTIC : HYBRID;
-      SimpleDateFormat dateFormat = createParser("yyyy-MM-dd", cal);
       SimpleDateFormat timeFormat = createParser("yyyy-MM-dd HH:mm:ss", cal);
+      Chronology readerChronology = readerProlepticGregorian
+          ? IsoChronology.INSTANCE : HybridChronology.INSTANCE;
+      DateTimeFormatter dateFormat = DateTimeFormatter.ISO_LOCAL_DATE.withChronology(readerChronology);
 
       // Check the file statistics
       ColumnStatistics[] colStats = reader.getStatistics();
       DateColumnStatistics dStats = (DateColumnStatistics) colStats[1];
       TimestampColumnStatistics tStats = (TimestampColumnStatistics) colStats[2];
       TimestampColumnStatistics iStats = (TimestampColumnStatistics) colStats[3];
-      assertEquals("0001-01-23", dateFormat.format(dStats.getMinimum()));
-      assertEquals("2047-01-23", dateFormat.format(dStats.getMaximum()));
+      assertEquals("0001-01-23", dStats.getMinimumLocalDate().format(dateFormat));
+      assertEquals("2047-01-23", dStats.getMaximumLocalDate().format(dateFormat));
       assertEquals("0001-03-21 00:12:34", timeFormat.format(tStats.getMinimum()));
       assertEquals("2047-03-21 15:12:34", timeFormat.format(tStats.getMaximum()));
       assertEquals("0001-03-21 00:12:34", timeFormat.format(iStats.getMinimum()));
@@ -173,8 +180,8 @@ public class TestProlepticConversions {
       dStats = (DateColumnStatistics) colStats[1];
       tStats = (TimestampColumnStatistics) colStats[2];
       iStats = (TimestampColumnStatistics) colStats[3];
-      assertEquals("0001-01-23", dateFormat.format(dStats.getMinimum()));
-      assertEquals("2047-01-23", dateFormat.format(dStats.getMaximum()));
+      assertEquals("0001-01-23", dStats.getMinimumLocalDate().format(dateFormat));
+      assertEquals("2047-01-23", dStats.getMaximumLocalDate().format(dateFormat));
       assertEquals("0001-03-21 00:12:34", timeFormat.format(tStats.getMinimum()));
       assertEquals("2047-03-21 15:12:34", timeFormat.format(tStats.getMaximum()));
       assertEquals("0001-03-21 00:12:34", timeFormat.format(iStats.getMinimum()));
@@ -190,8 +197,8 @@ public class TestProlepticConversions {
       for(int r=0; r < batch.size; ++r) {
         String expectedD = String.format("%04d-01-23", r * 2 + 1);
         String expectedT = String.format("%04d-03-21 %02d:12:34", 2 * r + 1, r % 24);
-        assertEquals("row " + r, expectedD, dateFormat.format(
-            new Date(TimeUnit.DAYS.toMillis(d.vector[r]))));
+        assertEquals("row " + r, expectedD, readerChronology.dateEpochDay(d.vector[r])
+            .format(dateFormat));
         assertEquals("row " + r, expectedT, timeFormat.format(t.asScratchTimestamp(r)));
         assertEquals("row " + r, expectedT, timeFormat.format(i.asScratchTimestamp(r)));
       }


### PR DESCRIPTION
This PR adds 4 new methods to the DateColumnStatistics.

* getMinimumLocalDate -> LocalDate
* getMinimumDayOfEpoch -> int

and the matching getMaximum functions. The current functions are deprecated. The DateColumnStatisticsImpl moves the minimum and maximum values to int instead of Integer, so they can be modified. The initial values are Integer.MAX_VALUE and MIN_VALUE.

The PPD code is changed to use LocalDate instead of Date.

