### PR TITLE
ORC-674: Update Dockerfiles

### DIFF
--- a/c++/src/wrap/orc-proto-wrapper.cc
+++ b/c++/src/wrap/orc-proto-wrapper.cc
@@ -15,6 +15,7 @@
 #include "Adaptor.hh"
 
 #if defined(__GNUC__) || defined(__clang__)
+  DIAGNOSTIC_IGNORE("-Warray-bounds")
   DIAGNOSTIC_IGNORE("-Wconversion")
   DIAGNOSTIC_IGNORE("-Wdeprecated")
   DIAGNOSTIC_IGNORE("-Wignored-qualifiers")

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,8 +1,8 @@
 ## Supported OSes
 
 * CentOS 7, and 8
-* Debian 8, 9, and 10
-* Ubuntu 14, 16, and 18
+* Debian 9, and 10
+* Ubuntu 16, 18, and 20
 
 ## Test
 

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM centos:7
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN yum check-update || true
 RUN yum -y install epel-release

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM centos:8
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN yum check-update || true
 RUN yum install -y \

--- a/docker/debian10/Dockerfile
+++ b/docker/debian10/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM debian:buster
-MAINTAINER Owen O'Malley <omalley@apache.org>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/docker/debian8/Dockerfile
+++ b/docker/debian8/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM debian:8
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 ADD sources.list apt.conf /etc/apt/
 

--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM debian:9
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -1,8 +1,8 @@
 centos7
 centos8
-debian8
 debian9
 debian10
-ubuntu14
 ubuntu16
 ubuntu18
+ubuntu20
+ubuntu20-clang

--- a/docker/ubuntu14/Dockerfile
+++ b/docker/ubuntu14/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM ubuntu:14.04
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN apt-get update
 RUN apt-get install -y software-properties-common

--- a/docker/ubuntu16/Dockerfile
+++ b/docker/ubuntu16/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM ubuntu:16.04
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN apt-get update
 RUN apt-get install -y \

--- a/docker/ubuntu18/Dockerfile
+++ b/docker/ubuntu18/Dockerfile
@@ -18,7 +18,7 @@
 #
 
 FROM ubuntu:18.04
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update

--- a/docker/ubuntu20-clang/Dockerfile
+++ b/docker/ubuntu20-clang/Dockerfile
@@ -14,30 +14,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ORC compile for Ubuntu 16 (clang 5)
+# ORC compile for Ubuntu 20 with clang
 #
 
-FROM ubuntu:16.04
-MAINTAINER Owen O'Malley <owen@hortonworks.com>
+FROM ubuntu:20.04
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
-RUN apt-get update
-RUN apt-get install -y wget software-properties-common
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main"
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update
 RUN apt-get install -y \
   cmake \
-  default-jdk \
-  clang-5.0 \
+  clang \
   git \
   libsasl2-dev \
   libssl-dev \
   make \
   maven \
+  openjdk-8-jdk \
   tzdata
+RUN update-java-alternatives --set java-1.8.0-openjdk-amd64
 
-ENV CC=clang-5.0
-ENV CXX=clang++-5.0
+ENV CC=clang
+ENV CXX=clang++
 
 WORKDIR /root
 VOLUME /root/.m2/repository

--- a/docker/ubuntu20/Dockerfile
+++ b/docker/ubuntu20/Dockerfile
@@ -18,6 +18,7 @@
 #
 
 FROM ubuntu:20.04
+MAINTAINER Apache ORC project <dev@orc.apache.org>
 
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -25,13 +25,13 @@ You'll want to install the usual set of developer tools, but at least:
 For each version of Linux, please check the corresponding Dockerfile, which
 is in the docker subdirectory, for the list of packages required to build ORC:
 
-* [CentOS 6]({{ page.dockerUrl }}/centos6/Dockerfile)
 * [CentOS 7]({{ page.dockerUrl }}/centos7/Dockerfile)
+* [CentOS 8]({{ page.dockerUrl }}/centos8/Dockerfile)
 * [Debian 8]({{ page.dockerUrl }}/debian8/Dockerfile)
 * [Debian 9]({{ page.dockerUrl }}/debian9/Dockerfile)
-* [Ubuntu 14]({{ page.dockerUrl }}/ubuntu14/Dockerfile)
 * [Ubuntu 16]({{ page.dockerUrl }}/ubuntu16/Dockerfile)
 * [Ubuntu 18]({{ page.dockerUrl }}/ubuntu18/Dockerfile)
+* [Ubuntu 20]({{ page.dockerUrl }}/ubuntu20/Dockerfile)
 
 To build a normal release:
 


### PR DESCRIPTION
Adds ubuntu 20 with gcc and clang.
Removes support for debian 8 and ubuntu 14.