### PR TITLE
ORC-747: Abstract Dictionary interface and refactoring

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -105,9 +105,11 @@ public enum OrcConf {
           "(default 10000 rows) else dictionary check will happen before\n" +
           "writing first stripe. In both cases, the decision to use\n" +
           "dictionary or not will be retained thereafter."),
-  DICTIONARY_FACTORY_CLASS_KEY("orc.dictionary.class.key", null,
-      "org.apache.orc.impl.StringRedBlackTree.StringRBTreeFactory",
-      "Key to specify the factory class in charge of generating dictionary."),
+  DICTIONARY_IMPL("orc.dictionary.implementation", null,
+      "rbtree",
+      "the implementation for the dictionary used for string-type column encoding.\n" +
+          "The legit value for this key could be 'rbtree' or 'hash' as it currently supports\n"
+          + " rbtree-based or hashTable-based implementation."),
   BLOOM_FILTER_COLUMNS("orc.bloom.filter.columns", "orc.bloom.filter.columns",
       "", "List of columns to create bloom filters for when writing."),
   BLOOM_FILTER_WRITE_VERSION("orc.bloom.filter.write.version",

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -105,11 +105,12 @@ public enum OrcConf {
           "(default 10000 rows) else dictionary check will happen before\n" +
           "writing first stripe. In both cases, the decision to use\n" +
           "dictionary or not will be retained thereafter."),
-  DICTIONARY_IMPL("orc.dictionary.implementation", null,
+  DICTIONARY_IMPL("orc.dictionary.implementation", "orc.dictionary.implementation",
       "rbtree",
       "the implementation for the dictionary used for string-type column encoding.\n" +
-          "The legit value for this key could be 'rbtree' or 'hash' as it currently supports\n"
-          + " rbtree-based or hashTable-based implementation."),
+          "The choices are:\n"
+          + " rbtree - use red-black tree as the implementation for the dictionary.\n"
+          + " hash (yet to be implemented) - use hash table as the implementation for the dictionary."),
   BLOOM_FILTER_COLUMNS("orc.bloom.filter.columns", "orc.bloom.filter.columns",
       "", "List of columns to create bloom filters for when writing."),
   BLOOM_FILTER_WRITE_VERSION("orc.bloom.filter.write.version",

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -105,6 +105,9 @@ public enum OrcConf {
           "(default 10000 rows) else dictionary check will happen before\n" +
           "writing first stripe. In both cases, the decision to use\n" +
           "dictionary or not will be retained thereafter."),
+  DICTIONARY_FACTORY_CLASS_KEY("orc.dictionary.class.key", null,
+      "org.apache.orc.impl.StringRedBlackTree.StringRBTreeFactory",
+      "Key to specify the factory class in charge of generating dictionary."),
   BLOOM_FILTER_COLUMNS("orc.bloom.filter.columns", "orc.bloom.filter.columns",
       "", "List of columns to create bloom filters for when writing."),
   BLOOM_FILTER_WRITE_VERSION("orc.bloom.filter.write.version",

--- a/java/core/src/java/org/apache/orc/impl/Dictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/Dictionary.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.Text;
+
+
+/**
+ * Interface to define the dictionary used for encoding value in columns of specific types like string, char, varchar, etc.
+ */
+public interface Dictionary {
+  int INITIAL_DICTIONARY_SIZE = 4096;
+
+  interface DictionaryFactory {
+    Dictionary createDict(Configuration conf);
+  }
+
+  /**
+   * Traverse the whole dictionary and apply the action.
+   */
+  void visit(Visitor visitor) throws IOException;
+
+  void clear();
+
+  /**
+   * Given the position index, return the original string before being encoded.
+   */
+  void getText(Text result, int originalPosition);
+
+  int add(String value);
+
+  int add(byte[] bytes, int offset, int length);
+
+  int size();
+
+  long getSizeInBytes();
+
+  /**
+   * The information about each node.
+   */
+  interface VisitorContext {
+    /**
+     * Get the position where the key was originally added.
+     * @return the number returned by add.
+     */
+    int getOriginalPosition();
+
+    /**
+     * Write the bytes for the string to the given output stream.
+     * @param out the stream to write to.
+     * @throws IOException
+     */
+    void writeBytes(OutputStream out) throws IOException;
+
+    /**
+     * Get the original string.
+     * @return the string
+     */
+    Text getText();
+
+    /**
+     * Get the number of bytes.
+     * @return the string's length in bytes
+     */
+    int getLength();
+  }
+
+  /**
+   * The interface for visitors.
+   */
+  interface Visitor {
+    /**
+     * Called once for each node of the tree in sort order.
+     * @param context the information about each node
+     * @throws IOException
+     */
+    void visit(VisitorContext context) throws IOException;
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/Dictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/Dictionary.java
@@ -29,11 +29,12 @@ import org.apache.hadoop.io.Text;
  * Interface to define the dictionary used for encoding value in columns of specific types like string, char, varchar, etc.
  */
 public interface Dictionary {
-  int INITIAL_DICTIONARY_SIZE = 4096;
-
-  interface DictionaryFactory {
-    Dictionary createDict(Configuration conf);
+  enum IMPL {
+    RBTREE,
+    HASH
   }
+
+  int INITIAL_DICTIONARY_SIZE = 4096;
 
   /**
    * Traverse the whole dictionary and apply the action.
@@ -46,8 +47,6 @@ public interface Dictionary {
    * Given the position index, return the original string before being encoded.
    */
   void getText(Text result, int originalPosition);
-
-  int add(String value);
 
   int add(byte[] bytes, int offset, int length);
 

--- a/java/core/src/java/org/apache/orc/impl/Dictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/Dictionary.java
@@ -45,7 +45,7 @@ public interface Dictionary {
   /**
    * Given the position index, return the original string before being encoded.
    */
-  void getText(Text result, int originalPosition);
+  void getText(Text result, int position);
 
   int add(byte[] bytes, int offset, int length);
 

--- a/java/core/src/java/org/apache/orc/impl/Dictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/Dictionary.java
@@ -21,7 +21,6 @@ package org.apache.orc.impl;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 
 

--- a/java/core/src/java/org/apache/orc/impl/StringRedBlackTree.java
+++ b/java/core/src/java/org/apache/orc/impl/StringRedBlackTree.java
@@ -20,7 +20,6 @@ package org.apache.orc.impl;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 
 /**
@@ -32,18 +31,11 @@ public class StringRedBlackTree extends RedBlackTree implements Dictionary {
   private final DynamicIntArray keyOffsets;
   private final Text newKey = new Text();
 
-  public static class StringRBTreeFactory implements Dictionary.DictionaryFactory {
-    public Dictionary createDict(Configuration conf) {
-      return new StringRedBlackTree(INITIAL_DICTIONARY_SIZE);
-    }
-  }
-
   public StringRedBlackTree(int initialCapacity) {
     super(initialCapacity);
     keyOffsets = new DynamicIntArray(initialCapacity);
   }
 
-  @Override
   public int add(String value) {
     newKey.set(value);
     return addNewKey();

--- a/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
@@ -26,13 +26,13 @@ import org.apache.orc.OrcProto;
 import org.apache.orc.StringColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.CryptoUtils;
+import org.apache.orc.impl.Dictionary;
 import org.apache.orc.impl.DynamicIntArray;
 import org.apache.orc.impl.IntegerWriter;
 import org.apache.orc.impl.OutStream;
 import org.apache.orc.impl.PositionRecorder;
 import org.apache.orc.impl.PositionedOutputStream;
 import org.apache.orc.impl.StreamName;
-import org.apache.orc.impl.StringRedBlackTree;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,12 +40,11 @@ import java.util.List;
 import java.util.function.Consumer;
 
 public abstract class StringBaseTreeWriter extends TreeWriterBase {
-  private static final int INITIAL_DICTIONARY_SIZE = 4096;
+  // Stream for dictionary's key
   private final OutStream stringOutput;
   protected final IntegerWriter lengthOutput;
+  // Stream for dictionary-encoded value
   private final IntegerWriter rowOutput;
-  protected final StringRedBlackTree dictionary =
-      new StringRedBlackTree(INITIAL_DICTIONARY_SIZE);
   protected final DynamicIntArray rows = new DynamicIntArray();
   protected final PositionedOutputStream directStreamOutput;
   private final List<OrcProto.RowIndexEntry> savedRowIndex =
@@ -55,6 +54,7 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
   // If the number of keys in a dictionary is greater than this fraction of
   //the total number of non-null rows, turn off dictionary encoding
   private final double dictionaryKeySizeThreshold;
+  protected Dictionary dictionary;
   protected boolean useDictionaryEncoding = true;
   private boolean isDirectV2 = true;
   private boolean doneDictionaryCheck;
@@ -64,6 +64,15 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
                        WriterEncryptionVariant encryption,
                        WriterContext writer) throws IOException {
     super(schema, encryption, writer);
+    Configuration conf = writer.getConfiguration();
+
+    String factoryClass = conf.get(OrcConf.DICTIONARY_FACTORY_CLASS_KEY.name());
+    try {
+      this.dictionary =
+          ((Dictionary.DictionaryFactory) Class.forName(factoryClass).newInstance()).createDict(conf);
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new IllegalStateException("Can't create factory instance for " + factoryClass, e);
+    }
     this.isDirectV2 = isNewWriteFormat(writer);
     directStreamOutput = writer.createStream(
         new StreamName(id, OrcProto.Stream.Kind.DATA, encryption));
@@ -79,7 +88,6 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
     }
     rowIndexValueCount.add(0L);
     buildIndex = writer.buildIndex();
-    Configuration conf = writer.getConfiguration();
     dictionaryKeySizeThreshold = writer.getDictionaryKeySizeThreshold(id);
     strideDictionaryCheck =
         OrcConf.ROW_INDEX_STRIDE_DICTIONARY_CHECK.getBoolean(conf);
@@ -109,7 +117,6 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
     // checking would not have happened. So do it again here.
     checkDictionaryEncoding();
 
-    checkDictionaryEncoding();
     if (!useDictionaryEncoding) {
       stringOutput.suppress();
     }
@@ -140,12 +147,11 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
       // Write the dictionary by traversing the red-black tree writing out
       // the bytes and lengths; and creating the map from the original order
       // to the final sorted order.
-
-      dictionary.visit(new StringRedBlackTree.Visitor() {
+      dictionary.visit(new Dictionary.Visitor() {
         private int currentId = 0;
 
         @Override
-        public void visit(StringRedBlackTree.VisitorContext context
+        public void visit(Dictionary.VisitorContext context
         ) throws IOException {
           context.writeBytes(stringOutput);
           lengthOutput.write(context.getLength());

--- a/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/StringBaseTreeWriter.java
@@ -65,7 +65,7 @@ public abstract class StringBaseTreeWriter extends TreeWriterBase {
   private boolean doneDictionaryCheck;
   private final boolean strideDictionaryCheck;
 
-  static Dictionary createDict(Configuration conf) {
+  private static Dictionary createDict(Configuration conf) {
     String dictImpl = conf.get(DICTIONARY_IMPL.name(),
         DICTIONARY_IMPL.getDefaultValue().toString()).toUpperCase();
     switch (Dictionary.IMPL.valueOf(dictImpl)) {

--- a/java/core/src/test/org/apache/orc/impl/TestStringRedBlackTree.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringRedBlackTree.java
@@ -108,7 +108,7 @@ public class TestStringRedBlackTree {
     }
   }
 
-  private static class MyVisitor implements StringRedBlackTree.Visitor {
+  private static class MyVisitor implements Dictionary.Visitor {
     private final String[] words;
     private final int[] order;
     private final DataOutputBuffer buffer = new DataOutputBuffer();
@@ -120,7 +120,7 @@ public class TestStringRedBlackTree {
     }
 
     @Override
-    public void visit(StringRedBlackTree.VisitorContext context
+    public void visit(Dictionary.VisitorContext context
                      ) throws IOException {
       String word = context.getText().toString();
       assertEquals("in word " + current, words[current], word);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
This PR contains the very first part to make the implementation of dictionary used for encoding pluggable, by introducing an interface `Dictionary`. The subsequent PR will add HashTable-based Dictionary implementation and compare with the existing RB-tree based dictionary. 

For reviewers: 
- Please comment if reflection-based initialization will be preferred or not since I didn't found much of that within the code base. 
- The `Dictionary` class isn't added with generic type declaration (e.g. we could use a generic type `T` to replace `Text`). Please let me know if that's necessary to add. 

### Why are the changes needed?

### How was this patch tested?
Since this is mostly a refactoring, it is just passing all existing unit tests. 
