### PR TITLE
ORC-673: PPD LTE Point equality comparison is wrong when RG MIN==MAX

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -636,7 +636,8 @@ public class RecordReaderImpl implements RecordReader {
         }
       case LESS_THAN_EQUALS:
         loc = range.compare(predObj);
-        if (loc == Location.AFTER || loc == Location.MAX) {
+        if (loc == Location.AFTER || loc == Location.MAX ||
+            (loc == Location.MIN && range.isSingleton())) {
           return range.addNull(TruthValue.YES);
         } else if (loc == Location.BEFORE) {
           return range.addNull(TruthValue.NO);

--- a/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
@@ -129,7 +129,7 @@ public class TestOrcTimestampPPD {
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("1970-01-01 00:00:00.0005"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    Assert.assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("1970-01-01 00:00:00.0005"), null);

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -1150,7 +1150,7 @@ public class TestRecordReaderImpl {
         evaluateInteger(createStringStats("c", "d", true), pred)); // min
     assertEquals(TruthValue.YES_NO_NULL,
         evaluateInteger(createStringStats("b", "d", true), pred)); // middle
-    assertEquals(TruthValue.YES_NO_NULL,
+    assertEquals(TruthValue.YES_NULL,
         evaluateInteger(createStringStats("c", "c", true), pred)); // same
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

FIx PPD Less than Equals comparison for min==max corner case

### Why are the changes needed?

Better PPD evaluation

### How was this patch tested?

Extra JUnit test