### PR TITLE
ORC-702: [C++] Support big ORC files in Windows

### DIFF
--- a/c++/src/OrcFile.cc
+++ b/c++/src/OrcFile.cc
@@ -30,6 +30,8 @@
 #include <io.h>
 #define S_IRUSR _S_IREAD
 #define S_IWUSR _S_IWRITE
+#define stat _stat64
+#define fstat _fstat64
 #else
 #include <unistd.h>
 #define O_BINARY 0


### PR DESCRIPTION
Backporting PR#584 to branch-1.6

**What changes were proposed in this pull request?**

Use 64-bit versions of fstat to support files bigger than 2GB in Windows.

**Why are the changes needed?**

To support big files.

**How was this patch tested?**

Manual