### PR TITLE
ORC-739: Use Maven Wrapper in java/CMakeLists.txt

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -15,7 +15,7 @@ set(NO_DOWNLOAD_MSG
   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn)
 
 # set the version in the POM file to match the CMake version string
-execute_process(COMMAND mvn versions:set -DnewVersion=${ORC_VERSION}
+execute_process(COMMAND ./mvnw versions:set -DnewVersion=${ORC_VERSION}
                                          -DgenerateBackupPoms=false
                                          -Pbenchmark
                                          ${NO_DOWNLOAD_MSG}
@@ -36,7 +36,7 @@ endif()
 
 add_custom_command(
    OUTPUT ${ORC_JARS}
-   COMMAND mvn ${NO_DOWNLOAD_MSG} ${JAVA_PROFILE}
+   COMMAND ./mvnw ${NO_DOWNLOAD_MSG} ${JAVA_PROFILE}
              -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} -DskipTests package
    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
    COMMENT "Build the java directory"
@@ -46,7 +46,7 @@ add_custom_target(java_build ALL DEPENDS ${ORC_JARS})
 
 add_test(
   NAME java-test
-  COMMAND mvn ${NO_DOWNLOAD_MSG} -Pcmake
+  COMMAND ./mvnw ${NO_DOWNLOAD_MSG} -Pcmake
            -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to replace `mvn` with `mvnw` in `java.CMakeLists.txt`.

### Why are the changes needed?

Some old OSes like CentOS7 may have the old Maven installation. Maven Wrapper will prevent build and test failures.

### How was this patch tested?

Pass the CIs and manually do the following.

```
$ cd docker
$ ./run-one.sh local ORC-739 centos7
...
exec: curl --silent --show-error -L https://www.apache.org/dyn/closer.lua?action=download&filename=/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
Using `mvn` from path: /root/orc/java/build/apache-maven-3.6.3/bin/mvn
...
Using `mvn` from path: /root/orc/java/build/apache-maven-3.6.3/bin/mvn
[INFO] Scanning for projects...
...
Test project /root/build
    Start 1: orc-test
1/3 Test #1: orc-test .........................   Passed    6.72 sec
    Start 2: java-test
2/3 Test #2: java-test ........................   Passed  103.21 sec
    Start 3: tool-test
3/3 Test #3: tool-test ........................   Passed   19.69 sec

100% tests passed, 0 tests failed out of 3

Total Test time (real) = 129.62 sec
Built target test-out
Finished centos7 at Fri Jan 22 06:33:19 PM PST 2021
```