### PR TITLE
ORC-603. Upgrade `tools` to use Hadoop 2.10.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,6 +70,7 @@
 
     <min.hadoop.version>2.2.0</min.hadoop.version>
     <hadoop.version>2.7.3</hadoop.version>
+    <tools.hadoop.version>3.2.2</tools.hadoop.version>
     <storage-api.version>2.7.2</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
     <maven.version>3.6.3</maven.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 
     <min.hadoop.version>2.2.0</min.hadoop.version>
     <hadoop.version>2.7.3</hadoop.version>
-    <tools.hadoop.version>3.2.2</tools.hadoop.version>
+    <tools.hadoop.version>2.10.1</tools.hadoop.version>
     <storage-api.version>2.7.2</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
     <maven.version>3.6.3</maven.version>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -62,7 +62,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs-client</artifactId>
+      <artifactId>hadoop-hdfs</artifactId>
       <version>${tools.hadoop.version}</version>
       <scope>compile</scope>
     </dependency>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.version}</version>
+      <version>${tools.hadoop.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
-      <version>${hadoop.version}</version>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <version>${tools.hadoop.version}</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `tools` module to use Apache Hadoop 2.10.1.

### Why are the changes needed?

This will make `orc-tools` CLI to use the latest and stable Hadoop 2.10.1 version.

### How was this patch tested?

Pass the CIs and manually check the dependency change with `mvn dependency:tree`

```
[INFO] ----------------------< org.apache.orc:orc-tools >----------------------
[INFO] Building ORC Tools 1.7.0-SNAPSHOT                                  [5/6]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.10:tree (default-cli) @ orc-tools ---
[INFO] org.apache.orc:orc-tools:jar:1.7.0-SNAPSHOT
[INFO] +- org.apache.orc:orc-core:jar:1.7.0-SNAPSHOT:compile
[INFO] |  +- org.apache.orc:orc-shims:jar:1.7.0-SNAPSHOT:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
[INFO] |  +- io.airlift:aircompressor:jar:0.16:compile
[INFO] |  +- javax.xml.bind:jaxb-api:jar:2.2.11:compile
[INFO] |  +- org.jetbrains:annotations:jar:17.0.0:compile
[INFO] |  \- org.threeten:threeten-extra:jar:1.5.0:compile
[INFO] +- com.google.code.gson:gson:jar:2.2.4:compile
[INFO] +- com.opencsv:opencsv:jar:3.9:compile
[INFO] +- commons-cli:commons-cli:jar:1.3.1:compile
[INFO] +- org.apache.commons:commons-lang3:jar:3.11:compile
[INFO] +- org.apache.hadoop:hadoop-common:jar:2.10.1:compile
[INFO] |  +- org.apache.hadoop:hadoop-annotations:jar:2.10.1:compile
[INFO] |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  +- xmlenc:xmlenc:jar:0.52:compile
[INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.2:compile
[INFO] |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.15:compile
[INFO] |  +- commons-io:commons-io:jar:2.4:compile
[INFO] |  +- commons-net:commons-net:jar:3.1:compile
[INFO] |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  +- org.mortbay.jetty:jetty-sslengine:jar:6.1.26:compile
[INFO] |  +- com.sun.jersey:jersey-core:jar:1.9:compile
[INFO] |  +- com.sun.jersey:jersey-server:jar:1.9:compile
[INFO] |  |  \- asm:asm:jar:3.1:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] |  +- log4j:log4j:jar:1.2.17:compile
[INFO] |  +- commons-lang:commons-lang:jar:2.6:compile
[INFO] |  +- commons-configuration:commons-configuration:jar:1.6:compile
[INFO] |  +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.25:compile
[INFO] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile
[INFO] |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.13:compile
[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:2.10.1:compile
[INFO] |  |  +- com.nimbusds:nimbus-jose-jwt:jar:7.9:compile
[INFO] |  |  |  +- com.github.stephenc.jcip:jcip-annotations:jar:1.0-1:compile
[INFO] |  |  |  \- net.minidev:json-smart:jar:2.3:compile (version selected from constraint [1.3.1,2.3])
[INFO] |  |  |     \- net.minidev:accessors-smart:jar:1.2:compile
[INFO] |  |  |        \- org.ow2.asm:asm:jar:5.0.4:compile
[INFO] |  |  +- org.apache.directory.server:apacheds-kerberos-codec:jar:2.0.0-M15:compile
[INFO] |  |  |  +- org.apache.directory.server:apacheds-i18n:jar:2.0.0-M15:compile
[INFO] |  |  |  +- org.apache.directory.api:api-asn1-api:jar:1.0.0-M20:compile
[INFO] |  |  |  \- org.apache.directory.api:api-util:jar:1.0.0-M20:compile
[INFO] |  |  \- org.apache.curator:curator-framework:jar:2.13.0:compile
[INFO] |  +- com.jcraft:jsch:jar:0.1.55:compile
[INFO] |  +- org.apache.curator:curator-client:jar:2.13.0:compile
[INFO] |  +- org.apache.htrace:htrace-core4:jar:4.1.0-incubating:compile
[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.4.6:runtime
[INFO] |  +- org.apache.commons:commons-compress:jar:1.19:compile
[INFO] |  +- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
[INFO] |  \- com.fasterxml.woodstox:woodstox-core:jar:5.0.3:compile
[INFO] +- org.apache.hadoop:hadoop-hdfs:jar:2.10.1:compile
[INFO] |  +- org.apache.hadoop:hadoop-hdfs-client:jar:2.10.1:compile
[INFO] |  |  \- com.squareup.okhttp:okhttp:jar:2.7.5:compile
[INFO] |  |     \- com.squareup.okio:okio:jar:1.6.0:compile
[INFO] |  +- io.netty:netty-all:jar:4.1.50.Final:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.9.10.6:compile
[INFO] |     +- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.10:compile
[INFO] |     \- com.fasterxml.jackson.core:jackson-core:jar:2.9.10:compile
[INFO] +- org.apache.hive:hive-storage-api:jar:2.7.2:compile
[INFO] +- org.codehaus.jettison:jettison:jar:1.1:compile
[INFO] +- org.slf4j:slf4j-api:jar:1.7.5:compile
[INFO] +- org.threeten:threetenbp:jar:1.3.5:compile
[INFO] +- com.google.guava:guava:jar:28.1-jre:compile
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.checkerframework:checker-qual:jar:2.8.1:compile
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.3.2:compile
[INFO] |  +- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] |  \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.18:compile
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.7.0:test
[INFO] |  +- org.apiguardian:apiguardian-api:jar:1.1.0:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.7.0:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.7.0:test
[INFO] |  \- org.junit.jupiter:junit-jupiter-api:jar:5.7.0:test
[INFO] \- org.junit.vintage:junit-vintage-engine:jar:5.7.0:test
[INFO]    \- junit:junit:jar:4.13:test
[INFO]       \- org.hamcrest:hamcrest-core:jar:1.3:test
```