### PR TITLE
ORC-684: [C++] Make Floating point NaN check more strict

### DIFF
--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -494,8 +494,7 @@ namespace orc {
             colStats.doublestatistics().has_minimum() &&
             colStats.doublestatistics().has_maximum()) {
           const auto& stats = colStats.doublestatistics();
-          if (!std::isfinite(stats.minimum()) || !std::isfinite(stats.maximum()) ||
-              !std::isfinite(stats.sum())) {
+          if (!std::isfinite(stats.sum())) {
               result = colStats.hasnull() ?
                       TruthValue::YES_NO_NULL : TruthValue::YES_NO;
           } else {

--- a/c++/test/TestPredicateLeaf.cc
+++ b/c++/test/TestPredicateLeaf.cc
@@ -104,8 +104,10 @@ namespace orc {
     colStats.set_numberofvalues(10);
 
     proto::DoubleStatistics * doubleStats = colStats.mutable_doublestatistics();
+    const auto& curr_sum = min + max;
     doubleStats->set_minimum(min);
     doubleStats->set_maximum(max);
+    doubleStats->set_sum(curr_sum);
     return colStats;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
ORC-636 added an extra check (part of RecordReaderImp) disabling PPD when DoubleColumnStats min, max or sum is a non-Finite number.

However, the check is unnecessarily broad – the way stats are updated, using just sum for the check would suffice.

### Why are the changes needed?
Make NAN check for DoubleStats (used for PPD) more strict

### How was this patch tested?
TestPredicateLeaf.cc