### PR TITLE
ORC-738: Add date type conversion support in `Java Tools`

### DIFF
--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -78,10 +78,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.threeten</groupId>
-      <artifactId>threetenbp</artifactId>
-    </dependency>
     <!-- orc-tools uber jar needs to include this -->
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -19,7 +19,15 @@ package org.apache.orc.tools.convert;
 
 import com.opencsv.CSVReader;
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.hive.ql.exec.vector.*;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DateColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.orc.RecordReader;
@@ -29,7 +37,11 @@ import org.apache.orc.TypeDescription;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 
@@ -246,7 +258,7 @@ public class CsvReader implements RecordReader {
 
         if (dt != null) {
           vector.vector[row] = dt.toEpochDay();
-        }  else {
+        } else {
           column.noNulls = false;
           column.isNull[row] = true;
         }
@@ -273,13 +285,11 @@ public class CsvReader implements RecordReader {
           ZonedDateTime zonedDateTime = ((ZonedDateTime) temporalAccessor);
           Timestamp timestamp = Timestamp.from(zonedDateTime.toInstant());
           vector.set(row, timestamp);
-        }
-        else if (temporalAccessor instanceof OffsetDateTime) {
+        } else if (temporalAccessor instanceof OffsetDateTime) {
           OffsetDateTime offsetDateTime = (OffsetDateTime) temporalAccessor;
           Timestamp timestamp = Timestamp.from(offsetDateTime.toInstant());
           vector.set(row, timestamp);
-        }
-        else if (temporalAccessor instanceof LocalDateTime) {
+        } else if (temporalAccessor instanceof LocalDateTime) {
           ZonedDateTime tz = ((LocalDateTime) temporalAccessor).atZone(ZoneId.systemDefault());
           Timestamp timestamp = Timestamp.from(tz.toInstant());
           vector.set(row, timestamp);

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -250,8 +250,7 @@ public class CsvReader implements RecordReader {
       if (values[offset] == null || nullString.equals(values[offset])) {
         column.noNulls = false;
         column.isNull[row] = true;
-      }
-      else {
+      } else {
         DateColumnVector vector = (DateColumnVector) column;
 
         final LocalDate dt = LocalDate.parse(values[offset]);

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -19,27 +19,19 @@ package org.apache.orc.tools.convert;
 
 import com.opencsv.CSVReader;
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.exec.vector.*;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-import org.threeten.bp.LocalDateTime;
-import org.threeten.bp.ZoneId;
-import org.threeten.bp.ZonedDateTime;
-import org.threeten.bp.format.DateTimeFormatter;
-import org.threeten.bp.temporal.TemporalAccessor;
+
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
 
 public class CsvReader implements RecordReader {
   private long rowNumber = 0;
@@ -238,6 +230,30 @@ public class CsvReader implements RecordReader {
     }
   }
 
+  class DateColumnConverter extends ConverterImpl {
+    DateColumnConverter(IntWritable offset) { super(offset); }
+
+    @Override
+    public void convert(String[] values, ColumnVector column, int row) {
+      if (values[offset] == null || nullString.equals(values[offset])) {
+        column.noNulls = false;
+        column.isNull[row] = true;
+      }
+      else {
+        DateColumnVector vector = (DateColumnVector) column;
+
+        final LocalDate dt = LocalDate.parse(values[offset]);
+
+        if (dt != null) {
+          vector.vector[row] = dt.toEpochDay();
+        }  else {
+          column.noNulls = false;
+          column.isNull[row] = true;
+        }
+      }
+    }
+  }
+
   class TimestampConverter extends ConverterImpl {
     TimestampConverter(IntWritable offset) {
       super(offset);
@@ -252,16 +268,20 @@ public class CsvReader implements RecordReader {
         TimestampColumnVector vector = (TimestampColumnVector) column;
         TemporalAccessor temporalAccessor =
             dateTimeFormatter.parseBest(values[offset],
-                ZonedDateTime.FROM, LocalDateTime.FROM);
+                ZonedDateTime::from, OffsetDateTime::from, LocalDateTime::from);
         if (temporalAccessor instanceof ZonedDateTime) {
           ZonedDateTime zonedDateTime = ((ZonedDateTime) temporalAccessor);
-          Timestamp timestamp = new Timestamp(zonedDateTime.toEpochSecond() * 1000L);
-          timestamp.setNanos(zonedDateTime.getNano());
+          Timestamp timestamp = Timestamp.from(zonedDateTime.toInstant());
           vector.set(row, timestamp);
-        } else if (temporalAccessor instanceof LocalDateTime) {
+        }
+        else if (temporalAccessor instanceof OffsetDateTime) {
+          OffsetDateTime offsetDateTime = (OffsetDateTime) temporalAccessor;
+          Timestamp timestamp = Timestamp.from(offsetDateTime.toInstant());
+          vector.set(row, timestamp);
+        }
+        else if (temporalAccessor instanceof LocalDateTime) {
           ZonedDateTime tz = ((LocalDateTime) temporalAccessor).atZone(ZoneId.systemDefault());
-          Timestamp timestamp = new Timestamp(tz.toEpochSecond() * 1000L);
-          timestamp.setNanos(tz.getNano());
+          Timestamp timestamp = Timestamp.from(tz.toInstant());
           vector.set(row, timestamp);
         } else {
           column.noNulls = false;
@@ -318,6 +338,8 @@ public class CsvReader implements RecordReader {
       case CHAR:
       case VARCHAR:
         return new BytesConverter(startOffset);
+      case DATE:
+        return new DateColumnConverter(startOffset);
       case TIMESTAMP:
       case TIMESTAMP_INSTANT:
         return new TimestampConverter(startOffset);

--- a/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
@@ -143,8 +143,7 @@ public class JsonReader implements RecordReader {
       if (value == null || value.isJsonNull()) {
         vect.noNulls = false;
         vect.isNull[row] = true;
-      }
-      else {
+      } else {
         DateColumnVector vector = (DateColumnVector) vect;
 
         final LocalDate dt = LocalDate.parse(value.getAsString());

--- a/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
@@ -24,17 +24,29 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonStreamParser;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
-import org.apache.hadoop.hive.ql.exec.vector.*;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DateColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-
-
 
 import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
-import java.time.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;
 import java.util.Iterator;
@@ -139,7 +151,7 @@ public class JsonReader implements RecordReader {
 
         if (dt != null) {
           vector.vector[row] = dt.toEpochDay();
-        }  else {
+        } else {
           vect.noNulls = false;
           vect.isNull[row] = true;
         }
@@ -161,13 +173,11 @@ public class JsonReader implements RecordReader {
           ZonedDateTime zonedDateTime = ((ZonedDateTime) temporalAccessor);
           Timestamp timestamp = Timestamp.from(zonedDateTime.toInstant());
           vector.set(row, timestamp);
-        }
-        else if (temporalAccessor instanceof OffsetDateTime) {
+        } else if (temporalAccessor instanceof OffsetDateTime) {
           OffsetDateTime offsetDateTime = (OffsetDateTime) temporalAccessor;
           Timestamp timestamp = Timestamp.from(offsetDateTime.toInstant());
           vector.set(row, timestamp);
-        }
-        else if (temporalAccessor instanceof LocalDateTime) {
+        } else if (temporalAccessor instanceof LocalDateTime) {
           ZonedDateTime tz = ((LocalDateTime) temporalAccessor).atZone(ZoneId.systemDefault());
           Timestamp timestamp = Timestamp.from(tz.toInstant());
           vector.set(row, timestamp);

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
@@ -33,7 +33,9 @@ import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class TestJsonReader {
     @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
* CSV and Json converters can now take in columns with date format instead of throwing an error on invalid type
* Removed threetenbp date/time library with standard java version
* Datetimes support OffsetDateTime formats, e.g. 2021-01-18T12:34:56.123+04:00
* Create timestamps from converting to Instant rather than manually setting seconds and nanos


### Why are the changes needed?
Date is a common datatype and should be supported instead of using hack with timestamps at 00:00:00
threetenbp library outdated and is not necessary for java 8+
Datetime formats should allow for OffsetDateTime as well as ZonedDateTime and LocalDateTime formats for full iso8601 compatibility


### How was this patch tested?
TestJsonReader.testDateTypeSupport
TestJsonReader.testDateTimeTypeSupport
