### PR TITLE
ORC-753: [C++] Clear stream state of ColumnReader after seek

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -534,6 +534,9 @@ namespace orc {
     std::unordered_map<uint64_t, PositionProvider>& positions) {
     ColumnReader::seekToRowGroup(positions);
     inputStream->seek(positions.at(columnId));
+    // clear buffer state after seek
+    bufferEnd = nullptr;
+    bufferPointer = nullptr;
   }
 
   class StringDictionaryColumnReader: public ColumnReader {
@@ -838,6 +841,9 @@ namespace orc {
     ColumnReader::seekToRowGroup(positions);
     blobStream->seek(positions.at(columnId));
     lengthRle->seek(positions.at(columnId));
+    // clear buffer state after seek
+    lastBuffer = nullptr;
+    lastBufferLength = 0;
   }
 
   class StructColumnReader: public ColumnReader {
@@ -1553,6 +1559,9 @@ namespace orc {
     ColumnReader::seekToRowGroup(positions);
     valueStream->seek(positions.at(columnId));
     scaleDecoder->seek(positions.at(columnId));
+    // clear buffer state after seek
+    buffer = nullptr;
+    bufferEnd = nullptr;
   }
 
   class Decimal128ColumnReader: public Decimal64ColumnReader {


### PR DESCRIPTION
### What changes were proposed in this pull request?
C++ ORC ColumnReaders of some types have cached buffer state to issue next I/O. This is fine if we read streams continuously. However, if we try to skip some row groups and seek to a random row group, the cached buffer state is wrong and may lead to undefined behavior. This patch fixes it by clearing all stream states in the ColumnReader.

### Why are the changes needed?
This fix is a prerequisite to introduce PPD to C++ ORC reader in that the read pattern requires seeking to any row group.

### How was this patch tested?
This is a trivial fix and just make sure it doesn't break any unit test case.
