### PR TITLE
ORC-274: Remove columnNames field from Reader.Options

### DIFF
--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -186,7 +186,6 @@ public interface Reader extends Closeable {
     private long length = Long.MAX_VALUE;
     private int positionalEvolutionLevel;
     private SearchArgument sarg = null;
-    private String[] columnNames = null;
     private Boolean useZeroCopy = null;
     private Boolean skipCorruptRecords = null;
     private TypeDescription schema = null;
@@ -272,14 +271,24 @@ public interface Reader extends Closeable {
     }
 
     /**
+     *  @deprecated columnNames are no needed for setting search argument. Method exists for backward compatibility.
+     *
      * Set search argument for predicate push down.
      * @param sarg the search argument
      * @param columnNames the column names for
      * @return this
      */
     public Options searchArgument(SearchArgument sarg, String[] columnNames) {
+      return searchArgument(sarg);
+    }
+
+    /**
+     * Set search argument for predicate push down.
+     * @param sarg the search argument
+     * @return this
+     */
+    public Options searchArgument(SearchArgument sarg) {
       this.sarg = sarg;
-      this.columnNames = columnNames;
       return this;
     }
 
@@ -390,8 +399,15 @@ public interface Reader extends Closeable {
       return preFilterColumns;
     }
 
+    /**
+     * Get the column-name mapping of search argument leaves.
+     * @return column names of predicate leaves or NULL when search argument not set
+     */
     public String[] getColumnNames() {
-      return columnNames;
+      if (this.sarg != null) {
+        return sarg.getLeaves().stream().map(l -> l.getColumnName()).toArray(String[]::new);
+      }
+      return null;
     }
 
     public long getMaxOffset() {

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -400,8 +400,8 @@ public interface Reader extends Closeable {
     }
 
     /**
-     * Get the column-name mapping of search argument leaves.
-     * @return column names of predicate leaves or NULL when search argument not set
+     * Get the search argument leaves' column-name mapping.
+     * @return an array of column names, one for every predicate leave, or NULL when search argument not set
      */
     public String[] getColumnNames() {
       if (this.sarg != null) {

--- a/java/core/src/test/org/apache/orc/TestStringDictionary.java
+++ b/java/core/src/test/org/apache/orc/TestStringDictionary.java
@@ -599,7 +599,7 @@ public class TestStringDictionary {
     SearchArgument sarg = SearchArgumentFactory.newBuilder(conf)
         .lessThan("str", PredicateLeaf.Type.STRING, "row 001000")
         .build();
-    RecordReader recordReader = reader.rows(reader.options().searchArgument(sarg, null));
+    RecordReader recordReader = reader.rows(reader.options().searchArgument(sarg));
     batch = reader.getSchema().createRowBatch();
     strVector = (BytesColumnVector) batch.cols[0];
     long base = 0;
@@ -624,7 +624,7 @@ public class TestStringDictionary {
         .lessThan("str", PredicateLeaf.Type.STRING, "row 001000")
         .build();
     try (Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf).filesystem(fs))) {
-      try (RecordReader recordReader = reader.rows(reader.options().searchArgument(sarg, null))) {
+      try (RecordReader recordReader = reader.rows(reader.options().searchArgument(sarg))) {
         VectorizedRowBatch batch = reader.getSchema().createRowBatch();
         BytesColumnVector strVector = (BytesColumnVector) batch.cols[0];
         long base = 0;

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
@@ -139,7 +139,7 @@ public class OrcInputFormat<V extends WritableComparable>
       byte[] sargBytes = Base64.decodeBase64(kryoSarg);
       SearchArgument sarg =
           new Kryo().readObject(new Input(sargBytes), SearchArgumentImpl.class);
-      options.searchArgument(sarg, sargColumns.split(","));
+      options.searchArgument(sarg);
     }
     return options;
   }

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -126,13 +126,12 @@ public class TestOrcFileEvolution {
       .newBuilder()
       .lessThan("c", PredicateLeaf.Type.LONG, 10L)
       .build();
-    String[] sCols = new String[]{null, null, "c"};
 
     checkEvolution("struct<a:int,b:string>", "struct<a:int,b:string,c:int>",
                    struct(1, "foo"),
                    struct(1, "foo", null),
                    (boolean) OrcConf.TOLERATE_MISSING_SCHEMA.getDefaultValue(),
-                   sArg, sCols, false);
+                   sArg, false);
   }
 
   @Test
@@ -357,13 +356,12 @@ public class TestOrcFileEvolution {
         .newBuilder()
         .lessThan("a", PredicateLeaf.Type.LONG, 10L)
         .build();
-      sCols = new String[]{null, "a", null};
     }
 
     checkEvolution(writerType, readerType,
                    inputRow, expectedOutput,
                    tolerateSchema,
-                   sArg, sCols, positional);
+                   sArg, positional);
   }
 
   private void checkEvolution(String writerType, String readerType,
@@ -379,7 +377,7 @@ public class TestOrcFileEvolution {
   private void checkEvolution(String writerType, String readerType,
                               Object inputRow, Object expectedOutput,
                               boolean tolerateSchema, SearchArgument sArg,
-                              String[] sCols, boolean positional) {
+                              boolean positional) {
     TypeDescription readTypeDescr = TypeDescription.fromString(readerType);
     TypeDescription writerTypeDescr = TypeDescription.fromString(writerType);
 
@@ -400,8 +398,8 @@ public class TestOrcFileEvolution {
                                            OrcFile.readerOptions(conf).filesystem(fs));
 
       Reader.Options options = reader.options().schema(readTypeDescr);
-      if (sArg != null && sCols != null) {
-        options.searchArgument(sArg, sCols);
+      if (sArg != null) {
+        options.searchArgument(sArg);
       }
 
       OrcMapredRecordReader<OrcStruct> recordReader =

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -330,13 +330,11 @@ public class TestOrcFileEvolution {
                                   boolean tolerateSchema, boolean addSarg,
                                   boolean positional) {
     SearchArgument sArg = null;
-    String[] sCols = null;
     if (addSarg) {
       sArg = SearchArgumentFactory
         .newBuilder()
         .lessThan("_col0", PredicateLeaf.Type.LONG, 10L)
         .build();
-      sCols = new String[]{null, "_col0", null};
     }
 
     checkEvolution(writerType, readerType,

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -342,7 +342,7 @@ public class TestOrcFileEvolution {
     checkEvolution(writerType, readerType,
                    inputRow, expectedOutput,
                    tolerateSchema,
-                   sArg, sCols, positional);
+                   sArg, positional);
   }
 
   private void checkEvolution(String writerType, String readerType,


### PR DESCRIPTION
### What changes were proposed in this pull request?
*  Remove the columnNames field from Reader.Options
*  Add searchArgument(SearchArgument sarg) as default method for SARG construction
*  Deprecate searchArgument(SearchArgument sarg, String[] columnNames)

### Why are the changes needed?
Codebase cleaning and simplification with API consistency

### How was this patch tested?
Extended existing tests