### PR TITLE
ORC-688: Allow CHAR to be promoted to STRING

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1944,14 +1944,9 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       return new DecimalFromStringGroupTreeReader(columnId, fileType, readerType, context);
 
     case CHAR:
-      return new StringGroupFromStringGroupTreeReader(columnId, fileType, readerType, context);
-
     case VARCHAR:
-      return new StringGroupFromStringGroupTreeReader(columnId, fileType, readerType, context);
-
     case STRING:
-      throw new IllegalArgumentException("No conversion of type " +
-          readerType.getCategory() + " to self needed");
+      return new StringGroupFromStringGroupTreeReader(columnId, fileType, readerType, context);
 
     case BINARY:
       return new BinaryTreeReader(columnId, context);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enable String conversion from varchar. 
Currently createStringConvertTreeReader in ConvertTreeReaderFactory is missing that opportunity


### Why are the changes needed?
Modify createStringConvertTreeReader to handle char, varchar and string as part of the same group.


### How was this patch tested?
TestSchemaEvolution.testCharToStringEvolution