### PR TITLE
ORC-745: Update README.md with new travis-ci.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Releases:
 * Downloads: <a href="http://orc.apache.org/downloads">Apache ORC downloads</a>
 
 The current build status:
-* Master branch <a href="https://travis-ci.org/apache/orc/branches">
-![master build status](https://travis-ci.org/apache/orc.svg?branch=master)</a>
-* <a href="https://travis-ci.org/apache/orc/pull_requests">Pull Requests</a>
+* Master branch <a href="https://travis-ci.com/github/apache/orc/branches">
+![master build status](https://travis-ci.com/github/apache/orc.svg?branch=master)</a>
+* <a href="https://travis-ci.com/github/apache/orc/pull_requests">Pull Requests</a>
 
 
 Bug tracking: <a href="http://orc.apache.org/bugs">Apache Jira</a>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update README.md with new travis-ci.com links.

### Why are the changes needed?

https://issues.apache.org/jira/browse/INFRA-21354 migrated Apache ORC Travis CI from travis-ci.org to travis-ci.com.

### How was this patch tested?

1. Since we migrated, travis-ci.com is triggered on this PR correctly.
   - https://travis-ci.com/github/apache/orc/builds/214961084
2. Manually click the new links.