### PR TITLE
ORC-689: Add GitHubAction job to publish snapshot

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -1,0 +1,24 @@
+name: Publish Snapshot
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  publish-snapshot:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 8
+
+    - name: Release Maven package
+      uses: samuelmeuli/action-maven-publish@v1
+      with:
+        directory: java
+        server_id: apache.snapshots.https
+        nexus_username: ${{ secrets.nexus_username }}
+        nexus_password: ${{ secrets.nexus_password }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `GitHub Action` job to publish snapshot like the following. The following is generated by this patch from my fork `master` branch.

- https://repository.apache.org/content/repositories/snapshots/org/apache/orc/orc-core/1.7.0-SNAPSHOT/

### Why are the changes needed?

Currently, Apache ORC community doesn't provide snapshot artifacts. It would be great if we provide it in order to help the downstream projects to test it in advance.

### How was this patch tested?

This is tested in my ORC fork and we need INFRA team's credential setup.

- https://github.com/dongjoon-hyun/orc/runs/1468464962 (I merged to my `master` branch and removed it after testing)
- https://issues.apache.org/jira/browse/INFRA-21150 (Upload snapshots from GitHub Actions)
