### PR TITLE
ORC-704: Publish snapshots at only apache repo

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish-snapshot:
+    if: github.repository == 'apache/orc'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to only publish snapshots at apache orc repo by adding an if statement. 
### Why are the changes needed?

To save the resources at the downstream.

### How was this patch tested?
N/A