### PR TITLE
ORC-737: Upgrade Spark to 3.1.0

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -43,7 +43,7 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.8.3</parquet.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <spark.version>2.4.6</spark.version>
+    <spark.version>3.1.0</spark.version>
     <storage-api.version>2.7.2</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>
@@ -358,12 +358,12 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-catalyst_2.11</artifactId>
+        <artifactId>spark-catalyst_2.12</artifactId>
         <version>${spark.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-core_2.11</artifactId>
+        <artifactId>spark-core_2.12</artifactId>
         <version>${spark.version}</version>
 	<exclusions>
 	  <exclusion>
@@ -386,7 +386,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-sql_2.11</artifactId>
+        <artifactId>spark-sql_2.12</artifactId>
         <version>${spark.version}</version>
         <exclusions>
           <exclusion>
@@ -401,7 +401,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.spark</groupId>
-        <artifactId>spark-avro_2.11</artifactId>
+        <artifactId>spark-avro_2.12</artifactId>
         <version>${spark.version}</version>
       </dependency>
       <dependency>
@@ -435,7 +435,7 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>2.11.8</version>
+        <version>2.12.10</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -139,6 +139,16 @@
       <artifactId>jackson-core</artifactId>
       <version>2.10.0</version>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.10.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.10.0</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -90,17 +90,16 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-catalyst_2.11</artifactId>
+      <artifactId>spark-catalyst_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
+      <artifactId>spark-core_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-sql_2.11</artifactId>
+      <artifactId>spark-sql_2.12</artifactId>
     </dependency>
-    <!-- Spark 2.4.6 uses Parquet 1.10.1 -->
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hadoop</artifactId>
@@ -109,7 +108,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-avro_2.11</artifactId>
+      <artifactId>spark-avro_2.12</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.janino</groupId>
@@ -134,6 +133,11 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.10.0</version>
     </dependency>
   </dependencies>
 

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -36,6 +36,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
+    <jackson.version>2.10.0</jackson.version>
   </properties>
 
   <dependencies>
@@ -137,17 +138,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.10.0</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.0</version>
+      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.10.0</version>
+      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark from 2.4.6 to 3.1.0 in benchmark module.
Please note that we will upgrade to Spark 3.1.1 immediately as soon as possible because 3.1.0 is not an official release.

### Why are the changes needed?

To use the latest version in benchmark.

### How was this patch tested?

```bash
$ cd java/bench

$ mvn package
INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for ORC Benchmarks 1.7.0-SNAPSHOT:
[INFO] 
[INFO] ORC Benchmarks ..................................... SUCCESS [  0.891 s]
[INFO] ORC Benchmarks Core ................................ SUCCESS [  5.977 s]
[INFO] ORC Benchmarks Hive ................................ SUCCESS [  6.855 s]
[INFO] ORC Benchmarks Spark ............................... SUCCESS [ 26.922 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  40.809 s
[INFO] Finished at: 2021-01-17T20:28:48-08:00
[INFO] ------------------------------------------------------------------------

$ java -jar spark/target/orc-benchmarks-spark-*.jar spark -i 1 -I 1 ~/data    
# JMH version: 1.20
# VM version: JDK 1.8.0_275, VM 25.275-b01
# VM invoker: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
# VM options: -server -Xms256m -Xmx2g -Dbench.root.dir=/home/dongjoon/data
# Warmup: 1 iterations, 10 s each
# Measurement: 1 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.apache.orc.bench.spark.SparkBenchmark.fullRead
# Parameters: (compression = none, dataset = taxi, format = orc)

# Run progress: 0.00% complete, ETA 00:27:00
# Fork: 1 of 1
# Warmup Iteration   1: [WARN ] Unable to load native-hadoop library for your platform... using builtin-java classes where applicable

Records: 22773249
Invocations: 1
Reads: 81
Bytes: 1333068794
11158424.688 us/op
Iteration   1: 
Records: 45546498
Invocations: 2
Reads: 162
Bytes: 2666137588
9776462.312 us/op
                 bytesPerRecord: 58.537 #
                 perRecord:      0.429 us/op
                 reads:          81.000 #
                 records:        22773249.000 #
...
```