### PR TITLE
MINOR: Rename GitHub Action job name to `Build and test`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,4 +1,4 @@
-name: master
+name: Build and test
 
 on:
   push:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename the job name of `build_and_test.yml` file to `Build and test`.

### Why are the changes needed?

Currently, this has a branch name.
- In `master` branch, `master` is the job name
- In `branch-1.6` branch, `branch-1.6` is the job name.

The correct usage is having the same name for the same jobs.

Note that GitHub Action log view page has a filtering feature by branch names because of this.

### How was this patch tested?

Pass the GitHub Action.