### PR TITLE
ORC-708: Use maven command directly

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -16,10 +16,11 @@ jobs:
       with:
         java-version: 8
 
-    - name: Release Maven package
-      uses: samuelmeuli/action-maven-publish@v1
-      with:
-        directory: java
-        server_id: apache.snapshots.https
-        nexus_username: ${{ secrets.NEXUS_USER }}
-        nexus_password: ${{ secrets.NEXUS_PW }}
+    - name: Publish snapshot
+      env:
+        ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+        ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
+      run: |
+        cd java
+        echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
+        mvn --settings settings.xml -DskipTests deploy


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `maven deploy` directly.

### Why are the changes needed?

Apache repository doesn't allow 3rd party GitHub Action script.

### How was this patch tested?

Tested locally.
