### PR TITLE
Partially rework cmake modules to accommodate library types

### DIFF
--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -155,7 +155,7 @@ CHECK_CXX_SOURCE_RUNS("
 )
 
 set(CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIR})
-set(CMAKE_REQUIRED_LIBRARIES zlib)
+set(CMAKE_REQUIRED_LIBRARIES orc_zlib)
 CHECK_CXX_SOURCE_COMPILES("
     #define Z_PREFIX
     #include<zlib.h>
@@ -174,12 +174,7 @@ configure_file (
 include_directories (
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${PROTOBUF_INCLUDE_DIR}
-  ${ZLIB_INCLUDE_DIR}
-  ${SNAPPY_INCLUDE_DIR}
-  ${LZ4_INCLUDE_DIR}
   ${LIBHDFSPP_INCLUDE_DIR}
-  ${ZSTD_INCLUDE_DIR}
   )
 
 add_custom_command(OUTPUT orc_proto.pb.h orc_proto.pb.cc
@@ -236,11 +231,11 @@ endif(BUILD_LIBHDFSPP)
 add_library (orc STATIC ${SOURCE_FILES})
 
 target_link_libraries (orc
-  protobuf
-  zlib
-  snappy
-  lz4
-  zstd
+  orc::protobuf
+  orc::zlib
+  orc::snappy
+  orc::lz4
+  orc::zstd
   ${LIBHDFSPP_LIBRARIES}
   )
 

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -14,10 +14,6 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/c++/src
   ${PROJECT_BINARY_DIR}/c++/include
   ${PROJECT_BINARY_DIR}/c++/src
-  ${PROTOBUF_INCLUDE_DIR}
-  ${ZLIB_INCLUDE_DIR}
-  ${SNAPPY_INCLUDE_DIR}
-  ${GTEST_INCLUDE_DIR}
 )
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS} ${WARN_FLAGS}")
@@ -54,11 +50,11 @@ add_executable (orc-test
 
 target_link_libraries (orc-test
   orc
-  lz4
-  protobuf
-  snappy
-  zlib
-  ${GTEST_LIBRARIES}
+  orc::lz4
+  orc::protobuf
+  orc::snappy
+  orc::zlib
+  orc::gmock
 )
 
 add_executable (create-test-files
@@ -67,7 +63,7 @@ add_executable (create-test-files
 
 target_link_libraries (create-test-files
   orc
-  protobuf
+  orc::protobuf
 )
 
 if (TEST_VALGRIND_MEMCHECK)

--- a/cmake_modules/FindGTest.cmake
+++ b/cmake_modules/FindGTest.cmake
@@ -13,8 +13,10 @@
 # GTEST_HOME environmental variable is used to check for GTest headers and static library
 
 # GTEST_INCLUDE_DIR: directory containing headers
-# GTEST_LIBS: directory containing gtest libraries
+# GMOCK_LIBRARY: path to libgmock
+# GTEST_LIBRARY: path to libgtest
 # GMOCK_STATIC_LIB: is set to gmock.a static library
+# GTEST_STATIC_LIB: is set to gtest.a static library
 # GTEST_FOUND is set if GTEST is found
 
 if (NOT "${GTEST_HOME}" STREQUAL "")
@@ -28,24 +30,40 @@ find_path (GTEST_INCLUDE_DIR gmock/gmock.h HINTS
   NO_DEFAULT_PATH
   PATH_SUFFIXES "include")
 
-find_library (GTEST_LIBRARIES NAMES gmock HINTS
+find_library (GMOCK_LIBRARY NAMES gmock HINTS
   ${_gtest_path}
   PATH_SUFFIXES "lib")
 
-if (GTEST_INCLUDE_DIR AND GTEST_LIBRARIES)
+find_library (GTEST_LIBRARY NAMES gtest HINTS
+  ${_gtest_path}
+  PATH_SUFFIXES "lib")
+
+find_library (GMOCK_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}gmock${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
+  ${_gtest_path}
+  PATH_SUFFIXES "lib")
+
+find_library (GTEST_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}gtest${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
+  ${_gtest_path}
+  PATH_SUFFIXES "lib")
+
+if (GTEST_INCLUDE_DIR AND GMOCK_LIBRARY)
   set (GTEST_FOUND TRUE)
-  get_filename_component (GTEST_LIBS ${GTEST_LIBRARIES} PATH )
   set (GTEST_HEADER_NAME gmock/gmock.h)
   set (GTEST_HEADER ${GTEST_INCLUDE_DIR}/${GTEST_HEADER_NAME})
-  set (GTEST_LIB_NAME gmock)
-  set (GMOCK_STATIC_LIB ${GTEST_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${GTEST_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
 else ()
   set (GTEST_FOUND FALSE)
 endif ()
 
 if (GTEST_FOUND)
   message (STATUS "Found the GTest header: ${GTEST_HEADER}")
-  message (STATUS "Found the GTest library: ${GMOCK_STATIC_LIB}")
+  message (STATUS "Found the GTest library: ${GTEST_LIBRARY}")
+  message (STATUS "Found the GMock library: ${GMOCK_LIBRARY}")
+  if (GTEST_STATIC_LIB)
+    message (STATUS "Found the GTest static library: ${GTEST_STATIC_LIB}")
+  endif ()
+  if (GMOCK_STATIC_LIB)
+    message (STATUS "Found the GMock static library: ${GMOCK_STATIC_LIB}")
+  endif ()
 else ()
   if (_gtest_path)
     set (GTEST_ERR_MSG "Could not find GTest. Looked in ${_gtest_path}.")
@@ -63,6 +81,7 @@ endif ()
 mark_as_advanced (
   GTEST_INCLUDE_DIR
   GMOCK_STATIC_LIB
-  GTEST_LIBS
-  GTEST_LIBRARIES
+  GTEST_STATIC_LIB
+  GMOCK_LIBRARY
+  GTEST_LIBRARY
 )

--- a/cmake_modules/FindLZ4.cmake
+++ b/cmake_modules/FindLZ4.cmake
@@ -13,7 +13,7 @@
 # LZ4_HOME environment variable is used to check for LZ4 headers and static library
 
 # LZ4_INCLUDE_DIR: directory containing headers
-# LZ4_LIBS: directory containing LZ4 libraries
+# LZ4_LIBRARY: path to liblz4
 # LZ4_STATIC_LIB: path to lz4.a
 # LZ4_FOUND: whether LZ4 has been found
 
@@ -28,24 +28,28 @@ find_path (LZ4_INCLUDE_DIR lz4.h HINTS
   NO_DEFAULT_PATH
   PATH_SUFFIXES "include")
 
-find_library (LZ4_LIBRARIES NAMES lz4 HINTS
+find_library (LZ4_LIBRARY NAMES lz4 HINTS
   ${_lz4_path}
   PATH_SUFFIXES "lib" "lib64")
 
-if (LZ4_INCLUDE_DIR AND LZ4_LIBRARIES)
+find_library (LZ4_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}${LZ4_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
+  ${_lz4_path}
+  PATH_SUFFIXES "lib" "lib64")
+
+if (LZ4_INCLUDE_DIR AND LZ4_LIBRARY)
   set (LZ4_FOUND TRUE)
-  get_filename_component (LZ4_LIBS ${LZ4_LIBRARIES} PATH)
   set (LZ4_HEADER_NAME lz4.h)
   set (LZ4_HEADER ${LZ4_INCLUDE_DIR}/${LZ4_HEADER_NAME})
-  set (LZ4_LIB_NAME lz4)
-  set (LZ4_STATIC_LIB ${LZ4_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${LZ4_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
 else ()
   set (LZ4_FOUND FALSE)
 endif ()
 
 if (LZ4_FOUND)
   message (STATUS "Found the LZ4 header: ${LZ4_HEADER}")
-  message (STATUS "Found the LZ4 library: ${LZ4_STATIC_LIB}")
+  message (STATUS "Found the LZ4 library: ${LZ4_LIBRARY}")
+  if (LZ4_STATIC_LIB)
+    message (STATUS "Found the LZ4 static library: ${LZ4_STATIC_LIB}")
+  endif ()
 else()
   if (_lz4_path)
     set (LZ4_ERR_MSG "Could not find LZ4. Looked in ${_lz4_path}.")
@@ -63,6 +67,5 @@ endif()
 mark_as_advanced (
   LZ4_INCLUDE_DIR
   LZ4_STATIC_LIB
-  LZ4_LIBS
-  LZ4_LIBRARIES
+  LZ4_LIBRARY
 )

--- a/cmake_modules/FindProtobuf.cmake
+++ b/cmake_modules/FindProtobuf.cmake
@@ -14,8 +14,9 @@
 
 # PROTOBUF_FOUND is set if Protobuf is found
 # PROTOBUF_INCLUDE_DIR: directory containing headers
-# PROTOBUF_LIBS: directory containing Protobuf libraries
+# PROTOBUF_LIBRARY: location of libprotobuf
 # PROTOBUF_STATIC_LIB: location of protobuf.a
+# PROTOC_LIBRARY: location of libprotoc
 # PROTOC_STATIC_LIB: location of protoc.a
 # PROTOBUF_EXECUTABLE: location of protoc
 
@@ -40,7 +41,15 @@ find_library (PROTOBUF_LIBRARY NAMES protobuf HINTS
   ${_protobuf_path}
   PATH_SUFFIXES "lib")
 
+find_library (PROTOBUF_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}protobuf${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
+  ${_protobuf_path}
+  PATH_SUFFIXES "lib")
+
 find_library (PROTOC_LIBRARY NAMES protoc HINTS
+  ${_protobuf_path}
+  PATH_SUFFIXES "lib")
+
+find_library (PROTOC_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}protoc${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
   ${_protobuf_path}
   PATH_SUFFIXES "lib")
 
@@ -51,20 +60,23 @@ find_program(PROTOBUF_EXECUTABLE protoc HINTS
 
 if (PROTOBUF_INCLUDE_DIR AND PROTOBUF_LIBRARY AND PROTOC_LIBRARY AND PROTOBUF_EXECUTABLE)
   set (PROTOBUF_FOUND TRUE)
-  get_filename_component (PROTOBUF_LIBS ${PROTOBUF_LIBRARY} PATH)
   set (PROTOBUF_LIB_NAME protobuf)
   set (PROTOC_LIB_NAME protoc)
-  set (PROTOBUF_STATIC_LIB ${PROTOBUF_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${PROTOBUF_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
-  set (PROTOC_STATIC_LIB ${PROTOBUF_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${PROTOC_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
 else ()
   set (PROTOBUF_FOUND FALSE)
 endif ()
 
 if (PROTOBUF_FOUND)
   message (STATUS "Found the Protobuf headers: ${PROTOBUF_INCLUDE_DIR}")
-  message (STATUS "Found the Protobuf library: ${PROTOBUF_STATIC_LIB}")
-  message (STATUS "Found the Protoc library: ${PROTOC_STATIC_LIB}")
+  message (STATUS "Found the Protobuf library: ${PROTOBUF_LIBRARY}")
+  message (STATUS "Found the Protoc library: ${PROTOC_LIBRARY}")
   message (STATUS "Found the Protoc executable: ${PROTOBUF_EXECUTABLE}")
+  if (PROTOBUF_STATIC_LIB)
+     message (STATUS "Found the Protobuf static library: ${PROTOBUF_STATIC_LIB}")
+  endif ()
+  if (PROTOC_STATIC_LIB)
+     message (STATUS "Found the Protoc static library: ${PROTOC_STATIC_LIB}")
+  endif ()
 else()
   if (_protobuf_path)
     set (PROTOBUF_ERR_MSG "Could not find Protobuf. Looked in ${_protobuf_path}.")
@@ -81,7 +93,8 @@ endif()
 
 mark_as_advanced (
   PROTOBUF_INCLUDE_DIR
-  PROTOBUF_LIBS
+  PROTOBUF_LIBRARY
   PROTOBUF_STATIC_LIB
   PROTOC_STATIC_LIB
+  PROTOC_LIBRARY
 )

--- a/cmake_modules/FindSnappy.cmake
+++ b/cmake_modules/FindSnappy.cmake
@@ -13,7 +13,7 @@
 # SNAPPY_HOME environmental variable is used to check for Snappy headers and static library
 
 # SNAPPY_INCLUDE_DIR: directory containing headers
-# SNAPPY_LIBS: directory containing snappy libraries
+# SNAPPY_LIBRARY: path to libsnappy
 # SNAPPY_STATIC_LIB: path to libsnappy.a
 # SNAPPY_FOUND: whether snappy has been found
 
@@ -28,24 +28,28 @@ find_path (SNAPPY_INCLUDE_DIR snappy.h HINTS
   NO_DEFAULT_PATH
   PATH_SUFFIXES "include")
 
-find_library (SNAPPY_LIBRARIES NAMES snappy HINTS
+find_library (SNAPPY_LIBRARY NAMES snappy HINTS
   ${_snappy_path}
   PATH_SUFFIXES "lib" "lib64")
 
-if (SNAPPY_INCLUDE_DIR AND SNAPPY_LIBRARIES)
+find_library (SNAPPY_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}${SNAPPY_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
+  ${_snappy_path}
+  PATH_SUFFIXES "lib" "lib64")
+
+if (SNAPPY_INCLUDE_DIR AND SNAPPY_LIBRARY)
   set (SNAPPY_FOUND TRUE)
-  get_filename_component (SNAPPY_LIBS ${SNAPPY_LIBRARIES} PATH)
   set (SNAPPY_HEADER_NAME snappy.h)
   set (SNAPPY_HEADER ${SNAPPY_INCLUDE_DIR}/${SNAPPY_HEADER_NAME})
-  set (SNAPPY_LIB_NAME snappy)
-  set (SNAPPY_STATIC_LIB ${SNAPPY_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${SNAPPY_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
 else ()
   set (SNAPPY_FOUND FALSE)
 endif ()
 
 if (SNAPPY_FOUND)
   message (STATUS "Found the Snappy header: ${SNAPPY_HEADER}")
-  message (STATUS "Found the Snappy library: ${SNAPPY_STATIC_LIB}")
+  message (STATUS "Found the Snappy library: ${SNAPPY_LIBRARY}")
+  if (SNAPPY_STATIC_LIB)
+      message (STATUS "Found the Snappy static library: ${SNAPPY_STATIC_LIB}")
+  endif()
 else()
   if (_snappy_path)
     set (SNAPPY_ERR_MSG "Could not find Snappy. Looked in ${_snappy_path}.")
@@ -63,6 +67,5 @@ endif()
 mark_as_advanced (
   SNAPPY_INCLUDE_DIR
   SNAPPY_STATIC_LIB
-  SNAPPY_LIBS
-  SNAPPY_LIBRARIES
+  SNAPPY_LIBRARY
 )

--- a/cmake_modules/FindZLIB.cmake
+++ b/cmake_modules/FindZLIB.cmake
@@ -13,7 +13,7 @@
 # ZLIB_HOME environmental variable is used to check for ZLIB headers and static library
 
 # ZLIB_INCLUDE_DIR: directory containing headers
-# ZLIB_LIBS: directory containing ZLIB libraries
+# ZLIB_LIBRARY: path to libz/libzlib
 # ZLIB_STATIC_LIB: path to zlib.a
 # ZLIB_FOUND: whether ZLIB has been found
 
@@ -32,23 +32,28 @@ if (NOT ZLIB_STATIC_LIB_NAME)
   set (ZLIB_STATIC_LIB_NAME z)
 endif()
 
-find_library (ZLIB_LIBRARIES NAMES ${ZLIB_STATIC_LIB_NAME} HINTS
+find_library (ZLIB_LIBRARY NAMES z zlib ${ZLIB_STATIC_LIB_NAME} HINTS
   ${_zlib_path}
   PATH_SUFFIXES "lib")
 
-if (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARIES)
+find_library (ZLIB_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_STATIC_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
+  ${_zlib_path}
+  PATH_SUFFIXES "lib")
+
+if (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARY)
   set (ZLIB_FOUND TRUE)
-  get_filename_component (ZLIB_LIBS ${ZLIB_LIBRARIES} PATH )
   set (ZLIB_HEADER_NAME zlib.h)
   set (ZLIB_HEADER ${ZLIB_INCLUDE_DIR}/${ZLIB_HEADER_NAME})
-  set (ZLIB_STATIC_LIB ${ZLIB_LIBS}/${CMAKE_STATIC_LIBRARY_PREFIX}${ZLIB_STATIC_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
 else ()
   set (ZLIB_FOUND FALSE)
 endif ()
 
 if (ZLIB_FOUND)
   message (STATUS "Found the ZLIB header: ${ZLIB_HEADER}")
-  message (STATUS "Found the ZLIB library: ${ZLIB_STATIC_LIB}")
+  message (STATUS "Found the ZLIB library: ${ZLIB_LIBRARY}")
+  if (ZLIB_STATIC_LIB)
+    message (STATUS "Found the ZLIB static library: ${ZLIB_STATIC_LIB}")
+  endif ()
 else()
   if (_zlib_path)
     set (ZLIB_ERR_MSG "Could not find ZLIB. Looked in ${_zlib_path}.")
@@ -66,6 +71,5 @@ endif()
 mark_as_advanced (
   ZLIB_INCLUDE_DIR
   ZLIB_STATIC_LIB
-  ZLIB_LIBS
-  ZLIB_LIBRARIES
+  ZLIB_LIBRARY
 )

--- a/cmake_modules/FindZSTD.cmake
+++ b/cmake_modules/FindZSTD.cmake
@@ -13,7 +13,7 @@
 # ZSTD_HOME environmental variable is used to check for Zstd headers and static library
 
 # ZSTD_INCLUDE_DIR: directory containing headers
-# ZSTD_LIBS: directory containing zstd libraries
+# ZSTD_LIBRARY: path to libzstd
 # ZSTD_STATIC_LIB: path to libzstd.a
 # ZSTD_FOUND: whether zstd has been found
 
@@ -23,32 +23,33 @@ endif()
 
 message (STATUS "ZSTD_HOME: ${ZSTD_HOME}")
 
-if (NOT ZSTD_STATIC_LIB_NAME)
-  set (ZSTD_STATIC_LIB_NAME ${CMAKE_STATIC_LIBRARY_PREFIX}zstd)
-endif()
-
 find_path (ZSTD_INCLUDE_DIR zstd.h HINTS
         ${_zstd_path}
         NO_DEFAULT_PATH
         PATH_SUFFIXES "include")
 
-find_library (ZSTD_LIBRARIES NAMES ${ZSTD_STATIC_LIB_NAME} HINTS
+find_library (ZSTD_LIBRARY NAMES zstd HINTS
         ${_zstd_path}
         PATH_SUFFIXES "lib")
 
-if (ZSTD_INCLUDE_DIR AND ZSTD_LIBRARIES)
+find_library (ZSTD_STATIC_LIB NAMES ${CMAKE_STATIC_LIBRARY_PREFIX}zstd${CMAKE_STATIC_LIBRARY_SUFFIX} HINTS
+        ${_zstd_path}
+        PATH_SUFFIXES "lib")
+
+if (ZSTD_INCLUDE_DIR AND ZSTD_LIBRARY)
   set (ZSTD_FOUND TRUE)
-  get_filename_component (ZSTD_LIBS ${ZSTD_LIBRARIES} PATH)
   set (ZSTD_HEADER_NAME zstd.h)
   set (ZSTD_HEADER ${ZSTD_INCLUDE_DIR}/${ZSTD_HEADER_NAME})
-  set (ZSTD_STATIC_LIB ${ZSTD_LIBS}/${ZSTD_STATIC_LIB_NAME}${CMAKE_STATIC_LIBRARY_SUFFIX})
 else ()
   set (ZSTD_FOUND FALSE)
 endif ()
 
 if (ZSTD_FOUND)
   message (STATUS "Found the zstd header: ${ZSTD_HEADER}")
-  message (STATUS "Found the zstd library: ${ZSTD_STATIC_LIB}")
+  message (STATUS "Found the zstd library: ${ZSTD_LIBRARY}")
+  if (ZSTD_STATIC_LIB)
+    message (STATUS "Found the zstd static library: ${ZSTD_STATIC_LIB}")
+  endif ()
 else()
   if (_ZSTD_path)
     set (ZSTD_ERR_MSG "Could not find zstd. Looked in ${_zstd_path}.")
@@ -66,6 +67,5 @@ endif()
 mark_as_advanced (
         ZSTD_INCLUDE_DIR
         ZSTD_STATIC_LIB
-        ZSTD_LIBS
-        ZSTD_LIBRARIES
+        ZSTD_LIBRARY
 )

--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -22,7 +22,6 @@ include_directories (
   ${PROJECT_BINARY_DIR}/c++/include
   ${PROJECT_SOURCE_DIR}/c++/src
   ${PROJECT_BINARY_DIR}/c++/src
-  ${PROTOBUF_INCLUDE_DIR}
   )
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g ${CXX11_FLAGS} ${WARN_FLAGS}")
@@ -51,7 +50,7 @@ add_executable (orc-metadata
 
 target_link_libraries (orc-metadata
   orc
-  protobuf
+  orc::protobuf
   ${CMAKE_THREAD_LIBS_INIT}
   )
 

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -16,9 +16,6 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/tools-c++/src
   ${PROJECT_BINARY_DIR}/c++/include
   ${PROJECT_BINARY_DIR}/c++/src
-  ${PROTOBUF_INCLUDE_DIR}
-  ${ZLIB_INCLUDE_DIR}
-  ${GTEST_INCLUDE_DIR}
 )
 
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX11_FLAGS} ${WARN_FLAGS}")
@@ -36,10 +33,10 @@ add_executable (tool-test
 
 target_link_libraries (tool-test
   orc
-  protobuf
-  zlib
-  snappy
-  ${GTEST_LIBRARIES}
+  orc::protobuf
+  orc::zlib
+  orc::snappy
+  orc::gmock
 )
 
 if (TEST_VALGRIND_MEMCHECK)


### PR DESCRIPTION
This patch allows selectively linking each third party library
statically with a fallback to dynamic, if not available

This is a follow up of the discussion at: https://github.com/apache/orc/pull/524