### PR TITLE
ORC-667: Positional mapping for nested struct types should not applied by default

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -513,7 +513,7 @@ public class SchemaEvolution {
             isOnlyImplicitConversion = false;
           }
 
-          if (positionalLevels == 0) {
+          if (positionalLevels <= 0) {
             List<String> readerFieldNames = readerType.getFieldNames();
             List<String> fileFieldNames = fileType.getFieldNames();
 

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -1737,6 +1737,20 @@ public class TestSchemaEvolution {
   }
 
   @Test
+  public void testStructInArrayWithoutPositionalEvolution() throws IOException {
+    options.forcePositionalEvolution(false);
+    options.positionalEvolutionLevel(Integer.MAX_VALUE);
+    TypeDescription file = TypeDescription.fromString("array<struct<x:string,y:int,z:double>>");
+    TypeDescription read = TypeDescription.fromString("array<struct<z:double,x:string,a:int,b:int>>");
+    SchemaEvolution evo = new SchemaEvolution(file, read, options);
+    assertEquals(1, evo.getFileType(1).getId());
+    assertEquals(4, evo.getFileType(2).getId());
+    assertEquals(2, evo.getFileType(3).getId());
+    assertNull(evo.getFileType(4));
+    assertNull(evo.getFileType(5));
+  }
+
+  @Test
   public void testPositionalEvolutionForStructInArray() throws IOException {
     options.forcePositionalEvolution(true);
     options.positionalEvolutionLevel(Integer.MAX_VALUE);


### PR DESCRIPTION
### What changes were proposed in this pull request?

[ORC-644](https://github.com/apache/orc/commit/bad383e9074b1597af50e85e77e7b6ce79147e39) (Support positional mapping for nested types) introduced a correctness regression on nested struct types. By default, `orc.force.positional.evolution` is false. However, currently it's applied for nested struct fields.

### Why are the changes needed?

[ORC-644](https://github.com/apache/orc/commit/bad383e9074b1597af50e85e77e7b6ce79147e39) changes like the following. However, `buildConversion` is a recursive function and `positionalLevels` becomes negative in the nested case.
```java
buildConversion(fileChildren.get(i),
-  readerChildren.get(i), 0);
+  readerChildren.get(i), positionalLevels - 1);
```

### How was this patch tested?

Pass the newly added test case.