### PR TITLE
ORC-680: Upgrade Travis CI linux os from Ubuntu 14.04 to Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 addons:
   homebrew:
     packages:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Travis CI from Ubuntu 14.04 to Ubuntu 16.04.

**BEFORE**
![Screen Shot 2020-10-28 at 4 38 14 PM](https://user-images.githubusercontent.com/9700541/97508116-0fdff600-193c-11eb-8ca5-38b5738e4708.png)

**AFTER**
![Screen Shot 2020-10-28 at 5 18 53 PM](https://user-images.githubusercontent.com/9700541/97510302-ac58c700-1941-11eb-871e-5057a531feaa.png)


### Why are the changes needed?

Travis CI `Trusty` has a wrong `javac`. We should use JDK8 for `javac`. This is fixed with this patch.
```
$ java -Xmx32m -version
openjdk version "1.8.0_141"
OpenJDK Runtime Environment (build 1.8.0_141-8u141-b15-3~14.04-b15)
OpenJDK 64-Bit Server VM (build 25.141-b15, mixed mode)

$ javac -J-Xmx32m -version
javac 9.0.1
```

ORC-674 and ORC-675 removed Ubuntu 14.04.

### How was this patch tested?

Pass the Travis CI.
