### PR TITLE
ORC-663: [C++] Support timestamp statistics with nanosecond

### DIFF
--- a/c++/include/orc/Statistics.hh
+++ b/c++/include/orc/Statistics.hh
@@ -305,26 +305,26 @@ namespace orc {
     virtual ~TimestampColumnStatistics();
 
     /**
-     * Check whether column minimum.
+     * Check whether minimum timestamp exists.
      * @return true if has minimum
      */
     virtual bool hasMinimum() const = 0;
 
     /**
-     * Check whether column maximum.
+     * Check whether maximum timestamp exists.
      * @return true if has maximum
      */
     virtual bool hasMaximum() const = 0;
 
     /**
-     * Get the minimum value for the column.
-     * @return minimum value
+     * Get the millisecond of minimum timestamp in UTC.
+     * @return minimum value in millisecond
      */
     virtual int64_t getMinimum() const = 0;
 
     /**
-     * Get the maximum value for the column.
-     * @return maximum value
+     * Get the millisecond of maximum timestamp in UTC.
+     * @return maximum value in millisecond
      */
     virtual int64_t getMaximum() const = 0;
 
@@ -352,7 +352,17 @@ namespace orc {
      */
     virtual int64_t getUpperBound() const = 0;
 
+    /**
+     * Get the last 6 digits of nanosecond of minimum timestamp.
+     * @return last 6 digits of nanosecond of minimum timestamp.
+     */
+    virtual int32_t getMinimumNano() const = 0;
 
+    /**
+     * Get the last 6 digits of nanosecond of maximum timestamp.
+     * @return last 6 digits of nanosecond of maximum timestamp.
+     */
+    virtual int32_t getMaximumNano() const = 0;
   };
 
   class Statistics {

--- a/c++/include/orc/Statistics.hh
+++ b/c++/include/orc/Statistics.hh
@@ -356,13 +356,13 @@ namespace orc {
      * Get the last 6 digits of nanosecond of minimum timestamp.
      * @return last 6 digits of nanosecond of minimum timestamp.
      */
-    virtual int32_t getMinimumNano() const = 0;
+    virtual int32_t getMinimumNanos() const = 0;
 
     /**
      * Get the last 6 digits of nanosecond of maximum timestamp.
      * @return last 6 digits of nanosecond of maximum timestamp.
      */
-    virtual int32_t getMaximumNano() const = 0;
+    virtual int32_t getMaximumNanos() const = 0;
   };
 
   class Statistics {

--- a/c++/include/orc/sargs/Literal.hh
+++ b/c++/include/orc/sargs/Literal.hh
@@ -59,7 +59,6 @@ namespace orc {
       bool operator>(const Timestamp& r) const { return r < *this; }
       bool operator>=(const Timestamp& r) const { return r <= *this; }
       int64_t getMillis() const { return second * 1000 + nano / 1000000; }
-      std::string toString() const;
       int64_t second;
       int32_t nano;
     };

--- a/c++/include/orc/sargs/Literal.hh
+++ b/c++/include/orc/sargs/Literal.hh
@@ -36,6 +36,34 @@ namespace orc {
    */
   class Literal {
   public:
+    struct Timestamp {
+      Timestamp() = default;
+      Timestamp(const Timestamp&) = default;
+      Timestamp(Timestamp&&) = default;
+      ~Timestamp() = default;
+      Timestamp(int64_t second_, int32_t nano_): second(second_), nano(nano_) {
+        // PASS
+      }
+      Timestamp& operator=(const Timestamp&) = default;
+      Timestamp& operator=(Timestamp&&) = default;
+      bool operator==(const Timestamp& r) const {
+        return second == r.second && nano == r.nano;
+      }
+      bool operator<(const Timestamp& r) const {
+        return second < r.second || (second == r.second && nano < r.nano);
+      }
+      bool operator<=(const Timestamp& r) const {
+        return second < r.second || (second == r.second && nano <= r.nano);
+      }
+      bool operator!=(const Timestamp& r) const { return !(*this == r); }
+      bool operator>(const Timestamp& r) const { return r < *this; }
+      bool operator>=(const Timestamp& r) const { return r <= *this; }
+      int64_t getMillis() const { return second * 1000 + nano / 1000000; }
+      std::string toString() const;
+      int64_t second;
+      int32_t nano;
+    };
+
     Literal(const Literal &r);
     ~Literal();
     Literal& operator=(const Literal& r);
@@ -63,9 +91,14 @@ namespace orc {
     Literal(bool val);
 
     /**
-     * Create a literal of Timestamp or DATE type
+     * Create a literal of DATE type
      */
     Literal(PredicateDataType type, int64_t val);
+
+    /**
+     * Create a literal of TIMESTAMP type
+     */
+    Literal(int64_t second, int32_t nano);
 
     /**
      * Create a literal of STRING type
@@ -82,7 +115,7 @@ namespace orc {
      */
     int64_t getLong() const;
     int64_t getDate() const;
-    int64_t getTimestamp() const;
+    Timestamp getTimestamp() const;
     double getFloat() const;
     std::string getString() const;
     bool getBool() const;
@@ -105,7 +138,7 @@ namespace orc {
       double DoubleVal;
       int64_t DateVal;
       char * Buffer;
-      int64_t TimeStampVal;
+      Timestamp TimeStampVal;
       Int128 DecimalVal;
       bool BooleanVal;
 

--- a/c++/include/orc/sargs/Literal.hh
+++ b/c++/include/orc/sargs/Literal.hh
@@ -41,26 +41,26 @@ namespace orc {
       Timestamp(const Timestamp&) = default;
       Timestamp(Timestamp&&) = default;
       ~Timestamp() = default;
-      Timestamp(int64_t second_, int32_t nano_): second(second_), nano(nano_) {
+      Timestamp(int64_t second_, int32_t nanos_): second(second_), nanos(nanos_) {
         // PASS
       }
       Timestamp& operator=(const Timestamp&) = default;
       Timestamp& operator=(Timestamp&&) = default;
       bool operator==(const Timestamp& r) const {
-        return second == r.second && nano == r.nano;
+        return second == r.second && nanos == r.nanos;
       }
       bool operator<(const Timestamp& r) const {
-        return second < r.second || (second == r.second && nano < r.nano);
+        return second < r.second || (second == r.second && nanos < r.nanos);
       }
       bool operator<=(const Timestamp& r) const {
-        return second < r.second || (second == r.second && nano <= r.nano);
+        return second < r.second || (second == r.second && nanos <= r.nanos);
       }
       bool operator!=(const Timestamp& r) const { return !(*this == r); }
       bool operator>(const Timestamp& r) const { return r < *this; }
       bool operator>=(const Timestamp& r) const { return r <= *this; }
-      int64_t getMillis() const { return second * 1000 + nano / 1000000; }
+      int64_t getMillis() const { return second * 1000 + nanos / 1000000; }
       int64_t second;
-      int32_t nano;
+      int32_t nanos;
     };
 
     Literal(const Literal &r);
@@ -97,7 +97,7 @@ namespace orc {
     /**
      * Create a literal of TIMESTAMP type
      */
-    Literal(int64_t second, int32_t nano);
+    Literal(int64_t second, int32_t nanos);
 
     /**
      * Create a literal of STRING type

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1802,7 +1802,7 @@ namespace orc {
         if (enableBloomFilter) {
           bloomFilter->addLong(millsUTC);
         }
-        tsStats->update(millsUTC, nanos[i] % 1000000);
+        tsStats->update(millsUTC, static_cast<int32_t>(nanos[i] % 1000000));
 
         if (secs[i] < 0 && nanos[i] != 0) {
           secs[i] += 1;

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1802,7 +1802,7 @@ namespace orc {
         if (enableBloomFilter) {
           bloomFilter->addLong(millsUTC);
         }
-        tsStats->update(millsUTC);
+        tsStats->update(millsUTC, nanos[i] % 1000000);
 
         if (secs[i] < 0 && nanos[i] != 0) {
           secs[i] += 1;

--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -317,8 +317,8 @@ namespace orc {
       _stats.setMaximum(0);
       _lowerBound = 0;
       _upperBound = 0;
-      _minimumNano = DEFAULT_MIN_NANOS;
-      _maximumNano = DEFAULT_MAX_NANOS;
+      _minimumNanos = DEFAULT_MIN_NANOS;
+      _maximumNanos = DEFAULT_MAX_NANOS;
     }else{
       const proto::TimestampStatistics& stats = pb.timestampstatistics();
       _stats.setHasMinimum(
@@ -329,9 +329,11 @@ namespace orc {
                 (stats.has_maximum() && (statContext.writerTimezone != nullptr)));
       _hasLowerBound = stats.has_minimumutc() || stats.has_minimum();
       _hasUpperBound = stats.has_maximumutc() || stats.has_maximum();
-      _minimumNano = stats.has_minimumnanos() ?
+      // to be consistent with java side, non-default minimumnanos and maximumnanos
+      // are added by one in their serialized form.
+      _minimumNanos = stats.has_minimumnanos() ?
                      stats.minimumnanos() - 1 : DEFAULT_MIN_NANOS;
-      _maximumNano = stats.has_maximumnanos() ?
+      _maximumNanos = stats.has_maximumnanos() ?
                      stats.maximumnanos() - 1 : DEFAULT_MAX_NANOS;
 
       // Timestamp stats are stored in milliseconds

--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -317,6 +317,8 @@ namespace orc {
       _stats.setMaximum(0);
       _lowerBound = 0;
       _upperBound = 0;
+      _minimumNano = DEFAULT_MIN_NANOS;
+      _maximumNano = DEFAULT_MAX_NANOS;
     }else{
       const proto::TimestampStatistics& stats = pb.timestampstatistics();
       _stats.setHasMinimum(
@@ -327,6 +329,10 @@ namespace orc {
                 (stats.has_maximum() && (statContext.writerTimezone != nullptr)));
       _hasLowerBound = stats.has_minimumutc() || stats.has_minimum();
       _hasUpperBound = stats.has_maximumutc() || stats.has_maximum();
+      _minimumNano = stats.has_minimumnanos() ?
+                     stats.minimumnanos() - 1 : DEFAULT_MIN_NANOS;
+      _maximumNano = stats.has_maximumnanos() ?
+                     stats.maximumnanos() - 1 : DEFAULT_MAX_NANOS;
 
       // Timestamp stats are stored in milliseconds
       if (stats.has_minimumutc()) {

--- a/c++/src/Statistics.hh
+++ b/c++/src/Statistics.hh
@@ -1214,8 +1214,8 @@ namespace orc {
     bool _hasUpperBound;
     int64_t _lowerBound;
     int64_t _upperBound;
-    int32_t _minimumNano;  // last 6 digits of nanosecond of minimum timestamp
-    int32_t _maximumNano;  // last 6 digits of nanosecond of maximum timestamp
+    int32_t _minimumNanos; // last 6 digits of nanosecond of minimum timestamp
+    int32_t _maximumNanos; // last 6 digits of nanosecond of maximum timestamp
     static constexpr int32_t DEFAULT_MIN_NANOS = 0;
     static constexpr int32_t DEFAULT_MAX_NANOS = 999999;
 
@@ -1289,18 +1289,18 @@ namespace orc {
         _stats.setHasMaximum(true);
         _stats.setMinimum(milli);
         _stats.setMaximum(milli);
-        _maximumNano = _minimumNano = nano;
+        _maximumNanos = _minimumNanos = nano;
       } else {
         if (milli <= _stats.getMinimum()) {
-          if (milli < _stats.getMinimum() || nano < _minimumNano) {
-            _minimumNano = nano;
+          if (milli < _stats.getMinimum() || nano < _minimumNanos) {
+            _minimumNanos = nano;
           }
           _stats.setMinimum(milli);
         }
 
         if (milli >= _stats.getMaximum()) {
-          if (milli > _stats.getMaximum() || nano > _maximumNano) {
-            _maximumNano = nano;
+          if (milli > _stats.getMaximum() || nano > _maximumNanos) {
+            _maximumNanos = nano;
           }
           _stats.setMaximum(milli);
         }
@@ -1320,20 +1320,20 @@ namespace orc {
           _stats.setHasMaximum(true);
           _stats.setMinimum(tsStats.getMinimum());
           _stats.setMaximum(tsStats.getMaximum());
-          _minimumNano = tsStats.getMinimumNano();
-          _maximumNano = tsStats.getMaximumNano();
+          _minimumNanos = tsStats.getMinimumNanos();
+          _maximumNanos = tsStats.getMaximumNanos();
         } else {
           if (tsStats.getMaximum() >= _stats.getMaximum()) {
             if (tsStats.getMaximum() > _stats.getMaximum() ||
-                tsStats.getMaximumNano() > _maximumNano) {
-              _maximumNano = tsStats.getMaximumNano();
+                tsStats.getMaximumNanos() > _maximumNanos) {
+              _maximumNanos = tsStats.getMaximumNanos();
             }
             _stats.setMaximum(tsStats.getMaximum());
           }
           if (tsStats.getMinimum() <= _stats.getMinimum()) {
             if (tsStats.getMinimum() < _stats.getMinimum() ||
-                tsStats.getMinimumNano() < _minimumNano) {
-              _minimumNano = tsStats.getMinimumNano();
+                tsStats.getMinimumNanos() < _minimumNanos) {
+              _minimumNanos = tsStats.getMinimumNanos();
             }
             _stats.setMinimum(tsStats.getMinimum());
           }
@@ -1343,8 +1343,8 @@ namespace orc {
 
     void reset() override {
       _stats.reset();
-      _minimumNano = DEFAULT_MIN_NANOS;
-      _maximumNano = DEFAULT_MAX_NANOS;
+      _minimumNanos = DEFAULT_MIN_NANOS;
+      _maximumNanos = DEFAULT_MAX_NANOS;
     }
 
     void toProtoBuf(proto::ColumnStatistics& pbStats) const override {
@@ -1356,11 +1356,11 @@ namespace orc {
       if (_stats.hasMinimum()) {
         tsStats->set_minimumutc(_stats.getMinimum());
         tsStats->set_maximumutc(_stats.getMaximum());
-        if (_minimumNano != DEFAULT_MIN_NANOS) {
-          tsStats->set_minimumnanos(_minimumNano + 1);
+        if (_minimumNanos != DEFAULT_MIN_NANOS) {
+          tsStats->set_minimumnanos(_minimumNanos + 1);
         }
-        if (_maximumNano != DEFAULT_MAX_NANOS) {
-          tsStats->set_maximumnanos(_maximumNano + 1);
+        if (_maximumNanos != DEFAULT_MAX_NANOS) {
+          tsStats->set_maximumnanos(_maximumNanos + 1);
         }
       } else {
         tsStats->clear_minimumutc();
@@ -1446,17 +1446,17 @@ namespace orc {
       }
     }
 
-    int32_t getMinimumNano() const override {
+    int32_t getMinimumNanos() const override {
       if (hasMinimum()) {
-        return _minimumNano;
+        return _minimumNanos;
       } else {
         throw ParseError("Minimum is not defined.");
       }
     }
 
-    int32_t getMaximumNano() const override {
+    int32_t getMaximumNanos() const override {
       if (hasMaximum()) {
-        return _maximumNano;
+        return _maximumNanos;
       } else {
         throw ParseError("Maximum is not defined.");
       }

--- a/c++/src/sargs/Literal.cc
+++ b/c++/src/sargs/Literal.cc
@@ -99,10 +99,10 @@ namespace orc {
     mHashCode = hashCode();
   }
 
-  Literal::Literal(int64_t second, int32_t nano) {
+  Literal::Literal(int64_t second, int32_t nanos) {
     mType = PredicateDataType::TIMESTAMP;
     mValue.TimeStampVal.second = second;
-    mValue.TimeStampVal.nano = nano;
+    mValue.TimeStampVal.nanos = nanos;
     mPrecision = 0;
     mScale = 0;
     mSize = sizeof(Timestamp);
@@ -179,7 +179,7 @@ namespace orc {
         break;
       case PredicateDataType::TIMESTAMP:
         sstream << mValue.TimeStampVal.second << "."
-                << mValue.TimeStampVal.nano;
+                << mValue.TimeStampVal.nanos;
         break;
       case PredicateDataType::FLOAT:
         sstream << mValue.DoubleVal;
@@ -209,7 +209,7 @@ namespace orc {
         return std::hash<int64_t>{}(mValue.DateVal);
       case PredicateDataType::TIMESTAMP:
         return std::hash<int64_t>{}(mValue.TimeStampVal.second) * 17 +
-          std::hash<int32_t>{}(mValue.TimeStampVal.nano);
+          std::hash<int32_t>{}(mValue.TimeStampVal.nanos);
       case PredicateDataType::FLOAT:
         return std::hash<double>{}(mValue.DoubleVal);
       case PredicateDataType::BOOLEAN:

--- a/c++/src/sargs/Literal.cc
+++ b/c++/src/sargs/Literal.cc
@@ -164,19 +164,6 @@ namespace orc {
     return *this;
   }
 
-  std::string Literal::Timestamp::toString() const {
-    time_t secs = static_cast<time_t>(second);
-    struct tm tmValue;
-    gmtime_r(&secs, &tmValue);
-    char timeBuffer[20];
-    strftime(timeBuffer, sizeof(timeBuffer), "%Y-%m-%d %H:%M:%S", &tmValue);
-    char nanoBuffer[10];
-    snprintf(nanoBuffer, sizeof(nanoBuffer), "%.9i", nano);
-    std::ostringstream buffer;
-    buffer << timeBuffer << "." << nanoBuffer;
-    return buffer.str();
-  }
-
   std::string Literal::toString() const {
     if (mIsNull) {
       return "null";
@@ -191,7 +178,8 @@ namespace orc {
         sstream << mValue.DateVal;
         break;
       case PredicateDataType::TIMESTAMP:
-        sstream << mValue.TimeStampVal.toString();
+        sstream << mValue.TimeStampVal.second << "."
+                << mValue.TimeStampVal.nano;
         break;
       case PredicateDataType::FLOAT:
         sstream << mValue.DoubleVal;

--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -549,10 +549,10 @@ namespace orc {
             stats.maximumnanos() - 1 : 999999;
           Literal::Timestamp minTimestamp(
             stats.minimumutc() / 1000,
-            (stats.minimumutc() % 1000) * 1000000 + minNano);
+            static_cast<int32_t>((stats.minimumutc() % 1000) * 1000000) + minNano);
           Literal::Timestamp maxTimestamp(
             stats.maximumutc() / 1000,
-            (stats.maximumutc() % 1000) * 1000000 + maxNano);
+            static_cast<int32_t>((stats.maximumutc() % 1000) * 1000000) + maxNano);
           result = evaluatePredicateRange(
             mOperator,
             literal2Timestamp(mLiterals),

--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -18,8 +18,8 @@
 
 #include "orc/BloomFilter.hh"
 #include "orc/Common.hh"
-#include "PredicateLeaf.hh"
 #include "orc/Type.hh"
+#include "PredicateLeaf.hh"
 
 #include <algorithm>
 #include <functional>
@@ -543,10 +543,12 @@ namespace orc {
             colStats.timestampstatistics().has_minimumutc() &&
             colStats.timestampstatistics().has_maximumutc()) {
           const auto& stats = colStats.timestampstatistics();
+          constexpr int32_t DEFAULT_MIN_NANOS = 0;
+          constexpr int32_t DEFAULT_MAX_NANOS = 999999;
           int32_t minNano = stats.has_minimumnanos() ?
-            stats.minimumnanos() - 1 : 0;
+            stats.minimumnanos() - 1 : DEFAULT_MIN_NANOS;
           int32_t maxNano = stats.has_maximumnanos() ?
-            stats.maximumnanos() - 1 : 999999;
+            stats.maximumnanos() - 1 : DEFAULT_MAX_NANOS;
           Literal::Timestamp minTimestamp(
             stats.minimumutc() / 1000,
             static_cast<int32_t>((stats.minimumutc() % 1000) * 1000000) + minNano);

--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -510,7 +510,7 @@ namespace orc {
         break;
       }
       case PredicateDataType::STRING: {
-        ///FIXME: check lowerBound and upperBound as well
+        ///TODO: check lowerBound and upperBound as well
         if (colStats.has_stringstatistics() &&
             colStats.stringstatistics().has_minimum() &&
             colStats.stringstatistics().has_maximum()) {

--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -427,9 +427,9 @@ namespace orc {
     return result;
   }
 
-  static std::vector<int64_t> literal2Timestamp(
+  static std::vector<Literal::Timestamp> literal2Timestamp(
                                            const std::vector<Literal>& values) {
-    std::vector<int64_t> result;
+    std::vector<Literal::Timestamp> result;
     std::for_each(values.cbegin(), values.cend(), [&](const Literal& val) {
       if (!val.isNull()) {
         result.emplace_back(val.getTimestamp());
@@ -510,6 +510,7 @@ namespace orc {
         break;
       }
       case PredicateDataType::STRING: {
+        ///FIXME: check lowerBound and upperBound as well
         if (colStats.has_stringstatistics() &&
             colStats.stringstatistics().has_minimum() &&
             colStats.stringstatistics().has_maximum()) {
@@ -542,11 +543,21 @@ namespace orc {
             colStats.timestampstatistics().has_minimumutc() &&
             colStats.timestampstatistics().has_maximumutc()) {
           const auto& stats = colStats.timestampstatistics();
+          int32_t minNano = stats.has_minimumnanos() ?
+            stats.minimumnanos() - 1 : 0;
+          int32_t maxNano = stats.has_maximumnanos() ?
+            stats.maximumnanos() - 1 : 999999;
+          Literal::Timestamp minTimestamp(
+            stats.minimumutc() / 1000,
+            (stats.minimumutc() % 1000) * 1000000 + minNano);
+          Literal::Timestamp maxTimestamp(
+            stats.maximumutc() / 1000,
+            (stats.maximumutc() % 1000) * 1000000 + maxNano);
           result = evaluatePredicateRange(
             mOperator,
             literal2Timestamp(mLiterals),
-            stats.minimumutc(),
-            stats.maximumutc(),
+            minTimestamp,
+            maxTimestamp,
             colStats.hasnull());
         }
         break;
@@ -634,7 +645,7 @@ namespace orc {
         result = TruthValue::YES_NO_NULL;
       }
     } else if (type == PredicateDataType::TIMESTAMP) {
-      if (bf->testLong(literal.getTimestamp())) {
+      if (bf->testLong(literal.getTimestamp().getMillis())) {
         result = TruthValue::YES_NO_NULL;
       }
     } else if (type == PredicateDataType::DATE) {

--- a/c++/test/TestColumnStatistics.cc
+++ b/c++/test/TestColumnStatistics.cc
@@ -257,14 +257,14 @@ namespace orc {
     tsStats->update(100);
     EXPECT_EQ(100, tsStats->getMaximum());
     EXPECT_EQ(100, tsStats->getMinimum());
-    EXPECT_EQ(0, tsStats->getMinimumNano());
-    EXPECT_EQ(999999, tsStats->getMaximumNano());
+    EXPECT_EQ(0, tsStats->getMinimumNanos());
+    EXPECT_EQ(999999, tsStats->getMaximumNanos());
 
     tsStats->update(150);
     EXPECT_EQ(150, tsStats->getMaximum());
     EXPECT_EQ(100, tsStats->getMinimum());
-    EXPECT_EQ(0, tsStats->getMinimumNano());
-    EXPECT_EQ(999999, tsStats->getMaximumNano());
+    EXPECT_EQ(0, tsStats->getMinimumNanos());
+    EXPECT_EQ(999999, tsStats->getMaximumNanos());
 
     // test merge
     std::unique_ptr<TimestampColumnStatisticsImpl> other(
@@ -276,8 +276,8 @@ namespace orc {
     tsStats->merge(*other);
     EXPECT_EQ(160, tsStats->getMaximum());
     EXPECT_EQ(90, tsStats->getMinimum());
-    EXPECT_EQ(0, tsStats->getMinimumNano());
-    EXPECT_EQ(999999, tsStats->getMaximumNano());
+    EXPECT_EQ(0, tsStats->getMinimumNanos());
+    EXPECT_EQ(999999, tsStats->getMaximumNanos());
   }
 
   TEST(ColumnStatistics, dateColumnStatistics) {
@@ -400,9 +400,9 @@ namespace orc {
       tsStats->increase(1);
     }
     EXPECT_EQ(102400, tsStats->getMaximum());
-    EXPECT_EQ(1024000, tsStats->getMaximumNano());
+    EXPECT_EQ(1024000, tsStats->getMaximumNanos());
     EXPECT_EQ(100, tsStats->getMinimum());
-    EXPECT_EQ(1000, tsStats->getMinimumNano());
+    EXPECT_EQ(1000, tsStats->getMinimumNanos());
 
     // update with same milli but different nanos
     tsStats->update(102400, 1024001);
@@ -410,9 +410,9 @@ namespace orc {
     tsStats->update(100, 1001);
     tsStats->update(100, 999);
     EXPECT_EQ(102400, tsStats->getMaximum());
-    EXPECT_EQ(1024001, tsStats->getMaximumNano());
+    EXPECT_EQ(1024001, tsStats->getMaximumNanos());
     EXPECT_EQ(100, tsStats->getMinimum());
-    EXPECT_EQ(999, tsStats->getMinimumNano());
+    EXPECT_EQ(999, tsStats->getMinimumNanos());
 
     // test merge with no change
     std::unique_ptr<TimestampColumnStatisticsImpl> other1(
@@ -423,9 +423,9 @@ namespace orc {
     }
     tsStats->merge(*other1);
     EXPECT_EQ(102400, tsStats->getMaximum());
-    EXPECT_EQ(1024001, tsStats->getMaximumNano());
+    EXPECT_EQ(1024001, tsStats->getMaximumNanos());
     EXPECT_EQ(100, tsStats->getMinimum());
-    EXPECT_EQ(999, tsStats->getMinimumNano());
+    EXPECT_EQ(999, tsStats->getMinimumNanos());
 
     // test merge with min/max change only in nano
     std::unique_ptr<TimestampColumnStatisticsImpl> other2(
@@ -434,9 +434,9 @@ namespace orc {
     other2->update(100, 998);
     tsStats->merge(*other2);
     EXPECT_EQ(102400, tsStats->getMaximum());
-    EXPECT_EQ(1024002, tsStats->getMaximumNano());
+    EXPECT_EQ(1024002, tsStats->getMaximumNanos());
     EXPECT_EQ(100, tsStats->getMinimum());
-    EXPECT_EQ(998, tsStats->getMinimumNano());
+    EXPECT_EQ(998, tsStats->getMinimumNanos());
 
     // test merge with min/max change in milli
     std::unique_ptr<TimestampColumnStatisticsImpl> other3(
@@ -445,9 +445,9 @@ namespace orc {
     other3->update(99, 1);
     tsStats->merge(*other3);
     EXPECT_EQ(102401, tsStats->getMaximum());
-    EXPECT_EQ(1, tsStats->getMaximumNano());
+    EXPECT_EQ(1, tsStats->getMaximumNanos());
     EXPECT_EQ(99, tsStats->getMinimum());
-    EXPECT_EQ(1, tsStats->getMinimumNano());
+    EXPECT_EQ(1, tsStats->getMinimumNanos());
   }
 
   TEST(ColumnStatistics, timestampColumnStatisticsProbubuf) {
@@ -469,8 +469,8 @@ namespace orc {
       new TimestampColumnStatisticsImpl(pbStats, ctx));
     EXPECT_EQ(100, tsStatsFromPb->getMinimum());
     EXPECT_EQ(200, tsStatsFromPb->getMaximum());
-    EXPECT_EQ(0, tsStatsFromPb->getMinimumNano());
-    EXPECT_EQ(999999, tsStatsFromPb->getMaximumNano());
+    EXPECT_EQ(0, tsStatsFromPb->getMinimumNanos());
+    EXPECT_EQ(999999, tsStatsFromPb->getMaximumNanos());
 
     tsStats->update(50, 5555);
     tsStats->update(500, 9999);
@@ -486,8 +486,8 @@ namespace orc {
     tsStatsFromPb.reset(new TimestampColumnStatisticsImpl(pbStats, ctx));
     EXPECT_EQ(50, tsStatsFromPb->getMinimum());
     EXPECT_EQ(500, tsStatsFromPb->getMaximum());
-    EXPECT_EQ(5555, tsStatsFromPb->getMinimumNano());
-    EXPECT_EQ(9999, tsStatsFromPb->getMaximumNano());
+    EXPECT_EQ(5555, tsStatsFromPb->getMinimumNanos());
+    EXPECT_EQ(9999, tsStatsFromPb->getMaximumNanos());
   }
 
 }

--- a/c++/test/TestColumnStatistics.cc
+++ b/c++/test/TestColumnStatistics.cc
@@ -257,10 +257,14 @@ namespace orc {
     tsStats->update(100);
     EXPECT_EQ(100, tsStats->getMaximum());
     EXPECT_EQ(100, tsStats->getMinimum());
+    EXPECT_EQ(0, tsStats->getMinimumNano());
+    EXPECT_EQ(999999, tsStats->getMaximumNano());
 
     tsStats->update(150);
     EXPECT_EQ(150, tsStats->getMaximum());
     EXPECT_EQ(100, tsStats->getMinimum());
+    EXPECT_EQ(0, tsStats->getMinimumNano());
+    EXPECT_EQ(999999, tsStats->getMaximumNano());
 
     // test merge
     std::unique_ptr<TimestampColumnStatisticsImpl> other(
@@ -270,8 +274,10 @@ namespace orc {
     other->setMinimum(90);
 
     tsStats->merge(*other);
-    EXPECT_EQ(160, other->getMaximum());
-    EXPECT_EQ(90, other->getMinimum());
+    EXPECT_EQ(160, tsStats->getMaximum());
+    EXPECT_EQ(90, tsStats->getMinimum());
+    EXPECT_EQ(0, tsStats->getMinimumNano());
+    EXPECT_EQ(999999, tsStats->getMaximumNano());
   }
 
   TEST(ColumnStatistics, dateColumnStatistics) {
@@ -383,4 +389,105 @@ namespace orc {
     decStats->update(Decimal(Int128("123456789012345678901234567890"), 10));
     EXPECT_FALSE(decStats->hasSum());
   }
+
+  TEST(ColumnStatistics, timestampColumnStatisticsWithNanos) {
+    std::unique_ptr<TimestampColumnStatisticsImpl> tsStats(
+      new TimestampColumnStatisticsImpl());
+
+    // normal operations
+    for (int32_t i = 1; i <= 1024; ++i) {
+      tsStats->update(i * 100, i * 1000);
+      tsStats->increase(1);
+    }
+    EXPECT_EQ(102400, tsStats->getMaximum());
+    EXPECT_EQ(1024000, tsStats->getMaximumNano());
+    EXPECT_EQ(100, tsStats->getMinimum());
+    EXPECT_EQ(1000, tsStats->getMinimumNano());
+
+    // update with same milli but different nanos
+    tsStats->update(102400, 1024001);
+    tsStats->update(102400, 1023999);
+    tsStats->update(100, 1001);
+    tsStats->update(100, 999);
+    EXPECT_EQ(102400, tsStats->getMaximum());
+    EXPECT_EQ(1024001, tsStats->getMaximumNano());
+    EXPECT_EQ(100, tsStats->getMinimum());
+    EXPECT_EQ(999, tsStats->getMinimumNano());
+
+    // test merge with no change
+    std::unique_ptr<TimestampColumnStatisticsImpl> other1(
+      new TimestampColumnStatisticsImpl());
+    for (int32_t i = 1; i <= 1024; ++i) {
+      other1->update(i * 100, i * 1000);
+      other1->increase(1);
+    }
+    tsStats->merge(*other1);
+    EXPECT_EQ(102400, tsStats->getMaximum());
+    EXPECT_EQ(1024001, tsStats->getMaximumNano());
+    EXPECT_EQ(100, tsStats->getMinimum());
+    EXPECT_EQ(999, tsStats->getMinimumNano());
+
+    // test merge with min/max change only in nano
+    std::unique_ptr<TimestampColumnStatisticsImpl> other2(
+      new TimestampColumnStatisticsImpl());
+    other2->update(102400, 1024002);
+    other2->update(100, 998);
+    tsStats->merge(*other2);
+    EXPECT_EQ(102400, tsStats->getMaximum());
+    EXPECT_EQ(1024002, tsStats->getMaximumNano());
+    EXPECT_EQ(100, tsStats->getMinimum());
+    EXPECT_EQ(998, tsStats->getMinimumNano());
+
+    // test merge with min/max change in milli
+    std::unique_ptr<TimestampColumnStatisticsImpl> other3(
+      new TimestampColumnStatisticsImpl());
+    other3->update(102401, 1);
+    other3->update(99, 1);
+    tsStats->merge(*other3);
+    EXPECT_EQ(102401, tsStats->getMaximum());
+    EXPECT_EQ(1, tsStats->getMaximumNano());
+    EXPECT_EQ(99, tsStats->getMinimum());
+    EXPECT_EQ(1, tsStats->getMinimumNano());
+  }
+
+  TEST(ColumnStatistics, timestampColumnStatisticsProbubuf) {
+    std::unique_ptr<TimestampColumnStatisticsImpl> tsStats(
+      new TimestampColumnStatisticsImpl());
+    tsStats->increase(2);
+    tsStats->update(100);
+    tsStats->update(200);
+
+    proto::ColumnStatistics pbStats;
+    tsStats->toProtoBuf(pbStats);
+    EXPECT_EQ(100, pbStats.timestampstatistics().minimumutc());
+    EXPECT_EQ(200, pbStats.timestampstatistics().maximumutc());
+    EXPECT_FALSE(pbStats.timestampstatistics().has_minimumnanos());
+    EXPECT_FALSE(pbStats.timestampstatistics().has_maximumnanos());
+
+    StatContext ctx(true, nullptr);
+    std::unique_ptr<TimestampColumnStatisticsImpl> tsStatsFromPb(
+      new TimestampColumnStatisticsImpl(pbStats, ctx));
+    EXPECT_EQ(100, tsStatsFromPb->getMinimum());
+    EXPECT_EQ(200, tsStatsFromPb->getMaximum());
+    EXPECT_EQ(0, tsStatsFromPb->getMinimumNano());
+    EXPECT_EQ(999999, tsStatsFromPb->getMaximumNano());
+
+    tsStats->update(50, 5555);
+    tsStats->update(500, 9999);
+    pbStats.Clear();
+    tsStats->toProtoBuf(pbStats);
+    EXPECT_EQ(50, pbStats.timestampstatistics().minimumutc());
+    EXPECT_EQ(500, pbStats.timestampstatistics().maximumutc());
+    EXPECT_TRUE(pbStats.timestampstatistics().has_minimumnanos());
+    EXPECT_TRUE(pbStats.timestampstatistics().has_maximumnanos());
+    EXPECT_EQ(5555 + 1, pbStats.timestampstatistics().minimumnanos());
+    EXPECT_EQ(9999 + 1, pbStats.timestampstatistics().maximumnanos());
+
+    tsStatsFromPb.reset(new TimestampColumnStatisticsImpl(pbStats, ctx));
+    EXPECT_EQ(50, tsStatsFromPb->getMinimum());
+    EXPECT_EQ(500, tsStatsFromPb->getMaximum());
+    EXPECT_EQ(5555, tsStatsFromPb->getMinimumNano());
+    EXPECT_EQ(9999, tsStatsFromPb->getMaximumNano());
+  }
+
 }

--- a/c++/test/TestSearchArgument.cc
+++ b/c++/test/TestSearchArgument.cc
@@ -36,9 +36,9 @@ namespace orc {
     EXPECT_EQ(PredicateDataType::BOOLEAN, literal2.getType());
     EXPECT_TRUE("false" == literal2.toString());
 
-    Literal literal3(static_cast<int64_t>(0), 123456789);
+    Literal literal3(static_cast<int64_t>(123456), 123456789);
     EXPECT_EQ(PredicateDataType::TIMESTAMP, literal3.getType());
-    EXPECT_TRUE("1970-01-01 00:00:00.123456789" == literal3.toString());
+    EXPECT_TRUE("123456.123456789" == literal3.toString());
 
     Literal literal4(Int128(54321), 6, 2);
     EXPECT_EQ(PredicateDataType::DECIMAL, literal4.getType());

--- a/c++/test/TestSearchArgument.cc
+++ b/c++/test/TestSearchArgument.cc
@@ -36,9 +36,9 @@ namespace orc {
     EXPECT_EQ(PredicateDataType::BOOLEAN, literal2.getType());
     EXPECT_TRUE("false" == literal2.toString());
 
-    Literal literal3(PredicateDataType::TIMESTAMP, 123456L);
+    Literal literal3(static_cast<int64_t>(0), 123456789);
     EXPECT_EQ(PredicateDataType::TIMESTAMP, literal3.getType());
-    EXPECT_TRUE("123456" == literal3.toString());
+    EXPECT_TRUE("1970-01-01 00:00:00.123456789" == literal3.toString());
 
     Literal literal4(Int128(54321), 6, 2);
     EXPECT_EQ(PredicateDataType::DECIMAL, literal4.getType());

--- a/c++/test/TestSearchArgument.cc
+++ b/c++/test/TestSearchArgument.cc
@@ -39,6 +39,7 @@ namespace orc {
     Literal literal3(static_cast<int64_t>(123456), 123456789);
     EXPECT_EQ(PredicateDataType::TIMESTAMP, literal3.getType());
     EXPECT_TRUE("123456.123456789" == literal3.toString());
+    EXPECT_EQ(123456123, literal3.getTimestamp().getMillis());
 
     Literal literal4(Int128(54321), 6, 2);
     EXPECT_EQ(PredicateDataType::DECIMAL, literal4.getType());


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Store nanosecond into TimestampColumnStatistics in C++ writer.
2. Be aware of nanosecond in the TimestampColumnStatistics.
3. Adde new functions in TimestampColumnStatistics to get nanosecond while keeping backward compatibility.
4. Fix PPD to utilize nanosecond or use a default value for timestamp columns.

### Why are the changes needed?
To be consistent with the java side.

### How was this patch tested?
Several new unit tests have been added to TestPredicateLeaf.cc, TestColumnStatistics.cc, and TestSearchArgument.cc.
