### PR TITLE
ORC-688: Allow CHAR to be promoted to STRING

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1914,14 +1914,9 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       return new DecimalFromStringGroupTreeReader(columnId, fileType, readerType, context);
 
     case CHAR:
-      return new StringGroupFromStringGroupTreeReader(columnId, fileType, readerType, context);
-
     case VARCHAR:
-      return new StringGroupFromStringGroupTreeReader(columnId, fileType, readerType, context);
-
     case STRING:
-      throw new IllegalArgumentException("No conversion of type " +
-          readerType.getCategory() + " to self needed");
+      return new StringGroupFromStringGroupTreeReader(columnId, fileType, readerType, context);
 
     case BINARY:
       return new BinaryTreeReader(columnId, context);

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -577,6 +577,38 @@ public class TestSchemaEvolution {
   }
 
   @Test
+  public void testCharToStringEvolution() throws IOException {
+    TypeDescription fileType = TypeDescription.fromString("struct<x:char(10)>");
+    TypeDescription readType = TypeDescription.fromString("struct<x:string>");
+    SchemaEvolution evo = new SchemaEvolution(fileType, readType, options);
+
+    TreeReaderFactory.Context treeContext =
+        new TreeReaderFactory.ReaderContext().setSchemaEvolution(evo);
+    TreeReaderFactory.TreeReader reader =
+        TreeReaderFactory.createTreeReader(readType, treeContext);
+
+    // Make sure the tree reader is built properly
+    assertEquals(TreeReaderFactory.StructTreeReader.class, reader.getClass());
+    TreeReaderFactory.TreeReader[] children =
+        ((TreeReaderFactory.StructTreeReader) reader).getChildReaders();
+    assertEquals(1, children.length);
+    assertEquals(ConvertTreeReaderFactory.StringGroupFromStringGroupTreeReader.class, children[0].getClass());
+
+    // Make sure that varchar behaves the same as char
+    fileType = TypeDescription.fromString("struct<x:varchar(10)>");
+    evo = new SchemaEvolution(fileType, readType, options);
+
+    treeContext = new TreeReaderFactory.ReaderContext().setSchemaEvolution(evo);
+    reader = TreeReaderFactory.createTreeReader(readType, treeContext);
+
+    // Make sure the tree reader is built properly
+    assertEquals(TreeReaderFactory.StructTreeReader.class, reader.getClass());
+    children = ((TreeReaderFactory.StructTreeReader) reader).getChildReaders();
+    assertEquals(1, children.length);
+    assertEquals(ConvertTreeReaderFactory.StringGroupFromStringGroupTreeReader.class, children[0].getClass());
+  }
+
+  @Test
   public void testStringToDecimalEvolution() throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
       testCaseName.getMethodName() + ".orc");


### PR DESCRIPTION
 ### What changes were proposed in this pull request?

This is a backport of #572.
    
Enable String conversion from varchar.
Currently createStringConvertTreeReader in ConvertTreeReaderFactory is missing that opportunity
    
### Why are the changes needed?
    
Modify createStringConvertTreeReader to handle char, varchar and string as part of the same group.
    
### How was this patch tested?
    
TestSchemaEvolution.testCharToStringEvolution
