### PR TITLE
ORC-734: Use org.apache.commons.lang3

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
 
-import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/java/core/src/java/org/apache/orc/impl/mask/RedactMaskFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/mask/RedactMaskFactory.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc.impl.mask;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -18,8 +18,8 @@
 
 package org.apache.orc;
 
-import org.apache.commons.lang.RandomStringUtils;
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/java/core/src/test/org/apache/orc/TestUnicode.java
+++ b/java/core/src/test/org/apache/orc/TestUnicode.java
@@ -24,7 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc.impl;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
@@ -22,7 +22,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -30,7 +30,7 @@ import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.cli.Options;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Although ORC-682 upgraded to `commons-lang3`, we are still using `commons-lang` classes.

### Why are the changes needed?

This will switch it completely.

### How was this patch tested?

Pass the CIs.

These are the all instances.
```
$ git grep org.apache.commons.lang.
core/src/java/org/apache/orc/impl/RecordReaderUtils.java:import org.apache.commons.lang3.builder.HashCodeBuilder;
core/src/java/org/apache/orc/impl/mask/RedactMaskFactory.java:import org.apache.commons.lang3.StringUtils;
core/src/test/org/apache/orc/TestColumnStatistics.java:import org.apache.commons.lang3.RandomStringUtils;
core/src/test/org/apache/orc/TestColumnStatistics.java:import org.apache.commons.lang3.StringEscapeUtils;
core/src/test/org/apache/orc/TestUnicode.java:import org.apache.commons.lang3.StringUtils;
core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java:import org.apache.commons.lang3.StringUtils;
mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java:import org.apache.commons.lang3.StringUtils;
tools/src/java/org/apache/orc/tools/FileDump.java:import org.apache.commons.lang3.StringUtils;
```