### PR TITLE
ORC-677: Add a deprecated legacy constructor SargApplier back

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -939,6 +939,17 @@ public class RecordReaderImpl implements RecordReader {
     private final boolean writerUsedProlepticGregorian;
     private final boolean convertToProlepticGregorian;
 
+    /**
+     * @deprecated Use the constructor having full parameters. This exists for backward compatibility.
+     */
+    public SargApplier(SearchArgument sarg,
+                       long rowIndexStride,
+                       SchemaEvolution evolution,
+                       OrcFile.WriterVersion writerVersion,
+                       boolean useUTCTimestamp) {
+      this(sarg, rowIndexStride, evolution, writerVersion, useUTCTimestamp, false, false);
+    }
+
     public SargApplier(SearchArgument sarg,
                        long rowIndexStride,
                        SchemaEvolution evolution,

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -2298,7 +2298,7 @@ public class TestRecordReaderImpl {
 
     boolean[] rows = applier.pickRowGroups(new ReaderImpl.StripeInformationImpl(stripe,  1, -1, null),
         indexes, null, encodings, null, false);
-    assertEquals(SargApplier.READ_ALL_RGS, rows); //cannot filter for new column, return all rows
+    assertEquals(true, Arrays.equals(SargApplier.READ_ALL_RGS, rows)); //cannot filter for new column, return all rows
   }
 
   private boolean[] includeAll(TypeDescription readerType) {

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.orc.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.sql.Date;
@@ -2357,5 +2359,23 @@ public class TestRecordReaderImpl {
     }
     assertTrue(isCalled);
     verify(mockedDataReader, times(1)).close();
+  }
+
+  @Test
+  public void testSargApplier() throws Exception {
+    Configuration conf = new Configuration();
+    TypeDescription schema = TypeDescription.createLong();
+    SearchArgument sarg = SearchArgumentFactory.newBuilder().build();
+    SchemaEvolution evo = new SchemaEvolution(schema, schema, new Reader.Options(conf));
+    RecordReaderImpl.SargApplier applier1 =
+      new RecordReaderImpl.SargApplier(sarg, 0, evo, OrcFile.WriterVersion.ORC_135, false);
+
+    Field f1 = RecordReaderImpl.SargApplier.class.getDeclaredField("writerUsedProlepticGregorian");
+    f1.setAccessible(true);
+    assertFalse((boolean)f1.get(applier1));
+
+    Field f2 = RecordReaderImpl.SargApplier.class.getDeclaredField("convertToProlepticGregorian");
+    f2.setAccessible(true);
+    assertFalse((boolean)f2.get(applier1));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a deprecated legacy constructor `SargApplier` back.

### Why are the changes needed?

ORC-27 removes this at Apache ORC 1.5.9 and 1.6.3 and this causes a compilation error at Apache Hive 3.1 branch (https://github.com/apache/hive/pull/1615).
- ORC-27: https://github.com/apache/orc/commit/949c7444ef98680026d9f2b93d7299b76cdfb030#diff-8678415090c906d11e0aa6241ba24643192cd66617c68d8deb0f7efe74dd2ba3L876-R883

### How was this patch tested?

Pass the CI with the newly added test case.