### PR TITLE
ORC-749 Add checkstyle:check to analyze profile.

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -41,8 +41,5 @@ jobs:
         mkdir -p ~/.m2
         mkdir build
         cd build
-        cmake ..
+        cmake -DANALYZE_JAVA=ON ..
         make package test-out
-        cd ../java
-        mvn apache-rat:check
-        mvn checkstyle:check

--- a/java/core/src/findbugs/exclude.xml
+++ b/java/core/src/findbugs/exclude.xml
@@ -49,21 +49,7 @@
   </Match>
   <Match>
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-    <Class name="org.apache.orc.impl.TestReaderImpl"/>
-    <Method name="testOptionSafety"/>
-  </Match>
-  <Match>
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-    <Class name="org.apache.orc.TestVectorOrcFile"/>
-    <Method name="testZstd"/>
-  </Match>
-  <Match>
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-    <Class name="org.apache.orc.impl.TestSchemaEvolution"/>
-  </Match>
-  <Match>
-    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
-    <Class name="org.apache.orc.TestStringDictionary"/>
+    <Class name="~org\.apache\.orc.*\.Test.*"/>
   </Match>
   <Match>
     <Bug pattern="EQ_UNUSUAL"/>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -185,23 +185,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
-        <configuration>
-          <checkstyleRules>
-            <module name="Checker">
-              <module name="FileTabCharacter">
-                <property name="eachLine" value="true"></property>
-              </module>
-              <module name="TreeWalker">
-                <module name="UnusedImports"/>
-              </module>
-            </module>
-          </checkstyleRules>
-        </configuration>
-      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -253,6 +236,32 @@
               <exclude>.idea/**</exclude>
               <exclude>**/*.iml</exclude>
             </excludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>3.1.1</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <checkstyleRules>
+              <module name="Checker">
+                <module name="FileTabCharacter">
+                  <property name="eachLine" value="true"></property>
+                </module>
+                <module name="TreeWalker">
+                  <module name="UnusedImports"/>
+                </module>
+              </module>
+            </checkstyleRules>
+            <failOnViolation>true</failOnViolation>
           </configuration>
         </plugin>
         <plugin>
@@ -372,6 +381,10 @@
           <plugin>
             <groupId>org.apache.rat</groupId>
             <artifactId>apache-rat-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-checkstyle-plugin</artifactId>
           </plugin>
         </plugins>
       </build>

--- a/java/tools/src/findbugs/exclude.xml
+++ b/java/tools/src/findbugs/exclude.xml
@@ -20,8 +20,16 @@
        See https://github.com/SERG-Delft/jpacman/pull/27 . -->
   <Match>
     <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
-    <Class name="org.apache.orc.tools.PrintVersion"/>
+    <Class name="~org\.apache\.orc\.tools\.(ScanData|PrintVersion)"/>
     <Method name="main"/>
+  </Match>
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    <Class name="~org\.apache\.orc.*\.Test.*"/>
+  </Match>
+  <Match>
+    <Bug pattern="RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE"/>
+    <Class name="~org\.apache\.orc.tools.(RowCount|ScanData)"/>
   </Match>
   <Match>
     <Bug pattern="REC_CATCH_EXCEPTION"/>


### PR DESCRIPTION
This change makes the analyze profile also run checkstyle:check. It pulls the manual rat and checkstyle checks into cmake's build.