### PR TITLE
ORC-670. RecordReaderImpl.findColumns should respect orc.schema.evolution.case.sensitive

### DIFF
--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -818,8 +818,12 @@ public class TypeDescription
    * @return the subtype
    */
   public TypeDescription findSubtype(String columnName) {
+    return findSubtype(columnName, true);
+  }
+
+  public TypeDescription findSubtype(String columnName, Boolean isSchemaEvolutionCaseAware) {
     ParserUtils.StringPosition source = new ParserUtils.StringPosition(columnName);
-    TypeDescription result = ParserUtils.findSubtype(this, source);
+    TypeDescription result = ParserUtils.findSubtype(this, source, isSchemaEvolutionCaseAware);
     if (source.hasCharactersLeft()) {
       throw new IllegalArgumentException("Remaining text in parsing field name "
           + source);

--- a/java/core/src/java/org/apache/orc/impl/ParserUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/ParserUtils.java
@@ -246,6 +246,12 @@ public class ParserUtils {
 
   public static TypeDescription findSubtype(TypeDescription schema,
                                             ParserUtils.StringPosition source) {
+    return findSubtype(schema, source, true);
+  }
+
+  public static TypeDescription findSubtype(TypeDescription schema,
+                                            ParserUtils.StringPosition source,
+                                            Boolean isSchemaEvolutionCaseAware) {
     List<String> names = ParserUtils.splitName(source);
     if (names.size() == 1 && INTEGER_PATTERN.matcher(names.get(0)).matches()) {
       return schema.findSubtype(Integer.parseInt(names.get(0)));
@@ -256,7 +262,18 @@ public class ParserUtils {
       String first = names.remove(0);
       switch (current.getCategory()) {
         case STRUCT: {
-          int posn = current.getFieldNames().indexOf(first);
+          int posn = -1;
+          if (isSchemaEvolutionCaseAware) {
+            posn = current.getFieldNames().indexOf(first);
+          } else {
+            // Case-insensitive search like ORC 1.5
+            for (int i = 0; i < current.getFieldNames().size(); i++) {
+              if (current.getFieldNames().get(i).equalsIgnoreCase(first)) {
+                posn = i;
+                break;
+              }
+            }
+          }
           if (posn == -1) {
             throw new IllegalArgumentException("Field " + first +
                 " not found in " + current.toString());

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -107,8 +107,8 @@ public class RecordReaderImpl implements RecordReader {
   static int findColumns(SchemaEvolution evolution,
                          String columnName) {
     try {
-      TypeDescription readerColumn =
-          evolution.getReaderBaseSchema().findSubtype(columnName);
+      TypeDescription readerColumn = evolution.getReaderBaseSchema().findSubtype(
+          columnName, evolution.isSchemaEvolutionCaseAware);
       TypeDescription fileColumn = evolution.getFileType(readerColumn);
       return fileColumn == null ? -1 : fileColumn.getId();
     } catch (IllegalArgumentException e) {

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -49,7 +49,7 @@ public class SchemaEvolution {
   private boolean hasConversion;
   private boolean isOnlyImplicitConversion;
   private final boolean isAcid;
-  private final boolean isSchemaEvolutionCaseAware;
+  final boolean isSchemaEvolutionCaseAware;
   /**
    * {@code true} if acid metadata columns should be decoded otherwise they will
    * be set to {@code null}.  {@link #acidEventFieldNames}.

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -113,6 +113,16 @@ public class TestRecordReaderImpl {
   }
 
   @Test
+  public void testFindColumnCaseInsensitively() throws Exception {
+    Configuration conf = new Configuration();
+    TypeDescription file = TypeDescription.fromString("struct<A:int>");
+    TypeDescription reader = TypeDescription.fromString("struct<a:int>");
+    conf.setBoolean("orc.schema.evolution.case.sensitive", false);
+    SchemaEvolution evo = new SchemaEvolution(file, reader, new Reader.Options(conf));
+    assertEquals(1, RecordReaderImpl.findColumns(evo, "A"));
+  }
+
+  @Test
   public void testForcePositionalEvolution() throws Exception {
     Configuration conf = new Configuration();
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache ORC 1.6.0 ~ 1.6.5 cannot handle predicate pushdown case-insensitively.

### Why are the changes needed?

This is a performance regression from Apache ORC 1.5.x. Without this patch, ORC 1.6.x cannot pass SPARK-32622 (case sensitivity in predicate pushdown) unit test cases.

This makes Apache ORC pass Apache Spark's `sql/core` module unit tests by fixing the last three failures. The remaining failures are in all `sql/hive` module due to another reasons.

### How was this patch tested?

Pass the newly added unit test case.