### PR TITLE
ORC-733: Upgrade Zookeeper to 3.6.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
     <hadoop.version>2.7.3</hadoop.version>
     <tools.hadoop.version>2.10.1</tools.hadoop.version>
     <storage-api.version>2.7.2</storage-api.version>
-    <zookeeper.version>3.4.6</zookeeper.version>
+    <zookeeper.version>3.6.2</zookeeper.version>
     <maven.version>3.6.3</maven.version>
   </properties>
 
@@ -659,7 +659,11 @@
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>
-            <artifactId>netty</artifactId>
+            <artifactId>netty-handler</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Zookeeper runtime dependency from 2.4.6 to 3.6.2.

### Why are the changes needed?

Zookeeper 2.4.6 has is a known issue on Java 14 environment. This upgrade is recommended by Zookeeper community for Java 14 and also Spark community is currently moving on too.
- https://issues.apache.org/jira/browse/ZOOKEEPER-3779 (Zookeeper client 3.4.x fails to connect when using Java 14)
- https://issues.apache.org/jira/browse/SPARK-34110 (Upgrade ZooKeeper to 3.6.2)

### How was this patch tested?

Pass the CIs.