### PR TITLE
ORC-669. Reduce breaking changes in ReaderImpl.java

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -67,12 +67,13 @@ public class ReaderImpl implements Reader {
   private final long maxLength;
   protected final Path path;
   protected final OrcFile.ReaderOptions options;
-  private final org.apache.orc.CompressionKind compressionKind;
+  protected final org.apache.orc.CompressionKind compressionKind;
   protected FSDataInputStream file;
   protected int bufferSize;
   // the unencrypted stripe statistics or null if they haven't been read yet
   protected List<OrcProto.StripeStatistics> stripeStatistics;
   private final int metadataSize;
+  protected final List<OrcProto.Type> types;
   private TypeDescription schema;
   private final List<OrcProto.UserMetadataItem> userMetadata;
   private final List<OrcProto.ColumnStatistics> fileStats;
@@ -526,6 +527,7 @@ public class ReaderImpl implements Reader {
       this.encryption = new ReaderEncryption(tail.getFooter(), schema,
           tail.getStripeStatisticsOffset(), tail.getTailBuffer(), stripes, options.getKeyProvider(), conf);
     }
+    this.types = OrcUtils.getOrcTypes(schema);
   }
 
   protected FileSystem getFileSystem() throws IOException {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Although this is `Implementation` class, this PR aims to reduce two breaking changes in `ReaderImpl.java` due to [ORC-520](https://github.com/apache/orc/pull/423) at Apache ORC 1.6.0 ~ 1.6.5.

### Why are the changes needed?

This helps Apache Hive and Spark works with Apache ORC 1.6.x by removing the following breaking changes with a minor and safe revision.

```
[info] org.apache.spark.sql.hive.orc.OrcHadoopFsRelationSuite *** ABORTED ***
[info]   java.lang.NoSuchFieldError: types
[info]   at org.apache.hadoop.hive.ql.io.orc.ReaderImpl.<init>(ReaderImpl.java:64)

[info] org.apache.spark.sql.hive.orc.HiveOrcHadoopFsRelationSuite *** ABORTED ***
[info]   java.lang.IllegalAccessError: tried to access field org.apache.orc.impl.ReaderImpl.compressionKind
from class org.apache.hadoop.hive.ql.io.orc.ReaderImpl
```

### How was this patch tested?

Manually review because this adds back a field and changes visibility of the field like ORC 1.5.x,