### PR TITLE
ORC-695: Publish daily snapshot

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -1,9 +1,8 @@
 name: Publish Snapshot
 
 on:
-  push:
-    branches:
-    - master
+  schedule:
+    - cron:  '0 0 * * *'
 
 jobs:
   publish-snapshot:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to switch to daily snapshot publishing instead of commit-by-commit snapshot publishing.

### Why are the changes needed?

This can recover the snapshot repository daily if the snapshot publishing fails due to some flakiness.

### How was this patch tested?

N/A.