### PR TITLE
ORC-671. Add OrcTail.getStripeStatistics back

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -627,7 +627,7 @@ public class ReaderImpl implements Reader {
     result.setPostscript(postscript);
     result.setFileLength(0);
     result.setPostscriptLength(0);
-    return new OrcTail(result.build(), new BufferChunk(0, 0), -1);
+    return new OrcTail(result.build(), new BufferChunk(0, 0), -1, this);
   }
 
   private static void read(FSDataInputStream file,
@@ -728,7 +728,7 @@ public class ReaderImpl implements Reader {
                 new IOException("Problem reading file footer " + path, thr);
     }
 
-    return new OrcTail(fileTailBuilder.build(), buffer, modificationTime);
+    return new OrcTail(fileTailBuilder.build(), buffer, modificationTime, this);
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `OrcTail.getStripeStatistics` back to mitigate backward compatibility partially. After this PR, the migration becomes much easier because changing `new OrcTail` is easier.
- If the existing app creates `OrcTail` via `extractFileTail` or `buildEmptyTail`, it will recover.
- For the other cases, the users need to migrate to `Reader.getStripeStatistics` or new `OrcTail` constructor.

### Why are the changes needed?

Apache ORC 1.6.0 ~ 1.6.5 removes `getStripeStatistics` during Proleptic time support. We had better keep the backward compatibility as a wrapper for the new API.
```
[info]   java.lang.RuntimeException: ORC split generation failed with exception: java.lang.NoSuchMethodError: org.apache.orc.impl.OrcTail.getStripeStatistics()Ljava/util/List;
[info]   at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat.generateSplitsInfo(OrcInputFormat.java:1731)
[info]   at org.apache.hadoop.hive.ql.io.orc.OrcInputFormat.getSplits(OrcInputFormat.java:1817)
```

### How was this patch tested?

This is a recovery of the old API.
