### PR TITLE
ORC-743: Convert SearchArguments to Filter to take advantage of LazyIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 *.iws
 .idea
 .DS_Store
+*.monopic

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ target
 *.iws
 .idea
 .DS_Store
-*.monopic

--- a/java/bench/core/pom.xml
+++ b/java/bench/core/pom.xml
@@ -23,7 +23,6 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <groupId>org.apache.orc</groupId>
   <artifactId>orc-benchmarks-core</artifactId>
   <version>1.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
@@ -95,12 +94,24 @@
       <artifactId>jmh-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
     </dependency>
   </dependencies>
 
@@ -116,6 +127,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
@@ -21,8 +21,6 @@ package org.apache.orc.bench.core;
 import org.apache.commons.cli.CommandLine;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.TypeDescription;
-import org.openjdk.jmh.runner.Runner;
-import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.TimeValue;

--- a/java/bench/core/src/java/org/apache/orc/bench/core/filter/ComputeSum.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/filter/ComputeSum.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+
+import java.util.function.BiFunction;
+
+public class ComputeSum {
+  public static long sumWithFunction(VectorizedRowBatch b) {
+    long sum = 0;
+    BiFunction<ColumnVector, Integer, Long> gv = RowFilterFactory::getLong;
+    ColumnVector v = b.cols[0];
+    Object o;
+
+    for (int i = 0; i < b.size; i++) {
+      o = RowFilterFactory.getValue(v, i, gv);
+      if (o != null) {
+        sum += (long) o;
+      }
+    }
+    return sum;
+  }
+
+  public static long sumDirect(VectorizedRowBatch b) {
+    long sum = 0;
+    LongColumnVector colVector = (LongColumnVector) b.cols[0];
+    long[] vector = colVector.vector;
+    if (colVector.isRepeating && (colVector.noNulls || !colVector.isNull[0])) {
+      sum += vector[0] * b.getSelectedSize();
+    } else if (colVector.noNulls) {
+      for (int i = 0; i < b.size; i++) {
+        sum += vector[i];
+      }
+    } else {
+      for (int i = b.getSelectedSize() - 1; i > -1; --i) {
+        if (!colVector.isNull[i]) {
+          sum += vector[i];
+        }
+      }
+    }
+    return sum;
+  }
+
+  public static long sumWithMethod(VectorizedRowBatch b) {
+    long sum = 0;
+    LongColumnVector colVector = (LongColumnVector) b.cols[0];
+    if (colVector.isRepeating && (colVector.noNulls || !colVector.isNull[0])) {
+      sum += getLongValue(colVector, 0) * b.getSelectedSize();
+    } else if (colVector.noNulls) {
+      for (int i = 0; i < b.size; i++) {
+        sum += getLongValue(colVector, i);
+      }
+    } else {
+      for (int i = b.getSelectedSize() - 1; i > -1; --i) {
+        if (!colVector.isNull[i]) {
+          sum += getLongValue(colVector, i);
+        }
+      }
+    }
+    return sum;
+  }
+
+  private static long getLongValue(ColumnVector v, int idx) {
+    LongColumnVector lv = (LongColumnVector) v;
+    return lv.vector[idx];
+  }
+}

--- a/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterBench.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterBench.java
@@ -1,0 +1,577 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import com.google.auto.service.AutoService;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.ParseException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.orc.OrcFile;
+import org.apache.orc.bench.core.OrcBenchmark;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.FilterFactory;
+import org.apache.orc.filter.impl.BatchFilter;
+import org.apache.orc.filter.impl.Filters;
+import org.apache.orc.filter.impl.LongEquals;
+import org.apache.orc.filter.impl.LongIn;
+import org.junit.Assert;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+import static org.apache.orc.bench.core.BenchmarkOptions.FORK;
+import static org.apache.orc.bench.core.BenchmarkOptions.GC;
+import static org.apache.orc.bench.core.BenchmarkOptions.HELP;
+import static org.apache.orc.bench.core.BenchmarkOptions.ITERATIONS;
+import static org.apache.orc.bench.core.BenchmarkOptions.MAX_MEMORY;
+import static org.apache.orc.bench.core.BenchmarkOptions.MIN_MEMORY;
+import static org.apache.orc.bench.core.BenchmarkOptions.TIME;
+import static org.apache.orc.bench.core.BenchmarkOptions.WARMUP_ITERATIONS;
+
+@AutoService(OrcBenchmark.class)
+public class FilterBench implements OrcBenchmark {
+  @Override
+  public String getName() {
+    return "filter";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Perform filter bench";
+  }
+
+  @Override
+  public void run(String[] args) throws Exception {
+    new Runner(parseOptions(args)).run();
+  }
+
+  private static CommandLine parseCommandLine(String[] args) {
+    org.apache.commons.cli.Options options = new org.apache.commons.cli.Options()
+      .addOption("h", HELP, false, "Provide help")
+      .addOption("i", ITERATIONS, true, "Number of iterations")
+      .addOption("I", WARMUP_ITERATIONS, true, "Number of warmup iterations")
+      .addOption("f", FORK, true, "How many forks to use")
+      .addOption("t", TIME, true, "How long each iteration is in seconds")
+      .addOption("m", MIN_MEMORY, true, "The minimum size of each JVM")
+      .addOption("M", MAX_MEMORY, true, "The maximum size of each JVM")
+      .addOption("g", GC, false, "Should GC be profiled");
+    CommandLine result;
+    try {
+      result = new DefaultParser().parse(options, args, true);
+    } catch (ParseException pe) {
+      System.err.println("Argument exception - " + pe.getMessage());
+      result = null;
+    }
+    if (result == null || result.hasOption(HELP) || result.getArgs().length == 0) {
+      new HelpFormatter().printHelp("java -jar <jar> <command> <options> <sub_cmd>\n"
+                                    + "sub_cmd:\nsimple\ncomplex\ngetvalue\n",
+                                    options);
+      System.err.println();
+      System.exit(1);
+    }
+    return result;
+  }
+
+  public static Options parseOptions(String[] args) throws IOException {
+    CommandLine options = parseCommandLine(args);
+    String cmd = options.getArgs()[0];
+    Class<?> cls;
+    switch (cmd) {
+      case "simple":
+        cls = SimpleFilter.class;
+        break;
+      case "complex":
+        cls = ComplexFilter.class;
+        break;
+      case "getvalue":
+        cls = GetValue.class;
+        break;
+      case "access":
+        cls = Access.class;
+        break;
+      case "equals":
+        cls = Equal.class;
+        break;
+      case "in":
+        cls = In.class;
+        break;
+      default:
+        throw new UnsupportedOperationException(String.format("Command %s is not supported", cmd));
+    }
+    OptionsBuilder builder = new OptionsBuilder();
+    builder.include(cls.getSimpleName());
+    if (options.hasOption(GC)) {
+      builder.addProfiler("hs_gc");
+    }
+    if (options.hasOption(ITERATIONS)) {
+      builder.measurementIterations(Integer.parseInt(options.getOptionValue(ITERATIONS)));
+    }
+    if (options.hasOption(WARMUP_ITERATIONS)) {
+      builder.warmupIterations(Integer.parseInt(options.getOptionValue(
+        WARMUP_ITERATIONS)));
+    }
+    if (options.hasOption(FORK)) {
+      builder.forks(Integer.parseInt(options.getOptionValue(
+        FORK)));
+    }
+    if (options.hasOption(TIME)) {
+      TimeValue iterationTime = TimeValue.seconds(Long.parseLong(
+        options.getOptionValue(TIME)));
+      builder.measurementTime(iterationTime);
+      builder.warmupTime(iterationTime);
+    }
+
+    String minMemory = options.getOptionValue(MIN_MEMORY, "256m");
+    String maxMemory = options.getOptionValue(MAX_MEMORY, "2g");
+    builder.jvmArgs("-server",
+                    "-Xms" + minMemory, "-Xmx" + maxMemory);
+    return builder.build();
+  }
+
+  private static Consumer<OrcFilterContext> createFilter(SearchArgument sArg,
+                                                      String fType,
+                                                      boolean normalize) {
+    switch (fType) {
+      case "row":
+        return RowFilterFactory.createRowFilter(sArg, normalize);
+      case "vector":
+        return FilterFactory.createVectorFilter(sArg,
+                                                FilterBenchUtil.schema,
+                                                OrcFile.Version.CURRENT,
+                                                normalize);
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  @OutputTimeUnit(value = TimeUnit.MICROSECONDS)
+  @Warmup(iterations = 20, time = 1)
+  @BenchmarkMode(value = Mode.AverageTime)
+  @Fork(value = 1)
+  @State(value = Scope.Benchmark)
+  @Measurement(iterations = 20, time = 1)
+  public static class SimpleFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleFilter.class);
+    private OrcFilterContext fc;
+    private int[] expSel;
+
+    @Param( {"4", "8", "16", "32", "256"})
+    private int fInSize;
+
+    @Param( {"row", "vector"})
+    private String fType;
+
+    private Consumer<OrcFilterContext> f;
+
+    @Setup
+    public void setup() {
+      Random rnd = new Random(1024);
+      VectorizedRowBatch b = FilterBenchUtil.createBatch(rnd);
+
+      fc = new OrcFilterContext(FilterBenchUtil.schema).setBatch(b);
+      Map.Entry<SearchArgument, int[]> r = FilterBenchUtil.createSArg(rnd, b, fInSize);
+      SearchArgument sArg = r.getKey();
+      expSel = r.getValue();
+      f = createFilter(sArg, fType, false);
+      LOG.info("Created {}", f);
+    }
+
+    @Benchmark
+    public void filter() {
+      // Reset the selection
+      FilterBenchUtil.unFilterBatch(fc);
+      f.accept(fc);
+    }
+
+    @TearDown
+    public void tearDown() {
+      FilterBenchUtil.validate(fc, expSel);
+      LOG.info("Selected {} rows", fc.getSelectedSize());
+    }
+  }
+
+  @OutputTimeUnit(value = TimeUnit.MICROSECONDS)
+  @Warmup(iterations = 20, time = 1)
+  @BenchmarkMode(value = Mode.AverageTime)
+  @Fork(value = 1)
+  @State(value = Scope.Benchmark)
+  @Measurement(iterations = 20, time = 1)
+  public static class ComplexFilter {
+    private static final Logger LOG = LoggerFactory.getLogger(ComplexFilter.class);
+
+    private OrcFilterContext fc;
+    private int[] expSel;
+
+    private final int inSize = 32;
+
+    @Param( {"2", "4", "8"})
+    private int fSize;
+
+    @Param( {"true", "false"})
+    private boolean normalize;
+
+    @Param( {"row", "vector"})
+    private String fType;
+
+    private Consumer<OrcFilterContext> f;
+    private final Configuration conf = new Configuration();
+
+    @Setup
+    public void setup() {
+      VectorizedRowBatch b = FilterBenchUtil.createBatch(new Random(1024));
+
+      fc = new OrcFilterContext(FilterBenchUtil.schema).setBatch(b);
+      conf.setBoolean("storage.sarg.normalize", normalize);
+      Map.Entry<SearchArgument, int[]> r = FilterBenchUtil.createComplexSArg(new Random(1024),
+                                                                             b,
+                                                                             inSize,
+                                                                             fSize);
+
+      SearchArgument sArg = r.getKey();
+      LOG.info("SearchArgument has {} leaves and {} expressions",
+               sArg.getLeaves().size(),
+               sArg.getExpression().getChildren().size());
+      expSel = r.getValue();
+      f = createFilter(sArg, fType, normalize);
+      LOG.info("Created {}", f);
+    }
+
+    @Benchmark
+    public void filter() {
+      // Reset the selection
+      FilterBenchUtil.unFilterBatch(fc);
+      f.accept(fc);
+    }
+
+    @TearDown
+    public void tearDown() {
+      FilterBenchUtil.validate(fc, expSel);
+      LOG.info("Selected {} rows", fc.getSelectedSize());
+    }
+
+  }
+
+  @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 2, time = 1)
+  @BenchmarkMode(value = Mode.AverageTime)
+  @Fork(value = 1)
+  @State(value = Scope.Benchmark)
+  @Measurement(iterations = 2, time = 1)
+  public static class GetValue {
+    private static final Logger LOG = LoggerFactory.getLogger(GetValue.class);
+    private VectorizedRowBatch b;
+    private long expSum = 0;
+    private long sum = 0;
+
+    @Setup
+    public void setup() {
+      b = FilterBenchUtil.createBatch(new Random(1024));
+      LongColumnVector lv = (LongColumnVector) b.cols[0];
+      for (int i = 0; i < b.size; i++) {
+        expSum += lv.vector[i];
+      }
+      LOG.info("BatchSize={}, repeating={}, nonulls={}, expSum={}",
+               b.size,
+               lv.isRepeating,
+               lv.noNulls,
+               expSum);
+    }
+
+    @Benchmark
+    public void getWithFunction() {
+      sum = ComputeSum.sumWithFunction(b);
+    }
+
+    @Benchmark
+    public void getWithMethod() {
+      sum = ComputeSum.sumWithMethod(b);
+    }
+
+    @Benchmark
+    public void direct() {
+      sum = ComputeSum.sumDirect(b);
+    }
+
+    @TearDown
+    public void tearDown() {
+      Assert.assertEquals(expSum, sum);
+    }
+  }
+
+  @OutputTimeUnit(value = TimeUnit.NANOSECONDS)
+  @Warmup(iterations = 2, time = 1)
+  @BenchmarkMode(value = Mode.AverageTime)
+  @Fork(value = 1)
+  @State(value = Scope.Benchmark)
+  @Measurement(iterations = 2, time = 1)
+  public static class Access {
+    private static final Logger LOG = LoggerFactory.getLogger(Access.class);
+    private long[] v;
+    private long expSum = 0;
+    private long sum = 0;
+
+    @Setup
+    public void setup() {
+      v = ((LongColumnVector) FilterBenchUtil.createBatch(new Random(1024)).cols[0]).vector;
+      for (long i : v) {
+        expSum += i;
+      }
+      LOG.info("BatchSize={}, expSum={}",
+               v.length,
+               expSum);
+    }
+
+    @Benchmark
+    public void methodAccessElements() {
+      sum = 0;
+      for (int i = 0; i < v.length; i++) {
+        sum += getLong(v, i);
+      }
+    }
+
+    @Benchmark
+    public void functionAccessElements() {
+      sum = 0;
+      BiFunction<long[], Integer, Long> f = Access::getLong;
+      for (int i = 0; i < v.length; i++) {
+        sum += f.apply(v, i);
+      }
+    }
+
+    private static long getLong(long[] es, int idx) {
+      return es[idx];
+    }
+
+    @Benchmark
+    public void indexAccessElements() {
+      sum = 0;
+      for (long l : v) {
+        sum += l;
+      }
+    }
+
+    @Benchmark
+    public void iterateElements() {
+      sum = 0;
+      for (long i : v) {
+        sum += i;
+      }
+    }
+
+    @TearDown
+    public void tearDown() {
+      Assert.assertEquals(expSum, sum);
+    }
+  }
+
+  @OutputTimeUnit(value = TimeUnit.MICROSECONDS)
+  @Warmup(iterations = 2, time = 1)
+  @BenchmarkMode(value = Mode.AverageTime)
+  @Fork(value = 1)
+  @State(value = Scope.Benchmark)
+  @Measurement(iterations = 2, time = 1)
+  public static class Equal {
+    private static final Logger LOG = LoggerFactory.getLogger(Equal.class);
+    private OrcFilterContext fc;
+    private int[] expSel;
+    private long value;
+    private BatchFilter gFilter;
+    private BatchFilter dFilter;
+    int size;
+
+    @Setup
+    public void setup() {
+      Random rnd = new Random(1024);
+      fc = new OrcFilterContext(FilterBenchUtil.schema).setBatch(FilterBenchUtil.createBatch(rnd));
+      size = fc.getSelectedSize();
+      expSel = new int[size];
+      LongColumnVector lv = (LongColumnVector) fc.findColumnVector("f1");
+      value = lv.vector[rnd.nextInt(size)];
+      int currSize = 0;
+      for (int i = 0; i < size; i++) {
+        if (value == lv.vector[i]) {
+          expSel[currSize++] = i;
+        }
+      }
+      LOG.info("BatchSize={}, repeating={}, nonulls={}, expCount={}",
+               size,
+               lv.isRepeating,
+               lv.noNulls,
+               currSize);
+      gFilter = new BatchFilter(new LongEquals("f1", value), null);
+      dFilter = new BatchFilter(new Filters.EqualsLongDirect("f1", value), null);
+    }
+
+    private void resetSel() {
+      fc.setSelectedSize(size);
+      fc.setSelectedInUse(false);
+    }
+
+    @Benchmark
+    public void directCheck() {
+      resetSel();
+      int currSize = 0;
+      LongColumnVector lv = (LongColumnVector) fc.findColumnVector("f1");
+      long[] vector = lv.vector;
+      int[] sel = fc.getSelected();
+      if (lv.isRepeating && (lv.noNulls || !lv.isNull[0])) {
+        if (value == vector[0]) {
+          for (int i = 0; i < size; i++) {
+            sel[currSize++] = i;
+          }
+        }
+      } else if (lv.noNulls) {
+        for (int i = 0; i < size; i++) {
+          if (value == vector[i]) {
+            sel[currSize++] = i;
+          }
+        }
+      } else {
+        for (int i = size - 1; i > -1; --i) {
+          if (!lv.isNull[i] && value == vector[i]) {
+            sel[currSize++] = i;
+          }
+        }
+      }
+      fc.setSelectedInUse(true);
+      fc.setSelectedSize(currSize);
+    }
+
+    @Benchmark
+    public void directFilter() {
+      resetSel();
+      dFilter.accept(fc);
+    }
+
+    @Benchmark
+    public void genericFilter() {
+      resetSel();
+      gFilter.accept(fc);
+    }
+
+    @TearDown
+    public void tearDown() {
+      Assert.assertArrayEquals(expSel, fc.getSelected());
+      Assert.assertTrue(fc.isSelectedInUse());
+    }
+  }
+
+  @OutputTimeUnit(value = TimeUnit.MICROSECONDS)
+  @Warmup(iterations = 20, time = 1)
+  @BenchmarkMode(value = Mode.AverageTime)
+  @Fork(value = 1)
+  @State(value = Scope.Benchmark)
+  @Measurement(iterations = 20, time = 1)
+  public static class In {
+    private static final Logger LOG = LoggerFactory.getLogger(Equal.class);
+    private OrcFilterContext fc;
+    private int[] expSel;
+    private BatchFilter arrayFilter;
+    private BatchFilter setFilter;
+    private int size;
+
+    @Param( {"8", "16", "64", "128", "1024"})
+    int inSize;
+
+    @Setup
+    public void setup() {
+      Random rnd = new Random(1024);
+      fc = new OrcFilterContext(FilterBenchUtil.schema).setBatch(FilterBenchUtil.createBatch(rnd));
+      size = fc.getSelectedSize();
+      expSel = new int[size];
+      LongColumnVector lv = (LongColumnVector) fc.findColumnVector("f1");
+      Set<Long> sValues = new HashSet<>(inSize);
+      for (int i = 0; i < inSize; i++) {
+        if (i % 2 == 0) {
+          sValues.add(rnd.nextLong());
+        } else {
+          sValues.add(lv.vector[rnd.nextInt(size)]);
+        }
+      }
+
+      int currSize = 0;
+      for (int i = 0; i < size; i++) {
+        if (sValues.contains(lv.vector[i])) {
+          expSel[currSize++] = i;
+        }
+      }
+      LOG.info("BatchSize={}, repeating={}, nonulls={}, expCount={}",
+               size,
+               lv.isRepeating,
+               lv.noNulls,
+               currSize);
+      arrayFilter = new BatchFilter(new LongIn("f1", Arrays.asList(sValues.toArray())), null);
+      setFilter = new BatchFilter(new Filters.InLongSet("f1", Arrays.asList(sValues.toArray())),
+                                  null);
+    }
+
+    private void resetSel() {
+      fc.setSelectedSize(size);
+      fc.setSelectedInUse(false);
+    }
+
+    @Benchmark
+    public void testArrayFilter() {
+      resetSel();
+      arrayFilter.accept(fc);
+    }
+
+    @Benchmark
+    public void testSetFilter() {
+      resetSel();
+      setFilter.accept(fc);
+    }
+
+    @TearDown
+    public void teardown() {
+      Assert.assertArrayEquals(expSel, fc.getSelected());
+      Assert.assertTrue(fc.isSelectedInUse());
+    }
+  }
+}

--- a/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterBenchUtil.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterBenchUtil.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.filter.OrcFilterContext;
+import org.junit.Assert;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+public class FilterBenchUtil {
+  static final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createLong());
+
+  static VectorizedRowBatch createBatch(Random rnd) {
+    VectorizedRowBatch b = schema.createRowBatch(1024);
+    LongColumnVector f1Vector = (LongColumnVector) b.cols[0];
+    LongColumnVector f2Vector = (LongColumnVector) b.cols[1];
+
+    for (int i = 0; i < b.getMaxSize(); i++) {
+      f1Vector.vector[b.size] = rnd.nextInt();
+      f2Vector.vector[b.size] = rnd.nextInt();
+      b.size++;
+    }
+    return b;
+  }
+
+  static Map.Entry<SearchArgument, int[]> createSArg(Random rnd,
+                                                     VectorizedRowBatch b,
+                                                     int inSize) {
+    LongColumnVector f1Vector = (LongColumnVector) b.cols[0];
+    LongColumnVector f2Vector = (LongColumnVector) b.cols[1];
+
+    Object[] f1Values = new Object[inSize];
+    Object[] f2Values = new Object[inSize];
+    Set<Integer> sel = new HashSet<>();
+
+    for (int i = 0; i < f1Values.length; i++) {
+      int selIdx = rnd.nextInt(b.getMaxSize());
+      f1Values[i] = f1Vector.vector[selIdx];
+      sel.add(selIdx);
+      selIdx = rnd.nextInt(b.getMaxSize());
+      f2Values[i] = f2Vector.vector[selIdx];
+      sel.add(selIdx);
+    }
+
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .in("f1", PredicateLeaf.Type.LONG, f1Values)
+      .in("f2", PredicateLeaf.Type.LONG, f2Values)
+      .end()
+      .build();
+    int[] s = sel.stream()
+      .mapToInt(Integer::intValue)
+      .toArray();
+    Arrays.sort(s);
+    return new AbstractMap.SimpleImmutableEntry<>(sArg, s);
+  }
+
+  static Map.Entry<SearchArgument, int[]> createComplexSArg(Random rnd,
+                                                            VectorizedRowBatch b,
+                                                            int inSize,
+                                                            int orSize) {
+    LongColumnVector f1Vector = (LongColumnVector) b.cols[0];
+    LongColumnVector f2Vector = (LongColumnVector) b.cols[1];
+
+    Object[] f1Values = new Object[inSize];
+    Object[] f2Values = new Object[inSize];
+    Set<Integer> sel = new HashSet<>();
+    SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+    builder.startOr();
+    builder.in("f2", PredicateLeaf.Type.LONG, f2Vector.vector[0], f2Vector.vector[1]);
+    sel.add(0);
+    sel.add(1);
+    int selIdx;
+    for (int i = 0; i < orSize; i++) {
+      builder.startAnd();
+      for (int j = 0; j < inSize; j++) {
+        selIdx = rnd.nextInt(b.getMaxSize());
+        f1Values[j] = f1Vector.vector[selIdx];
+        f2Values[j] = f2Vector.vector[selIdx];
+        sel.add(selIdx);
+      }
+      builder
+        .in("f1", PredicateLeaf.Type.LONG, f1Values)
+        .in("f2", PredicateLeaf.Type.LONG, f2Values);
+      builder.end();
+    }
+    builder.end();
+
+    int[] s = sel.stream()
+      .mapToInt(Integer::intValue)
+      .toArray();
+    Arrays.sort(s);
+    return new AbstractMap.SimpleImmutableEntry<>(builder.build(), s);
+  }
+
+  static void unFilterBatch(OrcFilterContext fc) {
+    fc.setSelectedInUse(false);
+    fc.setSelectedSize(1024);
+  }
+
+  static void validate(OrcFilterContext fc, int[] expSel) {
+    Assert.assertTrue(fc.isSelectedInUse());
+    Assert.assertEquals(expSel.length, fc.getSelectedSize());
+    Assert.assertArrayEquals(expSel, Arrays.copyOf(fc.getSelected(), expSel.length));
+  }
+
+}

--- a/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterUtil.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterUtil.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+import org.apache.orc.filter.impl.AndFilter;
+import org.apache.orc.filter.impl.LongIn;
+import org.apache.orc.filter.impl.OrFilter;
+import org.apache.orc.filter.impl.BatchFilter;
+
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class FilterUtil {
+  public static Map.Entry<Consumer<OrcFilterContext>, int[]> createComplexFilter(Random rnd,
+                                                                              VectorizedRowBatch b,
+                                                                              int inSize,
+                                                                              int orSize) {
+    LongColumnVector f1Vector = (LongColumnVector) b.cols[0];
+    LongColumnVector f2Vector = (LongColumnVector) b.cols[1];
+
+    Object[] f1Values = new Object[inSize];
+    Object[] f2Values = new Object[inSize];
+    Set<Integer> sel = new HashSet<>();
+    VectorFilter[] orFilters = new VectorFilter[orSize + 1];
+    orFilters[0] = new LongIn("f2",
+                              Arrays.asList(f2Vector.vector[0],
+                                            f2Vector.vector[1]));
+    sel.add(0);
+    sel.add(1);
+    int selIdx;
+
+    for (int i = 0; i < orSize; i++) {
+      for (int j = 0; j < inSize; j++) {
+        selIdx = rnd.nextInt(b.getMaxSize());
+        f1Values[j] = f1Vector.vector[selIdx];
+        f2Values[j] = f2Vector.vector[selIdx];
+        sel.add(selIdx);
+      }
+      orFilters[i + 1] = new AndFilter(new VectorFilter[] {
+        new LongIn("f1",
+                   Arrays.asList(f1Values)),
+        new LongIn("f2",
+                   Arrays.asList(f2Values))
+      });
+    }
+    BatchFilter root = new BatchFilter(
+      new OrFilter(orFilters),
+      new String[] {"f1", "f2"}
+    );
+
+    int[] s = sel.stream()
+      .mapToInt(Integer::intValue)
+      .toArray();
+    Arrays.sort(s);
+    return new AbstractMap.SimpleImmutableEntry<>(root, s);
+  }
+}

--- a/java/bench/core/src/java/org/apache/orc/bench/core/filter/RowFilter.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/filter/RowFilter.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.orc.filter.OrcFilterContext;
+
+import java.util.Set;
+import java.util.function.BiFunction;
+
+public interface RowFilter {
+  boolean accept(OrcFilterContext batch, int rowIdx);
+
+  class INRowFilter<T> implements RowFilter {
+
+    final String colName;
+    public final Set<T> inValues;
+    final BiFunction<ColumnVector, Integer, T> rowValue;
+
+    public INRowFilter(String colName,
+                       Set<T> inValues,
+                       BiFunction<ColumnVector, Integer, T> rowValue) {
+      this.colName = colName;
+      this.inValues = inValues;
+      this.rowValue = rowValue;
+    }
+
+    @Override
+    public boolean accept(OrcFilterContext batch, int rowIdx) {
+      return inValues.contains(getValue(batch.findColumnVector(colName), rowIdx, rowValue));
+    }
+
+    protected T getValue(ColumnVector v, int rowIdx, BiFunction<ColumnVector, Integer, T> f) {
+      int idx = rowIdx;
+      if (v.isRepeating) {
+        idx = 0;
+      }
+      if (v.noNulls || !v.isNull[idx]) {
+        return f.apply(v, idx);
+      } else {
+        return null;
+      }
+    }
+  }
+
+
+  class ORRowFilter implements RowFilter {
+
+    public final RowFilter[] filters;
+
+    public ORRowFilter(RowFilter[] filters) {
+      this.filters = filters;
+    }
+
+    @Override
+    public boolean accept(OrcFilterContext batch, int rowIdx) {
+      boolean result = true;
+      for (RowFilter filter : filters) {
+        result = filter.accept(batch, rowIdx);
+        if (result) {
+          break;
+        }
+      }
+      return result;
+    }
+  }
+
+  class ANDRowFilter implements RowFilter {
+
+    public final RowFilter[] filters;
+
+    public ANDRowFilter(RowFilter[] filters) {
+      this.filters = filters;
+    }
+
+    @Override
+    public boolean accept(OrcFilterContext batch, int rowIdx) {
+      boolean result = true;
+      for (RowFilter filter : filters) {
+        result = filter.accept(batch, rowIdx);
+        if (!result) {
+          break;
+        }
+      }
+      return result;
+    }
+  }
+}

--- a/java/bench/core/src/java/org/apache/orc/bench/core/filter/RowFilterFactory.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/filter/RowFilterFactory.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.io.sarg.ExpressionTree;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.FilterFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+
+public class RowFilterFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(RowFilterFactory.class);
+
+  public static Consumer<OrcFilterContext> createRowFilter(SearchArgument sArg) {
+    return createRowFilter(sArg, false);
+  }
+
+  static Consumer<OrcFilterContext> createRowFilter(SearchArgument sArg, boolean normalize) {
+    try {
+      Set<String> colIds = new HashSet<>();
+      RowFilter filter = createRowFilter(normalize ? sArg.getExpression() :
+                                           sArg.getUnexpandedExpression(),
+                                         colIds,
+                                         sArg.getLeaves());
+      return new RowBatchFilter(filter, colIds.toArray(new String[0]));
+    } catch (FilterFactory.UnSupportedSArgException e) {
+      LOG.warn("SArg: {} is not supported\n{}", sArg, e.getMessage());
+      return null;
+    }
+  }
+
+  public static RowFilter createRowFilter(ExpressionTree expr,
+                                          Set<String> colIds,
+                                          List<PredicateLeaf> leaves)
+    throws FilterFactory.UnSupportedSArgException {
+    RowFilter result;
+    switch (expr.getOperator()) {
+      case OR:
+        RowFilter[] orFilters = new RowFilter[expr.getChildren().size()];
+        for (int i = 0; i < expr.getChildren().size(); i++) {
+          orFilters[i] = createRowFilter(expr.getChildren().get(i), colIds, leaves);
+        }
+        result = new RowFilter.ORRowFilter(orFilters);
+        break;
+      case AND:
+        RowFilter[] andFilters = new RowFilter[expr.getChildren().size()];
+        for (int i = 0; i < expr.getChildren().size(); i++) {
+          andFilters[i] = createRowFilter(expr.getChildren().get(i), colIds, leaves);
+        }
+        result = new RowFilter.ANDRowFilter(andFilters);
+        break;
+      case LEAF:
+        result = createLeafFilter(leaves.get(expr.getLeaf()), colIds);
+        break;
+      default:
+        throw new FilterFactory.UnSupportedSArgException(String.format(
+          "SArg Expression: %s is not supported",
+          expr));
+    }
+    return result;
+  }
+
+  private static RowFilter createLeafFilter(PredicateLeaf leaf,
+                                            Set<String> colIds)
+    throws FilterFactory.UnSupportedSArgException {
+    RowFilter result;
+    colIds.add(leaf.getColumnName());
+
+    switch (leaf.getOperator()) {
+      case IN:
+        result = new RowFilter.INRowFilter<>(leaf.getColumnName(),
+                                             new HashSet<>(leaf.getLiteralList()),
+                                             getGet(leaf.getType()));
+        break;
+      default:
+        throw new FilterFactory.UnSupportedSArgException(String.format(
+          "Predicate: %s is not supported",
+          leaf));
+    }
+    return result;
+  }
+
+  public static BiFunction<ColumnVector, Integer, Object> getGet(PredicateLeaf.Type type) {
+    switch (type) {
+      case LONG:
+        return RowFilterFactory::getLong;
+      case STRING:
+        return RowFilterFactory::getString;
+      default:
+        return null;
+    }
+  }
+
+  public static long getLong(ColumnVector v, int rowIdx) {
+    return ((LongColumnVector) v).vector[rowIdx];
+  }
+
+  static String getString(ColumnVector v, int rowIdx) {
+    BytesColumnVector bv = (BytesColumnVector) v;
+    return new String(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx]);
+  }
+
+  public static <T> T getValue(ColumnVector v,
+                               int rowIdx,
+                               BiFunction<ColumnVector, Integer, T> f) {
+    int idx = rowIdx;
+    if (v.isRepeating) {
+      idx = 0;
+    }
+    if (v.noNulls || !v.isNull[idx]) {
+      return f.apply(v, idx);
+    } else {
+      return null;
+    }
+  }
+
+  public static class RowBatchFilter implements Consumer<OrcFilterContext> {
+
+    private final RowFilter filter;
+    private final String[] colNames;
+
+    private RowBatchFilter(RowFilter filter, String[] colNames) {
+      this.filter = filter;
+      this.colNames = colNames;
+    }
+
+    @Override
+    public void accept(OrcFilterContext batch) {
+      int size = 0;
+      int[] selected = batch.getSelected();
+
+      for (int i = 0; i < batch.getSelectedSize(); i++) {
+        if (filter.accept(batch, i)) {
+          selected[size] = i;
+          size += 1;
+        }
+      }
+      batch.setSelectedInUse(true);
+      batch.setSelected(selected);
+      batch.setSelectedSize(size);
+    }
+
+    public String[] getColNames() {
+      return colNames;
+    }
+  }
+}

--- a/java/bench/core/src/java/org/apache/orc/filter/impl/Filters.java
+++ b/java/bench/core/src/java/org/apache/orc/filter/impl/Filters.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class Filters {
+  public static class EqualsLongDirect implements VectorFilter {
+    private final String colName;
+    private final long aValue;
+
+    public EqualsLongDirect(String colName, long aValue) {
+      this.colName = colName;
+      this.aValue = aValue;
+    }
+
+    @Override
+    public void filter(OrcFilterContext fc,
+                       Selected bound,
+                       Selected selIn,
+                       Selected selOut) {
+      LongColumnVector v = (LongColumnVector) fc.findColumnVector(colName);
+      int inIdx = 0;
+      int currSize = 0;
+      int rowIdx;
+
+      if (v.isRepeating) {
+        if (v.vector[0] == aValue) {
+          // If the repeating value is allowed then allow the current selSize
+          for (int i = 0; i < bound.selSize; i++) {
+            rowIdx = bound.sel[i];
+            if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+              // Row already protected, no need to evaluate
+              inIdx++;
+              continue;
+            }
+            selOut.sel[currSize++] = rowIdx;
+          }
+        }
+      } else if (v.noNulls) {
+        for (int i = 0; i < bound.selSize; i++) {
+          rowIdx = bound.sel[i];
+
+          if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+            // Row already protected, no need to evaluate
+            inIdx++;
+            continue;
+          }
+
+          // Check the value
+          if (v.vector[rowIdx] == aValue) {
+            selOut.sel[currSize++] = rowIdx;
+          }
+        }
+      } else {
+        for (int i = 0; i < bound.selSize; i++) {
+          rowIdx = bound.sel[i];
+
+          if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+            // Row already protected, no need to evaluate
+            inIdx++;
+            continue;
+          }
+
+          // Check the value only if not null
+          if (!v.isNull[rowIdx] && v.vector[rowIdx] == aValue) {
+            selOut.sel[currSize++] = rowIdx;
+          }
+        }
+      }
+
+      selOut.selSize = currSize;
+
+    }
+
+  }
+
+  public static class InLongSet extends LeafFilter {
+    private final Set<Long> inValues;
+
+    public InLongSet(String colName, List<Object> values) {
+      super(colName);
+      inValues = new HashSet<>(values.size());
+      for (Object value : values) {
+        inValues.add((Long) value);
+      }
+    }
+
+    @Override
+    protected boolean allow(ColumnVector v, int rowIdx) {
+      return inValues.contains(((LongColumnVector) v).vector[rowIdx]);
+    }
+  }
+}

