### PR TITLE
ORC-707: FIX tzdata to recover Win32 build in AppVeyor (#590)

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -171,8 +171,8 @@ endif ()
 
 if (WIN32)
   ExternalProject_Add(tzdata_ep
-    URL "ftp://cygwin.osuosl.org/pub/cygwin/noarch/release/tzdata/tzdata-2020b-1.tar.xz"
-    URL_HASH MD5=1BE1D18B4042A5011E96D20054BEEF33
+    URL "ftp://cygwin.osuosl.org/pub/cygwin/noarch/release/tzdata/tzdata-2020e-1.tar.xz"
+    URL_HASH MD5=f387bd21bd54a68ef73a0b9fa20a9ff5
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND "")


### PR DESCRIPTION
### What changes were proposed in this pull request?
FIX tzdata to recover Win32 build in AppVeyor in 1.5 backporting #590 


### Why are the changes needed?
Recover win32 build


### How was this patch tested?
AppVeyor