### PR TITLE
ORC-724: PPD: Date IN single value comparison throws ClassCastException

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -649,7 +649,8 @@ public class RecordReaderImpl implements RecordReader {
           // for a single value, look through to see if that value is in the
           // set
           for (Object arg : predicate.getLiteralList()) {
-            if (range.compare((Comparable) arg) == Location.MIN) {
+            predObj = getBaseObjectForComparison(predicate.getType(), (Comparable) arg);
+            if (range.compare(predObj) == Location.MIN) {
               return range.addNull(TruthValue.YES);
             }
           }

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -1083,6 +1083,23 @@ public class TestRecordReaderImpl {
   }
 
   @Test
+  public void testInDatePredConversion() {
+    List<Object> args = new ArrayList<>();
+    args.add(toDate(LocalDate.ofEpochDay(15)));
+    PredicateLeaf pred = createPredicateLeaf
+        (PredicateLeaf.Operator.IN, PredicateLeaf.Type.DATE,
+            "x", null, args);
+    assertEquals(TruthValue.YES_NULL,
+        evaluateInteger(createDateStats(15, 15), pred));
+    assertEquals(TruthValue.YES_NO_NULL,
+        evaluateInteger(createDateStats(10, 30), pred));
+    assertEquals(TruthValue.NO_NULL,
+        evaluateInteger(createDateStats(5, 10), pred));
+    assertEquals(TruthValue.NO_NULL,
+        evaluateInteger(createDateStats(16, 30), pred));
+  }
+
+  @Test
   public void testBetween() {
     List<Object> args = new ArrayList<Object>();
     args.add(10L);


### PR DESCRIPTION
### What changes were proposed in this pull request?
PPD evaluation: Date type Pred baseObject normalization to LocalDate (comparable with ColumnStats)


### Why are the changes needed?
Date baseObject normalization is missing leading to ClassCastException when using single Value IN ppd evaluation.


### How was this patch tested?
TestRecordReaderImpl.testInDatePredConversion
