### PR TITLE
ORC-730: Add website link and description to GitHub page

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,4 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+---
 github:
+  description: "Apache ORC - the smallest, fastest columnar storage for Hadoop workloads"
+  homepage: https://orc.apache.org/
   enabled_merge_buttons:
     merge: false
     squash: true

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories
+# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
 ---
 github:
   description: "Apache ORC - the smallest, fastest columnar storage for Hadoop workloads"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add to `https://github.com/apache/orc`.
- website link
- project description

### Why are the changes needed?

To help a better UX. This will be displayed here (the red box).
![Screen Shot 2021-01-12 at 8 36 31 PM](https://user-images.githubusercontent.com/9700541/104407223-fa7b7080-5515-11eb-9865-3b3f96611e8b.png)


### How was this patch tested?

N/A