### PR TITLE
ORC-721: Use 'org.junit.Assert` instead of deprecated `junit.framework.Assert`.

### DIFF
--- a/java/core/src/test/org/apache/orc/TestCorruptTypes.java
+++ b/java/core/src/test/org/apache/orc/TestCorruptTypes.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class TestCorruptTypes {
 

--- a/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
+++ b/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.sql.Timestamp;

--- a/java/core/src/test/org/apache/orc/TestOrcDSTNoTimezone.java
+++ b/java/core/src/test/org/apache/orc/TestOrcDSTNoTimezone.java
@@ -34,8 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 /**

--- a/java/core/src/test/org/apache/orc/TestOrcNoTimezone.java
+++ b/java/core/src/test/org/apache/orc/TestOrcNoTimezone.java
@@ -34,8 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 /**

--- a/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
+++ b/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.apache.orc.TestVectorOrcFile.assertEmptyStats;
 import static org.junit.Assert.assertArrayEquals;
 

--- a/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
@@ -40,7 +40,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.TimeZone;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestOrcTimestampPPD {
   Path workDir =

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.sql.Timestamp;
@@ -26,7 +26,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.TimeZone;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone2.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone2.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.sql.Timestamp;

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone3.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone3.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.sql.Timestamp;

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone4.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone4.java
@@ -35,7 +35,7 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.TimeZone;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  *

--- a/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
@@ -15,7 +15,7 @@
  */
 package org.apache.orc;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.sql.Timestamp;

--- a/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
@@ -31,7 +31,7 @@ import java.security.Key;
 import java.util.List;
 import java.util.Random;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestCryptoUtils {
 

--- a/java/core/src/test/org/apache/orc/impl/TestMemoryManager.java
+++ b/java/core/src/test/org/apache/orc/impl/TestMemoryManager.java
@@ -28,7 +28,7 @@ import org.mockito.Mockito;
 
 import java.lang.management.ManagementFactory;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.apache.orc.impl.TestRecordReaderImpl.createPredicateLeaf;
 
 public class TestPredicatePushDownBounds {

--- a/java/core/src/test/org/apache/orc/impl/TestStringRedBlackTree.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringRedBlackTree.java
@@ -18,7 +18,7 @@
 
 package org.apache.orc.impl;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;

--- a/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
+++ b/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import java.sql.Date;
 import java.util.HashMap;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestHadoopShimsPre2_7 {
 

--- a/java/tools/src/test/org/apache/orc/impl/TestHadoopKeyProvider.java
+++ b/java/tools/src/test/org/apache/orc/impl/TestHadoopKeyProvider.java
@@ -26,7 +26,7 @@ import java.security.Key;
 import java.util.List;
 import java.util.Random;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestHadoopKeyProvider {
 

--- a/java/tools/src/test/org/apache/orc/tools/json/TestJsonSchemaFinder.java
+++ b/java/tools/src/test/org/apache/orc/tools/json/TestJsonSchemaFinder.java
@@ -25,7 +25,7 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.internal.LazilyParsedNumber;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TestJsonSchemaFinder {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to Use `org.junit.Assert` instead of deprecated `junit.framework.Assert`.

### Why are the changes needed?

`junit.framework.Assert` is deprecated.


### How was this patch tested?

Pass the CIs.