### PR TITLE
ORC-709: FIX Boolean to StringGroup schema evolution

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1753,48 +1753,48 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     //
     switch (readerType.getCategory()) {
 
-      case BOOLEAN:
-      case BYTE:
-      case SHORT:
-      case INT:
-      case LONG:
-        if (fileType.getCategory() == readerType.getCategory()) {
-          throw new IllegalArgumentException("No conversion of type " +
-                  readerType.getCategory() + " to self needed");
-        }
-        return new AnyIntegerFromAnyIntegerTreeReader(columnId, fileType, readerType,
-                context);
+    case BOOLEAN:
+    case BYTE:
+    case SHORT:
+    case INT:
+    case LONG:
+      if (fileType.getCategory() == readerType.getCategory()) {
+        throw new IllegalArgumentException("No conversion of type " +
+            readerType.getCategory() + " to self needed");
+      }
+      return new AnyIntegerFromAnyIntegerTreeReader(columnId, fileType, readerType,
+          context);
 
-      case FLOAT:
-      case DOUBLE:
-        return new DoubleFromAnyIntegerTreeReader(columnId, fileType,
-                context);
+    case FLOAT:
+    case DOUBLE:
+      return new DoubleFromAnyIntegerTreeReader(columnId, fileType,
+          context);
 
-      case DECIMAL:
-        return new DecimalFromAnyIntegerTreeReader(columnId, fileType, context);
+    case DECIMAL:
+      return new DecimalFromAnyIntegerTreeReader(columnId, fileType, context);
 
-      case STRING:
-      case CHAR:
-      case VARCHAR:
-        return new StringGroupFromBooleanTreeReader(columnId, fileType, readerType,
-                context);
+    case STRING:
+    case CHAR:
+    case VARCHAR:
+      return new StringGroupFromBooleanTreeReader(columnId, fileType, readerType,
+          context);
 
-      case TIMESTAMP:
-      case TIMESTAMP_INSTANT:
-        return new TimestampFromAnyIntegerTreeReader(columnId, fileType, context,
-                readerType.getCategory() == Category.TIMESTAMP_INSTANT);
+    case TIMESTAMP:
+    case TIMESTAMP_INSTANT:
+      return new TimestampFromAnyIntegerTreeReader(columnId, fileType, context,
+          readerType.getCategory() == Category.TIMESTAMP_INSTANT);
 
-      // Not currently supported conversion(s):
-      case BINARY:
-      case DATE:
+    // Not currently supported conversion(s):
+    case BINARY:
+    case DATE:
 
-      case STRUCT:
-      case LIST:
-      case MAP:
-      case UNION:
-      default:
-        throw new IllegalArgumentException("Unsupported type " +
-                readerType.getCategory());
+    case STRUCT:
+    case LIST:
+    case MAP:
+    case UNION:
+    default:
+      throw new IllegalArgumentException("Unsupported type " +
+          readerType.getCategory());
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1745,9 +1745,10 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   }
 
   private static TreeReader createBooleanConvertTreeReader(int columnId,
-                                                              TypeDescription fileType,
-                                                              TypeDescription readerType,
-                                                              Context context) throws IOException {
+                                                           TypeDescription fileType,
+                                                           TypeDescription readerType,
+                                                           Context context) throws IOException {
+
     // CONVERT from BOOLEAN to schema type.
     //
     switch (readerType.getCategory()) {
@@ -1801,6 +1802,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                               TypeDescription fileType,
                                                               TypeDescription readerType,
                                                               Context context) throws IOException {
+
     // CONVERT from (BYTE, SHORT, INT, LONG) to schema type.
     //
     switch (readerType.getCategory()) {
@@ -1854,6 +1856,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                           TypeDescription fileType,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
+
     // CONVERT from DOUBLE to schema type.
     switch (readerType.getCategory()) {
 
@@ -1900,6 +1903,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                            TypeDescription fileType,
                                                            TypeDescription readerType,
                                                            Context context) throws IOException {
+
     // CONVERT from DECIMAL to schema type.
     switch (readerType.getCategory()) {
 
@@ -1945,6 +1949,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                           TypeDescription fileType,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
+
     // CONVERT from STRING to schema type.
     switch (readerType.getCategory()) {
 
@@ -2042,6 +2047,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   private static TreeReader createDateConvertTreeReader(int columnId,
                                                         TypeDescription readerType,
                                                         Context context) throws IOException {
+
     // CONVERT from DATE to schema type.
     switch (readerType.getCategory()) {
 
@@ -2082,6 +2088,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
   private static TreeReader createBinaryConvertTreeReader(int columnId,
                                                           TypeDescription readerType,
                                                           Context context) throws IOException {
+
     // CONVERT from BINARY to schema type.
     switch (readerType.getCategory()) {
 

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1787,7 +1787,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     // Not currently supported conversion(s):
     case BINARY:
     case DATE:
-
     case STRUCT:
     case LIST:
     case MAP:

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1767,8 +1767,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
     case FLOAT:
     case DOUBLE:
-      return new DoubleFromAnyIntegerTreeReader(columnId, fileType,
-          context);
+      return new DoubleFromAnyIntegerTreeReader(columnId, fileType, context);
 
     case DECIMAL:
       return new DecimalFromAnyIntegerTreeReader(columnId, fileType, context);

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -579,11 +579,11 @@ public class TestSchemaEvolution {
   @Test
   public void testBooleanToStringEvolution() throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-            testCaseName.getMethodName() + ".orc");
+      testCaseName.getMethodName() + ".orc");
     TypeDescription schema = TypeDescription.createBoolean();
     Writer writer = OrcFile.createWriter(testFilePath,
-            OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
-                    .bufferSize(10000));
+      OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+        .bufferSize(10000));
     VectorizedRowBatch batch = new VectorizedRowBatch(1, 1024);
     LongColumnVector lcv = new LongColumnVector(1024);
     batch.cols[0] = lcv;
@@ -596,7 +596,7 @@ public class TestSchemaEvolution {
     writer.close();
 
     Reader reader = OrcFile.createReader(testFilePath,
-            OrcFile.readerOptions(conf).filesystem(fs));
+      OrcFile.readerOptions(conf).filesystem(fs));
     TypeDescription schemaOnRead = TypeDescription.createString();
     RecordReader rows = reader.rows(reader.options().schema(schemaOnRead));
     batch = schemaOnRead.createRowBatch();

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -577,6 +577,37 @@ public class TestSchemaEvolution {
   }
 
   @Test
+  public void testBooleanToStringEvolution() throws Exception {
+    testFilePath = new Path(workDir, "TestSchemaEvolution." +
+            testCaseName.getMethodName() + ".orc");
+    TypeDescription schema = TypeDescription.createBoolean();
+    Writer writer = OrcFile.createWriter(testFilePath,
+            OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
+                    .bufferSize(10000));
+    VectorizedRowBatch batch = new VectorizedRowBatch(1, 1024);
+    LongColumnVector lcv = new LongColumnVector(1024);
+    batch.cols[0] = lcv;
+    batch.reset();
+    batch.size = 3;
+    lcv.vector[0] = 1L; // True
+    lcv.vector[1] = 0L; // False
+    lcv.vector[2] = 1L; // True
+    writer.addRowBatch(batch);
+    writer.close();
+
+    Reader reader = OrcFile.createReader(testFilePath,
+            OrcFile.readerOptions(conf).filesystem(fs));
+    TypeDescription schemaOnRead = TypeDescription.createString();
+    RecordReader rows = reader.rows(reader.options().schema(schemaOnRead));
+    batch = schemaOnRead.createRowBatch();
+    rows.nextBatch(batch);
+    assertEquals("TRUE", ((BytesColumnVector) batch.cols[0]).toString(0));
+    assertEquals("FALSE", ((BytesColumnVector) batch.cols[0]).toString(1));
+    assertEquals("TRUE", ((BytesColumnVector) batch.cols[0]).toString(2));
+    rows.close();
+  }
+
+  @Test
   public void testCharToStringEvolution() throws IOException {
     TypeDescription fileType = TypeDescription.fromString("struct<x:char(10)>");
     TypeDescription readType = TypeDescription.fromString("struct<x:string>");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Special ConvertTreeReader for Boolean using StringGroupFromAnyIntegerTreeReader for String/Char/Varchar types for 1.6 branch

### Why are the changes needed?
Properly handle Boolean to String/Char/Varchar conversions


### How was this patch tested?
TestSchemaEvolution.testBooleanToStringEvolution