--- a/java/bench/core/src/test/org/apache/orc/bench/core/filter/ATestFilter.java
+++ b/java/bench/core/src/test/org/apache/orc/bench/core/filter/ATestFilter.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DateColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.impl.DateUtils;
+import org.junit.Assert;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+public class ATestFilter {
+  protected final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createString())
+    .addField("f3p", TypeDescription.createDate())
+    .addField("f3h", TypeDescription.createDate());
+  protected final OrcFilterContext fc = new OrcFilterContext(schema);
+
+  protected final VectorizedRowBatch batch = schema.createRowBatch();
+
+  protected void setBatch(Long[] f1Values, String[] f2Values) {
+    setBatch(f1Values, f2Values, new String[0]);
+  }
+
+  protected void setBatch(Long[] f1Values, String[] f2Values, String[] f3Values) {
+    final LongColumnVector f1Vector = (LongColumnVector) batch.cols[0];
+    final BytesColumnVector f2Vector = (BytesColumnVector) batch.cols[1];
+    final DateColumnVector f3p = (DateColumnVector) batch.cols[2];
+    final DateColumnVector f3h = (DateColumnVector) batch.cols[3];
+
+    batch.reset();
+    f1Vector.noNulls = true;
+    for (int i =0; i < f1Values.length; i++) {
+      if (f1Values[i] == null) {
+        f1Vector.noNulls = false;
+        f1Vector.isNull[i] = true;
+      } else {
+        f1Vector.isNull[i] = false;
+        f1Vector.vector[i] = f1Values[i];
+      }
+    }
+
+    for (int i = 0; i < f2Values.length; i++) {
+      if (f2Values[i] == null) {
+        f2Vector.noNulls = false;
+        f2Vector.isNull[i] = true;
+      } else {
+        f2Vector.isNull[i] = false;
+        byte[] bytes = f2Values[i].getBytes(StandardCharsets.UTF_8);
+        f2Vector.vector[i] = bytes;
+        f2Vector.start[i] = 0;
+        f2Vector.length[i] = bytes.length;
+      }
+    }
+
+    for (int i = 0; i < f3Values.length; i++) {
+      if (f3Values[i] == null) {
+        f3p.noNulls = false;
+        f3p.isNull[i] = true;
+        f3h.noNulls = false;
+        f3h.isNull[i] = true;
+      } else {
+        f3p.isNull[i] = false;
+        f3p.vector[i] = DateUtils.parseDate(f3Values[i], true);
+        f3h.isNull[i] = false;
+        f3h.vector[i] = DateUtils.parseDate(f3Values[i], false);
+      }
+    }
+    batch.size = f1Values.length;
+    fc.setBatch(batch);
+  }
+
+  protected void validateSelected(int... v) {
+    Assert.assertTrue(fc.isSelectedInUse());
+    Assert.assertEquals(v.length, fc.getSelectedSize());
+    Assert.assertArrayEquals(v, Arrays.copyOf(fc.getSelected(), v.length));
+  }
+
+  protected void validateNoneSelected() {
+    Assert.assertTrue(fc.isSelectedInUse());
+    Assert.assertEquals(0, fc.getSelectedSize());
+  }
+}

--- a/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestFilter.java
+++ b/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestFilter.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.orc.OrcFile;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.FilterFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.function.Consumer;
+
+@RunWith(Parameterized.class)
+public class TestFilter {
+  private static final Logger LOG = LoggerFactory.getLogger(TestFilter.class);
+  private static final long seed = 1024;
+  protected final Random rnd = new Random(seed);
+  protected final VectorizedRowBatch b = FilterBenchUtil.createBatch(rnd);
+  protected final OrcFilterContext fc = new OrcFilterContext(FilterBenchUtil.schema).setBatch(b);
+  protected final SearchArgument sArg;
+  protected final int[] expSel;
+  protected Consumer<OrcFilterContext> filter;
+
+  public TestFilter(String complexity, String filterType, boolean normalize) {
+    Map.Entry<SearchArgument, int[]> ft = null;
+    switch (complexity) {
+      case "simple":
+        ft = FilterBenchUtil.createSArg(new Random(seed), b, 5);
+        break;
+      case "complex":
+        ft = FilterBenchUtil.createComplexSArg(new Random(seed), b, 10, 8);
+        break;
+    }
+    sArg = ft.getKey();
+    LOG.info("SearchArgument has {} expressions", sArg.getExpression().getChildren().size());
+    expSel = ft.getValue();
+
+    switch (filterType) {
+      case "row":
+        filter = RowFilterFactory.createRowFilter(sArg, normalize);
+        break;
+      case "vector":
+        filter = FilterFactory.createVectorFilter(sArg,
+                                                  FilterBenchUtil.schema,
+                                                  OrcFile.Version.CURRENT,
+                                                  normalize);
+        break;
+    }
+  }
+
+  @Parameterized.Parameters(name = "#{index} - {0}+{1}")
+  public static List<Object[]> filters() {
+    return Arrays.asList(new Object[][] {
+      {"simple", "row", false},
+      {"simple", "vector", false},
+      {"complex", "row", true},
+      {"complex", "vector", true},
+      {"complex", "row", false},
+      {"complex", "vector", false},
+    });
+  }
+
+  @Before
+  public void setup() {
+    FilterBenchUtil.unFilterBatch(fc);
+  }
+
+  @Test
+  public void testFilter() {
+    filter.accept(fc.setBatch(b));
+    FilterBenchUtil.validate(fc, expSel);
+  }
+}

--- a/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestGetValue.java
+++ b/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestGetValue.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+
+public class TestGetValue {
+  private final VectorizedRowBatch b;
+  private final long expSum;
+
+  public TestGetValue() {
+    b = FilterBenchUtil.createBatch(new Random(1024));
+    LongColumnVector lv = (LongColumnVector) b.cols[0];
+    long s = 0;
+    for (int i = 0; i < b.size; i++) {
+      s += lv.vector[i];
+    }
+    expSum = s;
+    Assert.assertTrue(expSum != 0);
+  }
+
+  @Test
+  public void testFunctionValue() {
+    Assert.assertEquals(expSum, ComputeSum.sumWithFunction(b));
+  }
+
+  @Test
+  public void testMethodValue() {
+    Assert.assertEquals(expSum, ComputeSum.sumWithMethod(b));
+  }
+
+  @Test
+  public void testDirect() {
+    Assert.assertEquals(expSum, ComputeSum.sumDirect(b));
+  }
+}

--- a/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestRowFilter.java
+++ b/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestRowFilter.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.bench.core.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.FilterFactory;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class TestRowFilter extends ATestFilter {
+
+  private final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createString());
+  final OrcFilterContext fc = new OrcFilterContext(schema);
+
+  private final VectorizedRowBatch batch = schema.createRowBatch();
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testINLongConversion() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 2L, 3L)
+      .build();
+
+    Set<String> colIds = new HashSet<>();
+    RowFilter filter = RowFilterFactory.createRowFilter(sarg.getExpression(),
+                                                        colIds,
+                                                        sarg.getLeaves());
+    Assert.assertNotNull(filter);
+    Assert.assertTrue(filter instanceof RowFilter.INRowFilter);
+    Assert.assertEquals(new HashSet<>(Arrays.asList(1L, 2L, 3L)),
+                        ((RowFilter.INRowFilter<?>) filter).inValues);
+    Assert.assertEquals(1, colIds.size());
+    Assert.assertTrue(colIds.contains("f1"));
+
+    setBatch(new Long[] {1L, 0L, 2L, 4L, 3L},
+             new String[] {});
+    fc.setBatch(batch);
+
+    for (int i = 0; i < batch.size; i++) {
+      if (i % 2 == 0) {
+        Assert.assertTrue(filter.accept(fc, i));
+      } else {
+        Assert.assertFalse(filter.accept(fc, i));
+      }
+    }
+  }
+
+  @Test
+  public void testINStringConversion() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .in("f2", PredicateLeaf.Type.STRING, "a", "b")
+      .build();
+
+    Set<String> colIds = new HashSet<>();
+    RowFilter filter = RowFilterFactory.createRowFilter(sarg.getExpression(),
+                                                        colIds,
+                                                        sarg.getLeaves());
+    Assert.assertNotNull(filter);
+    Assert.assertTrue(filter instanceof RowFilter.INRowFilter);
+    Assert.assertEquals(new HashSet<>(Arrays.asList("a", "b")),
+                        ((RowFilter.INRowFilter<?>) filter).inValues);
+    Assert.assertEquals(1, colIds.size());
+    Assert.assertTrue(colIds.contains("f2"));
+
+    setBatch(new Long[] {1L, 0L, 2L, 4L, 3L},
+             new String[] {"a", "z", "b", "y", "a"});
+    fc.setBatch(batch);
+
+    for (int i = 0; i < batch.size; i++) {
+      if (i % 2 == 0) {
+        Assert.assertTrue(filter.accept(fc, i));
+      } else {
+        Assert.assertFalse(filter.accept(fc, i));
+      }
+    }
+  }
+
+  @Test
+  public void testORConversion() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 2L, 3L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "b", "c")
+      .end()
+      .build();
+
+    Set<String> colIds = new HashSet<>();
+    RowFilter filter = RowFilterFactory.createRowFilter(sarg.getExpression(),
+                                                        colIds,
+                                                        sarg.getLeaves());
+    Assert.assertNotNull(filter);
+    Assert.assertTrue(filter instanceof RowFilter.ORRowFilter);
+    Assert.assertEquals(2, ((RowFilter.ORRowFilter) filter).filters.length);
+    Assert.assertEquals(2, colIds.size());
+    Assert.assertTrue(colIds.contains("f1"));
+    Assert.assertTrue(colIds.contains("f2"));
+
+    // Setup the data such that the OR condition should select every row
+    setBatch(new Long[] {1L, 0L, 2L, 4L, 3L},
+             new String[] {"z", "a", "y", "b", "x"});
+    fc.setBatch(batch);
+
+
+    for (int i = 0; i < batch.size; i++) {
+      Assert.assertTrue(filter.accept(fc, i));
+    }
+  }
+
+  @Test
+  public void testANDConversion() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 2L, 3L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "b", "c")
+      .end()
+      .build();
+
+    Set<String> colIds = new HashSet<>();
+    RowFilter filter = RowFilterFactory.createRowFilter(sarg.getExpression(),
+                                                        colIds,
+                                                        sarg.getLeaves());
+    Assert.assertNotNull(filter);
+    Assert.assertTrue(filter instanceof RowFilter.ANDRowFilter);
+    Assert.assertEquals(2, ((RowFilter.ANDRowFilter) filter).filters.length);
+    Assert.assertEquals(2, colIds.size());
+    Assert.assertTrue(colIds.contains("f1"));
+    Assert.assertTrue(colIds.contains("f2"));
+
+    // Setup the data such that the AND condition should not select any row
+    setBatch(new Long[] {1L, 0L, 2L, 4L, 3L},
+             new String[] {"z", "a", "y", "b", "x"});
+    fc.setBatch(batch);
+
+    for (int i = 0; i < batch.size; i++) {
+      Assert.assertFalse(filter.accept(fc, i));
+    }
+  }
+
+  @Test
+  public void testUnSupportedSArg() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .equals("f1", PredicateLeaf.Type.LONG, 0L)
+      .build();
+
+    thrown.expect(FilterFactory.UnSupportedSArgException.class);
+    thrown.expectMessage("is not supported");
+    RowFilterFactory.createRowFilter(sarg.getExpression(), new HashSet<>(), sarg.getLeaves());
+  }
+}

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/RowFilterProjectionBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/RowFilterProjectionBenchmark.java
@@ -30,6 +30,7 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.OrcBenchmark;
 import org.apache.orc.bench.core.ReadCounters;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.filter.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -93,16 +94,16 @@ public class RowFilterProjectionBenchmark implements OrcBenchmark {
     }
   }
 
-  public static void customIntRowFilter(VectorizedRowBatch batch) {
+  public static void customIntRowFilter(OrcFilterContext batch) {
     int newSize = 0;
-    for (int row = 0; row < batch.size; ++row) {
+    for (int row = 0; row < batch.getSelectedSize(); ++row) {
       // Select ONLY specific keys
       if (filterValues.contains(row)) {
-        batch.selected[newSize++] = row;
+        batch.getSelected()[newSize++] = row;
       }
     }
-    batch.selectedInUse = true;
-    batch.size = newSize;
+    batch.setSelectedInUse(true);
+    batch.setSelectedSize(newSize);
   }
 
   @Benchmark

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.filter.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class BooleanRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.filter.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -128,15 +129,15 @@ public class DecimalRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.filter.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class DoubleRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.filter.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class StringRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.filter.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class TimestampRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -44,7 +44,7 @@
     <parquet.version>1.8.3</parquet.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spark.version>2.4.6</spark.version>
-    <storage-api.version>2.7.2</storage-api.version>
+    <storage-api.version>2.7.3-SNAPSHOT</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
   </properties>
 
@@ -56,6 +56,16 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.7.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>5.7.0</version>
+      </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
@@ -248,71 +258,79 @@
         <artifactId>hive-exec</artifactId>
         <classifier>core</classifier>
         <version>${hive.version}</version>
-	<exclusions>
-	  <exclusion>
-	    <groupId>org.apache.calcite</groupId>
-	    <artifactId>calcite-core</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.calcite</groupId>
-	    <artifactId>calcite-druid</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.calcite.avatica</groupId>
-	    <artifactId>avatica</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.hadoop</groupId>
-	    <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.logging.log4j</groupId>
-	    <artifactId>log4j-1.2-api</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.logging.log4j</groupId>
-	    <artifactId>log4j-slf4j-impl</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>stax</groupId>
-	    <artifactId>stax-api</artifactId>
-	  </exclusion>
-	</exclusions>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-core</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.calcite</groupId>
+            <artifactId>calcite-druid</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.calcite.avatica</groupId>
+            <artifactId>avatica</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-server-resourcemanager</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>stax</groupId>
+            <artifactId>stax-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.orc</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-serde</artifactId>
         <version>${hive.version}</version>
-	<exclusions>
-	  <exclusion>
-	    <groupId>javax.servlet</groupId>
-	    <artifactId>servlet-api</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.logging.log4j</groupId>
-	    <artifactId>log4j-1.2-api</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.logging.log4j</groupId>
-	    <artifactId>log4j-slf4j-impl</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.logging.log4j</groupId>
-	    <artifactId>log4j-web</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.apache.parquet</groupId>
-	    <artifactId>parquet-hadoop-bundle</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.eclipse.jetty.aggregate</groupId>
-	    <artifactId>jetty-all</artifactId>
-	  </exclusion>
-	  <exclusion>
-	    <groupId>org.eclipse.jetty.orbit</groupId>
-	    <artifactId>javax.servlet</artifactId>
-	  </exclusion>
-	</exclusions>
+        <exclusions>
+          <exclusion>
+            <groupId>javax.servlet</groupId>
+            <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-web</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop-bundle</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty.aggregate</groupId>
+            <artifactId>jetty-all</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.eclipse.jetty.orbit</groupId>
+            <artifactId>javax.servlet</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.orc</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>
@@ -441,13 +459,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
-	<scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-log4j12</artifactId>
         <version>${slf4j.version}</version>
-	<scope>runtime</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -37,6 +37,11 @@
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-shims</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-gen</artifactId>
+      <version>1.7.0-SNAPSHOT</version>
+    </dependency>
 
     <!-- inter-project -->
     <dependency>
@@ -151,12 +156,40 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>generate-sources</id>
+            <phase>generate-sources</phase>
+            <configuration>
+              <target>
+                <property name="compile.classpath"
+                          refid="maven.compile.classpath"/>
+                <taskdef name="filtergen"
+                         classname="org.apache.orc.gen.FilterGenerator"
+                         classpath="${compile.classpath}"/>
+                <mkdir dir="${project.build.directory}/generated-sources/java/org/apache/orc/filter/impl"/>
+                <mkdir dir="${project.build.directory}/generated-test-sources/java/org/apache/orc/filter/impl"/>
+                <filtergen templateDir="${basedir}/src/gen/filters"
+                           srcPkgDir="${project.build.directory}/generated-sources/java/org/apache/orc/filter/impl"
+                           testPkgDir="${project.build.directory}/generated-test-sources/java/org/apache/orc/filter/impl"
+                />
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/java/core/src/findbugs/exclude.xml
+++ b/java/core/src/findbugs/exclude.xml
@@ -70,4 +70,8 @@
     <Class name="org.apache.orc.TypeDescription"/>
     <Method name="equals" />
   </Match>
+  <Match>
+    <Bug pattern="URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"/>
+    <Class name="org.apache.orc.impl.reader.StripePlanner$StreamInformation"/>
+  </Match>
 </FindBugsFilter>

--- a/java/core/src/gen/filters/create_bt.txt
+++ b/java/core/src/gen/filters/create_bt.txt
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  public static LeafFilter create<Not>BetweenFilter(String colName,
+                                              PredicateLeaf.Type type,
+                                              Object low,
+                                              Object high,
+                                              TypeDescription colType,
+                                              OrcFile.Version version) {
+    switch (type) {
+      case BOOLEAN:
+        return new Long<Not>Between(colName, (boolean) low ? 1L : 0L, (boolean) high ? 1L : 0L);
+      case DATE:
+        //TODO Fix the predicate to be an Int instead of sql.Date
+        return new Long<Not>Between(colName, ((Date) low).toLocalDate().toEpochDay(), ((Date) high).toLocalDate().toEpochDay());
+      case DECIMAL:
+        HiveDecimalWritable dLow = (HiveDecimalWritable) low;
+        HiveDecimalWritable dHigh = (HiveDecimalWritable) high;
+        assert dLow.scale() <= colType.getScale() && dLow.scale() <= colType.getScale();
+        if (isDecimalAsLong(version, colType.getPrecision())) {
+          return new Long<Not>Between(colName, dLow.serialize64(colType.getScale()), dHigh.serialize64(colType.getScale()));
+        } else {
+          return new Decimal<Not>Between(colName, dLow, dHigh);
+        }
+      case FLOAT:
+        return new Float<Not>Between(colName, low, high);
+      case LONG:
+        return new Long<Not>Between(colName, low, high);
+      case STRING:
+        return new String<Not>Between(colName, low, high);
+      case TIMESTAMP:
+        return new Timestamp<Not>Between(colName, low, high);
+      default:
+        throw new IllegalArgumentException(String.format("<Not>Between does not support type: %s", type));
+    }
+  }

--- a/java/core/src/gen/filters/create_in.txt
+++ b/java/core/src/gen/filters/create_in.txt
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  public static LeafFilter create<Not>InFilter(String colName,
+                                              PredicateLeaf.Type type,
+                                              List<Object> inList,
+                                              TypeDescription colType,
+                                              OrcFile.Version version) {
+    switch (type) {
+      case BOOLEAN:
+        return new Long<Not>In(colName,
+                               inList.stream().map((Object v) -> (boolean) v ? 1L : 0L)
+                                 .collect(Collectors.toList()));
+      case DATE:
+        //TODO Fix the predicate to be an Int instead of sql.Date
+        return new Long<Not>In(colName,
+                               inList.stream()
+                                 .map((Object v) -> ((Date) v).toLocalDate().toEpochDay())
+                                 .collect(Collectors.toList()));
+      case DECIMAL:
+        if (isDecimalAsLong(version, colType.getPrecision())) {
+          List<Object> values = new ArrayList<>(inList.size());
+          for (int i = 0; i < inList.size(); i++) {
+            HiveDecimalWritable v = (HiveDecimalWritable) inList.get(i);
+            assert v.scale() <= colType.getScale();
+            values.add(v.serialize64(colType.getScale()));
+          }
+          return new Long<Not>In(colName, values);
+        } else {
+          return new Decimal<Not>In(colName, inList);
+        }
+      case FLOAT:
+        return new Float<Not>In(colName, inList);
+      case LONG:
+        return new Long<Not>In(colName, inList);
+      case STRING:
+        return new String<Not>In(colName, inList);
+      case TIMESTAMP:
+        return new Timestamp<Not>In(colName, inList);
+      default:
+        throw new IllegalArgumentException(String.format("<Not>In does not support type: %s", type));
+    }
+  }

--- a/java/core/src/gen/filters/create_leaf.txt
+++ b/java/core/src/gen/filters/create_leaf.txt
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  public static LeafFilter create<Not><Operator>Filter(String colName,
+                                              PredicateLeaf.Type type,
+                                              Object literal,
+                                              TypeDescription colType,
+                                              OrcFile.Version version) {
+    switch (type) {
+      case BOOLEAN:
+        return new Long<Not><Operator>(colName, (boolean) literal ? 1L : 0L);
+      case DATE:
+        //TODO Fix the predicate to be an Int instead of sql.Date
+        return new Long<Not><Operator>(colName, ((Date) literal).toLocalDate().toEpochDay());
+      case DECIMAL:
+        HiveDecimalWritable d = (HiveDecimalWritable) literal;
+        assert d.scale() <= colType.getScale();
+        if (isDecimalAsLong(version, colType.getPrecision())) {
+          return new Long<Not><Operator>(colName, d.serialize64(colType.getScale()));
+        } else {
+          return new Decimal<Not><Operator>(colName, d);
+        }
+      case FLOAT:
+        return new Float<Not><Operator>(colName, literal);
+      case LONG:
+        return new Long<Not><Operator>(colName, literal);
+      case STRING:
+        return new String<Not><Operator>(colName, literal);
+      case TIMESTAMP:
+        return new Timestamp<Not><Operator>(colName, literal);
+      default:
+        throw new IllegalArgumentException(String.format("<Not><Operator> does not support type: %s", type));
+    }
+  }

--- a/java/core/src/gen/filters/decimal_bt.txt
+++ b/java/core/src/gen/filters/decimal_bt.txt
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.filter.impl.LeafFilter;
+
+public class <ClassName> extends LeafFilter {
+  private final HiveDecimalWritable low;
+  private final HiveDecimalWritable high;
+
+  protected <ClassName>(String colName,
+                           Object low,
+                           Object high) {
+    super(colName);
+    this.low = (HiveDecimalWritable) low;
+    this.high = (HiveDecimalWritable) high;
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return ((DecimalColumnVector) v).vector[rowIdx].compareTo(low) <LowOp> 0
+           <LogOp> ((DecimalColumnVector) v).vector[rowIdx].compareTo(high) <HighOp> 0;
+  }
+}

--- a/java/core/src/gen/filters/decimal_cmp.txt
+++ b/java/core/src/gen/filters/decimal_cmp.txt
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.filter.impl.LeafFilter;
+
+public class <ClassName> extends LeafFilter {
+  private final HiveDecimalWritable aValue;
+
+  public <ClassName>(String colName,
+                          Object aValue) {
+    super(colName);
+    this.aValue = (HiveDecimalWritable) aValue;
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return ((DecimalColumnVector) v).vector[rowIdx].compareTo(aValue) <Operator> 0;
+  }
+}

--- a/java/core/src/gen/filters/decimal_in.txt
+++ b/java/core/src/gen/filters/decimal_in.txt
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class <ClassName> extends LeafFilter {
+
+  private final Set<HiveDecimalWritable> inValues;
+
+  protected <ClassName>(String colName, List<Object> values) {
+    super(colName);
+    inValues = new HashSet<>(values.size());
+    for (Object value : values) {
+      inValues.add((HiveDecimalWritable) value);
+    }
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return <NotOp>inValues.contains(((DecimalColumnVector) v).vector[rowIdx]);
+  }
+}

--- a/java/core/src/gen/filters/filter_binary_test.txt
+++ b/java/core/src/gen/filters/filter_binary_test.txt
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Test
+  public void test<Operator>() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .<SOperator>("<ColName>", PredicateLeaf.Type.<TypeName>,
+          getPredicateValue(PredicateLeaf.Type.<TypeName>, lowIdx),
+          getPredicateValue(PredicateLeaf.Type.<TypeName>, highIdx))
+      .build();
+    Assert.assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(PredicateLeaf.Operator.<OperatorName>, false);
+  }
+
+  @Test
+  public void testNot<Operator>() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .<SOperator>("<ColName>", PredicateLeaf.Type.<TypeName>,
+          getPredicateValue(PredicateLeaf.Type.<TypeName>, lowIdx),
+          getPredicateValue(PredicateLeaf.Type.<TypeName>, highIdx))
+      .end()
+      .build();
+    Assert.assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(PredicateLeaf.Operator.<OperatorName>, true);
+  }

--- a/java/core/src/gen/filters/filter_noarg_test.txt
+++ b/java/core/src/gen/filters/filter_noarg_test.txt
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  @Test
+  public void test<Operator>() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .<SOperator>("<ColName>", PredicateLeaf.Type.<TypeName>)
+      .build();
+    Assert.assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(PredicateLeaf.Operator.<OperatorName>, false);
+  }
+
+  @Test
+  public void testNot<Operator>() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .<SOperator>("<ColName>", PredicateLeaf.Type.<TypeName>)
+      .end()
+      .build();
+    Assert.assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(PredicateLeaf.Operator.<OperatorName>, true);
+  }

--- a/java/core/src/gen/filters/filter_test.txt
+++ b/java/core/src/gen/filters/filter_test.txt
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.filter.FilterFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class <ClassName> extends ATestGenFilter {
+
+<Methods>
+
+}

--- a/java/core/src/gen/filters/filter_unary_test.txt
+++ b/java/core/src/gen/filters/filter_unary_test.txt
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+  @Test
+  public void test<Operator>() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .<SOperator>("<ColName>", PredicateLeaf.Type.<TypeName>, getPredicateValue(PredicateLeaf.Type.<TypeName>, lowIdx))
+      .build();
+    Assert.assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(PredicateLeaf.Operator.<OperatorName>, false);
+  }
+
+  @Test
+  public void testNot<Operator>() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .<SOperator>("<ColName>", PredicateLeaf.Type.<TypeName>, getPredicateValue(PredicateLeaf.Type.<TypeName>, lowIdx))
+      .end()
+      .build();
+    Assert.assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(PredicateLeaf.Operator.<OperatorName>, true);
+  }

--- a/java/core/src/gen/filters/leaf_factory.txt
+++ b/java/core/src/gen/filters/leaf_factory.txt
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.filter.impl.LeafFilter;
+import org.apache.orc.filter.VectorFilter;
+
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.orc.impl.TreeReaderFactory.isDecimalAsLong;
+
+public class LeafFilterFactory {
+
+  private LeafFilterFactory() {
+
+  }
+
+<Methods>
+
+}

--- a/java/core/src/gen/filters/string_bt.txt
+++ b/java/core/src/gen/filters/string_bt.txt
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.nio.charset.StandardCharsets;
+
+public class <ClassName> extends LeafFilter {
+  final byte[] low;
+  final byte[] high;
+
+  public <ClassName>(String colName, Object low, Object high) {
+    super(colName);
+    this.low = ((String) low).getBytes(StandardCharsets.UTF_8);
+    this.high = ((String) high).getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    BytesColumnVector bv = (BytesColumnVector) v;
+    return StringExpr.compare(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx],
+                              low, 0, low.length) <LowOp> 0
+           <LogOp> StringExpr.compare(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx],
+                                 high, 0, high.length) <HighOp> 0;
+  }
+}

--- a/java/core/src/gen/filters/string_cmp.txt
+++ b/java/core/src/gen/filters/string_cmp.txt
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.nio.charset.StandardCharsets;
+
+public class <ClassName> extends LeafFilter {
+
+  private final byte[] aValue;
+
+  public <ClassName>(String colName, Object aValue) {
+    super(colName);
+    this.aValue = ((String) aValue).getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    BytesColumnVector bv = (BytesColumnVector) v;
+    return StringExpr.compare(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx],
+                              aValue, 0, aValue.length) <Operator> 0;
+  }
+}

--- a/java/core/src/gen/filters/string_eq.txt
+++ b/java/core/src/gen/filters/string_eq.txt
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.nio.charset.StandardCharsets;
+
+public class <ClassName> extends LeafFilter {
+
+  private final byte[] aValue;
+
+  public <ClassName>(String colName, Object aValue) {
+    super(colName);
+    this.aValue = ((String) aValue).getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    BytesColumnVector bv = (BytesColumnVector) v;
+    return <NotOp>StringExpr.equal(aValue, 0, aValue.length,
+                            bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx]);
+  }
+}

--- a/java/core/src/gen/filters/string_in.txt
+++ b/java/core/src/gen/filters/string_in.txt
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.orc.filter.impl.LeafFilter;
+import org.apache.orc.util.CuckooSetBytes;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class <ClassName> extends LeafFilter {
+
+  // The set object containing the IN list. This is optimized for lookup
+  // of the data type of the column.
+  private final CuckooSetBytes inSet;
+
+  public <ClassName>(String colName, List<Object> values) {
+    super(colName);
+    final byte[][] inValues = new byte[values.size()][];
+    for (int i = 0; i < values.size(); i++) {
+      inValues[i] = ((String) values.get(i)).getBytes(StandardCharsets.UTF_8);
+    }
+    inSet = new CuckooSetBytes(inValues.length);
+    inSet.load(inValues);
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    BytesColumnVector bv = (BytesColumnVector) v;
+    return <NotOp>inSet.lookup(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx]);
+  }
+}

--- a/java/core/src/gen/filters/timestamp_bt.txt
+++ b/java/core/src/gen/filters/timestamp_bt.txt
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.sql.Timestamp;
+
+public class <ClassName> extends LeafFilter {
+
+  private final Timestamp low;
+  private final Timestamp high;
+
+  public <ClassName>(String colName, Object low, Object high) {
+    super(colName);
+    this.low = (Timestamp) low;
+    this.high = (Timestamp) high;
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return ((TimestampColumnVector) v).compareTo(rowIdx, low) <LowOp> 0
+           <LogOp> ((TimestampColumnVector) v).compareTo(rowIdx, high) <HighOp> 0;
+  }
+}

--- a/java/core/src/gen/filters/timestamp_cmp.txt
+++ b/java/core/src/gen/filters/timestamp_cmp.txt
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.sql.Timestamp;
+
+public class <ClassName> extends LeafFilter {
+  private final Timestamp aValue;
+
+  public <ClassName>(String colName, Object aValue) {
+    super(colName);
+    this.aValue = (Timestamp) aValue;
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return ((TimestampColumnVector) v).compareTo(rowIdx, aValue) <Operator> 0;
+  }
+}

--- a/java/core/src/gen/filters/timestamp_in.txt
+++ b/java/core/src/gen/filters/timestamp_in.txt
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.sql.Timestamp;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class <ClassName> extends LeafFilter {
+  private final Set<Timestamp> inValues;
+
+  protected <ClassName>(String colName, List<Object> values) {
+    super(colName);
+    inValues = new HashSet<>(values.size());
+    for (Object value : values) {
+      inValues.add((Timestamp) value);
+    }
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return <NotOp>inValues.contains(((TimestampColumnVector) v).asScratchTimestamp(rowIdx));
+  }
+}

--- a/java/core/src/gen/filters/type_bt.txt
+++ b/java/core/src/gen/filters/type_bt.txt
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.<LeafVector>;
+import org.apache.orc.filter.impl.LeafFilter;
+
+public class <ClassName> extends LeafFilter {
+
+  private final <LeafType> low;
+  private final <LeafType> high;
+
+  public <ClassName>(String colName, Object low, Object high) {
+    super(colName);
+    this.low = (<LeafType>) low;
+    this.high = (<LeafType>) high;
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return ((<LeafVector>) v).vector[rowIdx] <LowOp> low
+           <LogOp> ((<LeafVector>) v).vector[rowIdx] <HighOp> high;
+  }
+}

--- a/java/core/src/gen/filters/type_cmp.txt
+++ b/java/core/src/gen/filters/type_cmp.txt
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.<LeafVector>;
+import org.apache.orc.filter.impl.LeafFilter;
+
+public class <ClassName> extends LeafFilter {
+  final <LeafType> aValue;
+
+  public <ClassName>(String colName, Object aValue) {
+    super(colName);
+    this.aValue = (<LeafType>) aValue;
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return ((<LeafVector>) v).vector[rowIdx] <Operator> aValue;
+  }
+}

--- a/java/core/src/gen/filters/type_in.txt
+++ b/java/core/src/gen/filters/type_in.txt
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.<LeafVector>;
+import org.apache.orc.filter.impl.LeafFilter;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class <ClassName> extends LeafFilter {
+  public final <LeafType>[] inValues;
+
+  public <ClassName>(String colName, List<Object> values) {
+    super(colName);
+    inValues = new <LeafType>[values.size()];
+    for (int i = 0; i < values.size(); i++) {
+      inValues[i] = (<LeafType>) values.get(i);
+    }
+    Arrays.sort(inValues);
+  }
+
+  @Override
+  protected boolean allow(ColumnVector v, int rowIdx) {
+    return Arrays.binarySearch(inValues, ((<LeafVector>) v).vector[rowIdx]) <InOp> 0;
+  }
+}

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -159,6 +159,11 @@ public enum OrcConf {
     "A boolean flag to enable overwriting of the output file if it already exists.\n"),
   IS_SCHEMA_EVOLUTION_CASE_SENSITIVE("orc.schema.evolution.case.sensitive", "orc.schema.evolution.case.sensitive", true,
           "A boolean flag to determine if the comparision of field names in schema evolution is case sensitive .\n"),
