### PR TITLE
ORC-703 : Fix RLE encoding bug on large negative integer.

### DIFF
--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -577,9 +577,10 @@ void RleEncoderV2::writePatchedBasedValues(EncodingOption& option) {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    uint32_t baseWidth = findClosestNumBits(option.min) + 1;
-    if (baseWidth > 64) {
-        baseWidth = 64;
+    uint32_t baseWidth = findClosestNumBits(option.min);
+    if (baseWidth < 64) {
+        // store the sign bit when baseWidth is less than 64
+        baseWidth++;
     } 
     const uint32_t baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     const uint32_t bb = (baseBytes - 1) << 5;

--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -577,11 +577,9 @@ void RleEncoderV2::writePatchedBasedValues(EncodingOption& option) {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    uint32_t baseWidth = findClosestNumBits(option.min);
-    if (baseWidth < 64) {
-        // store the sign bit when baseWidth is less than 64
-        baseWidth++;
-    } 
+    uint32_t baseBitsNum = findClosestNumBits(option.min);
+    // if Negative, sign bit is already accounted for
+    uint32_t baseWidth = isNegative ? baseBitsNum : baseBitsNum + 1;
     const uint32_t baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     const uint32_t bb = (baseBytes - 1) << 5;
 

--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -577,7 +577,10 @@ void RleEncoderV2::writePatchedBasedValues(EncodingOption& option) {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    const uint32_t baseWidth = findClosestNumBits(option.min) + 1;
+    uint32_t baseWidth = findClosestNumBits(option.min) + 1;
+    if (baseWidth > 64) {
+        baseWidth = 64;
+    } 
     const uint32_t baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     const uint32_t bb = (baseBytes - 1) << 5;
 

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -23,6 +23,7 @@
 
 #include "wrap/orc-proto-wrapper.hh"
 #include "wrap/gtest-wrapper.h"
+#include <iostream>
 
 #ifdef __clang__
   DIAGNOSTIC_IGNORE("-Wmissing-variable-declarations")
@@ -393,7 +394,7 @@ namespace orc {
     data[511] = std::numeric_limits<int64_t>::max();
 
     // Invoke the encoder.
-    const bool isSigned = false;
+    const bool isSigned = true;
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
 
     std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
@@ -416,7 +417,7 @@ namespace orc {
     data[511] = std::numeric_limits<int64_t>::max();
 
     // Invoke the encoder.
-    const bool isSigned = false;
+    const bool isSigned = true;
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
 
     std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
@@ -438,7 +439,7 @@ namespace orc {
                                 33333L };
 
     // Invoke the encoder.
-    const bool isSigned = false;
+    const bool isSigned = true;
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
 
     std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
@@ -462,7 +463,7 @@ namespace orc {
                                 std::numeric_limits<int64_t>::max() };
 
     // Invoke the encoder.
-    const bool isSigned = false;
+    const bool isSigned = true;
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
 
     std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -283,7 +283,7 @@ namespace orc {
   // This case is used to testing encoding large negative integer.
   // The minimum is -84742859065569280, it's a 57 bit width integer 
   // and 8 bytes is used to encoding it.
-  TEST_P(RleTest, RleV2_Patched_large_negative_number) {
+  TEST_P(RleTest, RleV2_Patched_large_negative_integer) {
     // write data
     const int numValues = 30;
     int64_t data[30] = {

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -280,6 +280,33 @@ namespace orc {
     decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
   }
 
+  // This case is used to testing encoding large negative integer.
+  // The minimum is -84742859065569280, it's a 57 bit width integer 
+  // and 8 bytes is used to encoding it.
+  TEST_P(RleTest, RleV2_Patched_large_negative_number) {
+    // write data
+    const int numValues = 30;
+    int64_t data[30] = {
+      -17887939293638656, -15605417571528704, -15605417571528704, -13322895849418752,
+      -13322895849418752, -84742859065569280, -15605417571528704, -13322895849418752,
+      -13322895849418752, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -15605417571528704, -13322895849418752, -13322895849418752,
+      -11040374127308800, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -13322895849418752};
+    // Invoke the encoder.
+    const bool isSigned = true;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
   TEST_P(RleTest, RleV2_delta_example) {
     int64_t data[10] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29};
     unsigned char expectedEncoded[8] = {0xc6, 0x09, 0x02, 0x02, 0x22, 0x42, 0x42, 0x46};

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -280,13 +280,206 @@ namespace orc {
     decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
   }
 
+  TEST_P(RleTest, RleV2_Patched_negative_min1) {
+    // write data
+    const int32_t numValues = 226;
+    int64_t data[numValues] = { 20, 2, 3, 2, 1, 3, 17, 71, 35, 2, 1, 139, 2, 2,
+        3, 1783, 475, 2, 1, 1, 3, 1, 3, 2, 32, 1, 2, 3, 1, 8, 30, 1, 3, 414, 1,
+        1, 135, 3, 3, 1, 414, 2, 1, 2, 2, 594, 2, 5, 6, 4, 11, 1, 2, 2, 1, 1,
+        52, 4, 1, 2, 7, 1, 17, 334, 1, 2, 1, 2, 2, 6, 1, 266, 1, 2, 217, 2, 6,
+        2, 13, 2, 2, 1, 2, 3, 5, 1, 2, 1, 7244, 11813, 1, 33, 2, -13, 1, 2, 3,
+        13, 1, 92, 3, 13, 5, 14, 9, 141, 12, 6, 15, 25, 1, 1, 1, 46, 2, 1, 1,
+        141, 3, 1, 1, 1, 1, 2, 1, 4, 34, 5, 78, 8, 1, 2, 2, 1, 9, 10, 2, 1, 4,
+        13, 1, 5, 4, 4, 19, 5, 1, 1, 1, 68, 33, 399, 1, 1885, 25, 5, 2, 4, 1,
+        1, 2, 16, 1, 2966, 3, 1, 1, 25501, 1, 1, 1, 66, 1, 3, 8, 131, 14, 5, 1,
+        2, 2, 1, 1, 8, 1, 1, 2, 1, 5, 9, 2, 3, 112, 13, 2, 2, 1, 5, 10, 3, 1,
+        1, 13, 2, 3, 4, 1, 3, 1, 1, 2, 1, 1, 2, 4, 2, 207, 1, 1, 2, 4, 3, 3, 2,
+        2, 16 };
+
+    // Invoke the encoder.
+    const bool isSigned = true;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
+  TEST_P(RleTest, RleV2_Patched_negative_min2) {
+    // write data
+    const int32_t numValues = 226;
+    int64_t data[numValues] = { 20, 2, 3, 2, 1, 3, 17, 71, 35, 2, 1, 139, 2, 2,
+        3, 1783, 475, 2, 1, 1, 3, 1, 3, 2, 32, 1, 2, 3, 1, 8, 30, 1, 3, 414, 1,
+        1, 135, 3, 3, 1, 414, 2, 1, 2, 2, 594, 2, 5, 6, 4, 11, 1, 2, 2, 1, 1,
+        52, 4, 1, 2, 7, 1, 17, 334, 1, 2, 1, 2, 2, 6, 1, 266, 1, 2, 217, 2, 6,
+        2, 13, 2, 2, 1, 2, 3, 5, 1, 2, 1, 7244, 11813, 1, 33, 2, -1, 1, 2, 3,
+        13, 1, 92, 3, 13, 5, 14, 9, 141, 12, 6, 15, 25, 1, 1, 1, 46, 2, 1, 1,
+        141, 3, 1, 1, 1, 1, 2, 1, 4, 34, 5, 78, 8, 1, 2, 2, 1, 9, 10, 2, 1, 4,
+        13, 1, 5, 4, 4, 19, 5, 1, 1, 1, 68, 33, 399, 1, 1885, 25, 5, 2, 4, 1,
+        1, 2, 16, 1, 2966, 3, 1, 1, 25501, 1, 1, 1, 66, 1, 3, 8, 131, 14, 5, 1,
+        2, 2, 1, 1, 8, 1, 1, 2, 1, 5, 9, 2, 3, 112, 13, 2, 2, 1, 5, 10, 3, 1,
+        1, 13, 2, 3, 4, 1, 3, 1, 1, 2, 1, 1, 2, 4, 2, 207, 1, 1, 2, 4, 3, 3, 2,
+        2, 16 };
+
+    // Invoke the encoder.
+    const bool isSigned = true;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
+  TEST_P(RleTest, RleV2_Patched_negative_min3) {
+    // write data
+    const int numValues = 226;
+    int64_t data[numValues] = { 20, 2, 3, 2, 1, 3, 17, 71, 35, 2, 1, 139, 2, 2,
+        3, 1783, 475, 2, 1, 1, 3, 1, 3, 2, 32, 1, 2, 3, 1, 8, 30, 1, 3, 414, 1,
+        1, 135, 3, 3, 1, 414, 2, 1, 2, 2, 594, 2, 5, 6, 4, 11, 1, 2, 2, 1, 1,
+        52, 4, 1, 2, 7, 1, 17, 334, 1, 2, 1, 2, 2, 6, 1, 266, 1, 2, 217, 2, 6,
+        2, 13, 2, 2, 1, 2, 3, 5, 1, 2, 1, 7244, 11813, 1, 33, 2, 0, 1, 2, 3,
+        13, 1, 92, 3, 13, 5, 14, 9, 141, 12, 6, 15, 25, 1, 1, 1, 46, 2, 1, 1,
+        141, 3, 1, 1, 1, 1, 2, 1, 4, 34, 5, 78, 8, 1, 2, 2, 1, 9, 10, 2, 1, 4,
+        13, 1, 5, 4, 4, 19, 5, 1, 1, 1, 68, 33, 399, 1, 1885, 25, 5, 2, 4, 1,
+        1, 2, 16, 1, 2966, 3, 1, 1, 25501, 1, 1, 1, 66, 1, 3, 8, 131, 14, 5, 1,
+        2, 2, 1, 1, 8, 1, 1, 2, 1, 5, 9, 2, 3, 112, 13, 2, 2, 1, 5, 10, 3, 1,
+        1, 13, 2, 3, 4, 1, 3, 1, 1, 2, 1, 1, 2, 4, 2, 207, 1, 1, 2, 4, 3, 3, 2,
+        2, 16 };
+
+    // Invoke the encoder.
+    const bool isSigned = true;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
+  TEST_P(RleTest, RleV2_Patched_negative_min4) {
+    // write data
+    const int numValues = 52;
+    int64_t data[numValues] = { 13, 13, 11, 8, 13, 10, 10, 11, 11, 14, 11, 7, 13,
+        12, 12, 11, 15, 12, 12, 9, 8, 10, 13, 11, 8, 6, 5, 6, 11, 7, 15, 10, 7,
+        6, 8, 7, 9, 9, 11, 33, 11, 3, 7, 4, 6, 10, 14, 12, 5, 14, 7, 6 };
+
+    // Invoke the encoder.
+    const bool isSigned = true;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
+  TEST_P(RleTest, RleV2_Patched_max1) {
+    // write data
+    const int numValues = 5120;
+    int64_t data[numValues];
+    for (int i = 0; i < numValues; i++) {
+      data[i] = std::rand() % 60;
+    }
+    data[511] = std::numeric_limits<int64_t>::max();
+
+    // Invoke the encoder.
+    const bool isSigned = false;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
+  TEST_P(RleTest, RleV2_Patched_max2) {
+    // write data
+    const int numValues = 5120;
+    int64_t data[numValues];
+    for (int i = 0; i < 5120; i++) {
+      data[i] = std::rand() % 60;
+    }
+    data[127] = std::numeric_limits<int64_t>::max();
+    data[256] = std::numeric_limits<int64_t>::max();
+    data[511] = std::numeric_limits<int64_t>::max();
+
+    // Invoke the encoder.
+    const bool isSigned = false;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
+  TEST_P(RleTest, RleV2_Patched_max3) {
+    // write data
+    const int numValues = 20;
+    int64_t data[numValues] = { 371946367L, 11963367L, 68639400007L, 100233367L,
+                                6367L, 10026367L, 3670000L, 3602367L, 4719226367L, 
+                                7196367L, 444442L, 210267L, 21033L, 160267L,
+                                400267L, 23634347L, 16027L, 46026367L,
+                                std::numeric_limits<int64_t>::max(),
+                                33333L };
+
+    // Invoke the encoder.
+    const bool isSigned = false;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
+  TEST_P(RleTest, RleV2_Patched_max4) {
+    // write data
+    const int numValues = 21;
+    int64_t data[numValues] = { 371292224226367L, 119622332222267L, 686329400222007L,
+                                100233333222367L, 636272333322222L, 10202633223267L,
+                                36700222022230L,  36023226224227L,  47192226364427L,
+                                71963622222447L,  22244444222222L,  21220263327442L,
+                                21032233332232L,  16026322232227L,  40022262272212L,
+                                23634342227222L,  16022222222227L,  46026362222227L,
+                                46026362222227L,  33322222222323L,
+                                std::numeric_limits<int64_t>::max() };
+
+    // Invoke the encoder.
+    const bool isSigned = false;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
   // This case is used to testing encoding large negative integer.
   // The minimum is -84742859065569280, it's a 57 bit width integer 
   // and 8 bytes is used to encoding it.
   TEST_P(RleTest, RleV2_Patched_large_negative_integer) {
     // write data
     const int numValues = 30;
-    int64_t data[30] = {
+    int64_t data[numValues] = {
       -17887939293638656, -15605417571528704, -15605417571528704, -13322895849418752,
       -13322895849418752, -84742859065569280, -15605417571528704, -13322895849418752,
       -13322895849418752, -15605417571528704, -13322895849418752, -13322895849418752,

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
@@ -286,7 +286,10 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    final int baseWidth = utils.findClosestNumBits(min) + 1;
+    int baseWidth = utils.findClosestNumBits(min) + 1;
+    if (baseWidth > 64) {
+        baseWidth = 64;
+    }
     final int baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     final int bb = (baseBytes - 1) << 5;
 

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
@@ -286,9 +286,10 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    int baseWidth = utils.findClosestNumBits(min) + 1;
-    if (baseWidth > 64) {
-        baseWidth = 64;
+    int baseWidth = utils.findClosestNumBits(min);
+    if (baseWidth < 64) {
+        // store the sign bit when baseWidth is less than 64
+        baseWidth++;
     }
     final int baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     final int bb = (baseBytes - 1) << 5;

--- a/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
+++ b/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
@@ -37,6 +37,8 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
 import org.apache.orc.PhysicalWriter;
+import org.apache.orc.Reader;
+import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.impl.writer.StreamOptions;
@@ -310,6 +312,42 @@ public class TestRLEv2 {
     // use PATCHED_BASE encoding
     assertEquals(true, outDump.contains("Stream: column 0 section DATA start: 3 length 583"));
     System.setOut(origOut);
+  }
+
+  @Test
+  public void testMaxPatchBaseValue() throws Exception {
+    TypeDescription schema = TypeDescription.createInt();
+    Writer w = OrcFile.createWriter(testFilePath,
+           OrcFile.writerOptions(conf)
+                    .compress(CompressionKind.NONE)
+                    .setSchema(schema)
+                    .rowIndexStride(0)
+                   .encodingStrategy(OrcFile.EncodingStrategy.COMPRESSION)
+                    .version(OrcFile.Version.V_0_12)
+    );
+
+    VectorizedRowBatch batch = schema.createRowBatch();
+    //the minimum value is beyond RunLengthIntegerWriterV2.BASE_VALUE_LIMIT
+    long[] input = {-9007199254740992l,-8725724278030337l,-1125762467889153l, -1l,-9007199254740992l,
+        -9007199254740992l, -497l,127l,-1l,-72057594037927936l,-4194304l,-9007199254740992l,-4503599593816065l,
+        -4194304l,-8936830510563329l,-9007199254740992l, -1l, -70334384439312l,-4063233l, -6755399441973249l};
+    for(long data: input) {
+      appendInt(batch, data);
+    }
+    w.addRowBatch(batch);
+    w.close();
+
+    try(Reader reader = OrcFile.createReader(testFilePath,
+            OrcFile.readerOptions(conf).filesystem(fs))) {
+      RecordReader rows = reader.rows();
+      batch = reader.getSchema().createRowBatch();
+      long[] output = null;
+      while (rows.nextBatch(batch)) {
+        output = new long[batch.size];
+        System.arraycopy(((LongColumnVector) batch.cols[0]).vector, 0, output, 0, batch.size);
+      }
+      assertArrayEquals(input, output);
+    }
   }
 
   static class TestOutputCatcher implements PhysicalWriter.OutputReceiver {

--- a/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
+++ b/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
@@ -37,8 +37,6 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
 import org.apache.orc.PhysicalWriter;
-import org.apache.orc.Reader;
-import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.impl.writer.StreamOptions;
@@ -312,42 +310,6 @@ public class TestRLEv2 {
     // use PATCHED_BASE encoding
     assertEquals(true, outDump.contains("Stream: column 0 section DATA start: 3 length 583"));
     System.setOut(origOut);
-  }
-
-  @Test
-  public void testBaseValueLimit() throws Exception {
-    TypeDescription schema = TypeDescription.createInt();
-    Writer w = OrcFile.createWriter(testFilePath,
-            OrcFile.writerOptions(conf)
-                    .compress(CompressionKind.NONE)
-                    .setSchema(schema)
-                    .rowIndexStride(0)
-                    .encodingStrategy(OrcFile.EncodingStrategy.COMPRESSION)
-                    .version(OrcFile.Version.V_0_12)
-    );
-
-    VectorizedRowBatch batch = schema.createRowBatch();
-    //the minimum value is beyond RunLengthIntegerWriterV2.BASE_VALUE_LIMIT
-    long[] input = {-9007199254740992l,-8725724278030337l,-1125762467889153l, -1l,-9007199254740992l,
-        -9007199254740992l, -497l,127l,-1l,-72057594037927936l,-4194304l,-9007199254740992l,-4503599593816065l,
-        -4194304l,-8936830510563329l,-9007199254740992l, -1l, -70334384439312l,-4063233l, -6755399441973249l};
-    for(long data: input) {
-      appendInt(batch, data);
-    }
-    w.addRowBatch(batch);
-    w.close();
-
-    try(Reader reader = OrcFile.createReader(testFilePath,
-            OrcFile.readerOptions(conf).filesystem(fs))) {
-      RecordReader rows = reader.rows();
-      batch = reader.getSchema().createRowBatch();
-      long[] output = null;
-      while (rows.nextBatch(batch)) {
-        output = new long[batch.size];
-        System.arraycopy(((LongColumnVector) batch.cols[0]).vector, 0, output, 0, batch.size);
-      }
-      assertArrayEquals(input, output);
-    }
   }
 
   static class TestOutputCatcher implements PhysicalWriter.OutputReceiver {


### PR DESCRIPTION
### What changes were proposed in this pull request?

ORC has use RLE to encoding/decoding integer.
Four types are comprised of the RLE encoding/decoding algorithm.
Short Repeat : used for short repeating integer sequences.
Direct : used for integer sequences whose values have a relatively constant bit width.
Patched Base : used for integer sequences whose bit widths varies a lot.
Delta : used for monotonically increasing or decreasing sequences.

### Why are the changes needed?

This bug occurs in **Patched Base** Type for large negative number.
In patched base, [we use 3 bits to store base value ](https://orc.apache.org/specification/ORCv2/)width that is encoded using 1 to 8 bytes.
If the base value is actually 8 bytes in length, the value for base width should be 7.
Currently, this value can go up to 8 what can result in inconsistent data as part of the encoding procedure.
In extreme cases, the encoding/decoding process can even be cored dump referring to an illegal address.

### How was this patch tested?

Pass the newly added UT.