### PR TITLE
ORC-711: Support CryptoExtension in create/decryptLocalKey

### DIFF
--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -167,7 +167,7 @@ public class HadoopShimsPre2_7 implements HadoopShims {
           KeyProviderCryptoExtension.EncryptedKeyVersion.createForDecryption(
               key.getKeyName(), buildKeyVersionName(key), iv, encryptedKey);
       try {
-        KeyProviderCryptoExtension.KeyVersion decryptedKey = null;
+        KeyProviderCryptoExtension.KeyVersion decryptedKey;
         if (provider instanceof KeyProviderCryptoExtension) {
           decryptedKey = ((KeyProviderCryptoExtension) provider).decryptEncryptedKey(param);
         } else if (provider instanceof CryptoExtension) {

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
+import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension.CryptoExtension;
 import org.apache.hadoop.crypto.key.KeyProviderFactory;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.orc.EncryptionAlgorithm;
@@ -166,9 +167,15 @@ public class HadoopShimsPre2_7 implements HadoopShims {
           KeyProviderCryptoExtension.EncryptedKeyVersion.createForDecryption(
               key.getKeyName(), buildKeyVersionName(key), iv, encryptedKey);
       try {
-        KeyProviderCryptoExtension.KeyVersion decryptedKey =
-            ((KeyProviderCryptoExtension) provider)
-                .decryptEncryptedKey(param);
+        KeyProviderCryptoExtension.KeyVersion decryptedKey = null;
+        if (provider instanceof KeyProviderCryptoExtension) {
+          decryptedKey = ((KeyProviderCryptoExtension) provider).decryptEncryptedKey(param);
+        } else if (provider instanceof CryptoExtension) {
+          decryptedKey = ((CryptoExtension) provider).decryptEncryptedKey(param);
+        } else {
+          throw new UnsupportedOperationException(
+              provider.getClass().getCanonicalName() + " is not supported.");
+        }
         return new LocalKey(algorithm, decryptedKey.getMaterial(),
                             encryptedKey);
       } catch (GeneralSecurityException e) {
@@ -186,10 +193,16 @@ public class HadoopShimsPre2_7 implements HadoopShims {
           KeyProviderCryptoExtension.EncryptedKeyVersion.createForDecryption(
               key.getKeyName(), buildKeyVersionName(key), iv, encryptedKey);
       try {
-        KeyProviderCryptoExtension.KeyVersion decrypted =
-            ((KeyProviderCryptoExtension) provider)
-                .decryptEncryptedKey(param);
-        return new SecretKeySpec(decrypted.getMaterial(),
+        KeyProviderCryptoExtension.KeyVersion decryptedKey;
+        if (provider instanceof KeyProviderCryptoExtension) {
+          decryptedKey = ((KeyProviderCryptoExtension) provider).decryptEncryptedKey(param);
+        } else if (provider instanceof CryptoExtension) {
+          decryptedKey = ((CryptoExtension) provider).decryptEncryptedKey(param);
+        } else {
+          throw new UnsupportedOperationException(
+              provider.getClass().getCanonicalName() + " is not supported.");
+        }
+        return new SecretKeySpec(decryptedKey.getMaterial(),
             algorithm.getAlgorithm());
       } catch (GeneralSecurityException e) {
         return null;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `CryptoExtension` in `create/decryptLocalKey` as `KeyProvider`.

### Why are the changes needed?

Currently, `ORC` supports `KeyProviderCryptoExtension` only.
```
public class KeyProviderCryptoExtension extends
    KeyProviderExtension<KeyProviderCryptoExtension.CryptoExtension>
```

When `LoadBalancingKMSClientProvider` is used as a `KeyProvider`, `ClassCastException` occurs because we cannot cast it to `KeyProviderCryptoExtension` currently.
```java
public class LoadBalancingKMSClientProvider extends KeyProvider implements
    CryptoExtension,
    KeyProviderDelegationTokenExtension.DelegationTokenExtension {
```

We need to support `CryptoExtension`, too.

### How was this patch tested?

Manually.