+  ALLOW_SARG_TO_FILTER("orc.sarg.to.filter", "org.sarg.to.filter", false,
+                       "A boolean flag to determine if a SArg is allowed to become a filter"),
+  ALLOW_SELECTED_VECTOR("orc.sarg.to.filter.selected", "orc.sarg.to.filter.selected", false,
+                            "A boolean flag to determine if selected vector is supported by reader when SArg conversion to filter is allowed. "
+                            + "If unsure please leave this as false otherwise you might see incorrect results"),
   WRITE_VARIABLE_LENGTH_BLOCKS("orc.write.variable.length.blocks", null, false,
       "A boolean flag as to whether the ORC writer should write variable length\n"
       + "HDFS blocks."),

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
-import org.apache.orc.filter.FilterContext;
+import org.apache.orc.filter.OrcFilterContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -195,7 +195,7 @@ public interface Reader extends Closeable {
     private Boolean skipCorruptRecords = null;
     private TypeDescription schema = null;
     private String[] preFilterColumns = null;
-    Consumer<FilterContext> skipRowCallback = null;
+    Consumer<OrcFilterContext> skipRowCallback = null;
     private DataReader dataReader = null;
     private Boolean tolerateMissingSchema = null;
     private boolean forcePositionalEvolution;
@@ -269,7 +269,7 @@ public interface Reader extends Closeable {
      *
      * @return this
      */
-    public Options setRowFilter(String[] filterColumnNames, Consumer<FilterContext> filterCallback) {
+    public Options setRowFilter(String[] filterColumnNames, Consumer<OrcFilterContext> filterCallback) {
       this.preFilterColumns = filterColumnNames;
       this.skipRowCallback =  filterCallback;
       return this;
@@ -386,7 +386,7 @@ public interface Reader extends Closeable {
       return sarg;
     }
 
-    public Consumer<FilterContext> getFilterCallback() {
+    public Consumer<OrcFilterContext> getFilterCallback() {
       return skipRowCallback;
     }
 

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -26,7 +26,9 @@ import java.util.function.Consumer;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.filter.FilterContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The interface for reading ORC files.
@@ -181,6 +183,8 @@ public interface Reader extends Closeable {
    * Options for creating a RecordReader.
    */
   class Options implements Cloneable {
+    private static final Logger LOG = LoggerFactory.getLogger(Options.class);
+
     private boolean[] include;
     private long offset = 0;
     private long length = Long.MAX_VALUE;
@@ -191,7 +195,7 @@ public interface Reader extends Closeable {
     private Boolean skipCorruptRecords = null;
     private TypeDescription schema = null;
     private String[] preFilterColumns = null;
-    Consumer<VectorizedRowBatch> skipRowCallback = null;
+    Consumer<FilterContext> skipRowCallback = null;
     private DataReader dataReader = null;
     private Boolean tolerateMissingSchema = null;
     private boolean forcePositionalEvolution;
@@ -265,7 +269,7 @@ public interface Reader extends Closeable {
      *
      * @return this
      */
-    public Options setRowFilter(String[] filterColumnNames, Consumer<VectorizedRowBatch> filterCallback) {
+    public Options setRowFilter(String[] filterColumnNames, Consumer<FilterContext> filterCallback) {
       this.preFilterColumns = filterColumnNames;
       this.skipRowCallback =  filterCallback;
       return this;
@@ -382,7 +386,7 @@ public interface Reader extends Closeable {
       return sarg;
     }
 
-    public Consumer<VectorizedRowBatch> getFilterCallback() {
+    public Consumer<FilterContext> getFilterCallback() {
       return skipRowCallback;
     }
 

--- a/java/core/src/java/org/apache/orc/filter/FilterContext.java
+++ b/java/core/src/java/org/apache/orc/filter/FilterContext.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.filter.MutableFilterContext;
+import org.apache.orc.TypeDescription;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * This defines the input for any filter operation.
+ *
+ * It offers a convenience method for finding the column vector from a given name, that the filters
+ * can invoke to get access to the column vector.
+ */
+public class FilterContext implements MutableFilterContext {
+
+  VectorizedRowBatch batch = null;
+  // Cache of field to ColumnVector, this is reset everytime the batch reference changes
+  private final Map<String, ColumnVector> vectors;
+  private final TypeDescription readSchema;
+
+  public FilterContext(TypeDescription readSchema) {
+    this.readSchema = readSchema;
+    this.vectors = new HashMap<>();
+  }
+
+  public FilterContext setBatch(@NotNull VectorizedRowBatch batch) {
+    if (batch != this.batch) {
+      this.batch = batch;
+      vectors.clear();
+    }
+    return this;
+  }
+
+  @Override
+  public void setFilterContext(boolean selectedInUse, int[] selected, int selectedSize) {
+    batch.setFilterContext(selectedInUse, selected, selectedSize);
+  }
+
+  @Override
+  public boolean validateSelected() {
+    return batch.validateSelected();
+  }
+
+  @Override
+  public int[] updateSelected(int i) {
+    return batch.updateSelected(i);
+  }
+
+  @Override
+  public void setSelectedInUse(boolean b) {
+    batch.setSelectedInUse(b);
+  }
+
+  @Override
+  public void setSelected(int[] ints) {
+    batch.setSelected(ints);
+  }
+
+  @Override
+  public void setSelectedSize(int i) {
+    batch.setSelectedSize(i);
+  }
+
+  @Override
+  public void reset() {
+    batch.reset();
+  }
+
+  @Override
+  public boolean isSelectedInUse() {
+    return batch.isSelectedInUse();
+  }
+
+  @Override
+  public int[] getSelected() {
+    return batch.getSelected();
+  }
+
+  @Override
+  public int getSelectedSize() {
+    return batch.getSelectedSize();
+  }
+
+  public ColumnVector[] getCols() {
+    return batch.cols;
+  }
+
+  /**
+   * Retrieves the column vector that matches the specified name. Allows support for nested struct
+   * references e.g. order.date where data is a field in a struct called order.
+   *
+   * @param name The column name whose vector should be retrieved
+   * @return The column vector
+   * @throws IllegalArgumentException if the field is not found or if the nested field is not part
+   * of a struct
+   */
+  public ColumnVector findColumnVector(String name) {
+    if (!vectors.containsKey(name)) {
+      vectors.put(name, findVector(name));
+    }
+
+    return vectors.get(name);
+  }
+
+  private ColumnVector findVector(String name) {
+    String[] refs = name.split(SPLIT_ON_PERIOD);
+    TypeDescription schema = readSchema;
+    List<String> fNames = schema.getFieldNames();
+    ColumnVector[] cols = batch.cols;
+    ColumnVector vector;
+
+    // Try to find the required column at the top level
+    int idx = findVectorIdx(refs[0], fNames);
+    vector = cols[idx];
+
+    // In case we are asking for a nested search further. Only nested struct references are allowed.
+    for (int i = 1; i < refs.length; i++) {
+      schema = schema.getChildren().get(idx);
+      if (schema.getCategory() != TypeDescription.Category.STRUCT) {
+        throw new IllegalArgumentException(String.format(
+          "Field %s:%s not a struct field does not allow nested reference",
+          refs[i - 1],
+          schema));
+      }
+      cols = ((StructColumnVector) vector).fields;
+      vector = cols[findVectorIdx(refs[i], schema.getFieldNames())];
+    }
+
+    return vector;
+  }
+
+  private static int findVectorIdx(String name, List<String> fieldNames) {
+    int idx = fieldNames.indexOf(name);
+    if (idx < 0) {
+      throw new IllegalArgumentException(String.format("Field %s not found in %s",
+                                                       name,
+                                                       fieldNames));
+    }
+    return idx;
+  }
+
+  private static final String SPLIT_ON_PERIOD = Pattern.quote(".");
+
+}

--- a/java/core/src/java/org/apache/orc/filter/FilterFactory.java
+++ b/java/core/src/java/org/apache/orc/filter/FilterFactory.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter;
+
+import org.apache.hadoop.hive.ql.io.sarg.ExpressionTree;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.filter.impl.AndFilter;
+import org.apache.orc.filter.impl.BatchFilter;
+import org.apache.orc.filter.impl.IsNotNullFilter;
+import org.apache.orc.filter.impl.IsNullFilter;
+import org.apache.orc.filter.impl.LeafFilterFactory;
+import org.apache.orc.filter.impl.OrFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class FilterFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(FilterFactory.class);
+
+  // For Testing only
+  public static Consumer<OrcFilterContext> createVectorFilter(SearchArgument sArg,
+                                                           TypeDescription readSchema) {
+    return createVectorFilter(sArg, readSchema, OrcFile.Version.UNSTABLE_PRE_2_0);
+  }
+
+  public static Consumer<OrcFilterContext> createVectorFilter(SearchArgument sArg,
+                                                           TypeDescription readSchema,
+                                                           OrcFile.Version version) {
+    return createVectorFilter(sArg, readSchema, version, false);
+  }
+
+  public static Consumer<OrcFilterContext> createVectorFilter(SearchArgument sArg,
+                                                           TypeDescription readSchema,
+                                                           OrcFile.Version version,
+                                                           boolean normalize) {
+    try {
+      Set<String> colIds = new HashSet<>();
+      //TODO Once HIVE-24458 is merged, should use the getUnexpandedExpression for performance
+      // reasons
+      VectorFilter filter = createVectorFilter(sArg.getExpression(),
+                                               colIds,
+                                               sArg.getLeaves(),
+                                               readSchema,
+                                               version);
+      return new BatchFilter(filter, colIds.toArray(new String[0]));
+    } catch (UnSupportedSArgException e) {
+      LOG.warn("SArg: {} is not supported\n{}", sArg, e.getMessage());
+      return null;
+    }
+  }
+
+  public static VectorFilter createVectorFilter(ExpressionTree expr,
+                                                Set<String> colIds,
+                                                List<PredicateLeaf> leaves,
+                                                TypeDescription readSchema,
+                                                OrcFile.Version version)
+    throws UnSupportedSArgException {
+    VectorFilter result;
+    switch (expr.getOperator()) {
+      case OR:
+        VectorFilter[] orFilters = new VectorFilter[expr.getChildren().size()];
+        for (int i = 0; i < expr.getChildren().size(); i++) {
+          orFilters[i] = createVectorFilter(expr.getChildren().get(i),
+                                            colIds,
+                                            leaves,
+                                            readSchema,
+                                            version);
+        }
+        result = new OrFilter(orFilters);
+        break;
+      case AND:
+        VectorFilter[] andFilters = new VectorFilter[expr.getChildren().size()];
+        for (int i = 0; i < expr.getChildren().size(); i++) {
+          andFilters[i] = createVectorFilter(expr.getChildren().get(i),
+                                             colIds,
+                                             leaves,
+                                             readSchema,
+                                             version);
+        }
+        result = new AndFilter(andFilters);
+        break;
+      case NOT:
+        // Not is expected to be pushed down that it only happens on leaf filters
+        ExpressionTree leaf = expr.getChildren().get(0);
+        assert leaf.getOperator() == ExpressionTree.Operator.LEAF;
+        result = createNotLeafVectorFilter(leaves.get(leaf.getLeaf()),
+                                           colIds,
+                                           readSchema,
+                                           version);
+        break;
+      case LEAF:
+        result = createLeafVectorFilter(leaves.get(expr.getLeaf()), colIds, readSchema, version);
+        break;
+      default:
+        throw new UnSupportedSArgException(String.format("SArg expression: %s is not supported",
+                                                         expr));
+    }
+    return result;
+  }
+
+  private static VectorFilter createLeafVectorFilter(PredicateLeaf leaf,
+                                                     Set<String> colIds,
+                                                     TypeDescription readSchema,
+                                                     OrcFile.Version version)
+    throws UnSupportedSArgException {
+    VectorFilter result;
+    colIds.add(leaf.getColumnName());
+    TypeDescription colType = readSchema.findSubtype(leaf.getColumnName());
+
+    switch (leaf.getOperator()) {
+      case IN:
+        result = LeafFilterFactory.createInFilter(leaf.getColumnName(),
+                                                  leaf.getType(),
+                                                  leaf.getLiteralList(),
+                                                  colType,
+                                                  version);
+        break;
+      case EQUALS:
+        result = LeafFilterFactory.createEqualsFilter(leaf.getColumnName(),
+                                                      leaf.getType(),
+                                                      leaf.getLiteral(),
+                                                      colType,
+                                                      version);
+        break;
+      case LESS_THAN:
+        result = LeafFilterFactory.createLessThanFilter(leaf.getColumnName(),
+                                                        leaf.getType(),
+                                                        leaf.getLiteral(),
+                                                        colType,
+                                                        version);
+        break;
+      case LESS_THAN_EQUALS:
+        result = LeafFilterFactory.createLessThanEqualsFilter(leaf.getColumnName(),
+                                                              leaf.getType(),
+                                                              leaf.getLiteral(),
+                                                              colType,
+                                                              version);
+        break;
+      case BETWEEN:
+        result = LeafFilterFactory.createBetweenFilter(leaf.getColumnName(),
+                                                       leaf.getType(),
+                                                       leaf.getLiteralList().get(0),
+                                                       leaf.getLiteralList().get(1),
+                                                       colType,
+                                                       version);
+        break;
+      case IS_NULL:
+        result = new IsNullFilter(leaf.getColumnName());
+        break;
+      default:
+        throw new UnSupportedSArgException(String.format("Predicate: %s is not supported", leaf));
+    }
+    return result;
+  }
+
+  private static VectorFilter createNotLeafVectorFilter(PredicateLeaf leaf,
+                                                        Set<String> colIds,
+                                                        TypeDescription readSchema,
+                                                        OrcFile.Version version)
+    throws UnSupportedSArgException {
+    VectorFilter result;
+    colIds.add(leaf.getColumnName());
+    TypeDescription colType = readSchema.findSubtype(leaf.getColumnName());
+
+    switch (leaf.getOperator()) {
+      case IN:
+        result = LeafFilterFactory.createNotInFilter(leaf.getColumnName(),
+                                                     leaf.getType(),
+                                                     leaf.getLiteralList(),
+                                                     colType,
+                                                     version);
+        break;
+      case EQUALS:
+        result = LeafFilterFactory.createNotEqualsFilter(leaf.getColumnName(),
+                                                         leaf.getType(),
+                                                         leaf.getLiteral(),
+                                                         colType,
+                                                         version);
+        break;
+      case LESS_THAN:
+        result = LeafFilterFactory.createNotLessThanFilter(leaf.getColumnName(),
+                                                           leaf.getType(),
+                                                           leaf.getLiteral(),
+                                                           colType,
+                                                           version);
+        break;
+      case LESS_THAN_EQUALS:
+        result = LeafFilterFactory.createNotLessThanEqualsFilter(leaf.getColumnName(),
+                                                                 leaf.getType(),
+                                                                 leaf.getLiteral(),
+                                                                 colType,
+                                                                 version);
+        break;
+      case BETWEEN:
+        result = LeafFilterFactory.createNotBetweenFilter(leaf.getColumnName(),
+                                                          leaf.getType(),
+                                                          leaf.getLiteralList().get(0),
+                                                          leaf.getLiteralList().get(1),
+                                                          colType,
+                                                          version);
+        break;
+      case IS_NULL:
+        result = new IsNotNullFilter(leaf.getColumnName());
+        break;
+      default:
+        throw new UnSupportedSArgException(String.format("Predicate: %s is not supported", leaf));
+    }
+    return result;
+  }
+
+  public static class UnSupportedSArgException extends Exception {
+
+    public UnSupportedSArgException(String message) {
+      super(message);
+    }
+  }
+}

--- a/java/core/src/java/org/apache/orc/filter/OrcFilterContext.java
+++ b/java/core/src/java/org/apache/orc/filter/OrcFilterContext.java
@@ -32,23 +32,23 @@ import java.util.regex.Pattern;
 
 /**
  * This defines the input for any filter operation.
- *
+ * <p>
  * It offers a convenience method for finding the column vector from a given name, that the filters
  * can invoke to get access to the column vector.
  */
-public class FilterContext implements MutableFilterContext {
+public class OrcFilterContext implements MutableFilterContext {
 
   VectorizedRowBatch batch = null;
   // Cache of field to ColumnVector, this is reset everytime the batch reference changes
   private final Map<String, ColumnVector> vectors;
   private final TypeDescription readSchema;
 
-  public FilterContext(TypeDescription readSchema) {
+  public OrcFilterContext(TypeDescription readSchema) {
     this.readSchema = readSchema;
     this.vectors = new HashMap<>();
   }
 
-  public FilterContext setBatch(@NotNull VectorizedRowBatch batch) {
+  public OrcFilterContext setBatch(@NotNull VectorizedRowBatch batch) {
     if (batch != this.batch) {
       this.batch = batch;
       vectors.clear();
@@ -117,7 +117,7 @@ public class FilterContext implements MutableFilterContext {
    * @param name The column name whose vector should be retrieved
    * @return The column vector
    * @throws IllegalArgumentException if the field is not found or if the nested field is not part
-   * of a struct
+   *                                  of a struct
    */
   public ColumnVector findColumnVector(String name) {
     if (!vectors.containsKey(name)) {

--- a/java/core/src/java/org/apache/orc/filter/VectorFilter.java
+++ b/java/core/src/java/org/apache/orc/filter/VectorFilter.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter;
+
+import org.apache.orc.filter.impl.Selected;
+
+public interface VectorFilter {
+
+  /**
+   * Filter the vectorized row batch that is wrapped into the FilterContext.
+   *  @param fc     The filter context that contains the VectorizedRowBatch
+   * @param bound  The bound of the scan
+   * @param selIn  The current selection
+   * @param selOut The result selection
+   */
+  void filter(OrcFilterContext fc, Selected bound, Selected selIn, Selected selOut);
+
+}

--- a/java/core/src/java/org/apache/orc/filter/impl/AndFilter.java
+++ b/java/core/src/java/org/apache/orc/filter/impl/AndFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+
+public class AndFilter implements VectorFilter {
+  public final VectorFilter[] filters;
+  private final Selected andBound = new Selected();
+
+  public AndFilter(VectorFilter[] filters) {
+    this.filters = filters;
+  }
+
+  @Override
+  public void filter(OrcFilterContext fc,
+                     Selected bound,
+                     Selected selIn,
+                     Selected selOut) {
+    andBound.set(bound);
+    for (VectorFilter f : filters) {
+      // For an AND filter, the bound and in are the same
+      f.filter(fc, andBound, selIn, selOut);
+      // Update the AND bound
+      andBound.set(selOut);
+    }
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/filter/impl/BatchFilter.java
+++ b/java/core/src/java/org/apache/orc/filter/impl/BatchFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+
+import java.util.function.Consumer;
+
+public class BatchFilter implements Consumer<OrcFilterContext> {
+
+  final VectorFilter filter;
+  private final String[] colNames;
+  private final Selected bound = new Selected();
+  private final Selected selIn = new Selected();
+  private final Selected selOut = new Selected();
+
+  public BatchFilter(VectorFilter filter, String[] colNames) {
+    this.filter = filter;
+    this.colNames = colNames;
+  }
+
+  @Override
+  public void accept(OrcFilterContext fc) {
+    // Define the bound to be the batch size
+    bound.initSelected(fc.getSelectedSize());
+    // None of the selected values are protected
+    selIn.selSize = 0;
+    // selOut is set to the selectedVector
+    selOut.sel = fc.getSelected();
+    selOut.selSize = 0;
+    filter.filter(fc, bound, selIn, selOut);
+
+    if (selOut.selSize < fc.getSelectedSize()) {
+      fc.setSelectedSize(selOut.selSize);
+      fc.setSelectedInUse(true);
+    } else if (selOut.selSize > fc.getSelectedSize()) {
+      throw new RuntimeException(
+        String.format("Unexpected state: Filtered size %s > input size %s",
+                      selOut.selSize, fc.getSelectedSize()));
+    }
+  }
+
+  public String[] getColNames() {
+    return colNames;
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/filter/impl/IsNotNullFilter.java
+++ b/java/core/src/java/org/apache/orc/filter/impl/IsNotNullFilter.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+
+public class IsNotNullFilter implements VectorFilter {
+
+  private final String colName;
+
+  public IsNotNullFilter(String colName) {
+    this.colName = colName;
+  }
+
+  @Override
+  public void filter(OrcFilterContext fc,
+                     Selected bound,
+                     Selected selIn,
+                     Selected selOut) {
+    ColumnVector v = fc.findColumnVector(colName);
+    int inIdx = 0;
+    int currSize = 0;
+    int rowIdx;
+
+    if (v.noNulls) {
+      // In case we don't have any nulls, then irrespective of the repeating status, select all the
+      // values
+      for (int i = 0; i < bound.selSize; i++) {
+        rowIdx = bound.sel[i];
+
+        if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+          // Row already protected, no need to evaluate
+          inIdx++;
+          continue;
+        }
+
+        // Select the row
+        selOut.sel[currSize++] = rowIdx;
+      }
+    } else if (!v.isRepeating) {
+      // As we have at least one null in this branch, we are only need to check if it is repeating
+      // otherwise the repeating value will be null.
+      for (int i = 0; i < bound.selSize; i++) {
+        rowIdx = bound.sel[i];
+
+        if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+          // Row already protected, no need to evaluate
+          inIdx++;
+          continue;
+        }
+
+        // Select if the value is not null
+        if (!v.isNull[rowIdx]) {
+          selOut.sel[currSize++] = rowIdx;
+        }
+      }
+    }
+
+    selOut.selSize = currSize;
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/filter/impl/IsNullFilter.java
+++ b/java/core/src/java/org/apache/orc/filter/impl/IsNullFilter.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+
+public class IsNullFilter implements VectorFilter {
+
+  private final String colName;
+
+  public IsNullFilter(String colName) {
+    this.colName = colName;
+  }
+
+  @Override
+  public void filter(OrcFilterContext fc,
+                     Selected bound,
+                     Selected selIn,
+                     Selected selOut) {
+    ColumnVector v = fc.findColumnVector(colName);
+    int inIdx = 0;
+    int currSize = 0;
+    int rowIdx;
+
+    if (!v.noNulls) {
+      // If the vector does not have nulls then none of them are selected
+      if (v.isRepeating) {
+        // If the repeating vector is null then set all as selected.
+        for (int i = 0; i < bound.selSize; i++) {
+          // Identify the rowIdx from the selected vector
+          rowIdx = bound.sel[i];
+          if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+            // Row already selected, no need to evaluate
+            inIdx++;
+            continue;
+          }
+          selOut.sel[currSize++] = rowIdx;
+        }
+      } else {
+        for (int i = 0; i < bound.selSize; i++) {
+          // Identify the rowIdx from the selected vector
+          rowIdx = bound.sel[i];
+          if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+            // Row already selected, no need to evaluate
+            inIdx++;
+            continue;
+          }
+
+          if (v.isNull[rowIdx]) {
+            selOut.sel[currSize++] = rowIdx;
+          }
+        }
+      }
+    }
+    selOut.selSize = currSize;
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/filter/impl/LeafFilter.java
+++ b/java/core/src/java/org/apache/orc/filter/impl/LeafFilter.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+
+public abstract class LeafFilter implements VectorFilter {
+  private final String colName;
+
+  protected LeafFilter(String colName) {
+    this.colName = colName;
+  }
+
+  @Override
+  public void filter(OrcFilterContext fc,
+                     Selected bound,
+                     Selected selIn,
+                     Selected selOut) {
+    ColumnVector v = fc.findColumnVector(colName);
+    int inIdx = 0;
+    int currSize = 0;
+    int rowIdx;
+
+    if (v.isRepeating) {
+      if (allow(v, 0)) {
+        // If the repeating value is allowed then allow the current selSize
+        for (int i = 0; i < bound.selSize; i++) {
+          rowIdx = bound.sel[i];
+          if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+            // Row already protected, no need to evaluate
+            inIdx++;
+            continue;
+          }
+          selOut.sel[currSize++] = rowIdx;
+        }
+      }
+    } else if (v.noNulls) {
+      for (int i = 0; i < bound.selSize; i++) {
+        rowIdx = bound.sel[i];
+
+        if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+          // Row already protected, no need to evaluate
+          inIdx++;
+          continue;
+        }
+
+        // Check the value
+        if (allow(v, rowIdx)) {
+          selOut.sel[currSize++] = rowIdx;
+        }
+      }
+    } else {
+      for (int i = 0; i < bound.selSize; i++) {
+        rowIdx = bound.sel[i];
+
+        if (inIdx < selIn.selSize && rowIdx == selIn.sel[inIdx]) {
+          // Row already protected, no need to evaluate
+          inIdx++;
+          continue;
+        }
+
+        // Check the value only if not null
+        if (!v.isNull[rowIdx] && allow(v, rowIdx)) {
+          selOut.sel[currSize++] = rowIdx;
+        }
+      }
+    }
+
+    selOut.selSize = currSize;
+  }
+
+  abstract protected boolean allow(ColumnVector v, int rowIdx);
+
+}

--- a/java/core/src/java/org/apache/orc/filter/impl/OrFilter.java
+++ b/java/core/src/java/org/apache/orc/filter/impl/OrFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+
+public class OrFilter implements VectorFilter {
+
+  public final VectorFilter[] filters;
+  private final Selected orOut = new Selected();
+
+  public OrFilter(VectorFilter[] filters) {
+    this.filters = filters;
+  }
+
+  public static void merge(Selected src, Selected tgt) {
+    int writeIdx = src.selSize + tgt.selSize - 1;
+    int srcIdx = src.selSize - 1;
+    int tgtIdx = tgt.selSize - 1;
+
+    while (tgtIdx >= 0 || srcIdx >= 0) {
+      if (srcIdx < 0 || (tgtIdx >= 0 && src.sel[srcIdx] < tgt.sel[tgtIdx])) {
+        // tgt is larger or src is exhausted
+        tgt.sel[writeIdx--] = tgt.sel[tgtIdx--];
+      } else {
+        // b is smaller or equal
+        tgt.sel[writeIdx--] = src.sel[srcIdx--];
+      }
+    }
+    tgt.selSize += src.selSize;
+  }
+
+  @Override
+  public void filter(OrcFilterContext fc,
+                     Selected bound,
+                     Selected selIn,
+                     Selected selOut) {
+    orOut.ensureSize(bound.selSize);
+    // Carry the current protections forward
+    selOut.set(selIn);
+    for (VectorFilter f : filters) {
+      // In case of OR since we have to append to existing output, pass an empty orOut
+      orOut.selSize = 0;
+      f.filter(fc, bound, selOut, orOut);
+      // During an OR operation the size cannot decrease
+      merge(orOut, selOut);
+    }
+  }
+}

--- a/java/core/src/java/org/apache/orc/filter/impl/Selected.java
+++ b/java/core/src/java/org/apache/orc/filter/impl/Selected.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+public class Selected {
+
+  static final Selected EMPTY_SELECTED = new Selected();
+
+  int[] sel;
+  int selSize;
+
+  Selected(int[] sel) {
+    this.sel = sel;
+    this.selSize = 0;
+  }
+
+  Selected() {
+    this(new int[1024]);
+  }
+
+  void initSelected(int batchSize) {
+    ensureSize(batchSize);
+    selSize = batchSize;
+    for (int i = 0; i < selSize; i++) {
+      sel[i] = i;
+    }
+  }
+
+  void ensureSize(int size) {
+    if (size > sel.length) {
+      sel = new int[size];
+      selSize = 0;
+    }
+  }
+
+  void set(Selected inBound) {
+    ensureSize(inBound.selSize);
+    System.arraycopy(inBound.sel, 0, sel, 0, inBound.selSize);
+    selSize = inBound.selSize;
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/BufferChunk.java
+++ b/java/core/src/java/org/apache/orc/impl/BufferChunk.java
@@ -69,8 +69,22 @@ public class BufferChunk extends DiskRangeList {
 
   @Override
   public DiskRange sliceAndShift(long offset, long end, long shiftBy) {
-    // Method has no code references
-    throw new UnsupportedOperationException();
+    assert offset <= end && offset >= this.offset && end <= this.end;
+    assert offset + shiftBy >= 0;
+    ByteBuffer sliceBuf = chunk.slice();
+    int newPos = (int) (offset - this.offset);
+    int newLimit = newPos + (int) (end - offset);
+    try {
+      sliceBuf.position(newPos);
+      sliceBuf.limit(newLimit);
+    } catch (Throwable t) {
+      LOG.error("Failed to slice buffer chunk with range" + " [" + this.offset + ", " + this.end
+          + "), position: " + chunk.position() + " limit: " + chunk.limit() + ", "
+          + (chunk.isDirect() ? "direct" : "array") + "; to [" + offset + ", " + end + ") "
+          + t.getClass());
+      throw new RuntimeException(t);
+    }
+    return new BufferChunk(sliceBuf, offset + shiftBy);
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/BufferChunk.java
+++ b/java/core/src/java/org/apache/orc/impl/BufferChunk.java
@@ -69,22 +69,8 @@ public class BufferChunk extends DiskRangeList {
 
   @Override
   public DiskRange sliceAndShift(long offset, long end, long shiftBy) {
-    assert offset <= end && offset >= this.offset && end <= this.end;
-    assert offset + shiftBy >= 0;
-    ByteBuffer sliceBuf = chunk.slice();
-    int newPos = (int) (offset - this.offset);
-    int newLimit = newPos + (int) (end - offset);
-    try {
-      sliceBuf.position(newPos);
-      sliceBuf.limit(newLimit);
-    } catch (Throwable t) {
-      LOG.error("Failed to slice buffer chunk with range" + " [" + this.offset + ", " + this.end
-          + "), position: " + chunk.position() + " limit: " + chunk.limit() + ", "
-          + (chunk.isDirect() ? "direct" : "array") + "; to [" + offset + ", " + end + ") "
-          + t.getClass());
-      throw new RuntimeException(t);
-    }
-    return new BufferChunk(sliceBuf, offset + shiftBy);
+    // Method has no code references
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/BufferChunkList.java
+++ b/java/core/src/java/org/apache/orc/impl/BufferChunkList.java
@@ -66,5 +66,4 @@ public class BufferChunkList {
     head = null;
     tail = null;
   }
-
 }

--- a/java/core/src/java/org/apache/orc/impl/BufferChunkList.java
+++ b/java/core/src/java/org/apache/orc/impl/BufferChunkList.java
@@ -22,6 +22,14 @@ package org.apache.orc.impl;
  * Builds a list of buffer chunks
  */
 public class BufferChunkList {
+  public BufferChunk getHead() {
+    return head;
+  }
+
+  public BufferChunk getTail() {
+    return tail;
+  }
+
   private BufferChunk head;
   private BufferChunk tail;
 
@@ -58,4 +66,5 @@ public class BufferChunkList {
     head = null;
     tail = null;
   }
+
 }

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -403,7 +403,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       fromReader.nextVector(previousVector, isNull, batchSize, filterContext, readLevel);
       LongColumnVector resultColVector = (LongColumnVector) previousVector;
       if (downCastNeeded) {
@@ -457,7 +458,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
@@ -542,7 +544,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
@@ -582,7 +585,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
@@ -618,7 +622,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
@@ -657,7 +662,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
@@ -693,7 +699,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
@@ -731,7 +738,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
@@ -768,7 +776,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
@@ -790,7 +799,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       // Read present/isNull stream
       fromReader.nextVector(previousVector, isNull, batchSize, filterContext, readLevel);
       DoubleColumnVector vector = (DoubleColumnVector) previousVector;
@@ -829,7 +839,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
@@ -876,7 +887,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
@@ -919,7 +931,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
@@ -964,7 +977,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
@@ -1006,7 +1020,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (fileDecimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         fileDecimalColVector = new DecimalColumnVector(batchSize, filePrecision, fileScale);
@@ -1041,7 +1056,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
@@ -1101,7 +1117,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
@@ -1150,7 +1167,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
@@ -1272,7 +1290,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
@@ -1310,7 +1329,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new DateColumnVector(batchSize);
@@ -1336,7 +1356,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       fromReader.nextVector(previousVector, isNull, batchSize, filterContext, readLevel);
 
       BytesColumnVector resultColVector = (BytesColumnVector) previousVector;
@@ -1398,7 +1419,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (inBytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         inBytesColVector = new BytesColumnVector(batchSize);
@@ -1442,7 +1464,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
@@ -1503,7 +1526,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
@@ -1562,7 +1586,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
@@ -1620,7 +1645,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
@@ -1663,7 +1689,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new DateColumnVector(batchSize);
@@ -1706,7 +1733,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
@@ -1758,7 +1786,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+                           FilterContext filterContext,
+                           ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -257,27 +257,27 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     }
 
     @Override
-    public void startStripe(StripePlanner planner, ReadLevel rLevel) throws IOException {
+    public void startStripe(StripePlanner planner, ReadLevel readLevel) throws IOException {
       // Pass-thru.
-      fromReader.startStripe(planner, rLevel);
+      fromReader.startStripe(planner, readLevel);
     }
 
     @Override
-    public void seek(PositionProvider[] index, ReadLevel rLevel) throws IOException {
+    public void seek(PositionProvider[] index, ReadLevel readLevel) throws IOException {
      // Pass-thru.
-      fromReader.seek(index, rLevel);
+      fromReader.seek(index, readLevel);
     }
 
     @Override
-    public void seek(PositionProvider index, ReadLevel rLevel) throws IOException {
+    public void seek(PositionProvider index, ReadLevel readLevel) throws IOException {
       // Pass-thru.
-      fromReader.seek(index, rLevel);
+      fromReader.seek(index, readLevel);
     }
 
     @Override
-    public void skipRows(long items, ReadLevel rLevel) throws IOException {
+    public void skipRows(long items, ReadLevel readLevel) throws IOException {
       // Pass-thru.
-      fromReader.skipRows(items, rLevel);
+      fromReader.skipRows(items, readLevel);
     }
 
     /**
@@ -403,8 +403,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
-      fromReader.nextVector(previousVector, isNull, batchSize, filterContext, rLevel);
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+      fromReader.nextVector(previousVector, isNull, batchSize, filterContext, readLevel);
       LongColumnVector resultColVector = (LongColumnVector) previousVector;
       if (downCastNeeded) {
         if (resultColVector.isRepeating) {
@@ -457,14 +457,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
         longColVector = (LongColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(doubleColVector, longColVector, batchSize);
     }
@@ -542,14 +542,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
         longColVector = (LongColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(decimalColVector, longColVector, batchSize);
     }
@@ -582,14 +582,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         longColVector = (LongColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(bytesColVector, longColVector, batchSize);
     }
@@ -618,14 +618,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         longColVector = (LongColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(timestampColVector, longColVector, batchSize);
     }
@@ -657,14 +657,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
         doubleColVector = (DoubleColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(longColVector, doubleColVector, batchSize);
     }
@@ -693,14 +693,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
         doubleColVector = (DoubleColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(decimalColVector, doubleColVector, batchSize);
     }
@@ -731,14 +731,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         doubleColVector = (DoubleColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(bytesColVector, doubleColVector, batchSize);
     }
@@ -768,14 +768,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         doubleColVector = (DoubleColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(timestampColVector, doubleColVector, batchSize);
     }
@@ -790,9 +790,9 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       // Read present/isNull stream
-      fromReader.nextVector(previousVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(previousVector, isNull, batchSize, filterContext, readLevel);
       DoubleColumnVector vector = (DoubleColumnVector) previousVector;
       if (previousVector.isRepeating) {
         vector.vector[0] = (float) vector.vector[0];
@@ -829,14 +829,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
         decimalColVector = previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(longColVector, decimalColVector, batchSize);
     }
@@ -876,14 +876,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
         decimalColVector = previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(doubleColVector, decimalColVector, batchSize);
     }
@@ -919,14 +919,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         decimalColVector = previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(bytesColVector, decimalColVector, batchSize);
     }
@@ -964,14 +964,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         decimalColVector = previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(timestampColVector, decimalColVector, batchSize);
     }
@@ -1006,14 +1006,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (fileDecimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         fileDecimalColVector = new DecimalColumnVector(batchSize, filePrecision, fileScale);
         decimalColVector = previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(fileDecimalColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(fileDecimalColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(fileDecimalColVector, decimalColVector, batchSize);
     }
@@ -1041,14 +1041,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(longColVector, bytesColVector, batchSize);
     }
@@ -1101,14 +1101,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(doubleColVector, bytesColVector, batchSize);
     }
@@ -1150,14 +1150,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
         bytesColVector = (BytesColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(decimalColVector, bytesColVector, batchSize);
     }
@@ -1272,14 +1272,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(timestampColVector, bytesColVector, batchSize);
     }
@@ -1310,14 +1310,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new DateColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(longColVector, bytesColVector, batchSize);
     }
@@ -1336,8 +1336,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
-      fromReader.nextVector(previousVector, isNull, batchSize, filterContext, rLevel);
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
+      fromReader.nextVector(previousVector, isNull, batchSize, filterContext, readLevel);
 
       BytesColumnVector resultColVector = (BytesColumnVector) previousVector;
 
@@ -1398,14 +1398,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (inBytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         inBytesColVector = new BytesColumnVector(batchSize);
         outBytesColVector = (BytesColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(inBytesColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(inBytesColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(inBytesColVector, outBytesColVector, batchSize);
     }
@@ -1442,7 +1442,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
@@ -1450,7 +1450,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream
-      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(longColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, true);
@@ -1503,7 +1503,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (doubleColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
@@ -1511,7 +1511,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream
-      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(doubleColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, true);
@@ -1562,7 +1562,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (decimalColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
@@ -1570,7 +1570,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream
-      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(decimalColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, true);
@@ -1620,14 +1620,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         timestampColVector = (TimestampColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(bytesColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, false);
@@ -1663,14 +1663,14 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (longColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new DateColumnVector(batchSize);
         timestampColVector = (TimestampColumnVector) previousVector;
       }
       // Read present/isNull stream
-      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(longColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, false);
@@ -1706,7 +1706,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (bytesColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
@@ -1722,7 +1722,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         }
       }
       // Read present/isNull stream
-      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(bytesColVector, longColVector, batchSize);
       if (dateColumnVector != null) {
@@ -1758,7 +1758,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void nextVector(ColumnVector previousVector,
                            boolean[] isNull,
                            final int batchSize,
-                           FilterContext filterContext, ReadLevel rLevel) throws IOException {
+                           FilterContext filterContext, ReadLevel readLevel) throws IOException {
       if (timestampColVector == null) {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
@@ -1769,7 +1769,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         }
       }
       // Read present/isNull stream
-      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, rLevel);
+      fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readLevel);
 
       convertVector(timestampColVector, longColVector, batchSize);
       if (longColVector instanceof DateColumnVector) {

--- a/java/core/src/java/org/apache/orc/impl/OrcAcidUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcAcidUtils.java
@@ -28,6 +28,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetDecoder;
+import java.nio.charset.StandardCharsets;
 
 public class OrcAcidUtils {
   public static final String ACID_STATS = "hive.acid.stats";
@@ -68,7 +69,7 @@ public class OrcAcidUtils {
     }
   }
 
-  private static final Charset utf8 = Charset.forName("UTF-8");
+  private static final Charset utf8 = StandardCharsets.UTF_8;
   private static final CharsetDecoder utf8Decoder = utf8.newDecoder();
 
   public static AcidStats parseAcidStats(Reader reader) {

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -74,7 +74,7 @@ public class ReaderImpl implements Reader {
   protected List<OrcProto.StripeStatistics> stripeStatistics;
   private final int metadataSize;
   protected final List<OrcProto.Type> types;
-  private TypeDescription schema;
+  private final TypeDescription schema;
   private final List<OrcProto.UserMetadataItem> userMetadata;
   private final List<OrcProto.ColumnStatistics> fileStats;
   private final List<StripeInformation> stripes;

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -545,7 +545,7 @@ public class RecordReaderUtils {
 
     private long currentGeneration = 0;
 
-    private final TreeMap<Key, ByteBuffer> getBufferTree(boolean direct) {
+    private TreeMap<Key, ByteBuffer> getBufferTree(boolean direct) {
       return direct ? directBuffers : buffers;
     }
 

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.OrcProto;
+import org.apache.orc.filter.OrcFilterContext;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
 import org.apache.orc.impl.reader.tree.BatchReader;
@@ -70,7 +71,7 @@ public class TreeReaderFactory {
 
     Set<Integer> getColumnFilterIds();
 
-    Consumer<org.apache.orc.filter.FilterContext> getColumnFilterCallback();
+    Consumer<OrcFilterContext> getColumnFilterCallback();
 
     boolean isSkipCorrupt();
 
@@ -97,7 +98,7 @@ public class TreeReaderFactory {
     private boolean useProlepticGregorian;
     private boolean fileUsedProlepticGregorian;
     private Set<Integer> filterColumnIds = Collections.emptySet();
-    Consumer<org.apache.orc.filter.FilterContext> filterCallback;
+    Consumer<OrcFilterContext> filterCallback;
 
     public ReaderContext setSchemaEvolution(SchemaEvolution evolution) {
       this.evolution = evolution;
@@ -109,7 +110,7 @@ public class TreeReaderFactory {
       return this;
     }
 
-    public ReaderContext setFilterCallback(Set<Integer> filterColumnsList, Consumer<org.apache.orc.filter.FilterContext> filterCallback) {
+    public ReaderContext setFilterCallback(Set<Integer> filterColumnsList, Consumer<OrcFilterContext> filterCallback) {
       this.filterColumnIds = filterColumnsList;
       this.filterCallback = filterCallback;
       return this;
@@ -153,7 +154,7 @@ public class TreeReaderFactory {
     }
 
     @Override
-    public Consumer<org.apache.orc.filter.FilterContext> getColumnFilterCallback() {
+    public Consumer<OrcFilterContext> getColumnFilterCallback() {
       return filterCallback;
     }
 
@@ -692,7 +693,6 @@ public class TreeReaderFactory {
 
     @Override
     public void startStripe(StripePlanner planner, ReadLevel readLevel) throws IOException {
-
       super.startStripe(planner, readLevel);
       StreamName name = new StreamName(columnId,
           OrcProto.Stream.Kind.DATA);
@@ -707,7 +707,6 @@ public class TreeReaderFactory {
 
     @Override
     public void seek(PositionProvider index, ReadLevel readLevel) throws IOException {
-
       super.seek(index, readLevel);
       reader.seek(index);
     }
@@ -1500,7 +1499,6 @@ public class TreeReaderFactory {
 
     @Override
     public void startStripe(StripePlanner planner, ReadLevel readLevel) throws IOException {
-
       super.startStripe(planner, readLevel);
       valueStream = planner.getStream(new StreamName(columnId,
           OrcProto.Stream.Kind.DATA));
@@ -1515,7 +1513,6 @@ public class TreeReaderFactory {
 
     @Override
     public void seek(PositionProvider index, ReadLevel readLevel) throws IOException {
-
       super.seek(index, readLevel);
       valueStream.seek(index);
       scaleReader.seek(index);
@@ -1729,7 +1726,6 @@ public class TreeReaderFactory {
 
     @Override
     public void skipRows(long items, ReadLevel readLevel) throws IOException {
-
       items = countNonNulls(items);
       HiveDecimalWritable scratchDecWritable = new HiveDecimalWritable();
       for (int i = 0; i < items; i++) {
@@ -2351,19 +2347,12 @@ public class TreeReaderFactory {
   public static class CharTreeReader extends StringTreeReader {
     int maxLength;
 
-    CharTreeReader(int columnId,
-                   int maxLength,
-                   Context context) throws IOException {
+    CharTreeReader(int columnId, int maxLength, Context context) throws IOException {
       this(columnId, maxLength, null, null, null, null, null, context);
     }
 
-    protected CharTreeReader(int columnId,
-                             int maxLength,
-                             InStream present,
-                             InStream data,
-                             InStream length,
-                             InStream dictionary,
-                             OrcProto.ColumnEncoding encoding,
+    protected CharTreeReader(int columnId, int maxLength, InStream present, InStream data,
+                             InStream length, InStream dictionary, OrcProto.ColumnEncoding encoding,
                              Context context) throws IOException {
       super(columnId, present, data, length, dictionary, encoding, context);
       this.maxLength = maxLength;
@@ -2417,19 +2406,12 @@ public class TreeReaderFactory {
   public static class VarcharTreeReader extends StringTreeReader {
     int maxLength;
 
-    VarcharTreeReader(int columnId,
-                      int maxLength,
-                      Context context) throws IOException {
+    VarcharTreeReader(int columnId, int maxLength, Context context) throws IOException {
       this(columnId, maxLength, null, null, null, null, null, context);
     }
 
-    protected VarcharTreeReader(int columnId,
-                                int maxLength,
-                                InStream present,
-                                InStream data,
-                                InStream length,
-                                InStream dictionary,
-                                OrcProto.ColumnEncoding encoding,
+    protected VarcharTreeReader(int columnId, int maxLength, InStream present, InStream data,
+                                InStream length, InStream dictionary, OrcProto.ColumnEncoding encoding,
                                 Context context) throws IOException {
       super(columnId, present, data, length, dictionary, encoding, context);
       this.maxLength = maxLength;
@@ -2959,5 +2941,4 @@ public class TreeReaderFactory {
       return new PrimitiveBatchReader(reader);
     }
   }
-
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -82,7 +82,6 @@ public class StripePlanner {
   private final OrcProto.Stream.Kind[] bloomFilterKinds;
   // does each column have a null stream?
   private final boolean[] hasNull;
-  // Filter columns ids
   private final Set<Integer> filterColIds;
 
   /**
@@ -93,7 +92,7 @@ public class StripePlanner {
    * @param version the file writer version
    * @param ignoreNonUtf8BloomFilter ignore old non-utf8 bloom filters
    * @param maxBufferSize the largest single buffer to use
-   * @param filterColIds Column Ids that indicate the filter columns
+   * @param filterColIds Column Ids that identify the filter columns
    */
   public StripePlanner(TypeDescription schema,
                        ReaderEncryption encryption,
@@ -175,9 +174,9 @@ public class StripePlanner {
   }
 
   public BufferChunkList readFollowData(OrcIndex index,
-                                          boolean[] rowGroupInclude,
-                                          int rgIdx,
-                                          boolean forceDirect)
+                                        boolean[] rowGroupInclude,
+                                        int rgIdx,
+                                        boolean forceDirect)
     throws IOException {
     BufferChunkList chunks = (index == null || rowGroupInclude == null)
       ? planDataReading(ReadLevel.FOLLOW)
@@ -390,7 +389,6 @@ public class StripePlanner {
 
   private void addChunk(BufferChunkList list, StreamInformation stream,
                         long offset, long length) {
-
     while (length > 0) {
       long thisLen = Math.min(length, maxBufferSize);
       BufferChunk chunk = new BufferChunk(offset, (int) thisLen);

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
@@ -52,8 +52,8 @@ public abstract class BatchReader {
 
   /**
    * Read the next batch of data from the file.
-   * @param batch     the batch to read into
-   * @param batchSize the number of rows to read
+   * @param batch        the batch to read into
+   * @param batchSize    the number of rows to read
    * @param readLevel    defines the read level i.e. ALL, LEAD or FOLLOW
    * @throws IOException errors reading the file
    */

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
@@ -38,8 +38,8 @@ public abstract class BatchReader {
     this.rootType = rootType;
   }
 
-  public void startStripe(StripePlanner planner, ReadLevel rLevel) throws IOException {
-    rootType.startStripe(planner, rLevel);
+  public void startStripe(StripePlanner planner, ReadLevel readLevel) throws IOException {
+    rootType.startStripe(planner, readLevel);
   }
 
   public void startStripe(StripePlanner planner) throws IOException {
@@ -54,12 +54,12 @@ public abstract class BatchReader {
    * Read the next batch of data from the file.
    * @param batch     the batch to read into
    * @param batchSize the number of rows to read
-   * @param rLevel    defines the read level i.e. ALL, LEAD or FOLLOW
+   * @param readLevel    defines the read level i.e. ALL, LEAD or FOLLOW
    * @throws IOException errors reading the file
    */
   public abstract void nextBatch(VectorizedRowBatch batch,
                                  int batchSize,
-                                 ReadLevel rLevel) throws IOException;
+                                 ReadLevel readLevel) throws IOException;
 
   public void nextBatch(VectorizedRowBatch batch, int batchSize) throws IOException {
     nextBatch(batch, batchSize, ReadLevel.ALL);
@@ -70,11 +70,11 @@ public abstract class BatchReader {
     batch.size = batchSize;
   }
 
-  public void skipRows(long rows, ReadLevel rLevel) throws IOException {
-    rootType.skipRows(rows, rLevel);
+  public void skipRows(long rows, ReadLevel readLevel) throws IOException {
+    rootType.skipRows(rows, readLevel);
   }
 
-  public void seek(PositionProvider[] index, ReadLevel rLevel) throws IOException {
-    rootType.seek(index, rLevel);
+  public void seek(PositionProvider[] index, ReadLevel readLevel) throws IOException {
+    rootType.seek(index, readLevel);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
@@ -38,8 +38,12 @@ public abstract class BatchReader {
     this.rootType = rootType;
   }
 
+  public void startStripe(StripePlanner planner, ReadLevel rLevel) throws IOException {
+    rootType.startStripe(planner, rLevel);
+  }
+
   public void startStripe(StripePlanner planner) throws IOException {
-    rootType.startStripe(planner);
+    startStripe(planner, ReadLevel.ALL);
   }
 
   public void setVectorColumnCount(int vectorColumnCount) {
@@ -50,21 +54,27 @@ public abstract class BatchReader {
    * Read the next batch of data from the file.
    * @param batch     the batch to read into
    * @param batchSize the number of rows to read
+   * @param rLevel    defines the read level i.e. ALL, LEAD or FOLLOW
    * @throws IOException errors reading the file
    */
   public abstract void nextBatch(VectorizedRowBatch batch,
-                                 int batchSize) throws IOException;
+                                 int batchSize,
+                                 ReadLevel rLevel) throws IOException;
+
+  public void nextBatch(VectorizedRowBatch batch, int batchSize) throws IOException {
+    nextBatch(batch, batchSize, ReadLevel.ALL);
+  }
 
   protected void resetBatch(VectorizedRowBatch batch, int batchSize) {
     batch.selectedInUse = false;
     batch.size = batchSize;
   }
 
-  public void skipRows(long rows) throws IOException {
-    rootType.skipRows(rows);
+  public void skipRows(long rows, ReadLevel rLevel) throws IOException {
+    rootType.skipRows(rows, rLevel);
   }
 
-  public void seek(PositionProvider[] index) throws IOException {
-    rootType.seek(index);
+  public void seek(PositionProvider[] index, ReadLevel rLevel) throws IOException {
+    rootType.seek(index, rLevel);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/LevelStructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/LevelStructBatchReader.java
@@ -15,24 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.orc.impl.reader.tree;
 
-import java.io.IOException;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.impl.TreeReaderFactory;
 
-public class PrimitiveBatchReader extends BatchReader {
-
-  public PrimitiveBatchReader(TypeReader rowReader) {
-    super(rowReader);
-  }
-
-  @Override
-  public void nextBatch(VectorizedRowBatch batch,
-                        int batchSize,
-                        ReadLevel rLevel) throws IOException {
-  batch.cols[0].reset();
-  batch.cols[0].ensureSize(batchSize, false);
-  rootType.nextVector(batch.cols[0], null, batchSize, batch, rLevel);
-  resetBatch(batch, batchSize);
+public class LevelStructBatchReader extends StructBatchReader {
+  public LevelStructBatchReader(LevelTypeReader rowReader,
+                                TreeReaderFactory.Context context) {
+    super(rowReader.getReader(), context);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/LevelTypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/LevelTypeReader.java
@@ -43,39 +43,39 @@ public class LevelTypeReader implements TypeReader {
   }
 
   @Override
-  public void startStripe(StripePlanner planner, ReadLevel rLevel) throws IOException {
-    if (reader.getReadLevel() != rLevel) {
+  public void startStripe(StripePlanner planner, ReadLevel readLevel) throws IOException {
+    if (reader.getReadLevel() != readLevel) {
       return;
     }
 
-    reader.startStripe(planner, rLevel);
+    reader.startStripe(planner, readLevel);
   }
 
   @Override
-  public void seek(PositionProvider[] index, ReadLevel rLevel) throws IOException {
-    if (reader.getReadLevel() != rLevel) {
+  public void seek(PositionProvider[] index, ReadLevel readLevel) throws IOException {
+    if (reader.getReadLevel() != readLevel) {
       return;
     }
 
-    reader.seek(index, rLevel);
+    reader.seek(index, readLevel);
   }
 
   @Override
-  public void seek(PositionProvider index, ReadLevel rLevel) throws IOException {
-    if (reader.getReadLevel() != rLevel) {
+  public void seek(PositionProvider index, ReadLevel readLevel) throws IOException {
+    if (reader.getReadLevel() != readLevel) {
       return;
     }
 
-    reader.seek(index, rLevel);
+    reader.seek(index, readLevel);
   }
 
   @Override
-  public void skipRows(long rows, ReadLevel rLevel) throws IOException {
-    if (reader.getReadLevel() != rLevel) {
+  public void skipRows(long rows, ReadLevel readLevel) throws IOException {
+    if (reader.getReadLevel() != readLevel) {
       return;
     }
 
-    reader.skipRows(rows, rLevel);
+    reader.skipRows(rows, readLevel);
   }
 
   @Override
@@ -83,12 +83,12 @@ public class LevelTypeReader implements TypeReader {
                          boolean[] isNull,
                          int batchSize,
                          FilterContext filterContext,
-                         ReadLevel rLevel) throws IOException {
-    if (reader.getReadLevel() != rLevel) {
+                         ReadLevel readLevel) throws IOException {
+    if (reader.getReadLevel() != readLevel) {
       return;
     }
 
-    reader.nextVector(previous, isNull, batchSize, filterContext, rLevel);
+    reader.nextVector(previous, isNull, batchSize, filterContext, readLevel);
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/LevelTypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/LevelTypeReader.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.reader.tree;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.io.filter.FilterContext;
+import org.apache.orc.OrcProto;
+import org.apache.orc.impl.PositionProvider;
+import org.apache.orc.impl.reader.StripePlanner;
+
+import java.io.IOException;
+
+/**
+ * Wrapper reader that implements the level logic.
+ * The methods are invoked on the reader only if the read level matches.
+ */
+public class LevelTypeReader implements TypeReader {
+  private final TypeReader reader;
+
+  public LevelTypeReader(TypeReader reader) {
+    this.reader = reader;
+  }
+
+  @Override
+  public void checkEncoding(OrcProto.ColumnEncoding encoding) throws IOException {
+    reader.checkEncoding(encoding);
+  }
+
+  @Override
+  public void startStripe(StripePlanner planner, ReadLevel rLevel) throws IOException {
+    if (reader.getReadLevel() != rLevel) {
+      return;
+    }
+
+    reader.startStripe(planner, rLevel);
+  }
+
+  @Override
+  public void seek(PositionProvider[] index, ReadLevel rLevel) throws IOException {
+    if (reader.getReadLevel() != rLevel) {
+      return;
+    }
+
+    reader.seek(index, rLevel);
+  }
+
+  @Override
+  public void seek(PositionProvider index, ReadLevel rLevel) throws IOException {
+    if (reader.getReadLevel() != rLevel) {
+      return;
+    }
+
+    reader.seek(index, rLevel);
+  }
+
+  @Override
+  public void skipRows(long rows, ReadLevel rLevel) throws IOException {
+    if (reader.getReadLevel() != rLevel) {
+      return;
+    }
+
+    reader.skipRows(rows, rLevel);
+  }
+
+  @Override
+  public void nextVector(ColumnVector previous,
+                         boolean[] isNull,
+                         int batchSize,
+                         FilterContext filterContext,
+                         ReadLevel rLevel) throws IOException {
+    if (reader.getReadLevel() != rLevel) {
+      return;
+    }
+
+    reader.nextVector(previous, isNull, batchSize, filterContext, rLevel);
+  }
+
+  @Override
+  public int getColumnId() {
+    return reader.getColumnId();
+  }
+
+  @Override
+  public ReadLevel getReadLevel() {
+    return reader.getReadLevel();
+  }
+
+  public TypeReader getReader() {
+    return reader;
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/PrimitiveBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/PrimitiveBatchReader.java
@@ -29,10 +29,10 @@ public class PrimitiveBatchReader extends BatchReader {
   @Override
   public void nextBatch(VectorizedRowBatch batch,
                         int batchSize,
-                        ReadLevel rLevel) throws IOException {
+                        ReadLevel readLevel) throws IOException {
   batch.cols[0].reset();
   batch.cols[0].ensureSize(batchSize, false);
-  rootType.nextVector(batch.cols[0], null, batchSize, batch, rLevel);
+  rootType.nextVector(batch.cols[0], null, batchSize, batch, readLevel);
   resetBatch(batch, batchSize);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/ReadLevel.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/ReadLevel.java
@@ -19,7 +19,7 @@
 package org.apache.orc.impl.reader.tree;
 
 public enum ReadLevel {
-  ALL,        // Read every column
-  LEAD,     // Read only the filter columns
+  ALL,     // Read every column
+  LEAD,    // Read only the filter columns
   FOLLOW   // Read the non-filter columns
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/ReadLevel.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/ReadLevel.java
@@ -15,24 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.orc.impl.reader.tree;
 
-import java.io.IOException;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-
-public class PrimitiveBatchReader extends BatchReader {
-
-  public PrimitiveBatchReader(TypeReader rowReader) {
-    super(rowReader);
-  }
-
-  @Override
-  public void nextBatch(VectorizedRowBatch batch,
-                        int batchSize,
-                        ReadLevel rLevel) throws IOException {
-  batch.cols[0].reset();
-  batch.cols[0].ensureSize(batchSize, false);
-  rootType.nextVector(batch.cols[0], null, batchSize, batch, rLevel);
-  resetBatch(batch, batchSize);
-  }
+public enum ReadLevel {
+  ALL,        // Read every column
+  LEAD,     // Read only the filter columns
+  FOLLOW   // Read the non-filter columns
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
@@ -50,22 +50,22 @@ public class StructBatchReader extends BatchReader {
                                TypeReader[] children,
                                int batchSize,
                                int index,
-                               ReadLevel rLevel)
+                               ReadLevel readLevel)
     throws IOException {
     ColumnVector colVector = batch.cols[index];
     if (colVector != null) {
       colVector.reset();
       colVector.ensureSize(batchSize, false);
-      children[index].nextVector(colVector, null, batchSize, batch, rLevel);
+      children[index].nextVector(colVector, null, batchSize, batch, readLevel);
     }
   }
 
   @Override
-  public void nextBatch(VectorizedRowBatch batch, int batchSize, ReadLevel rLevel)
+  public void nextBatch(VectorizedRowBatch batch, int batchSize, ReadLevel readLevel)
     throws IOException {
-    nextBatchLevel(batch, batchSize, rLevel);
+    nextBatchLevel(batch, batchSize, readLevel);
 
-    if (rLevel == ReadLevel.LEAD) {
+    if (readLevel == ReadLevel.LEAD) {
       // Apply filter callback to reduce number of # rows selected for decoding in the next
       // TreeReaders
       if (this.context.getColumnFilterCallback() != null) {
@@ -74,20 +74,20 @@ public class StructBatchReader extends BatchReader {
     }
   }
 
-  private void nextBatchLevel(VectorizedRowBatch batch, int batchSize, ReadLevel rLevel) throws IOException {
+  private void nextBatchLevel(VectorizedRowBatch batch, int batchSize, ReadLevel readLevel) throws IOException {
     TypeReader[] children = structReader.fields;
 
-    if (rLevel != ReadLevel.FOLLOW) {
+    if (readLevel != ReadLevel.FOLLOW) {
       // In case of FOLLOW we leave the selectedInUse untouched.
       batch.selectedInUse = false;
     }
 
     for (int i = 0; i < children.length
                     && (vectorColumnCount == -1 || i < vectorColumnCount); ++i) {
-      readBatchColumn(batch, children, batchSize, i, rLevel);
+      readBatchColumn(batch, children, batchSize, i, readLevel);
     }
 
-    if (rLevel != ReadLevel.FOLLOW) {
+    if (readLevel != ReadLevel.FOLLOW) {
       // Set the batch size when not dealing with follow columns
       batch.size = batchSize;
     }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
@@ -20,7 +20,7 @@ package org.apache.orc.impl.reader.tree;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.apache.orc.filter.FilterContext;
+import org.apache.orc.filter.OrcFilterContext;
 import org.apache.orc.impl.TreeReaderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,13 +32,12 @@ public class StructBatchReader extends BatchReader {
   // The reader context including row-filtering details
   private final TreeReaderFactory.Context context;
   private final TreeReaderFactory.StructTreeReader structReader;
-  private final FilterContext fc;
+  private final OrcFilterContext fc;
 
-  public StructBatchReader(TypeReader rowReader,
-                           TreeReaderFactory.Context context) {
+  public StructBatchReader(TypeReader rowReader, TreeReaderFactory.Context context) {
     super(rowReader);
     this.context = context;
-    this.fc = new FilterContext(context.getSchemaEvolution().getReaderSchema());
+    this.fc = new OrcFilterContext(context.getSchemaEvolution().getReaderSchema());
     if (rowReader instanceof TreeReaderFactory.StructTreeReader) {
       structReader = (TreeReaderFactory.StructTreeReader) rowReader;
     } else {

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
@@ -39,7 +39,8 @@ public interface TypeReader {
   void nextVector(ColumnVector previous,
                   boolean[] isNull,
                   int batchSize,
-                  FilterContext filterContext, ReadLevel readLevel) throws IOException;
+                  FilterContext filterContext,
+                  ReadLevel readLevel) throws IOException;
 
   int getColumnId();
 

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
@@ -28,18 +28,20 @@ import java.io.IOException;
 public interface TypeReader {
   void checkEncoding(OrcProto.ColumnEncoding encoding) throws IOException;
 
-  void startStripe(StripePlanner planner) throws IOException;
+  void startStripe(StripePlanner planner, ReadLevel rLevel) throws IOException;
 
-  void seek(PositionProvider[] index) throws IOException;
+  void seek(PositionProvider[] index, ReadLevel rLevel) throws IOException;
 
-  void seek(PositionProvider index) throws IOException;
+  void seek(PositionProvider index, ReadLevel rLevel) throws IOException;
 
-  void skipRows(long rows) throws IOException;
+  void skipRows(long rows, ReadLevel rLevel) throws IOException;
 
   void nextVector(ColumnVector previous,
                   boolean[] isNull,
                   int batchSize,
-                  FilterContext filterContext) throws IOException;
+                  FilterContext filterContext, ReadLevel rLevel) throws IOException;
 
   int getColumnId();
+
+  ReadLevel getReadLevel();
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
@@ -28,18 +28,18 @@ import java.io.IOException;
 public interface TypeReader {
   void checkEncoding(OrcProto.ColumnEncoding encoding) throws IOException;
 
-  void startStripe(StripePlanner planner, ReadLevel rLevel) throws IOException;
+  void startStripe(StripePlanner planner, ReadLevel readLevel) throws IOException;
 
-  void seek(PositionProvider[] index, ReadLevel rLevel) throws IOException;
+  void seek(PositionProvider[] index, ReadLevel readLevel) throws IOException;
 
-  void seek(PositionProvider index, ReadLevel rLevel) throws IOException;
+  void seek(PositionProvider index, ReadLevel readLevel) throws IOException;
 
-  void skipRows(long rows, ReadLevel rLevel) throws IOException;
+  void skipRows(long rows, ReadLevel readLevel) throws IOException;
 
   void nextVector(ColumnVector previous,
                   boolean[] isNull,
                   int batchSize,
-                  FilterContext filterContext, ReadLevel rLevel) throws IOException;
+                  FilterContext filterContext, ReadLevel readLevel) throws IOException;
 
   int getColumnId();
 

--- a/java/core/src/java/org/apache/orc/util/CuckooSetBytes.java
+++ b/java/core/src/java/org/apache/orc/util/CuckooSetBytes.java
@@ -1,0 +1,443 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.util;
+
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
+
+import java.util.Random;
+
+/**
+ * A high-performance set implementation used to support fast set membership testing,
+ * using Cuckoo hashing. This is used to support fast tests of the form
+ *
+ *       column IN ( <list-of-values )
+ *
+ * For details on the algorithm, see R. Pagh and F. F. Rodler, "Cuckoo Hashing,"
+ * Elsevier Science preprint, Dec. 2003. http://www.itu.dk/people/pagh/papers/cuckoo-jour.pdf.
+ *
+ * Copied from CuckooSetBytes@Apache Hive project for convenience
+ */
+public class CuckooSetBytes {
+  private byte[][] t1;
+  private byte[][] t2;
+  private byte[][] prev1 = null; // used for rehashing to get last set of values
+  private byte[][] prev2 = null; // " "
+  private int n; // current array size
+  private static final double PADDING_FACTOR = 1.0/0.40; // have minimum 40% fill factor
+  private int salt = 0;
+  private final Random gen = new Random(676983475);
+  private int rehashCount = 0;
+  private static final long INT_MASK  = 0x00000000ffffffffL;
+  private static final long BYTE_MASK = 0x00000000000000ffL;
+  // some prime numbers spaced about at powers of 2 in magnitude
+  static final int[] primes = {7, 13, 17, 23, 31, 53, 67, 89, 127, 269, 571, 1019, 2089,
+    4507, 8263, 16361, 32327, 65437, 131111, 258887, 525961, 999983, 2158909, 4074073,
+    8321801, 15485863, 32452867, 67867967, 122949829, 256203221, 553105253, 982451653,
+    1645333507, 2147483647};
+
+  /**
+   * Allocate a new set to hold expectedSize values. Re-allocation to expand
+   * the set is not implemented, so the expected size must be at least the
+   * size of the set to be inserted.
+   * @param expectedSize At least the size of the set of values that will be inserted.
+   */
+  public CuckooSetBytes(int expectedSize) {
+
+    // Choose array size. We have two hash tables to hold entries, so the sum
+    // of the two should have a bit more than twice as much space as the
+    // minimum required.
+    n = (int) (expectedSize * PADDING_FACTOR / 2.0);
+
+    // some prime numbers spaced about at powers of 2 in magnitude
+
+    // try to get prime number table size to have less dependence on good hash function
+    for (int i = 0; i != primes.length; i++) {
+      if (n <= primes[i]) {
+        n = primes[i];
+        break;
+      }
+    }
+
+    t1 = new byte[n][];
+    t2 = new byte[n][];
+    updateHashSalt();
+  }
+
+  /**
+   * Return true if and only if the value in byte array b beginning at start
+   * and ending at start+len is present in the set.
+   */
+  public boolean lookup(byte[] b, int start, int len) {
+
+    return entryEqual(t1, h1(b, start, len), b, start, len)
+        || entryEqual(t2, h2(b, start, len), b, start, len);
+  }
+
+  private static boolean entryEqual(byte[][] t, int hash, byte[] b, int start, int len) {
+    return t[hash] != null && StringExpr.equal(t[hash], 0, t[hash].length, b, start, len);
+  }
+
+  public void insert(byte[] x) {
+    byte[] temp;
+    if (lookup(x, 0, x.length)) {
+      return;
+    }
+
+    // Try to insert up to n times. Rehash if that fails.
+    for(int i = 0; i != n; i++) {
+      int hash1 = h1(x, 0, x.length);
+      if (t1[hash1] == null) {
+        t1[hash1] = x;
+        return;
+      }
+
+      // swap x and t1[h1(x)]
+      temp = t1[hash1];
+      t1[hash1] = x;
+      x = temp;
+
+      int hash2 = h2(x, 0, x.length);
+      if (t2[hash2] == null) {
+        t2[hash2] = x;
+        return;
+      }
+
+      // swap x and t2[h2(x)]
+      temp = t2[hash2];
+      t2[hash2] = x;
+      x = temp;
+    }
+    rehash();
+    insert(x);
+  }
+
+  /**
+   * Insert all values in the input array into the set.
+   */
+  public void load(byte[][] a) {
+    for (byte[] x : a) {
+      insert(x);
+    }
+  }
+
+  /**
+   * Try to insert with up to n value's "poked out". Return the last value poked out.
+   * If the value is not blank then we assume there was a cycle.
+   * Don't try to insert the same value twice. This is for use in rehash only,
+   * so you won't see the same value twice.
+   */
+  private byte[] tryInsert(byte[] x) {
+    byte[] temp;
+
+    for(int i = 0; i != n; i++) {
+      int hash1 = h1(x, 0, x.length);
+      if (t1[hash1] == null) {
+        t1[hash1] = x;
+        return null;
+      }
+
+      // swap x and t1[h1(x)]
+      temp = t1[hash1];
+      t1[hash1] = x;
+      x = temp;
+
+      int hash2 = h2(x, 0, x.length);
+      if (t2[hash2] == null) {
+        t2[hash2] = x;
+        return null;
+      }
+
+      // swap x and t2[h2(x)]
+      temp = t2[hash2];
+      t2[hash2] = x;
+      x = temp;
+      if (x == null) {
+        break;
+      }
+    }
+    return x;
+  }
+
+  /**
+   * first hash function
+   */
+  private int h1(byte[] b, int start, int len) {
+
+    // AND hash with mask to 0 out sign bit to make sure it's positive.
+    // Then we know taking the result mod n is in the range (0..n-1).
+    return (hash(b, start, len, 0) & 0x7FFFFFFF) % n;
+  }
+
+  /**
+   * second hash function
+   */
+  private int h2(byte[] b, int start, int len) {
+
+    // AND hash with mask to 0 out sign bit to make sure it's positive.
+    // Then we know taking the result mod n is in the range (0..n-1).
+    // Include salt as argument so this hash function can be varied
+    // if we need to rehash.
+    return (hash(b, start, len, salt) & 0x7FFFFFFF) % n;
+  }
+
+  /**
+   * In case of rehash, hash function h2 is changed by updating the
+   * salt value passed in to the function hash().
+   */
+  private void updateHashSalt() {
+    salt = gen.nextInt(0x7FFFFFFF);
+  }
+
+  private void rehash() {
+    rehashCount++;
+    if (rehashCount > 20) {
+      throw new RuntimeException("Too many rehashes");
+    }
+    updateHashSalt();
+
+    // Save original values
+    if (prev1 == null) {
+      prev1 = t1;
+      prev2 = t2;
+    }
+    t1 = new byte[n][];
+    t2 = new byte[n][];
+    for (byte[] v  : prev1) {
+      if (v != null) {
+        byte[] x = tryInsert(v);
+        if (x != null) {
+          rehash();
+          return;
+        }
+      }
+    }
+    for (byte[] v  : prev2) {
+      if (v != null) {
+        byte[] x = tryInsert(v);
+        if (x != null) {
+          rehash();
+          return;
+        }
+      }
+    }
+
+    // We succeeded in adding all the values, so
+    // clear the previous values recorded.
+    prev1 = null;
+    prev2 = null;
+  }
+
+  /**
+   * This is adapted from the org.apache.hadoop.util.hash.JenkinsHash package.
+   * The interface needed to be modified to suit the use here, by adding
+   * a start offset parameter to the hash function.
+   *
+   * In the future, folding this back into the original Hadoop package should
+   * be considered. This could could them import that package and use it.
+   * The original comments from the source are below.
+   *
+   * taken from  hashlittle() -- hash a variable-length key into a 32-bit value
+   *
+   * @param key the key (the unaligned variable-length array of bytes)
+   * @param nbytes number of bytes to include in hash
+   * @param initval can be any integer value
+   * @return a 32-bit value.  Every bit of the key affects every bit of the
+   * return value.  Two keys differing by one or two bits will have totally
+   * different hash values.
+   *
+   * <p>The best hash table sizes are powers of 2.  There is no need to do mod
+   * a prime (mod is sooo slow!).  If you need less than 32 bits, use a bitmask.
+   * For example, if you need only 10 bits, do
+   * <code>h = (h & hashmask(10));</code>
+   * In which case, the hash table should have hashsize(10) elements.
+   *
+   * <p>If you are hashing n strings byte[][] k, do it like this:
+   * for (int i = 0, h = 0; i < n; ++i) h = hash( k[i], h);
+   *
+   * <p>By Bob Jenkins, 2006.  bob_jenkins@burtleburtle.net.  You may use this
+   * code any way you wish, private, educational, or commercial.  It's free.
+   *
+   * <p>Use for hash table lookup, or anything where one collision in 2^^32 is
+   * acceptable.  Do NOT use for cryptographic purposes.
+  */
+  @SuppressWarnings("fallthrough")
+  private int hash(byte[] key, int start, int nbytes, int initval) {
+    int length = nbytes;
+    long a, b, c;       // We use longs because we don't have unsigned ints
+    a = b = c = (0x00000000deadbeefL + length + initval) & INT_MASK;
+    int offset = start;
+    for (; length > 12; offset += 12, length -= 12) {
+      a = (a + (key[offset] & BYTE_MASK)) & INT_MASK;
+      a = (a + (((key[offset + 1]  & BYTE_MASK) <<  8) & INT_MASK)) & INT_MASK;
+      a = (a + (((key[offset + 2]  & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      a = (a + (((key[offset + 3]  & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+      b = (b + (key[offset + 4]    & BYTE_MASK)) & INT_MASK;
+      b = (b + (((key[offset + 5]  & BYTE_MASK) <<  8) & INT_MASK)) & INT_MASK;
+      b = (b + (((key[offset + 6]  & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      b = (b + (((key[offset + 7]  & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+      c = (c + (key[offset + 8]    & BYTE_MASK)) & INT_MASK;
+      c = (c + (((key[offset + 9]  & BYTE_MASK) <<  8) & INT_MASK)) & INT_MASK;
+      c = (c + (((key[offset + 10] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+      c = (c + (((key[offset + 11] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+
+      /*
+       * mix -- mix 3 32-bit values reversibly.
+       * This is reversible, so any information in (a,b,c) before mix() is
+       * still in (a,b,c) after mix().
+       *
+       * If four pairs of (a,b,c) inputs are run through mix(), or through
+       * mix() in reverse, there are at least 32 bits of the output that
+       * are sometimes the same for one pair and different for another pair.
+       *
+       * This was tested for:
+       * - pairs that differed by one bit, by two bits, in any combination
+       *   of top bits of (a,b,c), or in any combination of bottom bits of
+       *   (a,b,c).
+       * - "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+       *   the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+       *    is commonly produced by subtraction) look like a single 1-bit
+       *    difference.
+       * - the base values were pseudorandom, all zero but one bit set, or
+       *   all zero plus a counter that starts at zero.
+       *
+       * Some k values for my "a-=c; a^=rot(c,k); c+=b;" arrangement that
+       * satisfy this are
+       *     4  6  8 16 19  4
+       *     9 15  3 18 27 15
+       *    14  9  3  7 17  3
+       * Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing for
+       * "differ" defined as + with a one-bit base and a two-bit delta.  I
+       * used http://burtleburtle.net/bob/hash/avalanche.html to choose
+       * the operations, constants, and arrangements of the variables.
+       *
+       * This does not achieve avalanche.  There are input bits of (a,b,c)
+       * that fail to affect some output bits of (a,b,c), especially of a.
+       * The most thoroughly mixed value is c, but it doesn't really even
+       * achieve avalanche in c.
+       *
+       * This allows some parallelism.  Read-after-writes are good at doubling
+       * the number of bits affected, so the goal of mixing pulls in the
+       * opposite direction as the goal of parallelism.  I did what I could.
+       * Rotates seem to cost as much as shifts on every machine I could lay
+       * my hands on, and rotates are much kinder to the top and bottom bits,
+       * so I used rotates.
+       *
+       * #define mix(a,b,c) \
+       * { \
+       *   a -= c;  a ^= rot(c, 4);  c += b; \
+       *   b -= a;  b ^= rot(a, 6);  a += c; \
+       *   c -= b;  c ^= rot(b, 8);  b += a; \
+       *   a -= c;  a ^= rot(c,16);  c += b; \
+       *   b -= a;  b ^= rot(a,19);  a += c; \
+       *   c -= b;  c ^= rot(b, 4);  b += a; \
+       * }
+       *
+       * mix(a,b,c);
+       */
+      a = (a - c) & INT_MASK;  a ^= rot(c, 4);  c = (c + b) & INT_MASK;
+      b = (b - a) & INT_MASK;  b ^= rot(a, 6);  a = (a + c) & INT_MASK;
+      c = (c - b) & INT_MASK;  c ^= rot(b, 8);  b = (b + a) & INT_MASK;
+      a = (a - c) & INT_MASK;  a ^= rot(c,16);  c = (c + b) & INT_MASK;
+      b = (b - a) & INT_MASK;  b ^= rot(a,19);  a = (a + c) & INT_MASK;
+      c = (c - b) & INT_MASK;  c ^= rot(b, 4);  b = (b + a) & INT_MASK;
+    }
+
+    //-------------------------------- last block: affect all 32 bits of (c)
+    switch (length) {                   // all the case statements fall through
+    case 12:
+      c = (c + (((key[offset + 11] & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+    case 11:
+      c = (c + (((key[offset + 10] & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+    case 10:
+      c = (c + (((key[offset + 9]  & BYTE_MASK) <<  8) & INT_MASK)) & INT_MASK;
+    case  9:
+      c = (c + (key[offset + 8]    & BYTE_MASK)) & INT_MASK;
+    case  8:
+      b = (b + (((key[offset + 7]  & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+    case  7:
+      b = (b + (((key[offset + 6]  & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+    case  6:
+      b = (b + (((key[offset + 5]  & BYTE_MASK) <<  8) & INT_MASK)) & INT_MASK;
+    case  5:
+      b = (b + (key[offset + 4]    & BYTE_MASK)) & INT_MASK;
+    case  4:
+      a = (a + (((key[offset + 3]  & BYTE_MASK) << 24) & INT_MASK)) & INT_MASK;
+    case  3:
+      a = (a + (((key[offset + 2]  & BYTE_MASK) << 16) & INT_MASK)) & INT_MASK;
+    case  2:
+      a = (a + (((key[offset + 1]  & BYTE_MASK) <<  8) & INT_MASK)) & INT_MASK;
+    case  1:
+      a = (a + (key[offset] & BYTE_MASK)) & INT_MASK;
+      break;
+    case  0:
+      return (int)(c & INT_MASK);
+    }
+    /*
+     * final -- final mixing of 3 32-bit values (a,b,c) into c
+     *
+     * Pairs of (a,b,c) values differing in only a few bits will usually
+     * produce values of c that look totally different.  This was tested for
+     * - pairs that differed by one bit, by two bits, in any combination
+     *   of top bits of (a,b,c), or in any combination of bottom bits of
+     *   (a,b,c).
+     *
+     * - "differ" is defined as +, -, ^, or ~^.  For + and -, I transformed
+     *   the output delta to a Gray code (a^(a>>1)) so a string of 1's (as
+     *   is commonly produced by subtraction) look like a single 1-bit
+     *   difference.
+     *
+     * - the base values were pseudorandom, all zero but one bit set, or
+     *   all zero plus a counter that starts at zero.
+     *
+     * These constants passed:
+     *   14 11 25 16 4 14 24
+     *   12 14 25 16 4 14 24
+     * and these came close:
+     *    4  8 15 26 3 22 24
+     *   10  8 15 26 3 22 24
+     *   11  8 15 26 3 22 24
+     *
+     * #define final(a,b,c) \
+     * {
+     *   c ^= b; c -= rot(b,14); \
+     *   a ^= c; a -= rot(c,11); \
+     *   b ^= a; b -= rot(a,25); \
+     *   c ^= b; c -= rot(b,16); \
+     *   a ^= c; a -= rot(c,4);  \
+     *   b ^= a; b -= rot(a,14); \
+     *   c ^= b; c -= rot(b,24); \
+     * }
+     *
+     */
+    c ^= b; c = (c - rot(b,14)) & INT_MASK;
+    a ^= c; a = (a - rot(c,11)) & INT_MASK;
+    b ^= a; b = (b - rot(a,25)) & INT_MASK;
+    c ^= b; c = (c - rot(b,16)) & INT_MASK;
+    a ^= c; a = (a - rot(c,4))  & INT_MASK;
+    b ^= a; b = (b - rot(a,14)) & INT_MASK;
+    c ^= b; c = (c - rot(b,24)) & INT_MASK;
+
+    return (int)(c & INT_MASK);
+  }
+
+  private static long rot(long val, int pos) {
+    return ((Integer.rotateLeft(
+        (int)(val & INT_MASK), pos)) & INT_MASK);
+  }
+}

--- a/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.filter.FilterContext;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class TestRowFilteringIOSkip {
+  private final static Logger LOG = LoggerFactory.getLogger(TestRowFilteringIOSkip.class);
+  private static final Path workDir = new Path(System.getProperty("test.tmp.dir",
+                                                                  "target" + File.separator + "test"
+                                                                  + File.separator + "tmp"));
+
+  private static Configuration conf;
+  private static FileSystem fs;
+  private static final Path filePath = new Path(workDir, "skip_file.orc");
+
+  private static final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createDecimal().withPrecision(20).withScale(6))
+    .addField("f3", TypeDescription.createLong())
+    .addField("f4", TypeDescription.createString())
+    .addField("ridx", TypeDescription.createLong());
+  private static final boolean[] FirstColumnOnly = new boolean[] {true, true, false, false, false
+    , false};
+  private static final long RowCount = 4000000L;
+  private static final String[] FilterColumns = new String[] {"f1", "ridx"};
+  private static final int scale = 3;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    conf = new Configuration();
+    fs = FileSystem.get(conf);
+
+    if (fs.exists(filePath)) {
+      return;
+    }
+
+    LOG.info("Creating file {} with schema {}", filePath, schema);
+    try (Writer writer = OrcFile.createWriter(filePath,
+                                              OrcFile.writerOptions(conf)
+                                                .fileSystem(fs)
+                                                .overwrite(true)
+                                                .rowIndexStride(8192)
+                                                .setSchema(schema))) {
+      Random rnd = new Random(1024);
+      VectorizedRowBatch b = schema.createRowBatch();
+      for (int rowIdx = 0; rowIdx < RowCount; rowIdx++) {
+        long v = rnd.nextLong();
+        for (int colIdx = 0; colIdx < schema.getChildren().size() - 1; colIdx++) {
+          switch (schema.getChildren().get(colIdx).getCategory()) {
+            case LONG:
+              ((LongColumnVector) b.cols[colIdx]).vector[b.size] = v;
+              break;
+            case DECIMAL:
+              HiveDecimalWritable d = new HiveDecimalWritable();
+              d.setFromLongAndScale(v, scale);
+              ((DecimalColumnVector) b.cols[colIdx]).vector[b.size] = d;
+              break;
+            case STRING:
+              ((BytesColumnVector) b.cols[colIdx]).setVal(b.size,
+                                                          String.valueOf(v)
+                                                            .getBytes(StandardCharsets.UTF_8));
+              break;
+            default:
+              throw new IllegalArgumentException();
+          }
+        }
+        // Populate the rowIdx
+        ((LongColumnVector) b.cols[4]).vector[b.size] = rowIdx;
+
+        b.size += 1;
+        if (b.size == b.getMaxSize()) {
+          writer.addRowBatch(b);
+          b.reset();
+        }
+      }
+      if (b.size > 0) {
+        writer.addRowBatch(b);
+        b.reset();
+      }
+    }
+    LOG.info("Created file {}", filePath);
+  }
+
+  @Test
+  public void writeIsSuccessful() throws IOException {
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    Assert.assertEquals(RowCount, r.getNumberOfRows());
+    Assert.assertTrue(r.getStripes().size() > 1);
+  }
+
+  @Test
+  public void readFirstColumn() throws IOException {
+    readStart();
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    VectorizedRowBatch b = schema.createRowBatch();
+    long rowCount = 0;
+    try (RecordReader rr = r.rows(r.options().include(FirstColumnOnly))) {
+      while (rr.nextBatch(b)) {
+        Assert.assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
+        rowCount += b.size;
+      }
+    }
+    FileSystem.Statistics stats = readEnd();
+    Assert.assertEquals(RowCount, rowCount);
+    // We should read less than half the length of the file
+    Assert.assertTrue(String.format("Bytes read %d is not half of file size %d",
+                                    stats.getBytesRead(),
+                                    r.getContentLength()),
+                      stats.getBytesRead() < r.getContentLength() / 2);
+  }
+
+  @Test
+  public void readWithSArg() throws IOException {
+    readStart();
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .in("f1", PredicateLeaf.Type.LONG, 0L)
+      .build();
+    Reader.Options options = r.options()
+      .searchArgument(sarg, new String[] {"f1"});
+    VectorizedRowBatch b = schema.createRowBatch();
+    long rowCount;
+    try (RecordReader rr = r.rows(options)) {
+      rowCount = validateFilteredRecordReader(rr, b);
+    }
+    double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
+    Assert.assertEquals(RowCount, rowCount);
+    Assert.assertTrue(p >= 100);
+  }
+
+  private long validateFilteredRecordReader(RecordReader rr, VectorizedRowBatch b)
+    throws IOException {
+    long rowCount = 0;
+    while (rr.nextBatch(b)) {
+      validateBatch(b, -1);
+      rowCount += b.size;
+    }
+    return rowCount;
+  }
+
+  private void validateBatch(VectorizedRowBatch b, long expRowNum) {
+    HiveDecimalWritable d = new HiveDecimalWritable();
+
+    for (int i = 0; i < b.size; i++) {
+      int rowIdx;
+      if (b.selectedInUse) {
+        rowIdx = b.selected[i];
+      } else {
+        rowIdx = i;
+      }
+      long expValue = ((LongColumnVector) b.cols[0]).vector[rowIdx];
+      d.setFromLongAndScale(expValue, scale);
+      Assert.assertEquals(d, ((DecimalColumnVector) b.cols[1]).vector[rowIdx]);
+      Assert.assertEquals(expValue, ((LongColumnVector) b.cols[2]).vector[rowIdx]);
+      BytesColumnVector sv = (BytesColumnVector) b.cols[3];
+      Assert.assertEquals(String.valueOf(expValue),
+                          sv.toString(rowIdx));
+      if (expRowNum != -1) {
+        Assert.assertEquals(expRowNum + i, ((LongColumnVector) b.cols[4]).vector[rowIdx]);
+      }
+    }
+  }
+
+  @Test
+  public void filterAllRows() throws IOException {
+    readStart();
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    VectorizedRowBatch b = schema.createRowBatch();
+    Reader.Options options = r.options()
+      .setRowFilter(FilterColumns, new InFilter(new HashSet<>(0), 0));
+    long rowCount = 0;
+    try (RecordReader rr = r.rows(options)) {
+      while (rr.nextBatch(b)) {
+        Assert.assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
+        Assert.assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
+        rowCount += b.size;
+      }
+    }
+    FileSystem.Statistics stats = readEnd();
+    Assert.assertEquals(0, rowCount);
+    // We should read less than half the length of the file
+    double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
+    Assert.assertTrue(String.format("Bytes read %.2f%% should be less than 50%%",
+                                    readPercentage),
+                      readPercentage < 50);
+  }
+
+  @Test
+  public void readEverything() throws IOException {
+    readStart();
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    VectorizedRowBatch b = schema.createRowBatch();
+    long rowCount;
+    try (RecordReader rr = r.rows()) {
+      rowCount = validateFilteredRecordReader(rr, b);
+    }
+    double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
+    Assert.assertEquals(RowCount, rowCount);
+    Assert.assertTrue(p >= 100);
+  }
+
+  private double readPercentage(FileSystem.Statistics stats, long fileSize) {
+    double p = stats.getBytesRead() * 100.0 / fileSize;
+    LOG.info(String.format("%nFileSize: %d%nReadSize: %d%nRead %%: %.2f",
+                           fileSize,
+                           stats.getBytesRead(),
+                           p));
+    return p;
+  }
+
+  @Test
+  public void readEverythingWithFilter() throws IOException {
+    readStart();
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    VectorizedRowBatch b = schema.createRowBatch();
+    long rowCount;
+    try (RecordReader rr = r.rows(r.options()
+                                    .setRowFilter(FilterColumns, new AllowAllFilter()))) {
+      rowCount = validateFilteredRecordReader(rr, b);
+    }
+    double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
+    Assert.assertEquals(RowCount, rowCount);
+    Assert.assertTrue(p >= 100);
+  }
+
+  @Test
+  public void filterAlternateBatches() throws IOException {
+    readStart();
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    VectorizedRowBatch b = schema.createRowBatch();
+    Reader.Options options = r.options()
+      .setRowFilter(FilterColumns, new AlternateFilter());
+    long rowCount;
+    try (RecordReader rr = r.rows(options)) {
+      rowCount = validateFilteredRecordReader(rr, b);
+    }
+    FileSystem.Statistics stats = readEnd();
+    double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
+    System.out.println("Read percentage: " + readPercentage);
+    Assert.assertTrue(RowCount > rowCount);
+  }
+
+  @Test
+  public void filterWithSeek() throws IOException {
+    readStart();
+    Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
+    VectorizedRowBatch b = schema.createRowBatch();
+    Reader.Options options = r.options()
+      .setRowFilter(FilterColumns, new AlternateFilter());
+
+    long seekRow;
+    try (RecordReader rr = r.rows(options)) {
+      // Validate the first batch
+      Assert.assertTrue(rr.nextBatch(b));
+      validateBatch(b, 0);
+      Assert.assertEquals(b.size, rr.getRowNumber());
+
+      // Read the next batch, will skip a batch that is filtered
+      Assert.assertTrue(rr.nextBatch(b));
+      validateBatch(b, 2048);
+      Assert.assertEquals(2048 + 1024, rr.getRowNumber());
+
+      // Seek forward
+      seekToRow(rr, b, 4096);
+
+      // Seek back to the filtered batch
+      long bytesRead = readEnd().getBytesRead();
+      seekToRow(rr, b, 1024);
+      // No IO should have taken place
+      Assert.assertEquals(bytesRead, readEnd().getBytesRead());
+
+      // Seek forward to next row group, where the first batch is not filtered
+      seekToRow(rr, b, 8192);
+
+      // Seek forward to next row group but position on filtered batch
+      seekToRow(rr, b, (8192 * 2) + 1024);
+
+      // Seek forward to next stripe
+      seekRow = r.getStripes().get(0).getNumberOfRows();
+      seekToRow(rr, b, seekRow);
+
+      // Seek back to previous stripe, filtered row, it should require more IO as a result of
+      // stripe change
+      bytesRead = readEnd().getBytesRead();
+      seekToRow(rr, b, 1024);
+      Assert.assertTrue("Change of stripe should require more IO",
+                        readEnd().getBytesRead() > bytesRead);
+    }
+    FileSystem.Statistics stats = readEnd();
+    double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
+    Assert.assertTrue(readPercentage > 130);
+  }
+
+  private void seekToRow(RecordReader rr, VectorizedRowBatch b, long row) throws IOException {
+    rr.seekToRow(row);
+    Assert.assertTrue(rr.nextBatch(b));
+    long expRowNum;
+    if ((row / b.getMaxSize()) % 2 == 0) {
+      expRowNum = row;
+    } else {
+      // As the seek batch gets filtered
+      expRowNum = row + b.getMaxSize();
+    }
+    validateBatch(b, expRowNum);
+    Assert.assertEquals(expRowNum + b.getMaxSize(), rr.getRowNumber());
+  }
+
+  private static class InFilter implements Consumer<FilterContext> {
+    private final Set<Long> ids;
+    private final int colIdx;
+
+    private InFilter(Set<Long> ids, int colIdx) {
+      this.ids = ids;
+      this.colIdx = colIdx;
+    }
+
+    @Override
+    public void accept(FilterContext b) {
+      int newSize = 0;
+      for (int i = 0; i < b.getSelectedSize(); i++) {
+        if (ids.contains(getValue(b, i))) {
+          b.getSelected()[newSize] = i;
+          newSize += 1;
+        }
+      }
+      b.setSelectedInUse(true);
+      b.setSelectedSize(newSize);
+    }
+
+    private Long getValue(FilterContext b, int rowIdx) {
+      LongColumnVector v = ((LongColumnVector) b.getCols()[colIdx]);
+      int valIdx = rowIdx;
+      if (v.isRepeating) {
+        valIdx = 0;
+      }
+      if (!v.noNulls && v.isNull[valIdx]) {
+        return null;
+      } else {
+        return v.vector[valIdx];
+      }
+    }
+  }
+
+  /**
+   * Fill odd batches values in a default read
+   * if ridx(rowIdx) / 1024 is even then allow otherwise fail
+   */
+  private static class AlternateFilter implements Consumer<FilterContext> {
+    @Override
+    public void accept(FilterContext b) {
+      LongColumnVector v = (LongColumnVector) b.getCols()[4];
+
+      if ((v.vector[0] / 1024) % 2 == 1) {
+        b.setSelectedInUse(true);
+        b.setSelectedSize(0);
+      }
+    }
+  }
+
+  private static class AllowAllFilter implements Consumer<FilterContext> {
+
+    @Override
+    public void accept(FilterContext batch) {
+      // do nothing every row is allowed
+    }
+
+  }
+
+  private static void readStart() {
+    FileSystem.clearStatistics();
+  }
+
+  private static FileSystem.Statistics readEnd() {
+    return FileSystem.getAllStatistics().get(0);
+  }
+}

--- a/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
-import org.apache.orc.filter.FilterContext;
+import org.apache.orc.filter.OrcFilterContext;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -346,7 +346,7 @@ public class TestRowFilteringIOSkip {
     Assert.assertEquals(expRowNum + b.getMaxSize(), rr.getRowNumber());
   }
 
-  private static class InFilter implements Consumer<FilterContext> {
+  private static class InFilter implements Consumer<OrcFilterContext> {
     private final Set<Long> ids;
     private final int colIdx;
 
@@ -356,7 +356,7 @@ public class TestRowFilteringIOSkip {
     }
 
     @Override
-    public void accept(FilterContext b) {
+    public void accept(OrcFilterContext b) {
       int newSize = 0;
       for (int i = 0; i < b.getSelectedSize(); i++) {
         if (ids.contains(getValue(b, i))) {
@@ -368,7 +368,7 @@ public class TestRowFilteringIOSkip {
       b.setSelectedSize(newSize);
     }
 
-    private Long getValue(FilterContext b, int rowIdx) {
+    private Long getValue(OrcFilterContext b, int rowIdx) {
       LongColumnVector v = ((LongColumnVector) b.getCols()[colIdx]);
       int valIdx = rowIdx;
       if (v.isRepeating) {
@@ -386,9 +386,9 @@ public class TestRowFilteringIOSkip {
    * Fill odd batches values in a default read
    * if ridx(rowIdx) / 1024 is even then allow otherwise fail
    */
-  private static class AlternateFilter implements Consumer<FilterContext> {
+  private static class AlternateFilter implements Consumer<OrcFilterContext> {
     @Override
-    public void accept(FilterContext b) {
+    public void accept(OrcFilterContext b) {
       LongColumnVector v = (LongColumnVector) b.getCols()[4];
 
       if ((v.vector[0] / 1024) % 2 == 1) {
@@ -398,10 +398,10 @@ public class TestRowFilteringIOSkip {
     }
   }
 
-  private static class AllowAllFilter implements Consumer<FilterContext> {
+  private static class AllowAllFilter implements Consumer<OrcFilterContext> {
 
     @Override
-    public void accept(FilterContext batch) {
+    public void accept(OrcFilterContext batch) {
       // do nothing every row is allowed
     }
 

--- a/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
@@ -277,7 +277,6 @@ public class TestRowFilteringIOSkip {
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    System.out.println("Read percentage: " + readPercentage);
     Assert.assertTrue(RowCount > rowCount);
   }
 

--- a/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
@@ -43,8 +43,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class TestRowFilteringNoSkip {
 
-  private final Path workDir = new Path(System.getProperty("test.tmp.dir", "target" + File.separator + "test"
-                                                                           + File.separator + "tmp"));
+  private Path workDir = new Path(System.getProperty("test.tmp.dir", "target" + File.separator + "test"
+      + File.separator + "tmp"));
 
   private Configuration conf;
   private FileSystem fs;

--- a/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.sql.Timestamp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Types that are not skipped at row-level include: Long, Short, Int, Date, Binary
@@ -42,8 +43,8 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestRowFilteringNoSkip {
 
-  private Path workDir = new Path(System.getProperty("test.tmp.dir", "target" + File.separator + "test"
-      + File.separator + "tmp"));
+  private final Path workDir = new Path(System.getProperty("test.tmp.dir", "target" + File.separator + "test"
+                                                                           + File.separator + "tmp"));
 
   private Configuration conf;
   private FileSystem fs;
@@ -110,11 +111,11 @@ public class TestRowFilteringNoSkip {
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
         Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        Assert.assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
         Assert.assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
-        assertEquals( true, col1.noNulls);
+        assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] != 0)
             noNullCnt ++;
@@ -179,11 +180,11 @@ public class TestRowFilteringNoSkip {
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
         Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        Assert.assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
         Assert.assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
-        assertEquals( true, col1.noNulls);
+        assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] != 0)
             noNullCount++;
@@ -249,11 +250,11 @@ public class TestRowFilteringNoSkip {
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
         Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        Assert.assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
         Assert.assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
-        assertEquals( true, col1.noNulls);
+        assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] != 0)
             noNullCnt ++;
@@ -261,7 +262,7 @@ public class TestRowFilteringNoSkip {
       }
       // For Short type ColumnVector filtering does not remove any data!
       Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
-      Assert.assertEquals(false, col2.isRepeating);
+      Assert.assertFalse(col2.isRepeating);
       Assert.assertEquals(0, batch.selected[0]);
       Assert.assertEquals(2, batch.selected[1]);
       Assert.assertTrue(col2.vector[0] > 0);
@@ -319,11 +320,11 @@ public class TestRowFilteringNoSkip {
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
         Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        Assert.assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
         Assert.assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
-        assertEquals( true, col1.noNulls);
+        assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] != 0)
             noNullCnt ++;
@@ -331,7 +332,7 @@ public class TestRowFilteringNoSkip {
       }
       // For Date type ColumnVector filtering does not remove any data!
       Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
-      Assert.assertEquals(false, col2.isRepeating);
+      Assert.assertFalse(col2.isRepeating);
       Assert.assertEquals(0, batch.selected[0]);
       Assert.assertEquals(2, batch.selected[1]);
       Assert.assertTrue(col2.vector[0] != 0);
@@ -391,11 +392,11 @@ public class TestRowFilteringNoSkip {
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
         Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        Assert.assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
         Assert.assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
-        assertEquals( true, col1.noNulls);
+        assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (!TestVectorOrcFile.getBinary(col2, r).equals(TestVectorOrcFile.bytes()))
             noNullCnt ++;

--- a/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
-import org.apache.orc.filter.FilterContext;
+import org.apache.orc.filter.OrcFilterContext;
 import org.apache.orc.impl.RecordReaderImpl;
 import org.junit.Assert;
 import org.junit.Before;
@@ -80,7 +80,7 @@ public class TestRowFilteringSkip {
   }
 
   // Filter all rows except: 924 and 940
-  public static void intAnyRowFilter(FilterContext batch) {
+  public static void intAnyRowFilter(OrcFilterContext batch) {
     // Dummy Filter implementation passing just one Batch row
     int newSize = 2;
     batch.getSelected()[0] = batch.getSelectedSize()-100;
@@ -90,7 +90,7 @@ public class TestRowFilteringSkip {
   }
 
   // Filter all rows except the first one
-  public static void intFirstRowFilter(FilterContext batch) {
+  public static void intFirstRowFilter(OrcFilterContext batch) {
     int newSize = 0;
     for (int row = 0; row <batch.getSelectedSize(); ++row) {
       if (row == 0) {
@@ -102,7 +102,7 @@ public class TestRowFilteringSkip {
   }
 
   // Filter out rows in a round-robbin fashion starting with a pass
-  public static void intRoundRobbinRowFilter(FilterContext batch) {
+  public static void intRoundRobbinRowFilter(OrcFilterContext batch) {
     int newSize = 0;
     int[] selected = batch.getSelected();
     for (int row = 0; row < batch.getSelectedSize(); ++row) {
@@ -116,7 +116,7 @@ public class TestRowFilteringSkip {
   }
 
   static int rowCount = 0;
-  public static void intCustomValueFilter(FilterContext batch) {
+  public static void intCustomValueFilter(OrcFilterContext batch) {
     LongColumnVector col1 = (LongColumnVector) batch.getCols()[0];
     int newSize = 0;
     for (int row = 0; row <batch.getSelectedSize(); ++row) {
@@ -1298,7 +1298,7 @@ public class TestRowFilteringSkip {
     }
   }
 
-  private static void notNullFilterMissing(FilterContext batch) {
+  private static void notNullFilterMissing(OrcFilterContext batch) {
     int selIdx = 0;
     ColumnVector cv = batch.getCols()[2];
     if (cv.isRepeating) {

--- a/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
@@ -1285,6 +1285,7 @@ public class TestRowFilteringSkip {
     try (RecordReaderImpl rows = (RecordReaderImpl) reader.rows(
       reader.options()
         .schema(readSchema)
+        .setAllowSelected(true)
         .setRowFilter(new String[]{"missing"}, TestRowFilteringSkip::notNullFilterMissing))) {
       VectorizedRowBatch batch = readSchema.createRowBatchV2();
 

--- a/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.Decimal64ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
@@ -28,6 +29,7 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.filter.FilterContext;
 import org.apache.orc.impl.RecordReaderImpl;
 import org.junit.Assert;
 import org.junit.Before;
@@ -43,6 +45,7 @@ import java.text.Format;
 import java.text.SimpleDateFormat;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Types that are skipped at row-level include: Decimal, Decimal64, Double, Float, Char, VarChar, String, Boolean, Timestamp
@@ -77,52 +80,54 @@ public class TestRowFilteringSkip {
   }
 
   // Filter all rows except: 924 and 940
-  public static void intAnyRowFilter(VectorizedRowBatch batch) {
+  public static void intAnyRowFilter(FilterContext batch) {
     // Dummy Filter implementation passing just one Batch row
     int newSize = 2;
-    batch.selected[0] = batch.size-100;
-    batch.selected[1] = 940;
-    batch.selectedInUse = true;
-    batch.size = newSize;
+    batch.getSelected()[0] = batch.getSelectedSize()-100;
+    batch.getSelected()[1] = 940;
+    batch.setSelectedInUse(true);
+    batch.setSelectedSize(newSize);
   }
 
   // Filter all rows except the first one
-  public static void intFirstRowFilter(VectorizedRowBatch batch) {
+  public static void intFirstRowFilter(FilterContext batch) {
     int newSize = 0;
-    for (int row = 0; row <batch.size; ++row) {
+    for (int row = 0; row <batch.getSelectedSize(); ++row) {
       if (row == 0) {
-        batch.selected[newSize++] = row;
+        batch.getSelected()[newSize++] = row;
       }
     }
-    batch.selectedInUse = true;
-    batch.size = newSize;
+    batch.setSelectedInUse(true);
+    batch.setSelectedSize(newSize);
   }
 
   // Filter out rows in a round-robbin fashion starting with a pass
-  public static void intRoundRobbinRowFilter(VectorizedRowBatch batch) {
+  public static void intRoundRobbinRowFilter(FilterContext batch) {
     int newSize = 0;
-    for (int row = 0; row < batch.size; ++row) {
+    int[] selected = batch.getSelected();
+    for (int row = 0; row < batch.getSelectedSize(); ++row) {
       if ((row % 2) == 0) {
-        batch.selected[newSize++] = row;
+        selected[newSize++] = row;
       }
     }
-    batch.selectedInUse = true;
-    batch.size = newSize;
+    batch.setSelectedInUse(true);
+    batch.setSelected(selected);
+    batch.setSelectedSize(newSize);
   }
 
   static int rowCount = 0;
-  public static void intCustomValueFilter(VectorizedRowBatch batch) {
-    LongColumnVector col1 = (LongColumnVector) batch.cols[0];
+  public static void intCustomValueFilter(FilterContext batch) {
+    LongColumnVector col1 = (LongColumnVector) batch.getCols()[0];
     int newSize = 0;
-    for (int row = 0; row <batch.size; ++row) {
+    for (int row = 0; row <batch.getSelectedSize(); ++row) {
       long val = col1.vector[row];
       if ((val == 2) || (val == 5) || (val == 13) || (val == 29) || (val == 70)) {
-        batch.selected[newSize++] = row;
+        batch.getSelected()[newSize++] = row;
       }
       rowCount++;
     }
-    batch.selectedInUse = true;
-    batch.size = newSize;
+    batch.setSelectedInUse(true);
+    batch.setSelectedSize(newSize);
   }
 
   @Test
@@ -1286,22 +1291,32 @@ public class TestRowFilteringSkip {
       long rowCount = 0;
       while (rows.nextBatch(batch)) {
         // All rows are selected as NullTreeReader does not support filters
-        Assert.assertFalse(batch.selectedInUse);
+        Assert.assertTrue(batch.selectedInUse);
         rowCount += batch.size;
       }
-      Assert.assertEquals(reader.getNumberOfRows(), rowCount);
+      Assert.assertEquals(0, rowCount);
     }
   }
 
-  private static void notNullFilterMissing(VectorizedRowBatch batch) {
+  private static void notNullFilterMissing(FilterContext batch) {
     int selIdx = 0;
-    for (int i = 0; i < batch.size; i++) {
-      if (!batch.cols[2].isNull[i]) {
-        batch.selected[selIdx++] = i;
+    ColumnVector cv = batch.getCols()[2];
+    if (cv.isRepeating) {
+      if (!cv.isNull[0]) {
+        for (int i = 0; i < batch.getSelectedSize(); i++) {
+          batch.getSelected()[selIdx++] = i;
+        }
+      }
+    } else {
+      for (int i = 0; i < batch.getSelectedSize(); i++) {
+        if (!batch.getCols()[2].isNull[i]) {
+          batch.getSelected()[selIdx++] = i;
+        }
       }
     }
-    batch.selectedInUse = true;
-    batch.size = selIdx;
+
+    batch.setSelectedInUse(true);
+    batch.setSelectedSize(selIdx);
   }
 
   @Test
@@ -1323,27 +1338,35 @@ public class TestRowFilteringSkip {
       assertEquals(1, reader.getStripes().size());
 
       int noNullCnt = 0;
+
       while (rows.nextBatch(batch)) {
         Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        Assert.assertNotNull(batch.selected);
         // Rows are filtered so it should never be 1024
         Assert.assertTrue(batch.size != ColumnBatchRows);
-        assertEquals( true, col1.noNulls);
+        assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
-          if (col1.vector[r] != 100)
-            noNullCnt ++;
+          if (col1.vector[r] != 100) noNullCnt ++;
         }
+        // We should always select only one value as the file is spaced such
+        Assert.assertEquals( 1, batch.size);
+        long val = col1.vector[batch.selected[0]] ;
+        // Check that we have read the valid value
+        Assert.assertTrue((val == 2) || (val == 5) || (val == 13) || (val == 29) || (val == 70));
+        if (val == 2) {
+          Assert.assertEquals(0, col5.getTime(batch.selected[0]));
+        } else {
+          Assert.assertNotEquals(0, col5.getTime(batch.selected[0]));
+        }
+
+        // Check that unselected is not populated
+        Assert.assertEquals(0, batch.selected[1]);
       }
 
       // Total rows of the file should be 25k
       Assert.assertEquals(25000, rowCount);
       // Make sure that our filter worked ( 5 rows with userId != 100)
       Assert.assertEquals(5, noNullCnt);
-      Assert.assertEquals(false, col5.isRepeating);
-      Assert.assertEquals(544, batch.selected[0]);
-      Assert.assertEquals(0, batch.selected[1]);
-      Assert.assertTrue(col5.getTime(0) == 0);
-      Assert.assertTrue(col5.getTime(544) != 0);
     }
   }
 }

--- a/java/core/src/test/org/apache/orc/filter/TestFilter.java
+++ b/java/core/src/test/org/apache/orc/filter/TestFilter.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.filter.impl.ATestFilter;
+import org.apache.orc.filter.impl.AndFilter;
+import org.apache.orc.filter.impl.BatchFilter;
+import org.apache.orc.filter.impl.LongIn;
+import org.apache.orc.filter.impl.OrFilter;
+import org.apache.orc.filter.impl.StringIn;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+
+public class TestFilter extends ATestFilter {
+
+  @Test
+  public void testAndOfOr() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .startOr()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 4L)
+      .end()
+      .startOr()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f2", PredicateLeaf.Type.STRING, "c", "e")
+      .end()
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+
+    BatchFilter filter = (BatchFilter) FilterFactory.createVectorFilter(sArg, schema);
+    filter.accept(fc);
+    assertArrayEquals(new String[]{"f1", "f2"}, filter.getColNames());
+    validateSelected(0, 2, 5);
+  }
+
+  @Test
+  public void testOrOfAnd() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "c")
+      .end()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 4L)
+      .in("f2", PredicateLeaf.Type.STRING, "c", "e")
+      .end()
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc.setBatch(batch));
+    validateSelected(0, 2);
+  }
+
+  @Test
+  public void testOrOfAndNative() {
+    VectorFilter f = new OrFilter(
+      new VectorFilter[] {
+        new AndFilter(new VectorFilter[] {
+          new LongIn("f1",
+                     Arrays.asList(1L, 6L)),
+          new StringIn("f2",
+                       Arrays.asList("a", "c"))
+        }),
+        new AndFilter(new VectorFilter[] {
+          new LongIn("f1",
+                     Arrays.asList(3L, 4L)),
+          new StringIn("f2",
+                       Arrays.asList("c", "e"))
+        })
+      }
+    );
+
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+
+    filter(f);
+    Assert.assertEquals(2, fc.getSelectedSize());
+    assertArrayEquals(new int[] {0, 2},
+                             Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
+  }
+
+  @Test
+  public void testAndNotNot() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .startNot()
+      .in("f1", PredicateLeaf.Type.LONG, 7L)
+      .end()
+      .startNot()
+      .isNull("f2", PredicateLeaf.Type.STRING)
+      .end()
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+
+    Consumer<OrcFilterContext> filter = FilterFactory.createVectorFilter(sArg, schema);
+    filter.accept(fc.setBatch(batch));
+    Assert.assertEquals(6, fc.getSelectedSize());
+    assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5},
+                             Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
+  }
+
+  @Test
+  public void testUnSupportedSArg() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .nullSafeEquals("f1", PredicateLeaf.Type.LONG, 0L)
+      .build();
+
+    Assert.assertNull(FilterFactory.createVectorFilter(sarg, schema));
+  }
+
+  @Test
+  public void testRepeatedProtected() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .in("f2", PredicateLeaf.Type.STRING, "a", "d")
+      .lessThan("f1", PredicateLeaf.Type.LONG, 6L)
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 1L, 1L, 1L, 1L, 1L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    batch.cols[0].isRepeating = true;
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc.setBatch(batch));
+    validateAllSelected(6);
+  }
+
+  @Test
+  public void testNullProtected() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .in("f2", PredicateLeaf.Type.STRING, "a", "d")
+      .lessThan("f1", PredicateLeaf.Type.LONG, 4L)
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 2L, null, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc.setBatch(batch));
+    validateSelected(0, 1, 3);
+  }
+
+  @Test
+  public void testUnsupportedNotLeaf() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .nullSafeEquals("f1", PredicateLeaf.Type.LONG, 2L)
+      .end()
+      .build();
+
+    assertNull(FilterFactory.createVectorFilter(sArg, schema));
+  }
+
+  @Test
+  public void testAndOrAnd() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .startOr()
+      .lessThan("f1", PredicateLeaf.Type.LONG, 3L)
+      .startAnd()
+      .equals("f2", PredicateLeaf.Type.STRING, "a")
+      .equals("f1", PredicateLeaf.Type.LONG, 5L)
+      .end()
+      .end()
+      .in("f2", PredicateLeaf.Type.STRING, "a", "c")
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 2L, null, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc.setBatch(batch));
+    validateSelected(0);
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/TestFilterContext.java
+++ b/java/core/src/test/org/apache/orc/filter/TestFilterContext.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.TypeDescription;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestFilterContext {
+
+  private final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createStruct()
+      .addField("f2a", TypeDescription.createLong())
+      .addField("f2b", TypeDescription.createString()))
+    .addField("f3", TypeDescription.createString());
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testSuccessfulRetrieval() {
+    VectorizedRowBatch b = createBatch();
+    FilterContext fc = new FilterContext(schema);
+    fc.setBatch(b);
+
+    validateF1Vector(fc.findColumnVector("f1"), 1);
+    validateF2Vector(fc.findColumnVector("f2"));
+    validateF2AVector(fc.findColumnVector("f2.f2a"));
+    validateF2BVector(fc.findColumnVector("f2.f2b"));
+    validateF3Vector(fc.findColumnVector("f3"));
+  }
+
+  @Test
+  public void testSuccessfulRetrievalWithBatchChange() {
+    VectorizedRowBatch b1 = createBatch();
+    VectorizedRowBatch b2 = createBatch();
+    ((LongColumnVector) b2.cols[0]).vector[0] = 100;
+    FilterContext fc = new FilterContext(schema);
+    fc.setBatch(b1);
+    validateF1Vector(fc.findColumnVector("f1"), 1);
+    // Change the batch
+    fc.setBatch(b2);
+    validateF1Vector(fc.findColumnVector("f1"), 100);
+  }
+
+  @Test
+  public void testMissingFieldTopLevel() {
+    VectorizedRowBatch b = createBatch();
+    FilterContext fc = new FilterContext(schema);
+    fc.setBatch(b);
+
+    // Missing field at top level
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Field f4 not found in");
+    fc.findColumnVector("f4");
+  }
+
+  @Test
+  public void testMissingFieldNestedLevel() {
+    VectorizedRowBatch b = createBatch();
+    FilterContext fc = new FilterContext(schema);
+    fc.setBatch(b);
+
+    // Missing field at top level
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Field c not found in [f2a, f2b]");
+    fc.findColumnVector("f2.c");
+  }
+
+  @Test
+  public void testNestingNonStructField() {
+    VectorizedRowBatch b = createBatch();
+    FilterContext fc = new FilterContext(schema);
+    fc.setBatch(b);
+
+    // Missing field at top level
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Field f3:string not a struct field does not allow nested reference");
+    fc.findColumnVector("f3.c");
+  }
+
+  @Test
+  public void testPropagations() {
+    FilterContext fc = new FilterContext(schema);
+    assertNull(fc.batch);
+    fc.setBatch(schema.createRowBatch());
+    assertNotNull(fc.batch);
+    assertFalse(fc.isSelectedInUse());
+
+    // Set selections
+    fc.setSelectedInUse(true);
+    fc.getSelected()[0] = 5;
+    fc.setSelectedSize(1);
+    assertTrue(fc.isSelectedInUse());
+    assertEquals(1, fc.getSelectedSize());
+    assertEquals(fc.batch.getMaxSize(), fc.getSelected().length);
+    assertArrayEquals(new int[] {5}, Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
+    assertTrue(fc.validateSelected());
+    fc.setSelectedSize(2);
+    assertFalse(fc.validateSelected());
+
+    // Use a new selected vector
+    fc.setSelected(new int[fc.batch.getMaxSize()]);
+    assertArrayEquals(new int[] {0, 0}, Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
+
+    // Increase the size of the vector
+    fc.reset();
+    assertFalse(fc.isSelectedInUse());
+    int currSize = fc.batch.getMaxSize();
+    assertEquals(currSize, fc.getSelected().length);
+    fc.updateSelected(currSize+ 1);
+    assertEquals(currSize + 1, fc.getSelected().length);
+
+    // Set the filter context
+    fc.setFilterContext(true, new int[3], 1);
+    assertTrue(fc.isSelectedInUse());
+    assertEquals(3, fc.batch.getMaxSize());
+    assertEquals(1, fc.getSelectedSize());
+  }
+
+  private VectorizedRowBatch createBatch() {
+    VectorizedRowBatch b = schema.createRowBatch();
+    LongColumnVector v1 = (LongColumnVector) b.cols[0];
+    StructColumnVector v2 = (StructColumnVector) b.cols[1];
+    LongColumnVector v2a = (LongColumnVector) v2.fields[0];
+    BytesColumnVector v2b = (BytesColumnVector) v2.fields[1];
+    BytesColumnVector v3 = (BytesColumnVector) b.cols[2];
+
+    v1.vector[0] = 1;
+    v2a.vector[0] = 2;
+    v2b.setVal(0, "3".getBytes(StandardCharsets.UTF_8));
+    v3.setVal(0, "4".getBytes(StandardCharsets.UTF_8));
+    return b;
+  }
+
+  private void validateF1Vector(ColumnVector v, long headValue) {
+    LongColumnVector l = (LongColumnVector) v;
+    Assert.assertEquals(headValue, l.vector[0]);
+  }
+
+  private void validateF2Vector(ColumnVector v) {
+    StructColumnVector s = (StructColumnVector) v;
+    validateF2AVector(s.fields[0]);
+    validateF2BVector(s.fields[1]);
+  }
+
+  private void validateF2AVector(ColumnVector v) {
+    LongColumnVector l = (LongColumnVector) v;
+    Assert.assertEquals(2, l.vector[0]);
+  }
+
+  private void validateF2BVector(ColumnVector v) {
+    BytesColumnVector b = (BytesColumnVector) v;
+    Assert.assertEquals("3", b.toString(0));
+  }
+
+  private void validateF3Vector(ColumnVector v) {
+    BytesColumnVector b = (BytesColumnVector) v;
+    Assert.assertEquals("4", b.toString(0));
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/TestOrcFilterContext.java
+++ b/java/core/src/test/org/apache/orc/filter/TestOrcFilterContext.java
@@ -39,7 +39,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-public class TestFilterContext {
+public class TestOrcFilterContext {
 
   private final TypeDescription schema = TypeDescription.createStruct()
     .addField("f1", TypeDescription.createLong())
@@ -54,7 +54,7 @@ public class TestFilterContext {
   @Test
   public void testSuccessfulRetrieval() {
     VectorizedRowBatch b = createBatch();
-    FilterContext fc = new FilterContext(schema);
+    OrcFilterContext fc = new OrcFilterContext(schema);
     fc.setBatch(b);
 
     validateF1Vector(fc.findColumnVector("f1"), 1);
@@ -69,7 +69,7 @@ public class TestFilterContext {
     VectorizedRowBatch b1 = createBatch();
     VectorizedRowBatch b2 = createBatch();
     ((LongColumnVector) b2.cols[0]).vector[0] = 100;
-    FilterContext fc = new FilterContext(schema);
+    OrcFilterContext fc = new OrcFilterContext(schema);
     fc.setBatch(b1);
     validateF1Vector(fc.findColumnVector("f1"), 1);
     // Change the batch
@@ -80,7 +80,7 @@ public class TestFilterContext {
   @Test
   public void testMissingFieldTopLevel() {
     VectorizedRowBatch b = createBatch();
-    FilterContext fc = new FilterContext(schema);
+    OrcFilterContext fc = new OrcFilterContext(schema);
     fc.setBatch(b);
 
     // Missing field at top level
@@ -92,7 +92,7 @@ public class TestFilterContext {
   @Test
   public void testMissingFieldNestedLevel() {
     VectorizedRowBatch b = createBatch();
-    FilterContext fc = new FilterContext(schema);
+    OrcFilterContext fc = new OrcFilterContext(schema);
     fc.setBatch(b);
 
     // Missing field at top level
@@ -104,7 +104,7 @@ public class TestFilterContext {
   @Test
   public void testNestingNonStructField() {
     VectorizedRowBatch b = createBatch();
-    FilterContext fc = new FilterContext(schema);
+    OrcFilterContext fc = new OrcFilterContext(schema);
     fc.setBatch(b);
 
     // Missing field at top level
@@ -115,7 +115,7 @@ public class TestFilterContext {
 
   @Test
   public void testPropagations() {
-    FilterContext fc = new FilterContext(schema);
+    OrcFilterContext fc = new OrcFilterContext(schema);
     assertNull(fc.batch);
     fc.setBatch(schema.createRowBatch());
     assertNotNull(fc.batch);

--- a/java/core/src/test/org/apache/orc/filter/impl/ATestFilter.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/ATestFilter.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+import org.junit.Assert;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
+import java.util.Arrays;
+
+public class ATestFilter {
+  protected final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createString())
+    .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(2))
+    .addField("f4", TypeDescription.createDouble())
+    .addField("f5", TypeDescription.createTimestamp());
+  protected final OrcFilterContext fc = new OrcFilterContext(schema);
+
+  protected final VectorizedRowBatch batch = schema.createRowBatch();
+
+  protected void setBatch(Long[] f1Values, String[] f2Values) {
+    setBatch(f1Values, f2Values, null, null, null);
+  }
+
+  protected void setBatch(Long[] f1Values,
+                          String[] f2Values,
+                          HiveDecimalWritable[] f3Values,
+                          Double[] f4Values,
+                          Timestamp[] f5Values) {
+
+    batch.reset();
+    for (int i = 0; i < f1Values.length; i++) {
+      setLong(f1Values[i], (LongColumnVector) batch.cols[0], i);
+      setString(f2Values[i], (BytesColumnVector) batch.cols[1], i);
+      if (f3Values != null) {
+        setDecimal(f3Values[i], (DecimalColumnVector) batch.cols[2], i);
+      }
+      if (f4Values != null) {
+        setDouble(f4Values[i], (DoubleColumnVector) batch.cols[3], i);
+      }
+      if (f5Values != null) {
+        setTimestamp(f5Values[i], (TimestampColumnVector) batch.cols[4], i);
+      }
+    }
+
+    batch.size = f1Values.length;
+    fc.setBatch(batch);
+  }
+
+  private void setTimestamp(Timestamp value, TimestampColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      v.isNull[idx] = false;
+      v.getScratchTimestamp().setTime(value.getTime());
+      v.getScratchTimestamp().setNanos(value.getNanos());
+      v.setFromScratchTimestamp(idx);
+    }
+  }
+
+  private void setDouble(Double value, DoubleColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      v.isNull[idx] = false;
+      v.vector[idx] = value;
+    }
+  }
+
+  private void setDecimal(HiveDecimalWritable value, DecimalColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      v.isNull[idx] = false;
+      v.vector[idx] = value;
+    }
+  }
+
+  private void setString(String value, BytesColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      v.isNull[idx] = false;
+      byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+      v.vector[idx] = bytes;
+      v.start[idx] = 0;
+      v.length[idx] = bytes.length;
+    }
+  }
+
+  private void setLong(Long value, LongColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      v.isNull[idx] = false;
+      v.vector[idx] = value;
+    }
+  }
+
+  protected void validateSelected(int... v) {
+    validateSelected(fc, v);
+  }
+
+  static void validateSelected(OrcFilterContext fc, int... v) {
+    Assert.assertTrue(fc.isSelectedInUse());
+    Assert.assertEquals(v.length, fc.getSelectedSize());
+    Assert.assertArrayEquals(v, Arrays.copyOf(fc.getSelected(), v.length));
+  }
+
+  protected void validateAllSelected(int size) {
+    validateAllSelected(fc, size);
+  }
+
+  static void validateAllSelected(OrcFilterContext fc, int size) {
+    Assert.assertFalse(fc.isSelectedInUse());
+    Assert.assertEquals(size, fc.getSelectedSize());
+  }
+
+  protected void validateNoneSelected() {
+    validateNoneSelected(fc);
+  }
+
+  static void validateNoneSelected(OrcFilterContext fc) {
+    Assert.assertTrue(fc.isSelectedInUse());
+    Assert.assertEquals(0, fc.getSelectedSize());
+  }
+
+  protected void filter(VectorFilter filter) {
+    new BatchFilter(filter, null).accept(fc);
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/ATestGenFilter.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/ATestGenFilter.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.junit.Before;
+
+import java.sql.Timestamp;
+import java.util.stream.IntStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class ATestGenFilter extends ATestFilter {
+  static final int lowIdx = 2;
+  static final int highIdx = 4;
+  static final int size = 6;
+
+  @Before
+  public void setup() {
+    HiveDecimalWritable[] decValues = new HiveDecimalWritable[] {
+      new HiveDecimalWritable(Long.MIN_VALUE + "100.01"),
+      new HiveDecimalWritable(0),
+      new HiveDecimalWritable(Long.MAX_VALUE + "100.01"),
+      new HiveDecimalWritable(Long.MAX_VALUE + "101.00"),
+      new HiveDecimalWritable(Long.MAX_VALUE + "101.01"),
+      null};
+    Timestamp[] tsValues = new Timestamp[] {
+      createTimestamp(-100000, 55),
+      createTimestamp(0, 0),
+      createTimestamp(0, 1),
+      createTimestamp(0, 2),
+      createTimestamp(123456, 1),
+      null
+    };
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, null},
+             new String[] {"a", "b", "c", "d", "e", null},
+             decValues,
+             new Double[] {1.01, 2.0, 2.1, 3.55, 4.0, null},
+             tsValues);
+  }
+
+  private Timestamp createTimestamp(long time, int nano) {
+    Timestamp result = new Timestamp(0);
+    result.setTime(time);
+    result.setNanos(nano);
+    return result;
+  }
+
+  protected Object getPredicateValue(PredicateLeaf.Type type, int idx) {
+    switch (type) {
+      case LONG:
+        return ((LongColumnVector) batch.cols[0]).vector[idx];
+      case STRING:
+        BytesColumnVector bv = (BytesColumnVector) batch.cols[1];
+        return new String(bv.vector[idx], bv.start[idx], bv.length[idx], UTF_8);
+      case DECIMAL:
+        return ((DecimalColumnVector) batch.cols[2]).vector[idx];
+      case FLOAT:
+        return ((DoubleColumnVector) batch.cols[3]).vector[idx];
+      case TIMESTAMP:
+        TimestampColumnVector tv = (TimestampColumnVector) batch.cols[4];
+        Timestamp value = new Timestamp(0);
+        value.setTime(tv.time[idx]);
+        value.setNanos(tv.nanos[idx]);
+        return value;
+      default:
+        throw new IllegalArgumentException(String.format("Type: %s is unsupported", type));
+    }
+  }
+
+  protected void validateSelected(PredicateLeaf.Operator op, boolean not) {
+    // Except for IS_NULL restrict the range to size - 1 as the last element is a null
+    switch (op) {
+      case EQUALS:
+        validateSelected(IntStream.range(0, size - 1)
+                           .filter(i -> not ^ (i == lowIdx))
+                           .toArray());
+        break;
+      case LESS_THAN:
+        validateSelected(IntStream.range(0, size - 1)
+                           .filter(i -> not ^ (i < lowIdx))
+                           .toArray());
+        break;
+      case LESS_THAN_EQUALS:
+        validateSelected(IntStream.range(0, size - 1)
+                           .filter(i -> not ^ (i <= lowIdx))
+                           .toArray());
+        break;
+      case IN:
+        validateSelected(IntStream.range(0, size - 1)
+                           .filter(i -> not ^ (i == lowIdx || i == highIdx))
+                           .toArray());
+        break;
+      case BETWEEN:
+        validateSelected(IntStream.range(0, size - 1)
+                           .filter(i -> not ^ (i >= lowIdx && i <= highIdx))
+                           .toArray());
+        break;
+      case IS_NULL:
+        validateSelected(IntStream.range(0, size)
+                           .filter(i -> not ^ (i == 5))
+                           .toArray());
+        break;
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/IsNullFilterTest.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/IsNullFilterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.filter.FilterFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+
+public class IsNullFilterTest extends ATestFilter {
+  @Test
+  public void nullFilterTest() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .isNull("f1", PredicateLeaf.Type.LONG)
+      .isNull("f2", PredicateLeaf.Type.STRING)
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 2L, null, 4L, 5L, null},
+             new String[] {"a", "b", "c", null, "e", "f"});
+    assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(2, 3, 5);
+  }
+
+  @Test
+  public void repeatedNullFilterTest() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .equals("f2", PredicateLeaf.Type.STRING, "c")
+      .isNull("f1", PredicateLeaf.Type.LONG)
+      .end()
+      .build();
+
+    setBatch(new Long[] {null, null, null, null, null, null},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    batch.cols[0].isRepeating = true;
+    batch.cols[0].noNulls = false;
+    batch.cols[1].isRepeating = false;
+    batch.cols[1].noNulls = false;
+    assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateAllSelected(6);
+  }
+
+  @Test
+  public void notNullFilterTest() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .startOr()
+      .isNull("f1", PredicateLeaf.Type.LONG)
+      .isNull("f2", PredicateLeaf.Type.STRING)
+      .end()
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 2L, null, 4L, 5L, null},
+             new String[] {"a", "b", "c", null, "e", "f"});
+    assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(0, 1, 4);
+  }
+
+  @Test
+  public void repeatedNotNullFilterTest() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .equals("f2", PredicateLeaf.Type.STRING, "c")
+      .startNot()
+      .isNull("f1", PredicateLeaf.Type.LONG)
+      .end()
+      .end()
+      .build();
+
+    setBatch(new Long[] {null, null, null, null, null, null},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    batch.cols[0].isRepeating = true;
+    batch.cols[0].noNulls = false;
+    batch.cols[1].isRepeating = false;
+    batch.cols[1].noNulls = true;
+    assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateSelected(2);
+  }
+
+  @Test
+  public void repeatedNotNullFilterNoNullsTest() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .equals("f2", PredicateLeaf.Type.STRING, "c")
+      .startNot()
+      .isNull("f1", PredicateLeaf.Type.LONG)
+      .end()
+      .end()
+      .build();
+
+    setBatch(new Long[] {1L, 1L, 1L, 1L, 1L, 1L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    batch.cols[0].isRepeating = true;
+    batch.cols[0].noNulls = true;
+    batch.cols[1].isRepeating = false;
+    batch.cols[1].noNulls = true;
+    assertFalse(fc.isSelectedInUse());
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+
+    validateAllSelected(6);
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/TestAndFilter.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/TestAndFilter.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.OrcFile;
+import org.apache.orc.filter.FilterFactory;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.VectorFilter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public class TestAndFilter extends ATestFilter {
+
+  @Test
+  public void testAndSelectsNothing() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    SearchArgument s = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .equals("f1", PredicateLeaf.Type.LONG, 3L)
+      .equals("f1", PredicateLeaf.Type.LONG, 4L)
+      .end()
+      .build();
+    Consumer<OrcFilterContext> f = FilterFactory.createVectorFilter(s,
+                                                                    schema,
+                                                                    OrcFile.Version.CURRENT);
+    Assert.assertFalse(fc.isSelectedInUse());
+    f.accept(fc);
+
+    validateNoneSelected();
+  }
+
+  @Test
+  public void testANDConversion() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 2L, 3L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "b", "c")
+      .end()
+      .build();
+
+    Set<String> colIds = new HashSet<>();
+    VectorFilter f = FilterFactory.createVectorFilter(sarg.getExpression(),
+                                                      colIds,
+                                                      sarg.getLeaves(),
+                                                      schema,
+                                                      OrcFile.Version.CURRENT);
+    Assert.assertNotNull(f);
+    Assert.assertTrue(f instanceof AndFilter);
+    Assert.assertEquals(2, ((AndFilter) f).filters.length);
+    Assert.assertEquals(2, colIds.size());
+    Assert.assertTrue(colIds.contains("f1"));
+    Assert.assertTrue(colIds.contains("f2"));
+
+    // Setup the data such that the AND condition should not select any row
+    setBatch(
+      new Long[] {1L, 0L, 2L, 4L, 3L},
+      new String[] {"z", "a", "y", "b", "x"});
+    fc.setBatch(batch);
+
+    filter(f);
+    Assert.assertTrue(fc.isSelectedInUse());
+    Assert.assertEquals(0, fc.getSelectedSize());
+  }
+
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/TestConvFilter.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/TestConvFilter.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.filter.OrcFilterContext;
+import org.apache.orc.filter.FilterFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Date;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+import static org.apache.orc.filter.impl.ATestFilter.validateSelected;
+
+public class TestConvFilter {
+  private final int scale = 4;
+  private final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createBoolean())
+    .addField("f2", TypeDescription.createDate())
+    .addField("f3", TypeDescription.createDecimal().withPrecision(18).withScale(scale));
+
+  private final OrcFilterContext fc = new OrcFilterContext(schema);
+  private final VectorizedRowBatch batch = schema.createRowBatchV2();
+
+  @Before
+  public void setup() throws ParseException {
+    setBatch();
+  }
+
+  @Test
+  public void testBooleanEquals() {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .equals("f1", PredicateLeaf.Type.BOOLEAN, true)
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 0, 3, 4);
+  }
+
+  @Test
+  public void testBooleanIn() {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .equals("f1", PredicateLeaf.Type.BOOLEAN, false)
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 1, 2);
+  }
+
+  @Test
+  public void testBooleanBetween() throws ParseException {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .between("f1", PredicateLeaf.Type.BOOLEAN, false, true)
+      .end()
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 0, 1, 2, 3, 4);
+  }
+
+  @Test
+  public void testDateEquals() throws ParseException {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .equals("f2", PredicateLeaf.Type.DATE, date("2000-01-01"))
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 1);
+  }
+
+  @Test
+  public void testDateIn() throws ParseException {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .in("f2", PredicateLeaf.Type.DATE, date("2000-01-01"), date("2100-06-07"))
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 1, 4);
+  }
+
+  @Test
+  public void testDateBetween() throws ParseException {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .between("f2", PredicateLeaf.Type.DATE, date("2000-01-01"), date("2100-06-07"))
+      .end()
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 1, 2, 3, 4);
+  }
+
+  @Test
+  public void testDecimalEquals() throws ParseException {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .equals("f3", PredicateLeaf.Type.DECIMAL, decimal(12345678))
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 2);
+  }
+
+  @Test
+  public void testDecimalIn() throws ParseException {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .in("f3", PredicateLeaf.Type.DECIMAL, decimal(0), decimal(Long.MAX_VALUE / 18))
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 1, 3);
+  }
+
+  @Test
+  public void testDecimalBetween() throws ParseException {
+    // Equals
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .between("f3", PredicateLeaf.Type.DECIMAL, decimal(0), decimal(Long.MAX_VALUE / 18))
+      .end()
+      .build();
+
+    FilterFactory.createVectorFilter(sArg, schema).accept(fc);
+    validateSelected(fc, 1, 2, 3);
+  }
+
+  protected void setBatch(Boolean[] f1Values, Date[] f2Values, HiveDecimalWritable[] f3Values) {
+    batch.reset();
+    for (int i = 0; i < f1Values.length; i++) {
+      setBoolean(f1Values[i], (LongColumnVector) batch.cols[0], i);
+      setDate(f2Values[i], (LongColumnVector) batch.cols[1], i);
+      setDecimal(f3Values[i], (LongColumnVector) batch.cols[2], i);
+    }
+
+    batch.size = f1Values.length;
+    fc.setBatch(batch);
+  }
+
+  private void setDecimal(HiveDecimalWritable value, LongColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      assert (HiveDecimalWritable.isPrecisionDecimal64(value.precision())
+              && value.scale() <= scale);
+      v.isNull[idx] = false;
+      v.vector[idx] = value.serialize64(scale);
+    }
+  }
+
+  private void setBoolean(Boolean value, LongColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      v.isNull[idx] = false;
+      v.vector[idx] = value ? 1 : 0;
+    }
+  }
+
+  private void setDate(Date value, LongColumnVector v, int idx) {
+    if (value == null) {
+      v.noNulls = false;
+      v.isNull[idx] = true;
+    } else {
+      v.isNull[idx] = false;
+      v.vector[idx] = value.toLocalDate().toEpochDay();
+    }
+  }
+
+  private final SimpleDateFormat fmt = new SimpleDateFormat("yyyy-MM-dd");
+
+  private Date date(String value) throws ParseException {
+    return new Date(fmt.parse(value).getTime());
+  }
+
+  private HiveDecimalWritable decimal(long lValue) {
+    return new HiveDecimalWritable(HiveDecimal.create(lValue, scale));
+  }
+
+  private void setBatch() throws ParseException {
+    setBatch(new Boolean[] {true, false, false, true, true, null},
+             new Date[] {
+               date("1900-01-01"),
+               date("2000-01-01"),
+               date("2000-01-02"),
+               date("2019-12-31"),
+               date("2100-06-07"),
+               null
+             },
+             new HiveDecimalWritable[] {
+               new HiveDecimalWritable(HiveDecimal.create(Long.MIN_VALUE / 9, scale)),
+               new HiveDecimalWritable(HiveDecimal.create(0, scale)),
+               new HiveDecimalWritable(HiveDecimal.create(12345678, scale)),
+               new HiveDecimalWritable(HiveDecimal.create(Long.MAX_VALUE / 18, scale)),
+               new HiveDecimalWritable(HiveDecimal.create(Long.MAX_VALUE / 9, scale)),
+               null
+             });
+
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/TestEquals.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/TestEquals.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.orc.filter.VectorFilter;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class TestEquals extends ATestFilter {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testFoundMatching() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    VectorFilter f = new LongEquals("f1", 3L);
+    Assert.assertFalse(fc.isSelectedInUse());
+    filter(f);
+
+    validateSelected(2);
+  }
+
+  @Test
+  public void testNothingFound() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, null},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    VectorFilter f = new LongEquals("f1", 8L);
+    Assert.assertFalse(fc.isSelectedInUse());
+    filter(f);
+
+    validateNoneSelected();
+  }
+
+  @Test
+  public void testRepeatingVector() {
+    setBatch(new Long[] {1L, null, null, null, null, null},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    fc.getCols()[0].isRepeating = true;
+    VectorFilter f = new LongEquals("f1", 1L);
+    filter(f);
+    validateAllSelected(6);
+  }
+
+  @Test
+  public void testRepeatingNull() {
+    setBatch(new Long[] {null, null, null, null, null, null},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    fc.getCols()[0].isRepeating = true;
+    VectorFilter f = new LongEquals("f1", 1L);
+    filter(f);
+    validateNoneSelected();
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/TestMergeSelected.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/TestMergeSelected.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestMergeSelected {
+  private final Selected src = new Selected();
+  private final Selected tgt = new Selected();
+
+  @Test
+  public void testBothEmpty() {
+    // Both are empty
+    src.sel = new int[10];
+    tgt.sel = new int[10];
+    OrFilter.merge(src, tgt);
+    Assert.assertArrayEquals(new int[10], tgt.sel);
+    Assert.assertEquals(0, tgt.selSize);
+  }
+
+  @Test
+  public void testTgtEmpty() {
+    // tgt has no selection
+    src.sel = new int[] {1, 3, 7, 0, 0};
+    src.selSize = 3;
+    tgt.sel = new int[5];
+    tgt.selSize = 0;
+    OrFilter.merge(src, tgt);
+    Assert.assertEquals(src.selSize, tgt.selSize);
+    Assert.assertArrayEquals(src.sel, tgt.sel);
+  }
+
+  @Test
+  public void testSrcEmpty() {
+    // current size is zero
+    src.sel = new int[5];
+    src.selSize = 0;
+    tgt.sel = new int[] {1, 3, 7, 0, 0};
+    tgt.selSize = 3;
+    OrFilter.merge(src, tgt);
+    Assert.assertEquals(3, tgt.selSize);
+    Assert.assertArrayEquals(new int[] {1, 3, 7, 0, 0}, tgt.sel);
+  }
+
+  @Test
+  public void testCurrSmallerThanAdd() {
+    // current size is zero
+    src.sel = new int[] {7, 0, 0, 0, 0};
+    src.selSize = 1;
+    tgt.sel = new int[] {1, 3, 0, 0, 0};
+    tgt.selSize = 2;
+    OrFilter.merge(src, tgt);
+    Assert.assertEquals(3, tgt.selSize);
+    Assert.assertArrayEquals(new int[] {1, 3, 7, 0, 0}, tgt.sel);
+  }
+
+  @Test
+  public void testAddSmallerThanCurr() {
+    // current size is zero
+    src.sel = new int[] {1, 7, 0, 0, 0};
+    src.selSize = 2;
+    tgt.sel = new int[] {3, 0, 0, 0, 0};
+    tgt.selSize = 1;
+    OrFilter.merge(src, tgt);
+    Assert.assertEquals(3, tgt.selSize);
+    Assert.assertArrayEquals(new int[] {1, 3, 7, 0, 0}, tgt.sel);
+  }
+
+  @Test
+  public void testNoChange() {
+    // current size is zero
+    src.sel = new int[] {0, 0, 0, 0, 0};
+    src.selSize = 0;
+    tgt.sel = new int[] {1, 3, 7, 0, 0};
+    tgt.selSize = 3;
+    OrFilter.merge(src, tgt);
+    Assert.assertEquals(3, tgt.selSize);
+    Assert.assertArrayEquals(new int[] {1, 3, 7, 0, 0}, tgt.sel);
+  }
+
+  @Test
+  public void testNewEnclosed() {
+    // current size is zero
+    src.sel = new int[] {1, 7, 0, 0, 0};
+    src.selSize = 2;
+    tgt.sel = new int[] {3, 4, 0, 0, 0};
+    tgt.selSize = 2;
+    OrFilter.merge(src, tgt);
+    Assert.assertEquals(4, tgt.selSize);
+    Assert.assertArrayEquals(new int[] {1, 3, 4, 7, 0}, tgt.sel);
+  }
+
+  @Test
+  public void testPrevEnclosed() {
+    // current size is zero
+    src.sel = new int[] {3, 4, 0, 0, 0};
+    src.selSize = 2;
+    tgt.sel = new int[] {1, 7, 0, 0, 0};
+    tgt.selSize = 2;
+    OrFilter.merge(src, tgt);
+    Assert.assertEquals(4, tgt.selSize);
+    Assert.assertArrayEquals(new int[] {1, 3, 4, 7, 0}, tgt.sel);
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/TestNotFilter.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/TestNotFilter.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.filter.FilterFactory;
+import org.apache.orc.filter.OrcFilterContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+public class TestNotFilter extends ATestFilter {
+
+  @Test
+  public void testUnboundedNot() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 5L)
+      .end()
+      .build();
+    Consumer<OrcFilterContext> f = FilterFactory.createVectorFilter(sArg, schema);
+    f.accept(fc.setBatch(batch));
+
+    validateSelected(0, 1, 3, 5);
+  }
+
+  @Test
+  public void testEmptyUnbounded() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .in("f1", PredicateLeaf.Type.LONG, 7L, 8L)
+      .end()
+      .build();
+    Consumer<OrcFilterContext> f = FilterFactory.createVectorFilter(sArg, schema);
+    f.accept(fc.setBatch(batch));
+
+    Assert.assertEquals(6, fc.getSelectedSize());
+    Assert.assertArrayEquals(new int[] {0, 1, 2, 3, 4, 5},
+                             Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
+  }
+
+  @Test
+  public void testBounded() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .in("f2", PredicateLeaf.Type.STRING, "b", "c")
+      .startNot()
+      .in("f1", PredicateLeaf.Type.LONG, 2L, 8L)
+      .end()
+      .end()
+      .build();
+    Consumer<OrcFilterContext> f = FilterFactory.createVectorFilter(sArg, schema);
+    f.accept(fc.setBatch(batch));
+
+    validateSelected(2);
+  }
+
+  @Test
+  public void testEmptyBounded() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .in("f2", PredicateLeaf.Type.STRING, "b", "c")
+      .startNot()
+      .in("f1", PredicateLeaf.Type.LONG, 7L, 8L)
+      .end()
+      .end()
+      .build();
+    Consumer<OrcFilterContext> f = FilterFactory.createVectorFilter(sArg, schema);
+    f.accept(fc.setBatch(batch));
+
+    validateSelected(1, 2);
+  }
+
+  @Test
+  public void testNotAndPushDown() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .startAnd()
+      .equals("f1", PredicateLeaf.Type.LONG, 3L)
+      .equals("f2", PredicateLeaf.Type.STRING, "c")
+      .end()
+      .end()
+      .build();
+
+    Consumer<OrcFilterContext> f = FilterFactory.createVectorFilter(sArg, schema);
+    f.accept(fc.setBatch(batch));
+
+    validateSelected(0, 1, 3, 4, 5);
+  }
+
+  @Test
+  public void testNotOrPushDown() {
+    setBatch(new Long[] {1L, 2L, 3L, 4L, 5L, 6L},
+             new String[] {"a", "b", "c", "d", "e", "f"});
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startNot()
+      .startOr()
+      .equals("f1", PredicateLeaf.Type.LONG, 3L)
+      .equals("f2", PredicateLeaf.Type.STRING, "d")
+      .end()
+      .end()
+      .build();
+
+    Consumer<OrcFilterContext> f = FilterFactory.createVectorFilter(sArg, schema);
+    f.accept(fc.setBatch(batch));
+
+    validateSelected(0, 1, 4, 5);
+  }
+}

--- a/java/core/src/test/org/apache/orc/filter/impl/TestOrFilter.java
+++ b/java/core/src/test/org/apache/orc/filter/impl/TestOrFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.filter.impl;
+
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.orc.OrcFile;
+import org.apache.orc.filter.FilterFactory;
+import org.apache.orc.filter.VectorFilter;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class TestOrFilter extends ATestFilter {
+  @Test
+  public void testORConversion() throws FilterFactory.UnSupportedSArgException {
+    SearchArgument sarg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 2L, 3L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "b", "c")
+      .end()
+      .build();
+
+    Set<String> colIds = new HashSet<>();
+    VectorFilter f = FilterFactory.createVectorFilter(sarg.getExpression(),
+                                                      colIds,
+                                                      sarg.getLeaves(),
+                                                      schema,
+                                                      OrcFile.Version.CURRENT);
+    Assert.assertNotNull(f);
+    Assert.assertTrue(f instanceof OrFilter);
+    Assert.assertEquals(2, ((OrFilter) f).filters.length);
+    Assert.assertEquals(2, colIds.size());
+    Assert.assertTrue(colIds.contains("f1"));
+    Assert.assertTrue(colIds.contains("f2"));
+
+    // Setup the data such that the OR condition should select every row
+    setBatch(
+      new Long[] {1L, 0L, 2L, 4L, 3L},
+      new String[] {"z", "a", "y", "b", "x"});
+    fc.setBatch(batch);
+    filter(f);
+    validateAllSelected(5);
+  }
+}

--- a/java/core/src/test/org/apache/orc/util/CuckooSetBytesTest.java
+++ b/java/core/src/test/org/apache/orc/util/CuckooSetBytesTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.util;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+public class CuckooSetBytesTest {
+
+  // maximum table size
+  private static final int MAX_SIZE = 65437;
+
+  @Test
+  public void testSetBytes() {
+    String[] strings = {"foo", "bar", "baz", "a", "", "x1341", "Z"};
+    String[] negativeStrings = {"not", "in", "the", "set", "foobar"};
+    byte[][] values = getByteArrays(strings);
+    byte[][] negatives = getByteArrays(negativeStrings);
+
+    // load set
+    CuckooSetBytes s = new CuckooSetBytes(strings.length);
+    for(byte[] v : values) {
+      s.insert(v);
+    }
+
+    // test that the values we added are there
+    for(byte[] v : values) {
+      assertTrue(s.lookup(v, 0, v.length));
+    }
+
+    // test that values that we know are missing are shown to be absent
+    for (byte[] v : negatives) {
+      assertFalse(s.lookup(v, 0, v.length));
+    }
+
+    // Test that we can search correctly using a buffer and pulling
+    // a sequence of bytes out of the middle of it. In this case it
+    // is the 3 letter sequence "foo".
+    byte[] buf = getUTF8Bytes("thewordfooisinhere");
+    assertTrue(s.lookup(buf, 7, 3));
+  }
+
+  @Test
+  public void testSetBytesLargeRandom() {
+    byte[][] values;
+    Random gen = new Random(98763537);
+    for(int i = 0; i < 200;) {
+
+      // Make a random array of byte arrays
+      int size = gen.nextInt() % MAX_SIZE;
+      if (size <= 0) {   // ensure size is >= 1, otherwise try again
+        continue;
+      }
+      i++;
+      values = new byte[size][];
+      loadRandomBytes(values, gen);
+
+      // load them into a set
+      CuckooSetBytes s = new CuckooSetBytes(size);
+      loadSet(s, values);
+
+      // look them up to make sure they are all there
+      for (int j = 0; j != size; j++) {
+        assertTrue(s.lookup(values[j], 0, values[j].length));
+      }
+    }
+  }
+
+  public void loadRandomBytes(byte[][] values, Random gen) {
+    for (int i = 0; i != values.length; i++) {
+      values[i] = getUTF8Bytes(Integer.toString(gen.nextInt()));
+    }
+  }
+
+  private byte[] getUTF8Bytes(String s) {
+    byte[] v = null;
+    try {
+      v = s.getBytes(StandardCharsets.UTF_8);
+    } catch (Exception e) {
+      ; // won't happen
+    }
+    return v;
+  }
+
+  // Get an array of UTF-8 byte arrays from an array of strings
+  private byte[][] getByteArrays(String[] strings) {
+    byte[][] values = new byte[strings.length][];
+    for(int i = 0; i != strings.length; i++) {
+      try {
+        values[i] = strings[i].getBytes(StandardCharsets.UTF_8);
+      } catch (Exception e) {
+        ; // can't happen
+      }
+    }
+    return values;
+  }
+
+  private void loadSet(CuckooSetBytes s, byte[][] values) {
+    for (byte[] v: values) {
+      s.insert(v);
+    }
+  }
+
+}

--- a/java/core/src/test/resources/log4j.properties
+++ b/java/core/src/test/resources/log4j.properties
@@ -18,4 +18,3 @@ log4j.appender.stdout.layout.ConversionPattern=%p\t%d{ISO8601}\t%r\t%c\t[%t]\t%m
 
 # Suppress the warnings about native io not being available
 log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
-log4j.logger.org.apache.orc.TestRowFilteringIOSkip=INFO

--- a/java/core/src/test/resources/log4j.properties
+++ b/java/core/src/test/resources/log4j.properties
@@ -18,3 +18,4 @@ log4j.appender.stdout.layout.ConversionPattern=%p\t%d{ISO8601}\t%r\t%c\t[%t]\t%m
 
 # Suppress the warnings about native io not being available
 log4j.logger.org.apache.hadoop.util.NativeCodeLoader=ERROR
+log4j.logger.org.apache.orc.TestRowFilteringIOSkip=INFO

--- a/java/gen/pom.xml
+++ b/java/gen/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>orc</artifactId>
+    <groupId>org.apache.orc</groupId>
+    <version>1.7.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>orc-gen</artifactId>
+  <name>ORC Code Generation</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/java/gen/src/findbugs/exclude.xml
+++ b/java/gen/src/findbugs/exclude.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<FindBugsFilter>
+
+</FindBugsFilter>

--- a/java/gen/src/main/java/org/apache/orc/gen/FilterGenerator.java
+++ b/java/gen/src/main/java/org/apache/orc/gen/FilterGenerator.java
@@ -1,0 +1,568 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.gen;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.orc.gen.FilterGenerator.FilterOp.BETWEEN;
+import static org.apache.orc.gen.FilterGenerator.FilterOp.EQUALS;
+import static org.apache.orc.gen.FilterGenerator.FilterOp.IN;
+import static org.apache.orc.gen.FilterGenerator.FilterOp.NOT;
+import static org.apache.orc.gen.FilterGenerator.FilterType.DECIMAL;
+import static org.apache.orc.gen.FilterGenerator.FilterType.FLOAT;
+import static org.apache.orc.gen.FilterGenerator.FilterType.LONG;
+import static org.apache.orc.gen.FilterGenerator.FilterType.STRING;
+import static org.apache.orc.gen.FilterGenerator.FilterType.TIMESTAMP;
+
+public class FilterGenerator {
+  private static final Logger LOG = LoggerFactory.getLogger(FilterGenerator.class);
+  private final Generator gtr = new Generator();
+  private File templateDir;
+  private File srcPkgDir = null;
+  private File testPkgDir = null;
+
+  private static String readFile(File tFile) throws IOException {
+    StringBuilder b = new StringBuilder();
+    String line;
+    try (BufferedReader r = new BufferedReader(new InputStreamReader(new FileInputStream(tFile),
+                                                                     StandardCharsets.UTF_8))) {
+      while ((line = r.readLine()) != null) {
+        b.append(line);
+        b.append("\n");
+      }
+    }
+    return b.toString();
+  }
+
+  private static void writeFile(String content, File file)
+    throws IOException {
+    try (BufferedWriter w = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file),
+                                                                      StandardCharsets.UTF_8))) {
+      w.write(content);
+    }
+  }
+
+  static String toPascalCase(String word) {
+    return toCapCase(word, true);
+  }
+
+  static String toCamelCase(String word) {
+    return toCapCase(word, false);
+  }
+
+  static String toCapCase(String word, boolean pascal) {
+    if (word == null || word.isEmpty()) {
+      return word;
+    } else {
+      word = word.toLowerCase();
+      StringBuilder b = new StringBuilder();
+      for (String part : word.split("_")) {
+        if (part.isEmpty()) {
+          b.append("_");
+        } else {
+          if (pascal || b.length() > 0) {
+            b.append(Character.toUpperCase(part.charAt(0)));
+            b.append(part.substring(1));
+          } else {
+            b.append(part);
+          }
+        }
+      }
+      return b.toString();
+    }
+  }
+
+  public void setSrcPkgDir(String srcPkgDir) {
+    this.srcPkgDir = new File(srcPkgDir);
+  }
+
+  public void setTestPkgDir(String testPkgDir) {
+    this.testPkgDir = new File(testPkgDir);
+  }
+
+  public void setTemplateDir(String templateDir) {
+    this.templateDir = new File(templateDir);
+  }
+
+  public void execute() throws IOException, IllegalAccessException {
+    LOG.info("Generating using templates: {} to src dir {} and test dir {}",
+             templateDir,
+             srcPkgDir,
+             testPkgDir);
+
+    if (srcPkgDir.mkdirs()) {
+      LOG.info("Created pkg dir {}", srcPkgDir);
+    }
+
+    for (boolean not : new boolean[] {false, true}) {
+      writeSimpleOpFilters(not);
+      writeStringOpFilters(not);
+      writeDecimalOpFilters(not);
+      writeTimestampOpFilters(not);
+    }
+    writeLeafFilterFactory();
+    writeFilterTests();
+  }
+
+  private void writeFilterTests() throws IOException {
+    StringBuilder buffer = new StringBuilder();
+    String unaryTest = readFile(new File(templateDir, "filter_unary_test.txt"));
+    String noArgTest = readFile(new File(templateDir, "filter_noarg_test.txt"));
+    String binaryTest = readFile(new File(templateDir, "filter_binary_test.txt"));
+    int colIdx = 0;
+    for (FilterType fType : Arrays.asList(LONG, STRING, DECIMAL, FLOAT, TIMESTAMP)) {
+      buffer.setLength(0);
+      colIdx++;
+      for (FilterOp fOp : FilterOp.values()) {
+        if (fOp == NOT) {
+          continue;
+        }
+        gtr.clear();
+        gtr.filterType(fType);
+        gtr.filterOp(fOp);
+        gtr.addTestOps(colIdx);
+        switch (fOp) {
+          case IS_NULL:
+            buffer.append(gtr.build(noArgTest));
+            break;
+          case BETWEEN:
+          case IN:
+            buffer.append(gtr.build(binaryTest));
+            break;
+          default:
+            buffer.append(gtr.build(unaryTest));
+            break;
+        }
+      }
+      // Generate the class
+      gtr.clear();
+      String className = "Test" + fType.getPC() + "Filters";
+      gtr.addTag(Tag.METHODS, buffer.toString());
+      gtr.addTag(Tag.CLASS_NAME, className);
+      writeFile(gtr.build(new File(templateDir, "filter_test.txt"), false),
+                new File(testPkgDir, className + ".java"));
+    }
+  }
+
+  private void writeTimestampOpFilters(boolean not) throws IOException {
+    for (FilterOp fOp : FilterOp.values()) {
+      if (!fOp.comparison) {
+        continue;
+      }
+
+      gtr.clear();
+      gtr.filterType(TIMESTAMP)
+        .filterOp(fOp)
+        .not(not)
+        .addCmpOp();
+      writeFile(gtr.build(new File(templateDir, "timestamp_cmp.txt")),
+                new File(srcPkgDir, gtr.fileName()));
+    }
+
+    // Write between filter
+    gtr.clear();
+    gtr.filterType(TIMESTAMP)
+      .filterOp(BETWEEN)
+      .not(not)
+      .addBtOp();
+    writeFile(gtr.build(new File(templateDir, "timestamp_bt.txt")),
+              new File(srcPkgDir, gtr.fileName()));
+
+    // Write in filter
+    gtr.clear();
+    gtr.filterType(TIMESTAMP)
+      .filterOp(IN)
+      .not(not)
+      .addNotOp();
+    writeFile(gtr.build(new File(templateDir, "timestamp_in.txt")),
+              new File(srcPkgDir, gtr.fileName()));
+  }
+
+  private void writeLeafFilterFactory() throws IOException {
+    StringBuilder buffer = new StringBuilder();
+    String methodTemplate = readFile(new File(templateDir, "create_leaf.txt"));
+
+    for (boolean not : Arrays.asList(false, true)) {
+      // Generate the methods
+      for (FilterOp fOp : FilterOp.values()) {
+        if (!fOp.comparison) {
+          continue;
+        }
+
+        gtr.clear();
+        gtr.addTag(Tag.OPERATOR, fOp.getPC())
+          .addTag(Tag.NOT, not ? NOT.getPC() : "");
+        buffer.append(gtr.build(methodTemplate));
+      }
+
+      // Add the Between method
+      gtr.clear();
+      gtr.addTag(Tag.NOT, not ? NOT.getPC() : "");
+      buffer.append(gtr.build(new File(templateDir, "create_bt.txt")));
+
+      // Add the In method
+      gtr.clear();
+      gtr.addTag(Tag.NOT, not ? NOT.getPC() : "");
+      buffer.append(gtr.build(new File(templateDir, "create_in.txt")));
+    }
+
+
+    // Generate the class
+    gtr.clear();
+    gtr.addTag(Tag.METHODS, buffer.toString());
+    writeFile(gtr.build(new File(templateDir, "leaf_factory.txt")),
+              new File(srcPkgDir, "LeafFilterFactory.java"));
+  }
+
+  private void writeDecimalOpFilters(boolean not) throws IOException {
+    for (FilterOp fOp : FilterOp.values()) {
+      if (!fOp.comparison) {
+        continue;
+      }
+
+      gtr.clear();
+      gtr.filterType(DECIMAL)
+        .filterOp(fOp)
+        .not(not)
+        .addCmpOp();
+      writeFile(gtr.build(new File(templateDir, "decimal_cmp.txt")),
+                new File(srcPkgDir, gtr.fileName()));
+    }
+
+    // Write Between
+    gtr.clear();
+    gtr.filterType(DECIMAL)
+      .filterOp(BETWEEN)
+      .not(not)
+      .addBtOp();
+    writeFile(gtr.build(new File(templateDir, "decimal_bt.txt")),
+              new File(srcPkgDir, gtr.fileName()));
+
+    // Write In
+    gtr.clear();
+    gtr.filterType(DECIMAL)
+      .filterOp(IN)
+      .not(not)
+      .addNotOp();
+    writeFile(gtr.build(new File(templateDir, "decimal_in.txt")),
+              new File(srcPkgDir, gtr.fileName()));
+  }
+
+  private void writeStringOpFilters(boolean not) throws IOException {
+    // Write equals
+    gtr.clear();
+    gtr.filterType(STRING)
+      .filterOp(EQUALS)
+      .not(not)
+      .addNotOp();
+    writeFile(gtr.build(new File(templateDir, "string_eq.txt")),
+              new File(srcPkgDir, gtr.fileName()));
+
+    // Write compare operators
+    for (FilterOp fOp : Arrays.asList(FilterOp.LESS_THAN, FilterOp.LESS_THAN_EQUALS)) {
+      gtr.clear();
+      gtr.filterType(STRING)
+        .filterOp(fOp)
+        .not(not)
+        .addCmpOp();
+      writeFile(gtr.build(new File(templateDir, "string_cmp.txt")),
+                new File(srcPkgDir, gtr.fileName()));
+    }
+
+    // Write between
+    gtr.clear();
+    gtr.filterType(STRING)
+      .filterOp(BETWEEN)
+      .not(not)
+      .addBtOp();
+    writeFile(gtr.build(new File(templateDir, "string_bt.txt")),
+              new File(srcPkgDir, gtr.fileName()));
+
+    // Write string in
+    gtr.clear();
+    gtr.filterType(STRING)
+      .filterOp(IN)
+      .not(not)
+      .addNotOp();
+    writeFile(gtr.build(new File(templateDir, "string_in.txt")),
+              new File(srcPkgDir, gtr.fileName()));
+  }
+
+  private void writeSimpleOpFilters(boolean not) throws IOException, IllegalAccessException {
+    for (FilterType fType : FilterType.values()) {
+      if (!fType.simple) {
+        continue;
+      }
+
+      // Write comparison filters
+      for (FilterOp fOp : FilterOp.values()) {
+        if (!fOp.comparison) {
+          continue;
+        }
+        writeSimpleOpFilter(fType, fOp, not);
+      }
+
+      // Write between filters
+      gtr.clear();
+      gtr.filterType(fType)
+        .filterOp(BETWEEN)
+        .not(not)
+        .addBtOp()
+        .addTypeParams();
+      writeFile(gtr.build(new File(templateDir, "type_bt.txt")),
+                new File(srcPkgDir, gtr.fileName()));
+
+      // Write in filters
+      gtr.clear();
+      gtr.filterType(fType)
+        .filterOp(IN)
+        .not(not)
+        .addInOp()
+        .addTypeParams();
+      writeFile(gtr.build(new File(templateDir, "type_in.txt")),
+                new File(srcPkgDir, gtr.fileName()));
+    }
+  }
+
+  private void writeSimpleOpFilter(FilterType fType, FilterOp fOp, boolean not)
+    throws IOException, IllegalAccessException {
+    String content = genSimpleOpFilter(fType, fOp, not);
+    writeFile(content, new File(srcPkgDir, gtr.fileName()));
+  }
+
+  String genSimpleOpFilter(FilterType fType, FilterOp fOp, boolean not)
+    throws IOException, IllegalAccessException {
+    if (!fType.simple || !fOp.comparison) {
+      throw new IllegalAccessException(String.format(
+        "FilterType %s, FilterOp %s does now allow simple generation", fType, fOp));
+    }
+    gtr.clear();
+    gtr.filterType(fType)
+      .filterOp(fOp)
+      .not(not)
+      .addTypeParams()
+      .addCmpOp();
+
+    return gtr.build(new File(templateDir, "type_cmp.txt"));
+  }
+
+  private enum Tag {
+    OPERATOR,
+    CLASS_NAME,
+    LEAF_TYPE,
+    LEAF_VECTOR,
+    METHODS,
+    LOW_OP,
+    HIGH_OP,
+    LOG_OP,
+    IN_OP,
+    NOT_OP,
+    NOT,
+    S_OPERATOR,
+    TYPE_NAME, OPERATOR_NAME, COL_NAME;
+
+    private String getCC() {
+      return String.format("<%s>", toPascalCase(name()));
+    }
+  }
+
+  enum FilterType {
+    LONG(true, "long", "LongColumnVector"),
+    FLOAT(true, "double", "DoubleColumnVector"),
+    TIMESTAMP(false, null, null),
+    DECIMAL(false, null, null),
+    STRING(false, null, null);
+
+    final boolean simple;
+    final String leafType;
+    final String leafVector;
+
+    FilterType(boolean simple, String leafType, String leafVector) {
+      this.simple = simple;
+      this.leafType = leafType;
+      this.leafVector = leafVector;
+    }
+
+    FilterType(boolean simple) {
+      this(simple, null, null);
+    }
+
+    String getPC() {
+      return toPascalCase(name());
+    }
+  }
+
+  enum FilterOp {
+    EQUALS(true, "==", "!="),
+    LESS_THAN(true, "<", ">="),
+    LESS_THAN_EQUALS(true, "<=", ">"),
+    BETWEEN(),
+    IN(false, ">=", "<"),
+    IS_NULL(false, null, null),
+    NOT(false, "", "!");
+
+    final boolean comparison;
+    final String op;
+    final String notOp;
+
+    FilterOp(boolean comparison, String op, String notOp) {
+      this.comparison = comparison;
+      this.op = op;
+      this.notOp = notOp;
+    }
+
+    FilterOp() {
+      this(false, null, null);
+    }
+
+    String getPC() {
+      return toPascalCase(name());
+    }
+
+    String getCC() {
+      return toCamelCase(name());
+    }
+  }
+
+  private static class Generator {
+    private final Map<Tag, String> subs = new HashMap<>(10);
+    private FilterOp fOp;
+    private FilterType fType;
+    private boolean not;
+
+    void clear() {
+      subs.clear();
+    }
+
+    Generator filterOp(FilterOp fOp) {
+      this.fOp = fOp;
+      return this;
+    }
+
+    Generator filterType(FilterType fType) {
+      this.fType = fType;
+      return this;
+    }
+
+    Generator not(boolean not) {
+      this.not = not;
+      return this;
+    }
+
+    private void addClassName() {
+      subs.put(Tag.CLASS_NAME, makeClassName(fOp, fType, not));
+    }
+
+    private String makeClassName(FilterOp fOp, FilterType fType, boolean not) {
+      return fType.getPC() + (not ? NOT.getPC() + fOp.getPC() : fOp.getPC());
+    }
+
+    private Generator addTypeParams() {
+      subs.put(Tag.LEAF_VECTOR, fType.leafVector);
+      subs.put(Tag.LEAF_TYPE, fType.leafType);
+      return this;
+    }
+
+    Generator addTag(Tag tag, String rpl) {
+      subs.put(tag, rpl);
+      return this;
+    }
+
+    Generator addCmpOp() {
+      subs.put(Tag.OPERATOR, not ? fOp.notOp : fOp.op);
+      return this;
+    }
+
+    Generator addTestOps(int colIdx) {
+      subs.put(Tag.OPERATOR, fOp.getPC());
+      subs.put(Tag.S_OPERATOR, fOp.getCC());
+      subs.put(Tag.TYPE_NAME, fType.name());
+      subs.put(Tag.OPERATOR_NAME, fOp.name());
+      subs.put(Tag.COL_NAME, "f" + colIdx);
+      return this;
+    }
+
+    Generator addBtOp() {
+      String logOp;
+      String lowOp;
+      String highOp;
+
+      if (not) {
+        logOp = "||";
+        lowOp = "<";
+        highOp = ">";
+      } else {
+        logOp = "&&";
+        lowOp = ">=";
+        highOp = "<=";
+      }
+
+      subs.put(Tag.LOG_OP, logOp);
+      subs.put(Tag.LOW_OP, lowOp);
+      subs.put(Tag.HIGH_OP, highOp);
+      return this;
+    }
+
+    String build(String content) {
+      for (Map.Entry<Tag, String> entry : subs.entrySet()) {
+        content = content.replaceAll(entry.getKey().getCC(), entry.getValue());
+      }
+      return content;
+    }
+
+    String build(File tFile, boolean addClassName) throws IOException {
+      if (addClassName) {
+        addClassName();
+      }
+      return build(readFile(tFile));
+    }
+
+    String build(File tFile) throws IOException {
+      return build(tFile, true);
+    }
+
+    String fileName() {
+      return subs.get(Tag.CLASS_NAME) + ".java";
+    }
+
+    public Generator addInOp() {
+      subs.put(Tag.IN_OP, not ? IN.notOp : IN.op);
+      return this;
+    }
+
+    public Generator addNotOp() {
+      subs.put(Tag.NOT_OP, not ? NOT.notOp : NOT.op);
+      return this;
+    }
+  }
+}

--- a/java/gen/src/test/java/org/apache/orc/gen/FilterGeneratorTest.java
+++ b/java/gen/src/test/java/org/apache/orc/gen/FilterGeneratorTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.gen;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class FilterGeneratorTest {
+
+  private final FilterGenerator fg;
+
+  public FilterGeneratorTest() {
+    this.fg = new FilterGenerator();
+    fg.setTemplateDir("../core/src/gen/filters/");
+  }
+
+
+  @Test
+  public void simpleGenTest() throws IOException, IllegalAccessException {
+    String content = fg.genSimpleOpFilter(FilterGenerator.FilterType.LONG,
+                                          FilterGenerator.FilterOp.EQUALS,
+                                          false);
+    Assert.assertNotNull(content);
+    Assert.assertFalse(content.contains("<ClassName>"));
+    Assert.assertFalse(content.contains("<LeafType>"));
+    Assert.assertFalse(content.contains("<LeafVector>"));
+    Assert.assertFalse(content.contains("<Operator>"));
+    Assert.assertFalse(content.contains(FilterGenerator.FilterOp.EQUALS.notOp));
+  }
+
+  @Test
+  public void simpleGenNotTest() throws IOException, IllegalAccessException {
+    String content = fg.genSimpleOpFilter(FilterGenerator.FilterType.LONG,
+                                          FilterGenerator.FilterOp.EQUALS,
+                                          true);
+    Assert.assertNotNull(content);
+    Assert.assertFalse(content.contains("<ClassName>"));
+    Assert.assertFalse(content.contains("<LeafType>"));
+    Assert.assertFalse(content.contains("<LeafVector>"));
+    Assert.assertFalse(content.contains("<Operator>"));
+    Assert.assertTrue(content.contains(FilterGenerator.FilterOp.EQUALS.notOp));
+  }
+
+  @Test
+  public void pascalCaseTest() {
+    Assert.assertNull(FilterGenerator.toPascalCase(null));
+    Assert.assertEquals("", FilterGenerator.toPascalCase(""));
+    Assert.assertEquals("Abcd", FilterGenerator.toPascalCase("abcd"));
+    Assert.assertEquals("Abcda", FilterGenerator.toPascalCase("Abcda"));
+    Assert.assertEquals("A", FilterGenerator.toPascalCase("a"));
+    Assert.assertEquals("LessThan", FilterGenerator.toPascalCase("LESS_THAN"));
+    Assert.assertEquals("__LessThan", FilterGenerator.toPascalCase("__LESS_THAN"));
+  }
+
+  @Test
+  public void camelCaseTest() {
+    Assert.assertNull(FilterGenerator.toCamelCase(null));
+    Assert.assertEquals("", FilterGenerator.toCamelCase(""));
+    Assert.assertEquals("abcd", FilterGenerator.toCamelCase("abcd"));
+    Assert.assertEquals("abcda", FilterGenerator.toCamelCase("Abcda"));
+    Assert.assertEquals("a", FilterGenerator.toCamelCase("a"));
+    Assert.assertEquals("lessThan", FilterGenerator.toCamelCase("LESS_THAN"));
+    Assert.assertEquals("__LessThan", FilterGenerator.toCamelCase("__LESS_THAN"));
+  }
+}

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
@@ -153,8 +153,10 @@ public class OrcInputFormat<V extends WritableComparable>
     Reader file = OrcFile.createReader(split.getPath(),
         OrcFile.readerOptions(conf)
             .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(conf)));
-    return new OrcMapredRecordReader<>(file, buildOptions(conf,
-        file, split.getStart(), split.getLength()));
+    //Mapreduce supports selected vector
+    Reader.Options options =  buildOptions(conf, file, split.getStart(), split.getLength())
+      .setAllowSelected(true);
+    return new OrcMapredRecordReader<>(file,options);
   }
 
   /**

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcMapredRecordReader.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcMapredRecordReader.java
@@ -59,6 +59,7 @@ public class OrcMapredRecordReader<V extends WritableComparable>
   private final RecordReader batchReader;
   private final VectorizedRowBatch batch;
   private int rowInBatch;
+  private final boolean[] included;
 
   public OrcMapredRecordReader(RecordReader reader,
                                TypeDescription schema) throws IOException {
@@ -66,6 +67,7 @@ public class OrcMapredRecordReader<V extends WritableComparable>
     this.batch = schema.createRowBatch();
     this.schema = schema;
     rowInBatch = 0;
+    this.included = null;
   }
 
   protected OrcMapredRecordReader(Reader fileReader,
@@ -78,6 +80,7 @@ public class OrcMapredRecordReader<V extends WritableComparable>
     }
     this.batch = schema.createRowBatch();
     rowInBatch = 0;
+    this.included = options.getInclude();
   }
 
   /**
@@ -98,16 +101,22 @@ public class OrcMapredRecordReader<V extends WritableComparable>
     if (!ensureBatch()) {
       return false;
     }
+    int rowIdx = batch.selectedInUse ? batch.selected[rowInBatch] : rowInBatch;
     if (schema.getCategory() == TypeDescription.Category.STRUCT) {
       OrcStruct result = (OrcStruct) value;
       List<TypeDescription> children = schema.getChildren();
       int numberOfChildren = children.size();
       for(int i=0; i < numberOfChildren; ++i) {
-        result.setFieldValue(i, nextValue(batch.cols[i], rowInBatch,
-            children.get(i), result.getFieldValue(i)));
+        TypeDescription child = children.get(i);
+        if (included == null || included[child.getId()]) {
+          result.setFieldValue(i, nextValue(batch.cols[i], rowIdx, child,
+                                            result.getFieldValue(i)));
+        } else {
+          result.setFieldValue(i, null);
+        }
       }
     } else {
-      nextValue(batch.cols[0], rowInBatch, schema, value);
+      nextValue(batch.cols[0], rowIdx, schema, value);
     }
     rowInBatch += 1;
     return true;

--- a/java/mapreduce/src/java/org/apache/orc/mapreduce/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapreduce/OrcInputFormat.java
@@ -68,9 +68,14 @@ public class OrcInputFormat<V extends WritableComparable>
     Reader file = OrcFile.createReader(split.getPath(),
         OrcFile.readerOptions(conf)
             .maxLength(OrcConf.MAX_FILE_LENGTH.getLong(conf)));
-    return new OrcMapreduceRecordReader<>(file,
-        org.apache.orc.mapred.OrcInputFormat.buildOptions(conf,
-            file, split.getStart(), split.getLength()));
+    //Mapreduce supports selected vector
+    Reader.Options options =
+      org.apache.orc.mapred.OrcInputFormat.buildOptions(conf,
+                                                        file,
+                                                        split.getStart(),
+                                                        split.getLength())
+      .setAllowSelected(true);
+    return new OrcMapreduceRecordReader<>(file, options);
   }
 
   @Override

--- a/java/mapreduce/src/java/org/apache/orc/mapreduce/OrcMapreduceRecordReader.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapreduce/OrcMapreduceRecordReader.java
@@ -44,6 +44,7 @@ public class OrcMapreduceRecordReader<V extends WritableComparable>
   private final VectorizedRowBatch batch;
   private int rowInBatch;
   private final V row;
+  private final boolean[] include;
 
   public OrcMapreduceRecordReader(RecordReader reader,
                                   TypeDescription schema) throws IOException {
@@ -52,6 +53,7 @@ public class OrcMapreduceRecordReader<V extends WritableComparable>
     this.schema = schema;
     rowInBatch = 0;
     this.row = (V) OrcStruct.createValue(schema);
+    this.include = null;
   }
 
   public OrcMapreduceRecordReader(Reader fileReader,
@@ -65,6 +67,7 @@ public class OrcMapreduceRecordReader<V extends WritableComparable>
     this.batch = schema.createRowBatch();
     rowInBatch = 0;
     this.row = (V) OrcStruct.createValue(schema);
+    this.include = options.getInclude();
   }
 
   /**
@@ -96,16 +99,22 @@ public class OrcMapreduceRecordReader<V extends WritableComparable>
     if (!ensureBatch()) {
       return false;
     }
+    int rowIdx = batch.selectedInUse ? batch.selected[rowInBatch] : rowInBatch;
     if (schema.getCategory() == TypeDescription.Category.STRUCT) {
       OrcStruct result = (OrcStruct) row;
       List<TypeDescription> children = schema.getChildren();
       int numberOfChildren = children.size();
       for(int i=0; i < numberOfChildren; ++i) {
-        result.setFieldValue(i, OrcMapredRecordReader.nextValue(batch.cols[i], rowInBatch,
-            children.get(i), result.getFieldValue(i)));
+        TypeDescription child = children.get(i);
+        if (include == null || include[child.getId()]) {
+          result.setFieldValue(i, OrcMapredRecordReader.nextValue(batch.cols[i], rowIdx,
+                                                                  child, result.getFieldValue(i)));
+        } else {
+          result.setFieldValue(i, null);
+        }
       }
     } else {
-      OrcMapredRecordReader.nextValue(batch.cols[0], rowInBatch, schema, row);
+      OrcMapredRecordReader.nextValue(batch.cols[0], rowIdx, schema, row);
     }
     rowInBatch += 1;
     return true;

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestMapRedFiltering.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestMapRedFiltering.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.mapred;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.orc.OrcConf;
+import org.apache.orc.mapreduce.FilterTestUtil;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+
+import static org.apache.orc.mapreduce.FilterTestUtil.RowCount;
+import static org.apache.orc.mapreduce.FilterTestUtil.validateRow;
+
+
+public class TestMapRedFiltering {
+  private static final Path workDir = new Path(System.getProperty("test.tmp.dir",
+                                                                  "target" + File.separator + "test"
+                                                                  + File.separator + "tmp"));
+
+  private static Configuration conf;
+  private static FileSystem fs;
+  private static final Path filePath = new Path(workDir, "mapred_skip_file.orc");
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    conf = new Configuration();
+    fs = FileSystem.get(conf);
+    FilterTestUtil.createFile(conf, fs, filePath);
+  }
+
+  @Test
+  public void readWithSArg() throws IOException, InterruptedException {
+    OrcConf.ALLOW_SARG_TO_FILTER.setBoolean(conf, false);
+    OrcConf.INCLUDE_COLUMNS.setString(conf,"0,1,2,3,4");
+    OrcInputFormat.setSearchArgument(conf,
+                                     SearchArgumentFactory.newBuilder()
+                                       .in("f1", PredicateLeaf.Type.LONG, 0L)
+                                       .build(),
+                                     new String[] {"f1"});
+    FileSplit split = new FileSplit(filePath,
+                                    0, fs.getFileStatus(filePath).getLen(),
+                                    new String[0]);
+    FilterTestUtil.readStart();
+    RecordReader<NullWritable, OrcStruct> r = new OrcInputFormat<OrcStruct>()
+      .getRecordReader(split, new JobConf(conf), null);
+    long rowCount = validateFilteredRecordReader(r);
+    double p = FilterTestUtil.readPercentage(FilterTestUtil.readEnd(),
+                                             fs.getFileStatus(filePath).getLen());
+    Assert.assertEquals(FilterTestUtil.RowCount, rowCount);
+    Assert.assertTrue(p >= 100);
+  }
+
+  @Test
+  public void readWithSArgAsFilter() throws IOException {
+    OrcConf.ALLOW_SARG_TO_FILTER.setBoolean(conf, true);
+    OrcConf.INCLUDE_COLUMNS.setString(conf,"0,1,2,3,4");
+    OrcInputFormat.setSearchArgument(conf,
+                                     SearchArgumentFactory.newBuilder()
+                                       .in("f1", PredicateLeaf.Type.LONG, 0L)
+                                       .build(),
+                                     new String[] {"f1"});
+    FileSplit split = new FileSplit(filePath,
+                                    0, fs.getFileStatus(filePath).getLen(),
+                                    new String[0]);
+    FilterTestUtil.readStart();
+    RecordReader<NullWritable, OrcStruct> r = new OrcInputFormat<OrcStruct>()
+      .getRecordReader(split, new JobConf(conf), null);
+    long rowCount = validateFilteredRecordReader(r);
+    double p = FilterTestUtil.readPercentage(FilterTestUtil.readEnd(),
+                                             fs.getFileStatus(filePath).getLen());
+    Assert.assertEquals(0, rowCount);
+    Assert.assertTrue(p < 30);
+  }
+
+  @Test
+  public void readSingleRowWFilter() throws IOException, InterruptedException {
+    int cnt = 100;
+    Random r = new Random(cnt);
+    long ridx = 0;
+
+    while (cnt > 0) {
+      ridx = r.nextInt((int) RowCount);
+      readSingleRowWfilter(ridx);
+      cnt -= 1;
+    }
+
+  }
+
+  private static long validateFilteredRecordReader(RecordReader<NullWritable, OrcStruct> rr)
+    throws IOException {
+    OrcStruct row = new OrcStruct(FilterTestUtil.schema);
+    long rowCount = 0;
+    while (rr.next(NullWritable.get(), row)) {
+      FilterTestUtil.validateRow(row);
+      rowCount += 1;
+    }
+    return rowCount;
+  }
+
+  private void readSingleRowWfilter(long idx) throws IOException, InterruptedException {
+    OrcConf.ALLOW_SARG_TO_FILTER.setBoolean(conf, true);
+    OrcInputFormat.setSearchArgument(conf,
+                                     SearchArgumentFactory.newBuilder()
+                                       .in("ridx", PredicateLeaf.Type.LONG, idx)
+                                       .build(),
+                                     new String[] {"ridx"});
+    OrcConf.INCLUDE_COLUMNS.setString(conf, "0,1,2,4");
+    FileSplit split = new FileSplit(filePath,
+                                    0, fs.getFileStatus(filePath).getLen(),
+                                    new String[0]);
+    FilterTestUtil.readStart();
+    RecordReader<NullWritable, OrcStruct> r = new OrcInputFormat<OrcStruct>()
+      .getRecordReader(split, new JobConf(conf), null);
+    OrcStruct row = new OrcStruct(FilterTestUtil.schema);
+    long rowCount = 0;
+    while (r.next(NullWritable.get(), row)) {
+      FilterTestUtil.validateLimitedRow(row, idx);
+      rowCount += 1;
+    }
+    Assert.assertEquals(1, rowCount);
+    r.close();
+  }
+}

--- a/java/mapreduce/src/test/org/apache/orc/mapreduce/FilterTestUtil.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapreduce/FilterTestUtil.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.mapreduce;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.orc.OrcFile;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+import org.apache.orc.mapred.OrcStruct;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+public class FilterTestUtil {
+  private final static Logger LOG = LoggerFactory.getLogger(FilterTestUtil.class);
+  public static final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createDecimal().withPrecision(20).withScale(6))
+    .addField("f3", TypeDescription.createLong())
+    .addField("f4", TypeDescription.createString())
+    .addField("ridx", TypeDescription.createLong());
+  public static final long RowCount = 4000000L;
+  private static final int scale = 3;
+
+  public static void createFile(Configuration conf, FileSystem fs, Path filePath)
+    throws IOException {
+    if (fs.exists(filePath)) {
+      return;
+    }
+
+    LOG.info("Creating file {} with schema {}", filePath, schema);
+    try (Writer writer = OrcFile.createWriter(filePath,
+                                              OrcFile.writerOptions(conf)
+                                                .fileSystem(fs)
+                                                .overwrite(true)
+                                                .rowIndexStride(8192)
+                                                .setSchema(schema))) {
+      Random rnd = new Random(1024);
+      VectorizedRowBatch b = schema.createRowBatch();
+      for (int rowIdx = 0; rowIdx < RowCount; rowIdx++) {
+        long v = rnd.nextLong();
+        for (int colIdx = 0; colIdx < schema.getChildren().size() - 1; colIdx++) {
+          switch (schema.getChildren().get(colIdx).getCategory()) {
+            case LONG:
+              ((LongColumnVector) b.cols[colIdx]).vector[b.size] = v;
+              break;
+            case DECIMAL:
+              HiveDecimalWritable d = new HiveDecimalWritable();
+              d.setFromLongAndScale(v, scale);
+              ((DecimalColumnVector) b.cols[colIdx]).vector[b.size] = d;
+              break;
+            case STRING:
+              ((BytesColumnVector) b.cols[colIdx]).setVal(b.size,
+                                                          String.valueOf(v)
+                                                            .getBytes(StandardCharsets.UTF_8));
+              break;
+            default:
+              throw new IllegalArgumentException();
+          }
+        }
+        // Populate the rowIdx
+        ((LongColumnVector) b.cols[4]).vector[b.size] = rowIdx;
+
+        b.size += 1;
+        if (b.size == b.getMaxSize()) {
+          writer.addRowBatch(b);
+          b.reset();
+        }
+      }
+      if (b.size > 0) {
+        writer.addRowBatch(b);
+        b.reset();
+      }
+    }
+    LOG.info("Created file {}", filePath);
+  }
+
+  public static void validateRow(OrcStruct row, long expId) {
+    HiveDecimalWritable d = new HiveDecimalWritable();
+
+    if (expId > 0) {
+      Assert.assertEquals(expId, ((LongWritable) row.getFieldValue(4)).get());
+    }
+    for (int i = 0; i < row.getNumFields(); i++) {
+      long expValue = ((LongWritable) row.getFieldValue(0)).get();
+      d.setFromLongAndScale(expValue, scale);
+      Assert.assertEquals(d, row.getFieldValue(1));
+      Assert.assertEquals(expValue, ((LongWritable) row.getFieldValue(2)).get());
+      Assert.assertEquals(String.valueOf(expValue),
+                          row.getFieldValue(3).toString());
+    }
+  }
+
+  public static void validateLimitedRow(OrcStruct row, long expId) {
+    HiveDecimalWritable d = new HiveDecimalWritable();
+
+    if (expId > 0) {
+      Assert.assertEquals(expId, ((LongWritable) row.getFieldValue(4)).get());
+    }
+    for (int i = 0; i < row.getNumFields(); i++) {
+      long expValue = ((LongWritable) row.getFieldValue(0)).get();
+      d.setFromLongAndScale(expValue, scale);
+      Assert.assertEquals(d, row.getFieldValue(1));
+      Assert.assertEquals(expValue, ((LongWritable) row.getFieldValue(2)).get());
+    }
+  }
+
+  public static void validateRow(OrcStruct row) {
+    validateRow(row, -1);
+  }
+
+  public static double readPercentage(FileSystem.Statistics stats, long fileSize) {
+    double p = stats.getBytesRead() * 100.0 / fileSize;
+    LOG.info(String.format("FileSize: %d%nReadSize: %d%nRead %%: %.2f",
+                           fileSize,
+                           stats.getBytesRead(),
+                           p));
+    return p;
+  }
+
+  public static void readStart() {
+    FileSystem.clearStatistics();
+  }
+
+  public static FileSystem.Statistics readEnd() {
+    return FileSystem.getAllStatistics().get(0);
+  }
+}

--- a/java/mapreduce/src/test/org/apache/orc/mapreduce/TestMapReduceFiltering.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapreduce/TestMapReduceFiltering.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.mapreduce;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.TaskType;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+import org.apache.orc.OrcConf;
+import org.apache.orc.mapred.OrcStruct;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+
+import static org.apache.orc.mapreduce.FilterTestUtil.RowCount;
+import static org.apache.orc.mapreduce.FilterTestUtil.validateLimitedRow;
+import static org.apache.orc.mapreduce.FilterTestUtil.validateRow;
+
+
+public class TestMapReduceFiltering {
+  private static final Path workDir = new Path(System.getProperty("test.tmp.dir",
+                                                                  "target" + File.separator + "test"
+                                                                  + File.separator + "tmp"));
+
+  private static Configuration conf;
+  private static FileSystem fs;
+  private static final Path filePath = new Path(workDir, "mapreduce_skip_file.orc");
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    conf = new Configuration();
+    fs = FileSystem.get(conf);
+    FilterTestUtil.createFile(conf, fs, filePath);
+  }
+
+  @Test
+  public void readWithSArg() throws IOException, InterruptedException {
+    TaskAttemptID id = new TaskAttemptID("jt", 0, TaskType.MAP, 0, 0);
+    OrcConf.ALLOW_SARG_TO_FILTER.setBoolean(conf, false);
+    OrcConf.INCLUDE_COLUMNS.setString(conf, "0,1,2,3,4");
+    OrcInputFormat.setSearchArgument(conf,
+                                     SearchArgumentFactory.newBuilder()
+                                       .in("f1", PredicateLeaf.Type.LONG, 0L)
+                                       .build(),
+                                     new String[] {"f1"});
+    FileSplit split = new FileSplit(filePath,
+                                    0, fs.getFileStatus(filePath).getLen(),
+                                    new String[0]);
+    TaskAttemptContext attemptContext = new TaskAttemptContextImpl(conf, id);
+    FilterTestUtil.readStart();
+    org.apache.hadoop.mapreduce.RecordReader<NullWritable, OrcStruct> r =
+      new OrcInputFormat<OrcStruct>().createRecordReader(split,
+                                                         attemptContext);
+    long rowCount = validateFilteredRecordReader(r);
+    double p = FilterTestUtil.readPercentage(FilterTestUtil.readEnd(),
+                                             fs.getFileStatus(filePath).getLen());
+    Assert.assertEquals(FilterTestUtil.RowCount, rowCount);
+    Assert.assertTrue(p >= 100);
+  }
+
+  @Test
+  public void readWithSArgAsFilter() throws IOException, InterruptedException {
+    TaskAttemptID id = new TaskAttemptID("jt", 1, TaskType.MAP, 0, 0);
+    OrcConf.ALLOW_SARG_TO_FILTER.setBoolean(conf, true);
+    OrcConf.INCLUDE_COLUMNS.setString(conf, "0,1,2,3,4");
+    OrcInputFormat.setSearchArgument(conf,
+                                     SearchArgumentFactory.newBuilder()
+                                       .in("f1", PredicateLeaf.Type.LONG, 0L)
+                                       .build(),
+                                     new String[] {"f1"});
+    FileSplit split = new FileSplit(filePath,
+                                    0, fs.getFileStatus(filePath).getLen(),
+                                    new String[0]);
+    TaskAttemptContext attemptContext = new TaskAttemptContextImpl(conf, id);
+    FilterTestUtil.readStart();
+    org.apache.hadoop.mapreduce.RecordReader<NullWritable, OrcStruct> r =
+      new OrcInputFormat<OrcStruct>().createRecordReader(split,
+                                                         attemptContext);
+    long rowCount = validateFilteredRecordReader(r);
+    double p = FilterTestUtil.readPercentage(FilterTestUtil.readEnd(),
+                                             fs.getFileStatus(filePath).getLen());
+    Assert.assertEquals(0, rowCount);
+    Assert.assertTrue(p < 30);
+  }
+
+  @Test
+  public void readSingleRowWFilter() throws IOException, InterruptedException {
+    int cnt = 100;
+    Random r = new Random(cnt);
+    long ridx = 0;
+
+    while (cnt > 0) {
+      ridx = r.nextInt((int) RowCount);
+      testSingleRowWfilter(ridx);
+      cnt -= 1;
+    }
+
+  }
+
+  private void testSingleRowWfilter(long idx) throws IOException, InterruptedException {
+    TaskAttemptID id = new TaskAttemptID("jt", 1, TaskType.MAP, 0, 0);
+    OrcConf.ALLOW_SARG_TO_FILTER.setBoolean(conf, true);
+    OrcConf.INCLUDE_COLUMNS.setString(conf, "0,1,2,4");
+    OrcInputFormat.setSearchArgument(conf,
+                                     SearchArgumentFactory.newBuilder()
+                                       .in("ridx", PredicateLeaf.Type.LONG, idx)
+                                       .build(),
+                                     new String[] {"ridx"});
+    FileSplit split = new FileSplit(filePath,
+                                    0, fs.getFileStatus(filePath).getLen(),
+                                    new String[0]);
+    TaskAttemptContext attemptContext = new TaskAttemptContextImpl(conf, id);
+    FilterTestUtil.readStart();
+    org.apache.hadoop.mapreduce.RecordReader<NullWritable, OrcStruct> r =
+      new OrcInputFormat<OrcStruct>().createRecordReader(split,
+                                                         attemptContext);
+    long rowCount = 0;
+    while (r.nextKeyValue()) {
+      validateLimitedRow(r.getCurrentValue(), idx);
+      rowCount += 1;
+    }
+    r.close();
+    Assert.assertEquals(1, rowCount);
+  }
+
+  private static long validateFilteredRecordReader(org.apache.hadoop.mapreduce.RecordReader<NullWritable
+    , OrcStruct> rr)
+    throws IOException, InterruptedException {
+    long rowCount = 0;
+    while (rr.nextKeyValue()) {
+      validateRow(rr.getCurrentValue());
+      rowCount += 1;
+    }
+    return rowCount;
+  }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -59,6 +59,7 @@
     <module>mapreduce</module>
     <module>tools</module>
     <module>examples</module>
+    <module>gen</module>
   </modules>
 
   <properties>
@@ -268,7 +269,19 @@
               </goals>
               <configuration>
                 <sources>
-                  <source>${project.build.directory}/generated-sources</source>
+                  <source>${project.build.directory}/generated-sources/java</source>
+                </sources>
+              </configuration>
+            </execution>
+            <execution>
+              <id>add-test-sources</id>
+              <phase>generate-test-sources</phase>
+              <goals>
+                <goal>add-test-source</goal>
+              </goals>
+              <configuration>
+                <sources>
+                  <source>${project.build.directory}/generated-test-sources/java</source>
                 </sources>
               </configuration>
             </execution>
@@ -294,6 +307,7 @@
                 <inputDirectories>
                   <include>../../proto</include>
                 </inputDirectories>
+                <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
               </configuration>
             </execution>
           </executions>

--- a/site/develop/design/lazy_filter.md
+++ b/site/develop/design/lazy_filter.md
@@ -1,0 +1,352 @@
+* [Lazy Filter](#LazyFilter)
+  * [Background](#Background)
+  * [Design](#Design)
+    * [SArg to Filter](#SArgtoFilter)
+    * [Read](#Read)
+  * [Configuration](#Configuration)
+  * [Tests](#Tests)
+  * [Appendix](#Appendix)
+    * [Benchmarks](#Benchmarks)
+      * [Row vs Vector](#RowvsVector)
+      * [Filter](#Filter)
+
+# Lazy Filter <a id="LazyFilter"></a>
+
+## Background <a id="Background"></a>
+
+This feature request started as a result of a large search that is performed with the following characteristics:
+
+* The search fields are not part of partition, bucket or sort fields.
+* The table is a very large table.
+* The predicates result in very few rows compared to the scan size.
+* The search columns are a significant subset of selection columns in the query.
+
+Initial analysis showed that we could have a significant benefit by lazily reading the non-search columns only when we
+have a match. We explore the design and some benchmarks in subsequent sections.
+
+## Design <a id="Design"></a>
+
+This builds further on [ORC-577][ORC-577] which currently only restricts deserialization for some selected data types
+but does not improve on IO.
+
+On a high level the design includes the following components:
+
+```text
+┌──────────────┐          ┌────────────────────────┐
+│              │          │          Read          │
+│              │          │                        │
+│              │          │     ┌────────────┐     │
+│SArg to Filter│─────────▶│     │Read Filter │     │
+│              │          │     │  Columns   │     │
+│              │          │     └────────────┘     │
+│              │          │            │           │
+└──────────────┘          │            ▼           │
+                          │     ┌────────────┐     │
+                          │     │Apply Filter│     │
+                          │     └────────────┘     │
+                          │            │           │
+                          │            ▼           │
+                          │     ┌────────────┐     │
+                          │     │Read Select │     │
+                          │     │  Columns   │     │
+                          │     └────────────┘     │
+                          │                        │
+                          │                        │
+                          └────────────────────────┘
+```
+
+* **SArg to Filter**: Converts Search Arguments passed down into filters for efficient application during scans.
+* **Read**: Performs the lazy read using the filters.
+  * **Read Filter Columns**: Read the filter columns from the file.
+  * **Apply Filter**: Apply the filter on the read filter columns.
+  * **Read Select Columns**: If filter selects at least a row then read the remaining columns.
+
+### SArg to Filter <a id="SArgtoFilter"></a>
+
+SArg to Filter converts the passed SArg into a filter. This enables automatic compatibility with both Spark and Hive as
+they already push down Search Arguments down to ORC.
+
+The SArg is automatically converted into a [Vector Filter][vfilter]. Which is applied during the read process. Two
+filter types were evaluated:
+
+* [Row Filter][rfilter] that evaluates each row across all the predicates once.
+* [Vector Filter][vfilter] that evaluates each filter across the entire vector and adjusts the subsequent evaluation.
+
+While a row based filter is easier to code, it is much [slower][rowvvector] to process. We also see a significant
+[performance gain][rowvvector] in the absence of normalization.
+
+The builder for search argument should allow skipping normalization during the [build][build]. This has already been
+proposed as part of [HIVE-24458][HIVE-24458].
+
+### Read <a id="Read"></a>
+
+The read process has the following changes:
+
+```text
+                         │
+                         │
+                         │
+┌────────────────────────▼────────────────────────┐
+│               ┏━━━━━━━━━━━━━━━━┓                │
+│               ┃Plan ++Search++ ┃                │
+│               ┃    Columns     ┃                │
+│               ┗━━━━━━━━━━━━━━━━┛                │
+│                 Read   │Stripe                  │
+└────────────────────────┼────────────────────────┘
+                         │
+                         ▼
+
+
+                         │
+                         │
+┌────────────────────────▼────────────────────────┐
+│               ┏━━━━━━━━━━━━━━━━┓                │
+│               ┃Read ++Search++ ┃                │
+│               ┃    Columns     ┃◀─────────┐     │
+│               ┗━━━━━━━━━━━━━━━━┛          │     │
+│                        │              Size = 0  │
+│                        ▼                  │     │
+│               ┏━━━━━━━━━━━━━━━━┓          │     │
+│               ┃  Apply Filter  ┃──────────┘     │
+│               ┗━━━━━━━━━━━━━━━━┛                │
+│                    Size > 0                     │
+│                        │                        │
+│                        ▼                        │
+│               ┏━━━━━━━━━━━━━━━━┓                │
+│               ┃  Plan Select   ┃                │
+│               ┃    Columns     ┃                │
+│               ┗━━━━━━━━━━━━━━━━┛                │
+│                        │                        │
+│                        ▼                        │
+│               ┏━━━━━━━━━━━━━━━━┓                │
+│               ┃  Read Select   ┃                │
+│               ┃    Columns     ┃                │
+│               ┗━━━━━━━━━━━━━━━━┛                │
+│                   Next │Batch                   │
+└────────────────────────┼────────────────────────┘
+                         │
+                         ▼
+```
+
+The read process changes:
+
+* **Read Stripe** used to plan the read of all (search + select) columns. This is enhanced to plan and fetch only the
+  search columns. The rest of the stripe planning process optimizations remain unchanged e.g. partial read planning of
+  the stripe based on RowGroup statistics.
+* **Next Batch** identifies the processing that takes place when `RecordReader.nextBatch` is invoked.
+  * **Read Search Columns** takes place instead of reading all the selected columns. This is in sync with the planning
+    that has taken place during **Read Stripe** where only the search columns have been planned.
+  * **Apply Filter** on the batch that at this point only includes search columns. Evaluate the result of the filter:
+    * **Size = 0** indicates all records have been filtered out. Given this we proceed to the next batch of search
+      columns.
+    * **Size > 0** indicates that at least one record accepted by the filter. This record needs to be substantiated with
+      other columns.
+  * **Plan Select Columns** is invoked to perform read of the select columns. The planning happens as follows:
+    * Determine the current position of the read within the stripe and plan the read for the select columns from this
+      point forward to the end of the stripe.
+    * The Read planning of select columns respects the row groups filtered out as a result of the stripe planning.
+    * Fetch the select columns using the above plan.
+  * **Read Select Columns** into the vectorized row batch
+  * Return this batch.
+
+The current implementation performs a single read for the select columns in a stripe.
+
+```text
+┌──────────────────────────────────────────────────┐
+│ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ │
+│ │RG0 │ │RG1 │ │RG2■│ │RG3 │ │RG4 │ │RG5■│ │RG6 │ │
+│ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ │
+│                      Stripe                      │
+└──────────────────────────────────────────────────┘
+```
+
+The above diagram depicts a stripe with 7 Row Groups out of which **RG2** and **RG5** are selected by the filter. The
+current implementation does the following:
+
+* Start the read planning process from the first match RG2
+* Read to the end of the stripe that includes RG6
+* Based on the above fetch skips RG0 and RG1 subject to compression block boundaries
+
+The above logic could be enhanced to perform say **2 or n** reads before reading to the end of stripe. The current
+implementation allows 0 reads before reading to the end of the stripe. The value of **n** could be configurable but
+should avoid too many short reads.
+
+The read behavior changes as follows with multiple reads being allowed within a stripe for select columns:
+
+```text
+┌──────────────────────────────────────────────────┐
+│ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ │
+│ │    │ │    │ │■■■■│ │■■■■│ │■■■■│ │■■■■│ │■■■■│ │
+│ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ │
+│              Current implementation              │
+└──────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────┐
+│ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐ │
+│ │    │ │    │ │■■■■│ │    │ │    │ │■■■■│ │■■■■│ │
+│ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ └────┘ │
+│               Allow 1 partial read               │
+└──────────────────────────────────────────────────┘
+```
+
+The figure shows that we could read significantly fewer bytes by performing an additional read before reading to the end
+of stripe. This shall be included as a subsequent enhancement to this patch.
+
+## Configuration <a id="Configuration"></a>
+
+The following configuration options are exposed that control the filter behavior:
+
+|Property                   |Type   |Default|
+|:---                       |:---   |:---   |
+|orc.sarg.to.filter         |boolean|false  |
+|orc.sarg.to.filter.selected|boolean|false  |
+
+* `orc.sarg.to.filter` can be used to turn off the SArg to filter conversion. This might be particularly relevant in 
+  cases where the filter is expensive and does not eliminate a lot of records.
+* `orc.sarg.to.filter.selected` is an important setting that if incorrectly enabled results in wrong output. The 
+  `VectorizedRowBatch` has a selected vector that defines which rows are selected. This property should be set to `true`
+  only if the consumer respects the selected vector in determining the valid rows.
+
+## Tests <a id="Tests"></a>
+
+We evaluated this patch against a search job with the following stats:
+
+* Table
+  * Size: ~**420 TB**
+  * Data fields: ~**120**
+  * Partition fields: **3**
+* Scan
+  * Search fields: 3 data fields with large (~ 1000 value) IN clauses compounded by **OR**.
+  * Select fields: 16 data fields (includes the 3 search fields), 1 partition field
+  * Search:
+    * Size: ~**180 TB**
+    * Records: **3.99 T**
+  * Selected:
+    * Size: ~**100 MB**
+    * Records: **1 M**
+
+We have observed the following reductions:
+
+|Test    |IO Reduction %|CPU Reduction %|
+|:---    |          ---:|           ---:|
+|Same    |            45|             47|
+|SELECT *|            70|             87|
+
+* The savings are more significant as you increase the number of select columns with respect to the search columns
+* When the filter selects most data, no significant penalty observed as a result of 2 IO compared with a single IO
+  * We do have a penalty as a result of the filter application on the selected records.
+
+## Appendix <a id="Appendix"></a>
+
+### Benchmarks <a id="Benchmarks"></a>
+
+#### Row vs Vector <a id="RowvsVector"></a>
+
+We start with a decision of using a Row filter vs a Vector filter. The Row filter has the advantage of simpler code vs
+the Vector filter.
+
+```bash
+java -jar target/orc-benchmarks-core-1.7.0-SNAPSHOT-uber.jar filter simple
+```
+
+|Benchmark               |(fInSize)|(fType)|Mode| Cnt| Score|Error  |Units|
+|:---                    |     ---:|:---   |:---|---:|  ---:|:---   |:--- |
+|SimpleFilterBench.filter|        4|row    |avgt|  20|52.260|± 0.109|us/op|
+|SimpleFilterBench.filter|        4|vector |avgt|  20|19.699|± 0.044|us/op|
+|SimpleFilterBench.filter|        8|row    |avgt|  20|59.648|± 0.179|us/op|
+|SimpleFilterBench.filter|        8|vector |avgt|  20|28.655|± 0.036|us/op|
+|SimpleFilterBench.filter|       16|row    |avgt|  20|56.480|± 0.190|us/op|
+|SimpleFilterBench.filter|       16|vector |avgt|  20|46.757|± 0.124|us/op|
+|SimpleFilterBench.filter|       32|row    |avgt|  20|57.780|± 0.111|us/op|
+|SimpleFilterBench.filter|       32|vector |avgt|  20|52.060|± 0.333|us/op|
+|SimpleFilterBench.filter|      256|row    |avgt|  20|50.898|± 0.275|us/op|
+|SimpleFilterBench.filter|      256|vector |avgt|  20|85.684|± 0.351|us/op|
+
+Explanation:
+
+* **fInSize** calls out the number of values in the IN clause.
+* **fType** calls out the whether the filter is a row based filter, or a vector based filter.
+
+Observations:
+
+* The vector based filter is significantly faster than the row based filter.
+  * At best, vector was faster by **59.62%**
+  * At worst, vector was faster by **32.14%**
+* The performance of the filters is deteriorates with the increase of the IN values, however even in this case the
+  vector filter is much better than the row filter.
+
+In the next test we use a complex filter with both AND, and OR to understand the impact of Conjunctive Normal Form on
+the filter performance. The Search Argument builder by default performs a CNF. The advantage of the CNF would again be a
+simpler code base.
+
+```bash
+java -jar target/orc-benchmarks-core-1.7.0-SNAPSHOT-uber.jar filter complex
+```
+
+|Benchmark                |(fSize)|(fType)|(normalize)|Mode| Cnt|    Score|Error    |Units|
+|:---                     |   ---:|:---   |:---       |:---|---:|     ---:|:---     |:--- |
+|ComplexFilterBench.filter|      2|row    |true       |avgt|  20|  102.238|± 0.715  |us/op|
+|ComplexFilterBench.filter|      2|row    |false      |avgt|  20|   90.945|± 0.574  |us/op|
+|ComplexFilterBench.filter|      2|vector |true       |avgt|  20|   74.321|± 0.156  |us/op|
+|ComplexFilterBench.filter|      2|vector |false      |avgt|  20|   78.119|± 0.351  |us/op|
+|ComplexFilterBench.filter|      4|row    |true       |avgt|  20|  306.338|± 2.026  |us/op|
+|ComplexFilterBench.filter|      4|row    |false      |avgt|  20|  148.042|± 0.770  |us/op|
+|ComplexFilterBench.filter|      4|vector |true       |avgt|  20|  267.405|± 1.202  |us/op|
+|ComplexFilterBench.filter|      4|vector |false      |avgt|  20|  136.284|± 0.637  |us/op|
+|ComplexFilterBench.filter|      8|row    |true       |avgt|  20|10443.581|± 114.033|us/op|
+|ComplexFilterBench.filter|      8|row    |false      |avgt|  20|  253.560|± 1.069  |us/op|
+|ComplexFilterBench.filter|      8|vector |true       |avgt|  20| 9907.765|± 49.208 |us/op|
+|ComplexFilterBench.filter|      8|vector |false      |avgt|  20|  247.714|± 0.651  |us/op|
+
+Explanation:
+
+* **fSize** identifies the size of the OR clause that will be normalized.
+* **normalize** identifies whether normalize was carried out on the Search Argument.
+
+Observations:
+
+* Vector filter is better than the row filter as expected.
+* Normalizing the search argument results in a significant performance penalty given the explosion of the operator tree
+  * In case where an AND includes 8 ORs, the unnormalized version is faster by **97.32%**
+
+#### Filter <a id="Filter"></a>
+
+```bash
+java -jar target/orc-benchmarks-core-1.7.0-SNAPSHOT-uber.jar filter -I 10 -i 10 access
+```
+
+|Benchmark                                |Mode| Cnt|   Score|Error   |Units|
+|:---                                     |:---|---:|    ---:|:---    |:--- |
+|FilterBench.Access.functionAccessElements|avgt|  10|8500.316|± 31.981|ns/op|
+|FilterBench.Access.indexAccessElements   |avgt|  10| 304.152|± 2.142 |ns/op|
+|FilterBench.Access.iterateElements       |avgt|  10| 305.280|± 1.079 |ns/op|
+|FilterBench.Access.methodAccessElements  |avgt|  10| 304.163|± 1.346 |ns/op|
+
+```bash
+java -jar target/orc-benchmarks-core-1.7.0-SNAPSHOT-uber.jar filter -I 10 -i 10 getvalue
+```
+
+|Benchmark                           |Mode| Cnt|   Score|Error   |Units|
+|:---                                |:---|---:|    ---:|:---    |:--- |
+|FilterBench.GetValue.direct         |avgt|  10| 303.281|± 0.687 |ns/op|
+|FilterBench.GetValue.getWithFunction|avgt|  10|6278.365|± 32.261|ns/op|
+|FilterBench.GetValue.getWithMethod  |avgt|  10| 305.961|± 0.523 |ns/op|
+
+```bash
+java -jar target/orc-benchmarks-core-1.7.0-SNAPSHOT-uber.jar filter -I 10 -i 10 equals
+```
+
+|Benchmark                      |Mode| Cnt|Score|Error  |Units|
+|:---                           |:---|---:| ---:|:---   |:--- |
+|FilterBench.Equal.directCheck  |avgt|  10|0.297|± 0.001|us/op|
+|FilterBench.Equal.directFilter |avgt|  10|1.126|± 0.007|us/op|
+|FilterBench.Equal.genericFilter|avgt|  10|1.273|± 0.004|us/op|
+
+[ORC-577]: https://issues.apache.org/jira/browse/ORC-577
+
+[HIVE-24458]: https://issues.apache.org/jira/browse/HIVE-24458
+
+[vfilter]: ../src/java/org/apache/orc/filter/VectorFilter.java
+
+[rowvvector]: #RowvsVector
+
+[build]: https://github.com/apache/hive/blob/storage-branch-2.7/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java#L491


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added conversion of SArg into filters to take advantage of the LazyIO introduced by ORC-742
    * Created Vector filters for leaf, And, Or, Batch
    * Code generation for data type and operator filters
    * Test code generation for data type and operator filters
    * Benchmark tests for the filters in the bench module

### Why are the changes needed?
With ORC-742, FOLLOW (non-filter) columns are evaluated lazily. Spark and Hive are already passing down SearchArguments to ORC. This change allows the conversion of the SearchArguments to a filter to gain the improvements of ORC-742.

### How was this patch tested?
* Unit tests were added
* Performance tests were added to the Bench module
