### PR TITLE
ORC-703 : Fix RLE encoding bug on large negative integer.

### DIFF
--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -577,9 +577,10 @@ void RleEncoderV2::writePatchedBasedValues(EncodingOption& option) {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    uint32_t baseWidth = findClosestNumBits(option.min) + 1;
-    if (baseWidth > 64) {
-        baseWidth = 64;
+    uint32_t baseWidth = findClosestNumBits(option.min);
+    if (baseWidth < 64) {
+        // store the sign bit when baseWidth is less than 64
+        baseWidth++;
     } 
     const uint32_t baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     const uint32_t bb = (baseBytes - 1) << 5;

--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -577,7 +577,10 @@ void RleEncoderV2::writePatchedBasedValues(EncodingOption& option) {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    const uint32_t baseWidth = findClosestNumBits(option.min) + 1;
+    uint32_t baseWidth = findClosestNumBits(option.min) + 1;
+    if (baseWidth > 64) {
+        baseWidth = 64;
+    } 
     const uint32_t baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     const uint32_t bb = (baseBytes - 1) << 5;
 

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -283,7 +283,7 @@ namespace orc {
   // This case is used to testing encoding large negative integer.
   // The minimum is -84742859065569280, it's a 57 bit width integer 
   // and 8 bytes is used to encoding it.
-  TEST_P(RleTest, RleV2_Patched_large_negative_number) {
+  TEST_P(RleTest, RleV2_Patched_large_negative_integer) {
     // write data
     const int numValues = 30;
     int64_t data[30] = {

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -280,6 +280,33 @@ namespace orc {
     decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
   }
 
+  // This case is used to testing encoding large negative integer.
+  // The minimum is -84742859065569280, it's a 57 bit width integer 
+  // and 8 bytes is used to encoding it.
+  TEST_P(RleTest, RleV2_Patched_large_negative_number) {
+    // write data
+    const int numValues = 30;
+    int64_t data[30] = {
+      -17887939293638656, -15605417571528704, -15605417571528704, -13322895849418752,
+      -13322895849418752, -84742859065569280, -15605417571528704, -13322895849418752,
+      -13322895849418752, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -15605417571528704, -13322895849418752, -13322895849418752,
+      -11040374127308800, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -15605417571528704, -13322895849418752, -13322895849418752,
+      -15605417571528704, -13322895849418752};
+    // Invoke the encoder.
+    const bool isSigned = true;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(data, numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, data, numValues, nullptr, isSigned);
+  }
+
   TEST_P(RleTest, RleV2_delta_example) {
     int64_t data[10] = {2, 3, 5, 7, 11, 13, 17, 19, 23, 29};
     unsigned char expectedEncoded[8] = {0xc6, 0x09, 0x02, 0x02, 0x22, 0x42, 0x42, 0x46};

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
@@ -286,7 +286,10 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    final int baseWidth = utils.findClosestNumBits(min) + 1;
+    int baseWidth = utils.findClosestNumBits(min) + 1;
+    if (baseWidth > 64) {
+        baseWidth = 64;
+    }
     final int baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     final int bb = (baseBytes - 1) << 5;
 

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
@@ -286,9 +286,10 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    int baseWidth = utils.findClosestNumBits(min) + 1;
-    if (baseWidth > 64) {
-        baseWidth = 64;
+    int baseWidth = utils.findClosestNumBits(min);
+    if (baseWidth < 64) {
+        // store the sign bit when baseWidth is less than 64
+        baseWidth++;
     }
     final int baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     final int bb = (baseBytes - 1) << 5;

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
@@ -286,11 +286,10 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
     // find the number of bytes required for base and shift it by 5 bits
     // to accommodate patch width. The additional bit is used to store the sign
     // of the base value.
-    int baseWidth = utils.findClosestNumBits(min);
-    if (baseWidth < 64) {
-        // store the sign bit when baseWidth is less than 64
-        baseWidth++;
-    }
+    int baseBitsNum = utils.findClosestNumBits(min);
+    // if Negative, sign bit is already accounted for
+    final int baseWidth = isNegative ? baseBitsNum : baseBitsNum + 1;
+
     final int baseBytes = baseWidth % 8 == 0 ? baseWidth / 8 : (baseWidth / 8) + 1;
     final int bb = (baseBytes - 1) << 5;
 
@@ -534,7 +533,7 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
       // fallback to DIRECT encoding.
       // The decision to use patched base was based on zigzag values, but the
       // actual patching is done on base reduced literals.
-      if ((brBits100p - brBits95p) != 0 && Math.abs(min) < BASE_VALUE_LIMIT) {
+      if ((brBits100p - brBits95p) != 0) {
         encoding = EncodingType.PATCHED_BASE;
         preparePatchedBlob();
         return;

--- a/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
+++ b/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
@@ -1224,41 +1224,8 @@ public class TestNewIntegerEncoding {
   // and 8 bytes is used to encoding it.
   @Test
   public void testPatchedBaseLargeNegativeInteger() throws Exception {
-    TypeDescription schema = TypeDescription.createLong();
-
-    List<Long> input = Lists.newArrayList();
-    for (int i = 0; i < 30; ++i) {
-      input.add(-17887939293638656L);
-      input.add(-15605417571528704L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-      input.add(-13322895849418752L);
-      input.add(-84742859065569280L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-      input.add(-13322895849418752L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-      input.add(-13322895849418752L);
-      input.add(-15605417571528704L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-      input.add(-13322895849418752L);
-      input.add(-15605417571528704L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-      input.add(-13322895849418752L);
-      input.add(-11040374127308800L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-      input.add(-13322895849418752L);
-      input.add(-15605417571528704L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-      input.add(-13322895849418752L);
-      input.add(-15605417571528704L);
-      input.add(-13322895849418752L);
-    }
+    TypeDescription schema = TypeDescription.createStruct()
+        .addField("int", TypeDescription.createLong());
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -1266,9 +1233,43 @@ public class TestNewIntegerEncoding {
             .stripeSize(100000)
             .bufferSize(10000)
             .encodingStrategy(encodingStrategy));
-    VectorizedRowBatch batch = schema.createRowBatch(5120);
-    for(Long l : input) {
-      appendLong(batch, l);
+    VectorizedRowBatch batch = schema.createRowBatch();
+
+    List<Long> longList = Lists.newArrayList();
+    for (int i = 0; i < 25; ++i) {
+      longList.add(-17887939293638656L);
+      longList.add(-15605417571528704L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+      longList.add(-13322895849418752L);
+      longList.add(-84742859065569280L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+      longList.add(-13322895849418752L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+      longList.add(-13322895849418752L);
+      longList.add(-15605417571528704L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+      longList.add(-13322895849418752L);
+      longList.add(-15605417571528704L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+      longList.add(-13322895849418752L);
+      longList.add(-11040374127308800L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+      longList.add(-13322895849418752L);
+      longList.add(-15605417571528704L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+      longList.add(-13322895849418752L);
+      longList.add(-15605417571528704L);
+      longList.add(-13322895849418752L);
+    }
+    for (Long currLong : longList) {
+      appendLong(batch, currLong);
     }
     writer.addRowBatch(batch);
     writer.close();
@@ -1278,11 +1279,11 @@ public class TestNewIntegerEncoding {
     RecordReader rows = reader.rows();
     batch = reader.getSchema().createRowBatch();
     int idx = 0;
-    while (rows.nextBatch(batch)) {
-      for(int r=0; r < batch.size; ++r) {
-        assertEquals(input.get(idx++).longValue(),
-            ((LongColumnVector) batch.cols[0]).vector[r]);
-      }
+    assertEquals(rows.nextBatch(batch), true);
+    assertEquals(batch.size, longList.size());
+    for (int r = 0; r < batch.size; ++r) {
+      assertEquals(longList.get(idx++).longValue(),
+          ((LongColumnVector) batch.cols[0]).vector[r]);
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
