### PR TITLE
ORC-741: Schema Evolution missing column not handled in the presence of filters

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -104,17 +104,10 @@ public class RecordReaderImpl implements RecordReader {
    */
   static int findColumns(SchemaEvolution evolution,
                          String columnName) {
-    try {
-      TypeDescription readerColumn = evolution.getReaderBaseSchema().findSubtype(
-          columnName, evolution.isSchemaEvolutionCaseAware);
-      TypeDescription fileColumn = evolution.getFileType(readerColumn);
-      return fileColumn == null ? -1 : fileColumn.getId();
-    } catch (IllegalArgumentException e) {
-      if (LOG.isDebugEnabled()){
-        LOG.debug("{}", e.getMessage());
-      }
-      return -1;
-    }
+    TypeDescription readerColumn = evolution.getReaderBaseSchema().findSubtype(
+        columnName, evolution.isSchemaEvolutionCaseAware);
+    TypeDescription fileColumn = evolution.getFileType(readerColumn);
+    return fileColumn == null ? -1 : fileColumn.getId();
   }
 
   /**
@@ -231,11 +224,9 @@ public class RecordReaderImpl implements RecordReader {
     if (options.getPreFilterColumnNames() != null) {
       for (String colName : options.getPreFilterColumnNames()) {
         int expandColId = findColumns(evolution, colName);
+        // If the column is not present in the file then this can be ignored from read.
         if (expandColId != -1) {
           filterColIds.add(expandColId);
-        } else {
-          throw new IllegalArgumentException("Filter could not find column with name: " +
-              colName + " on " + evolution.getReaderBaseSchema());
         }
       }
       LOG.info("Filter Columns: " + filterColIds);

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -100,14 +100,21 @@ public class RecordReaderImpl implements RecordReader {
    *
    * @param evolution the mapping from reader to file schema
    * @param columnName  the fully qualified column name to look for
-   * @return the file column number or -1 if the column wasn't found
+   * @return the file column number or -1 if the column wasn't found in the file schema
+   * @throws IllegalArgumentException if the column was not found in the reader schema
    */
   static int findColumns(SchemaEvolution evolution,
                          String columnName) {
-    TypeDescription readerColumn = evolution.getReaderBaseSchema().findSubtype(
-        columnName, evolution.isSchemaEvolutionCaseAware);
-    TypeDescription fileColumn = evolution.getFileType(readerColumn);
-    return fileColumn == null ? -1 : fileColumn.getId();
+    try {
+      TypeDescription readerColumn = evolution.getReaderBaseSchema().findSubtype(
+          columnName, evolution.isSchemaEvolutionCaseAware);
+      TypeDescription fileColumn = evolution.getFileType(readerColumn);
+      return fileColumn == null ? -1 : fileColumn.getId();
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Filter could not find column with name: " +
+                                         columnName + " on " + evolution.getReaderBaseSchema(),
+                                         e);
+    }
   }
 
   /**

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -235,17 +235,18 @@ public class TestOrcFileEvolution {
   @Test
   public void testPreHive4243CheckEqual() {
     // Expect success on equal schemas
-    checkEvolution("struct<_col0:int,_col1:string>",
+    checkEvolutionPosn("struct<_col0:int,_col1:string>",
                    "struct<_col0:int,_col1:string>",
                    struct(1, "foo"),
-                   struct(1, "foo", null), false, addSarg, false);
+                   struct(1, "foo", null),
+                   false, addSarg, false);
   }
 
   @Test
   public void testPreHive4243Check() {
     // Expect exception on strict compatibility check
     thrown.expectMessage("HIVE-4243");
-    checkEvolution("struct<_col0:int,_col1:string>",
+    checkEvolutionPosn("struct<_col0:int,_col1:string>",
                    "struct<_col0:int,_col1:string,_col2:double>",
                    struct(1, "foo"),
                    struct(1, "foo", null), false, addSarg, false);
@@ -253,17 +254,18 @@ public class TestOrcFileEvolution {
 
   @Test
   public void testPreHive4243AddColumn() {
-    checkEvolution("struct<_col0:int,_col1:string>",
+    checkEvolutionPosn("struct<_col0:int,_col1:string>",
                    "struct<_col0:int,_col1:string,_col2:double>",
                    struct(1, "foo"),
-                   struct(1, "foo", null), true, addSarg, false);
+                   struct(1, "foo", null),
+                   true, addSarg, false);
   }
 
   @Test
   public void testPreHive4243AddColumnMiddle() {
     // Expect exception on type mismatch
     thrown.expect(SchemaEvolution.IllegalEvolutionException.class);
-    checkEvolution("struct<_col0:int,_col1:double>",
+    checkEvolutionPosn("struct<_col0:int,_col1:double>",
                    "struct<_col0:int,_col1:date,_col2:double>",
                    struct(1, 1.0),
                    null, true, addSarg, false);
@@ -310,6 +312,26 @@ public class TestOrcFileEvolution {
         struct(11, 2, 3),
         struct(11, 2, 3, null),
         false, addSarg, true);
+  }
+
+  private void checkEvolutionPosn(String writerType, String readerType,
+                                  Object inputRow, Object expectedOutput,
+                                  boolean tolerateSchema, boolean addSarg,
+                                  boolean positional) {
+    SearchArgument sArg = null;
+    String[] sCols = null;
+    if (addSarg) {
+      sArg = SearchArgumentFactory
+        .newBuilder()
+        .lessThan("_col0", PredicateLeaf.Type.LONG, 10L)
+        .build();
+      sCols = new String[]{null, "_col0", null};
+    }
+
+    checkEvolution(writerType, readerType,
+                   inputRow, expectedOutput,
+                   tolerateSchema,
+                   sArg, sCols, positional);
   }
 
   private void checkEvolution(String writerType, String readerType,

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.orc.*;
 import org.apache.orc.TypeDescription.Category;
 import org.apache.orc.impl.SchemaEvolution;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -233,13 +234,25 @@ public class TestOrcFileEvolution {
   }
 
   @Test
+  public void testMissingColumnFromReaderSchema() {
+    // Expect failure if the column is missing from the reader schema, as column a that is added
+    // by the SArg is missing from the reader schema
+    Assert.assertThrows("Field a not found in", IllegalArgumentException.class,
+                        () -> checkEvolution("struct<b:int,c:string>",
+                                       "struct<b:int,c:string>",
+                                       struct(1, "foo"),
+                                       struct(1, "foo", null),
+                                       true, true, false));
+
+  }
+
+  @Test
   public void testPreHive4243CheckEqual() {
     // Expect success on equal schemas
     checkEvolutionPosn("struct<_col0:int,_col1:string>",
                    "struct<_col0:int,_col1:string>",
                    struct(1, "foo"),
-                   struct(1, "foo", null),
-                   false, addSarg, false);
+                   struct(1, "foo", null), false, addSarg, false);
   }
 
   @Test
@@ -257,8 +270,7 @@ public class TestOrcFileEvolution {
     checkEvolutionPosn("struct<_col0:int,_col1:string>",
                    "struct<_col0:int,_col1:string,_col2:double>",
                    struct(1, "foo"),
-                   struct(1, "foo", null),
-                   true, addSarg, false);
+                   struct(1, "foo", null), true, addSarg, false);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
The following changes are proposed during the resolution of columns:
* If a column is not found in the read schema, then fail with an `IllegalArgumentException`
* If a column is not found in the file, then do not fail but instead treat as `NullReader`

### Why are the changes needed?
In the absence of the patch, when the filter columns referred to missing columns in the file we were incorrectly getting an `IllegalArgumentException` instead of handling it as a missing column in the file.

### How was this patch tested?
Unit tests were added to verify this behavior
