### PR TITLE
ORC-706: Put back DataReaderProperties default maxDiskRangeChunkLimit

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
+++ b/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.orc.OrcConf;
 
 import java.util.function.Supplier;
 
@@ -76,7 +77,7 @@ public final class DataReaderProperties {
     private FSDataInputStream file;
     private InStream.StreamOptions compression;
     private boolean zeroCopy;
-    private int maxDiskRangeChunkLimit;
+    private int maxDiskRangeChunkLimit = (int) OrcConf.ORC_MAX_DISK_RANGE_CHUNK_LIMIT.getDefaultValue();;
 
     private Builder() {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
ORC-487 removed the default maxDiskRangeChunkLimit from DataReaderProperties.
Even though the class builder is used to set the desired value, we should still keep the default value for backwards-compatibility.


### Why are the changes needed?
Backwards-compatibility


### How was this patch tested?
N/A
