### PR TITLE
ORC-725: Disable merge commits from Github `Merge Button`

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,5 @@
+github:
+  enabled_merge_buttons:
+    merge: false
+    squash: true
+    rebase: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

According to the infra team's guide, [INFRA-21289](https://issues.apache.org/jira/browse/INFRA-21289
), this PR aims to disable merge commits from GitHub `Merge Button`.

### Why are the changes needed?

This will prevent accidental merge commits.

This PR follows the guide
- https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#git.asf.yamlfeatures-Mergebuttons

### How was this patch tested?

N/A