### PR TITLE
ORC-709: FIX Boolean to StringGroup schema evolution

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1783,45 +1783,46 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     //
     switch (readerType.getCategory()) {
 
-      case BOOLEAN:
-      case BYTE:
-      case SHORT:
-      case INT:
-      case LONG:
-        if (fileType.getCategory() == readerType.getCategory()) {
-          throw new IllegalArgumentException("No conversion of type " +
-                  readerType.getCategory() + " to self needed");
-        }
-        return new AnyIntegerFromAnyIntegerTreeReader(columnId, fileType, readerType,
-                context);
+    case BOOLEAN:
+    case BYTE:
+    case SHORT:
+    case INT:
+    case LONG:
+      if (fileType.getCategory() == readerType.getCategory()) {
+        throw new IllegalArgumentException("No conversion of type " +
+            readerType.getCategory() + " to self needed");
+      }
+      return new AnyIntegerFromAnyIntegerTreeReader(columnId, fileType, readerType,
+          context);
 
-      case FLOAT:
-      case DOUBLE:
-        return new DoubleFromAnyIntegerTreeReader(columnId, fileType, context);
+    case FLOAT:
+    case DOUBLE:
+      return new DoubleFromAnyIntegerTreeReader(columnId, fileType, context);
 
-      case DECIMAL:
-        return new DecimalFromAnyIntegerTreeReader(columnId, fileType, context);
+    case DECIMAL:
+      return new DecimalFromAnyIntegerTreeReader(columnId, fileType, context);
 
-      case STRING:
-      case CHAR:
-      case VARCHAR:
-        return new StringGroupFromBooleanTreeReader(columnId, fileType, readerType, context);
+    case STRING:
+    case CHAR:
+    case VARCHAR:
+      return new StringGroupFromBooleanTreeReader(columnId, fileType, readerType,
+          context);
 
-      case TIMESTAMP:
-      case TIMESTAMP_INSTANT:
-        return new TimestampFromAnyIntegerTreeReader(columnId, fileType, context,
-                readerType.getCategory() == Category.TIMESTAMP_INSTANT);
+    case TIMESTAMP:
+    case TIMESTAMP_INSTANT:
+      return new TimestampFromAnyIntegerTreeReader(columnId, fileType, context,
+          readerType.getCategory() == Category.TIMESTAMP_INSTANT);
 
-      // Not currently supported conversion(s):
-      case BINARY:
-      case DATE:
-      case STRUCT:
-      case LIST:
-      case MAP:
-      case UNION:
-      default:
-        throw new IllegalArgumentException("Unsupported type " +
-                readerType.getCategory());
+    // Not currently supported conversion(s):
+    case BINARY:
+    case DATE:
+    case STRUCT:
+    case LIST:
+    case MAP:
+    case UNION:
+    default:
+      throw new IllegalArgumentException("Unsupported type " +
+          readerType.getCategory());
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1775,9 +1775,10 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   }
 
   private static TypeReader createBooleanConvertTreeReader(int columnId,
-                                                              TypeDescription fileType,
-                                                              TypeDescription readerType,
-                                                              Context context) throws IOException {
+                                                           TypeDescription fileType,
+                                                           TypeDescription readerType,
+                                                           Context context) throws IOException {
+
     // CONVERT from BOOLEAN to schema type.
     //
     switch (readerType.getCategory()) {
@@ -1828,6 +1829,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                               TypeDescription fileType,
                                                               TypeDescription readerType,
                                                               Context context) throws IOException {
+
     // CONVERT from (BYTE, SHORT, INT, LONG) to schema type.
     //
     switch (readerType.getCategory()) {
@@ -1881,6 +1883,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                           TypeDescription fileType,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
+
     // CONVERT from DOUBLE to schema type.
     switch (readerType.getCategory()) {
 
@@ -1927,6 +1930,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                            TypeDescription fileType,
                                                            TypeDescription readerType,
                                                            Context context) throws IOException {
+
     // CONVERT from DECIMAL to schema type.
     switch (readerType.getCategory()) {
 
@@ -1972,6 +1976,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                           TypeDescription fileType,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
+
     // CONVERT from STRING to schema type.
     switch (readerType.getCategory()) {
 
@@ -2069,6 +2074,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   private static TypeReader createDateConvertTreeReader(int columnId,
                                                         TypeDescription readerType,
                                                         Context context) throws IOException {
+
     // CONVERT from DATE to schema type.
     switch (readerType.getCategory()) {
 
@@ -2109,6 +2115,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   private static TypeReader createBinaryConvertTreeReader(int columnId,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
+
     // CONVERT from BINARY to schema type.
     switch (readerType.getCategory()) {
 

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1774,12 +1774,61 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     }
   }
 
+  private static TypeReader createBooleanConvertTreeReader(int columnId,
+                                                              TypeDescription fileType,
+                                                              TypeDescription readerType,
+                                                              Context context) throws IOException {
+    // CONVERT from BOOLEAN to schema type.
+    //
+    switch (readerType.getCategory()) {
+
+      case BOOLEAN:
+      case BYTE:
+      case SHORT:
+      case INT:
+      case LONG:
+        if (fileType.getCategory() == readerType.getCategory()) {
+          throw new IllegalArgumentException("No conversion of type " +
+                  readerType.getCategory() + " to self needed");
+        }
+        return new AnyIntegerFromAnyIntegerTreeReader(columnId, fileType, readerType,
+                context);
+
+      case FLOAT:
+      case DOUBLE:
+        return new DoubleFromAnyIntegerTreeReader(columnId, fileType, context);
+
+      case DECIMAL:
+        return new DecimalFromAnyIntegerTreeReader(columnId, fileType, context);
+
+      case STRING:
+      case CHAR:
+      case VARCHAR:
+        return new StringGroupFromBooleanTreeReader(columnId, fileType, readerType, context);
+
+      case TIMESTAMP:
+      case TIMESTAMP_INSTANT:
+        return new TimestampFromAnyIntegerTreeReader(columnId, fileType, context,
+                readerType.getCategory() == Category.TIMESTAMP_INSTANT);
+
+      // Not currently supported conversion(s):
+      case BINARY:
+      case DATE:
+      case STRUCT:
+      case LIST:
+      case MAP:
+      case UNION:
+      default:
+        throw new IllegalArgumentException("Unsupported type " +
+                readerType.getCategory());
+    }
+  }
+
   private static TypeReader createAnyIntegerConvertTreeReader(int columnId,
                                                               TypeDescription fileType,
                                                               TypeDescription readerType,
                                                               Context context) throws IOException {
-
-    // CONVERT from (BOOLEAN, BYTE, SHORT, INT, LONG) to schema type.
+    // CONVERT from (BYTE, SHORT, INT, LONG) to schema type.
     //
     switch (readerType.getCategory()) {
 
@@ -1832,7 +1881,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                           TypeDescription fileType,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
-
     // CONVERT from DOUBLE to schema type.
     switch (readerType.getCategory()) {
 
@@ -1879,7 +1927,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                            TypeDescription fileType,
                                                            TypeDescription readerType,
                                                            Context context) throws IOException {
-
     // CONVERT from DECIMAL to schema type.
     switch (readerType.getCategory()) {
 
@@ -1925,7 +1972,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                           TypeDescription fileType,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
-
     // CONVERT from STRING to schema type.
     switch (readerType.getCategory()) {
 
@@ -2023,7 +2069,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   private static TypeReader createDateConvertTreeReader(int columnId,
                                                         TypeDescription readerType,
                                                         Context context) throws IOException {
-
     // CONVERT from DATE to schema type.
     switch (readerType.getCategory()) {
 
@@ -2064,8 +2109,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   private static TypeReader createBinaryConvertTreeReader(int columnId,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
-
-    // CONVERT from DATE to schema type.
+    // CONVERT from BINARY to schema type.
     switch (readerType.getCategory()) {
 
     case STRING:
@@ -2145,7 +2189,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
    *   DecimalFromStringGroupTreeReader (written)
    *
    * To STRING, CHAR, VARCHAR:
-   *   Convert from (BOOLEAN, BYTE, SHORT, INT, LONG) using to string conversion
+   *   Convert from (BYTE, SHORT, INT, LONG) using to string conversion
+   *   Convert from BOOLEAN using boolean (True/False) conversion
    *   Convert from (FLOAT, DOUBLE) using to string conversion
    *   Convert from DECIMAL using HiveDecimal.toString
    *   Convert from CHAR by stripping pads
@@ -2155,6 +2200,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
    *   Convert from BINARY using Text.decode
    *
    *   StringGroupFromAnyIntegerTreeReader (written)
+   *   StringGroupFromBooleanTreeReader (written)
    *   StringGroupFromFloatTreeReader (written)
    *   StringGroupFromDoubleTreeReader (written)
    *   StringGroupFromDecimalTreeReader (written)
@@ -2233,12 +2279,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
     switch (fileType.getCategory()) {
 
-    case BOOLEAN:
     case BYTE:
     case SHORT:
     case INT:
     case LONG:
       return createAnyIntegerConvertTreeReader(columnId, fileType, readerType, context);
+
+    case BOOLEAN:
+      return createBooleanConvertTreeReader(columnId, fileType, readerType, context);
 
     case FLOAT:
     case DOUBLE:

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -582,11 +582,11 @@ public class TestSchemaEvolution {
   @Test
   public void testBooleanToStringEvolution() throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-            testCaseName.getMethodName() + ".orc");
+      testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createBoolean();
     Writer writer = OrcFile.createWriter(testFilePath,
-            OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
-                    .bufferSize(10000));
+      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+        .bufferSize(10000));
     VectorizedRowBatch batch = new VectorizedRowBatch(1, 1024);
     LongColumnVector lcv = new LongColumnVector(1024);
     batch.cols[0] = lcv;
@@ -599,7 +599,7 @@ public class TestSchemaEvolution {
     writer.close();
 
     Reader reader = OrcFile.createReader(testFilePath,
-            OrcFile.readerOptions(conf).filesystem(fs));
+      OrcFile.readerOptions(conf).filesystem(fs));
     TypeDescription schemaOnRead = TypeDescription.createString();
     RecordReader rows = reader.rows(reader.options().schema(schemaOnRead));
     batch = schemaOnRead.createRowBatch();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Special ConvertTreeReader for Boolean using StringGroupFromAnyIntegerTreeReader for String/Char/Varchar types

### Why are the changes needed?
Properly handle Boolean to String/Char/Varchar conversions


### How was this patch tested?
TestSchemaEvolution.testBooleanToStringEvolution