### PR TITLE
ORC-735: ConvertTool should not fail at a single ORC file.

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
@@ -75,6 +75,9 @@ public class ConvertTool {
         Reader reader = OrcFile.createReader(file.path,
             OrcFile.readerOptions(conf)
                 .filesystem(file.filesystem));
+        if (files.size() == 1) {
+          return reader.getSchema();
+        }
         schemaFinder.addSchema(reader.getSchema());
       }
     }


### PR DESCRIPTION

### What changes were proposed in this pull request?

This PR aims to fix a bug in ConvertTool by using the provided schema in case of a single file. 


### Why are the changes needed?

**BEFORE**
```
 % java -jar tools/target/orc-tools-1.7.0-SNAPSHOT-uber.jar convert ../examples/TestOrcFile.test1.orc
Merging schema from ../examples/TestOrcFile.test1.orc
Exception in thread "main" java.lang.IllegalArgumentException: Unhandled type map<string,struct<int1:int,string1:string>>
        at org.apache.orc.tools.json.JsonSchemaFinder.makeHiveType(JsonSchemaFinder.java:314)
        at org.apache.orc.tools.json.JsonSchemaFinder.makeHiveType(JsonSchemaFinder.java:301)
        at org.apache.orc.tools.json.JsonSchemaFinder.addSchema(JsonSchemaFinder.java:319)
        at org.apache.orc.tools.convert.ConvertTool.buildSchema(ConvertTool.java:81)
        at org.apache.orc.tools.convert.ConvertTool.<init>(ConvertTool.java:188)
        at org.apache.orc.tools.convert.ConvertTool.main(ConvertTool.java:168)
        at org.apache.orc.tools.Driver.main(Driver.java:108)
```

**AFTER**
```
% java -jar tools/target/orc-tools-1.7.0-SNAPSHOT-uber.jar convert ../examples/TestOrcFile.test1.orc
Merging schema from ../examples/TestOrcFile.test1.orc
Processing ../examples/TestOrcFile.test1.orc
```

### How was this patch tested?

Manually do the above procedure.