### PR TITLE
ORC-755: Added OrcFilterContext that accomplishes the following:

### DIFF
--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/RowFilterProjectionBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/RowFilterProjectionBenchmark.java
@@ -30,6 +30,7 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.OrcBenchmark;
 import org.apache.orc.bench.core.ReadCounters;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -93,16 +94,16 @@ public class RowFilterProjectionBenchmark implements OrcBenchmark {
     }
   }
 
-  public static void customIntRowFilter(VectorizedRowBatch batch) {
+  public static void customIntRowFilter(OrcFilterContext batch) {
     int newSize = 0;
-    for (int row = 0; row < batch.size; ++row) {
+    for (int row = 0; row < batch.getSelectedSize(); ++row) {
       // Select ONLY specific keys
       if (filterValues.contains(row)) {
-        batch.selected[newSize++] = row;
+        batch.getSelected()[newSize++] = row;
       }
     }
-    batch.selectedInUse = true;
-    batch.size = newSize;
+    batch.setSelectedInUse(true);
+    batch.setSelectedSize(newSize);
   }
 
   @Benchmark

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class BooleanRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -128,15 +129,15 @@ public class DecimalRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class DoubleRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class StringRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
@@ -26,6 +26,7 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.bench.core.Utilities;
+import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -127,15 +128,15 @@ public class TimestampRowFilterBenchmark extends org.openjdk.jmh.Main {
       return filterValues;
     }
 
-    public static void customIntRowFilter(VectorizedRowBatch batch) {
+    public static void customIntRowFilter(OrcFilterContext batch) {
       int newSize = 0;
-      for (int row = 0; row < batch.size; ++row) {
+      for (int row = 0; row < batch.getSelectedSize(); ++row) {
         if (filterValues[row]) {
-          batch.selected[newSize++] = row;
+          batch.getSelected()[newSize++] = row;
         }
       }
-      batch.selectedInUse = true;
-      batch.size = newSize;
+      batch.setSelectedInUse(true);
+      batch.setSelectedSize(newSize);
     }
   }
 

--- a/java/core/src/java/org/apache/orc/OrcFilterContext.java
+++ b/java/core/src/java/org/apache/orc/OrcFilterContext.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.io.filter.MutableFilterContext;
+
+/**
+ * This defines the input for any filter operation. This is an extension of
+ * [[{@link VectorizedRowBatch}]] with schema.
+ * <p>
+ * This offers a convenience method of finding the column vector from a given column name
+ * that the filters can invoke to get access to the column vector.
+ */
+public interface OrcFilterContext extends MutableFilterContext {
+  /**
+   * Retrieves the column vector that matches the specified name. Allows support for nested struct
+   * references e.g. order.date where data is a field in a struct called order.
+   *
+   * @param name The column name whose vector should be retrieved
+   * @return The column vector
+   * @throws IllegalArgumentException if the field is not found or if the nested field is not part
+   *                                  of a struct
+   */
+  ColumnVector[] findColumnVector(String name);
+
+  /**
+   * Utility method for determining if the leaf vector of the branch can be treated as having
+   * noNulls.
+   * This method navigates from the top to the leaf and checks if we have nulls anywhere in the
+   * branch as compared to checking just the leaf vector.
+   *
+   * @param vectorBranch The input vector branch from the root to the leaf
+   * @return true if the entire branch satisfies noNull else false
+   */
+  static boolean noNulls(ColumnVector[] vectorBranch) {
+    for (ColumnVector v : vectorBranch) {
+      if (!v.noNulls) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Utility method for determining if a particular row element in the vector branch is null.
+   * This method navigates from the top to the leaf and checks if we have nulls anywhere in the
+   * branch as compared to checking just the leaf vector.
+   *
+   * @param vectorBranch The input vector branch from the root to the leaf
+   * @param idx          The row index being tested
+   * @return true if the entire branch is not null for the idx otherwise false
+   * @throws IllegalArgumentException If a multivalued vector such as List or Map is encountered in
+   *                                  the branch.
+   */
+  static boolean isNull(ColumnVector[] vectorBranch, int idx) throws IllegalArgumentException {
+    for (ColumnVector v : vectorBranch) {
+      if (v instanceof ListColumnVector || v instanceof MapColumnVector) {
+        throw new IllegalArgumentException(String.format(
+          "Found vector: %s in branch. List and Map vectors are not supported in isNull "
+          + "determination", v));
+      }
+      if (!v.noNulls && v.isNull[idx]) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/java/core/src/java/org/apache/orc/OrcFilterContext.java
+++ b/java/core/src/java/org/apache/orc/OrcFilterContext.java
@@ -34,10 +34,12 @@ import org.apache.hadoop.hive.ql.io.filter.MutableFilterContext;
 public interface OrcFilterContext extends MutableFilterContext {
   /**
    * Retrieves the column vector that matches the specified name. Allows support for nested struct
-   * references e.g. order.date where data is a field in a struct called order.
+   * references e.g. order.date where date is a field in a struct called order.
    *
    * @param name The column name whose vector should be retrieved
-   * @return The column vector
+   * @return The column vectors from the root to the column name. The array levels match the name
+   * levels with Array[0] referring to the top level, followed by the subsequent levels. For
+   * example of order.date Array[0] refers to order and Array[1] refers to date
    * @throws IllegalArgumentException if the field is not found or if the nested field is not part
    *                                  of a struct
    */
@@ -79,7 +81,7 @@ public interface OrcFilterContext extends MutableFilterContext {
           "Found vector: %s in branch. List and Map vectors are not supported in isNull "
           + "determination", v));
       }
-      if (!v.noNulls && v.isNull[idx]) {
+      if (!v.noNulls && (v.isRepeating || v.isNull[idx])) {
         return true;
       }
     }

--- a/java/core/src/java/org/apache/orc/OrcFilterContext.java
+++ b/java/core/src/java/org/apache/orc/OrcFilterContext.java
@@ -81,7 +81,8 @@ public interface OrcFilterContext extends MutableFilterContext {
           "Found vector: %s in branch. List and Map vectors are not supported in isNull "
           + "determination", v));
       }
-      if (!v.noNulls && (v.isRepeating || v.isNull[idx])) {
+      // v.noNulls = false does not mean that we have at least one null value
+      if (!v.noNulls && v.isNull[v.isRepeating ? 0 : idx]) {
         return true;
       }
     }

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -26,7 +26,6 @@ import java.util.function.Consumer;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 
 /**
  * The interface for reading ORC files.
@@ -191,7 +190,7 @@ public interface Reader extends Closeable {
     private Boolean skipCorruptRecords = null;
     private TypeDescription schema = null;
     private String[] preFilterColumns = null;
-    Consumer<VectorizedRowBatch> skipRowCallback = null;
+    Consumer<OrcFilterContext> skipRowCallback = null;
     private DataReader dataReader = null;
     private Boolean tolerateMissingSchema = null;
     private boolean forcePositionalEvolution;
@@ -265,7 +264,7 @@ public interface Reader extends Closeable {
      *
      * @return this
      */
-    public Options setRowFilter(String[] filterColumnNames, Consumer<VectorizedRowBatch> filterCallback) {
+    public Options setRowFilter(String[] filterColumnNames, Consumer<OrcFilterContext> filterCallback) {
       this.preFilterColumns = filterColumnNames;
       this.skipRowCallback =  filterCallback;
       return this;
@@ -382,7 +381,7 @@ public interface Reader extends Closeable {
       return sarg;
     }
 
-    public Consumer<VectorizedRowBatch> getFilterCallback() {
+    public Consumer<OrcFilterContext> getFilterCallback() {
       return skipRowCallback;
     }
 

--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -783,24 +783,9 @@ public class TypeDescription
    * @return the subtype
    */
   public TypeDescription findSubtype(int goal) {
-    // call getId method to make sure the ids are assigned
-    int id = getId();
-    if (goal < id || goal > maxId) {
-      throw new IllegalArgumentException("Unknown type id " + id + " in " +
-          toJson());
-    }
-    if (goal == id) {
-      return this;
-    } else {
-      TypeDescription prev = null;
-      for(TypeDescription next: children) {
-        if (next.id > goal) {
-          return prev.findSubtype(goal);
-        }
-        prev = next;
-      }
-      return prev.findSubtype(goal);
-    }
+    ParserUtils.TypeFinder result = new ParserUtils.TypeFinder(this);
+    ParserUtils.findSubtype(this, goal, result);
+    return result.current;
   }
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
@@ -112,8 +112,9 @@ public class OrcFilterContextImpl implements OrcFilterContext {
   public ColumnVector[] findColumnVector(String name) {
     if (!vectors.containsKey(name)) {
       vectors.put(name,
-                  ParserUtils.findBranchVectors(readSchema,
+                  ParserUtils.findColumnVectors(readSchema,
                                                 new ParserUtils.StringPosition(name),
+                                                true,
                                                 batch));
     }
     return vectors.get(name);

--- a/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * that the filters can invoke to get access to the column vector.
  */
 public class OrcFilterContextImpl implements OrcFilterContext {
-  VectorizedRowBatch batch = null;
+  private VectorizedRowBatch batch = null;
   // Cache of field to ColumnVector, this is reset everytime the batch reference changes
   private final Map<String, ColumnVector[]> vectors;
   private final TypeDescription readSchema;
@@ -51,6 +51,14 @@ public class OrcFilterContextImpl implements OrcFilterContext {
       vectors.clear();
     }
     return this;
+  }
+
+  /**
+   * For testing only
+   * @return The batch reference against which the cache is maintained
+   */
+  VectorizedRowBatch getBatch() {
+    return batch;
   }
 
   @Override

--- a/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.OrcFilterContext;
+import org.apache.orc.TypeDescription;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This defines the input for any filter operation. This is an extension of
+ * [[{@link VectorizedRowBatch}]] with schema.
+ * <p>
+ * This offers a convenience method of finding the column vector from a given column name
+ * that the filters can invoke to get access to the column vector.
+ */
+public class OrcFilterContextImpl implements OrcFilterContext {
+  VectorizedRowBatch batch = null;
+  // Cache of field to ColumnVector, this is reset everytime the batch reference changes
+  private final Map<String, ColumnVector[]> vectors;
+  private final TypeDescription readSchema;
+
+  public OrcFilterContextImpl(TypeDescription readSchema) {
+    this.readSchema = readSchema;
+    this.vectors = new HashMap<>();
+  }
+
+  public OrcFilterContext setBatch(@NotNull VectorizedRowBatch batch) {
+    if (batch != this.batch) {
+      this.batch = batch;
+      vectors.clear();
+    }
+    return this;
+  }
+
+  @Override
+  public void setFilterContext(boolean selectedInUse, int[] selected, int selectedSize) {
+    batch.setFilterContext(selectedInUse, selected, selectedSize);
+  }
+
+  @Override
+  public boolean validateSelected() {
+    return batch.validateSelected();
+  }
+
+  @Override
+  public int[] updateSelected(int i) {
+    return batch.updateSelected(i);
+  }
+
+  @Override
+  public void setSelectedInUse(boolean b) {
+    batch.setSelectedInUse(b);
+  }
+
+  @Override
+  public void setSelected(int[] ints) {
+    batch.setSelected(ints);
+  }
+
+  @Override
+  public void setSelectedSize(int i) {
+    batch.setSelectedSize(i);
+  }
+
+  @Override
+  public void reset() {
+    batch.reset();
+  }
+
+  @Override
+  public boolean isSelectedInUse() {
+    return batch.isSelectedInUse();
+  }
+
+  @Override
+  public int[] getSelected() {
+    return batch.getSelected();
+  }
+
+  @Override
+  public int getSelectedSize() {
+    return batch.getSelectedSize();
+  }
+
+  // For testing only
+  public ColumnVector[] getCols() {
+    return batch.cols;
+  }
+
+  @Override
+  public ColumnVector[] findColumnVector(String name) {
+    if (!vectors.containsKey(name)) {
+      vectors.put(name,
+                  ParserUtils.findBranchVectors(readSchema,
+                                                new ParserUtils.StringPosition(name),
+                                                batch));
+    }
+    return vectors.get(name);
+  }
+}

--- a/java/core/src/java/org/apache/orc/impl/ParserUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/ParserUtils.java
@@ -409,12 +409,12 @@ public class ParserUtils {
     private final ColumnVector[] result;
     private int resultIdx = 0;
 
-    ColumnFinder(TypeDescription schema, VectorizedRowBatch batch, List<String> levels) {
+    ColumnFinder(TypeDescription schema, VectorizedRowBatch batch, int levels) {
       top = batch.cols;
       if (schema.getCategory() == TypeDescription.Category.STRUCT) {
-        result = new ColumnVector[levels.size()];
+        result = new ColumnVector[levels];
       } else {
-        result = new ColumnVector[levels.size() + 1];
+        result = new ColumnVector[levels + 1];
         current = top[0];
         addResult(current);
       }
@@ -456,7 +456,7 @@ public class ParserUtils {
                                                  boolean isCaseSensitive,
                                                  VectorizedRowBatch batch) {
     List<String> names = ParserUtils.splitName(source);
-    ColumnFinder result = new ColumnFinder(schema, batch, names);
+    ColumnFinder result = new ColumnFinder(schema, batch, names.size());
     findColumn(removeAcid(schema), names, isCaseSensitive, result);
     return result.result;
   }

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.OrcProto;
+import org.apache.orc.OrcFilterContext;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
 import org.apache.orc.impl.reader.tree.BatchReader;
@@ -67,7 +68,7 @@ public class TreeReaderFactory {
 
     Set<Integer> getColumnFilterIds();
 
-    Consumer<VectorizedRowBatch> getColumnFilterCallback();
+    Consumer<OrcFilterContext> getColumnFilterCallback();
 
     boolean isSkipCorrupt();
 
@@ -94,7 +95,7 @@ public class TreeReaderFactory {
     private boolean useProlepticGregorian;
     private boolean fileUsedProlepticGregorian;
     private Set<Integer> filterColumnIds = Collections.emptySet();
-    Consumer<VectorizedRowBatch> filterCallback;
+    Consumer<OrcFilterContext> filterCallback;
 
     public ReaderContext setSchemaEvolution(SchemaEvolution evolution) {
       this.evolution = evolution;
@@ -106,7 +107,7 @@ public class TreeReaderFactory {
       return this;
     }
 
-    public ReaderContext setFilterCallback(Set<Integer> filterColumnsList, Consumer<VectorizedRowBatch> filterCallback) {
+    public ReaderContext setFilterCallback(Set<Integer> filterColumnsList, Consumer<OrcFilterContext> filterCallback) {
       this.filterColumnIds = filterColumnsList;
       this.filterCallback = filterCallback;
       return this;
@@ -150,7 +151,7 @@ public class TreeReaderFactory {
     }
 
     @Override
-    public Consumer<VectorizedRowBatch> getColumnFilterCallback() {
+    public Consumer<OrcFilterContext> getColumnFilterCallback() {
       return filterCallback;
     }
 

--- a/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
+++ b/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
@@ -1,0 +1,202 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
+import org.apache.orc.impl.OrcFilterContextImpl;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TestOrcFilterContext {
+  private final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createString())
+    .addField("f3",
+              TypeDescription.createStruct()
+                .addField("a", TypeDescription.createInt())
+                .addField("b", TypeDescription.createLong())
+                .addField("c",
+                          TypeDescription.createMap(TypeDescription.createInt(),
+                                                    TypeDescription.createDate())))
+    .addField("f4",
+              TypeDescription.createList(TypeDescription.createStruct()
+                                           .addField("a", TypeDescription.createChar())
+                                           .addField("b", TypeDescription.createBoolean())))
+    .addField("f5",
+              TypeDescription.createMap(TypeDescription.createInt(),
+                                        TypeDescription.createDate()))
+    .addField("f6",
+              TypeDescription.createUnion()
+                .addUnionChild(TypeDescription.createInt())
+                .addUnionChild(TypeDescription.createStruct()
+                                 .addField("a", TypeDescription.createDate())
+                                 .addField("b",
+                                           TypeDescription.createList(TypeDescription.createChar()))
+                )
+    );
+  private final OrcFilterContext filterContext = new OrcFilterContextImpl(schema)
+    .setBatch(schema.createRowBatch());
+
+  @Before
+  public void setup() {
+    filterContext.reset();
+  }
+
+  @Test
+  public void testTopLevelElementaryType() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("f1");
+    assertEquals(1, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(LongColumnVector.class));
+  }
+
+  @Test
+  public void testTopLevelCompositeType() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("f3");
+    assertEquals(1, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(StructColumnVector.class));
+
+    vectorBranch = filterContext.findColumnVector("f4");
+    assertEquals(1, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(ListColumnVector.class));
+
+    vectorBranch = filterContext.findColumnVector("f5");
+    assertEquals(1, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(MapColumnVector.class));
+
+    vectorBranch = filterContext.findColumnVector("f6");
+    assertEquals(1, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(UnionColumnVector.class));
+  }
+
+  @Test
+  public void testNestedType() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("f3.a");
+    assertEquals(2, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(StructColumnVector.class));
+    assertThat(vectorBranch[1], instanceOf(LongColumnVector.class));
+
+    vectorBranch = filterContext.findColumnVector("f3.c");
+    assertEquals(2, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(StructColumnVector.class));
+    assertThat(vectorBranch[1], instanceOf(MapColumnVector.class));
+
+    vectorBranch = filterContext.findColumnVector("f6.1.b");
+    assertEquals(3, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(UnionColumnVector.class));
+    assertThat(vectorBranch[1], instanceOf(StructColumnVector.class));
+    assertThat(vectorBranch[2], instanceOf(ListColumnVector.class));
+  }
+
+  @Test
+  public void testTopLevelVector() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("f3");
+    vectorBranch[0].noNulls = true;
+    assertTrue(OrcFilterContext.noNulls(vectorBranch));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 0));
+
+    vectorBranch[0].noNulls = false;
+    vectorBranch[0].isNull[0] = true;
+    assertFalse(OrcFilterContext.noNulls(vectorBranch));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 0));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 1));
+  }
+
+  @Test
+  public void testNestedVector() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("f3.a");
+    vectorBranch[0].noNulls = true;
+    vectorBranch[1].noNulls = true;
+    assertTrue(OrcFilterContext.noNulls(vectorBranch));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 0));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 1));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 2));
+
+    vectorBranch = filterContext.findColumnVector("f3.a");
+    vectorBranch[0].noNulls = false;
+    vectorBranch[0].isNull[0] = true;
+    vectorBranch[1].noNulls = true;
+    assertFalse(OrcFilterContext.noNulls(vectorBranch));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 0));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 1));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 2));
+
+    vectorBranch = filterContext.findColumnVector("f3.a");
+    vectorBranch[0].noNulls = true;
+    vectorBranch[1].noNulls = false;
+    vectorBranch[1].isNull[2] = true;
+    assertFalse(OrcFilterContext.noNulls(vectorBranch));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 0));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 1));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 2));
+
+    vectorBranch = filterContext.findColumnVector("f3.a");
+    vectorBranch[0].noNulls = false;
+    vectorBranch[0].isNull[0] = true;
+    vectorBranch[1].noNulls = false;
+    vectorBranch[1].isNull[2] = true;
+    assertFalse(OrcFilterContext.noNulls(vectorBranch));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 0));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 1));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 2));
+  }
+
+  @Test
+  public void testTopLevelList() {
+    TypeDescription topListSchema = TypeDescription.createList(
+      TypeDescription.createStruct()
+        .addField("a", TypeDescription.createChar())
+        .addField("b", TypeDescription
+          .createBoolean()));
+    OrcFilterContext fc = new OrcFilterContextImpl(topListSchema)
+      .setBatch(topListSchema.createRowBatch());
+    ColumnVector[] vectorBranch = fc.findColumnVector("_elem");
+    assertThat(vectorBranch[0], instanceOf(ListColumnVector.class));
+    assertThat(vectorBranch[1], instanceOf(StructColumnVector.class));
+  }
+
+  @Test
+  public void testUnsupportedIsNullUse() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("f4._elem.a");
+    assertEquals(3, vectorBranch.length);
+    assertThat(vectorBranch[0], instanceOf(ListColumnVector.class));
+    assertThat(vectorBranch[1], instanceOf(StructColumnVector.class));
+    assertThat(vectorBranch[2], instanceOf(BytesColumnVector.class));
+
+    assertTrue(OrcFilterContext.noNulls(vectorBranch));
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                      () -> OrcFilterContext.isNull(vectorBranch,
+                                                                                    0));
+    assertThat(exception.getMessage(), containsString("ListColumnVector"));
+    assertThat(exception.getMessage(), containsString("List and Map vectors are not supported"));
+  }
+}

--- a/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
+++ b/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
@@ -214,6 +214,7 @@ public class TestOrcFilterContext {
 
     vectorBranch[0].noNulls = false;
     vectorBranch[0].isRepeating = true;
+    vectorBranch[0].isNull[0] = true;
     vectorBranch[1].noNulls = true;
     assertFalse(OrcFilterContext.noNulls(vectorBranch));
     assertTrue(OrcFilterContext.isNull(vectorBranch, 0));

--- a/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
+++ b/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
@@ -200,4 +200,24 @@ public class TestOrcFilterContext {
     assertThat(exception.getMessage(), containsString("ListColumnVector"));
     assertThat(exception.getMessage(), containsString("List and Map vectors are not supported"));
   }
+
+  @Test
+  public void testRepeatingVector() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("f3.a");
+    vectorBranch[0].noNulls = true;
+    vectorBranch[0].isRepeating = true;
+    vectorBranch[1].noNulls = true;
+    assertTrue(OrcFilterContext.noNulls(vectorBranch));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 0));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 1));
+    assertFalse(OrcFilterContext.isNull(vectorBranch, 2));
+
+    vectorBranch[0].noNulls = false;
+    vectorBranch[0].isRepeating = true;
+    vectorBranch[1].noNulls = true;
+    assertFalse(OrcFilterContext.noNulls(vectorBranch));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 0));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 1));
+    assertTrue(OrcFilterContext.isNull(vectorBranch, 2));
+  }
 }

--- a/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
+++ b/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
@@ -180,6 +180,7 @@ public class TestOrcFilterContext {
     OrcFilterContext fc = new OrcFilterContextImpl(topListSchema)
       .setBatch(topListSchema.createRowBatch());
     ColumnVector[] vectorBranch = fc.findColumnVector("_elem");
+    assertEquals(2, vectorBranch.length);
     assertThat(vectorBranch[0], instanceOf(ListColumnVector.class));
     assertThat(vectorBranch[1], instanceOf(StructColumnVector.class));
   }

--- a/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
@@ -107,9 +107,9 @@ public class TestOrcFilterContextImpl {
   @Test
   public void testPropagations() {
     OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
-    assertNull(fc.batch);
+    assertNull(fc.getBatch());
     fc.setBatch(schema.createRowBatch());
-    assertNotNull(fc.batch);
+    assertNotNull(fc.getBatch());
     assertFalse(fc.isSelectedInUse());
 
     // Set selections
@@ -118,20 +118,20 @@ public class TestOrcFilterContextImpl {
     fc.setSelectedSize(1);
     assertTrue(fc.isSelectedInUse());
     assertEquals(1, fc.getSelectedSize());
-    assertEquals(fc.batch.getMaxSize(), fc.getSelected().length);
+    assertEquals(fc.getBatch().getMaxSize(), fc.getSelected().length);
     assertArrayEquals(new int[] {5}, Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
     assertTrue(fc.validateSelected());
     fc.setSelectedSize(2);
     assertFalse(fc.validateSelected());
 
     // Use a new selected vector
-    fc.setSelected(new int[fc.batch.getMaxSize()]);
+    fc.setSelected(new int[fc.getBatch().getMaxSize()]);
     assertArrayEquals(new int[] {0, 0}, Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
 
     // Increase the size of the vector
     fc.reset();
     assertFalse(fc.isSelectedInUse());
-    int currSize = fc.batch.getMaxSize();
+    int currSize = fc.getBatch().getMaxSize();
     assertEquals(currSize, fc.getSelected().length);
     fc.updateSelected(currSize + 1);
     assertEquals(currSize + 1, fc.getSelected().length);
@@ -139,7 +139,7 @@ public class TestOrcFilterContextImpl {
     // Set the filter context
     fc.setFilterContext(true, new int[3], 1);
     assertTrue(fc.isSelectedInUse());
-    assertEquals(3, fc.batch.getMaxSize());
+    assertEquals(3, fc.getBatch().getMaxSize());
     assertEquals(1, fc.getSelectedSize());
   }
 

--- a/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.TypeDescription;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class TestOrcFilterContextImpl {
+
+  private final TypeDescription schema = TypeDescription.createStruct()
+    .addField("f1", TypeDescription.createLong())
+    .addField("f2", TypeDescription.createStruct()
+      .addField("f2a", TypeDescription.createLong())
+      .addField("f2b", TypeDescription.createString()))
+    .addField("f3", TypeDescription.createString());
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testSuccessfulRetrieval() {
+    VectorizedRowBatch b = createBatch();
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    fc.setBatch(b);
+
+    validateF1Vector(fc.findColumnVector("f1"), 1);
+    validateF2Vector(fc.findColumnVector("f2"));
+    validateF2AVector(fc.findColumnVector("f2.f2a"));
+    validateF2BVector(fc.findColumnVector("f2.f2b"));
+    validateF3Vector(fc.findColumnVector("f3"));
+  }
+
+  @Test
+  public void testSuccessfulRetrievalWithBatchChange() {
+    VectorizedRowBatch b1 = createBatch();
+    VectorizedRowBatch b2 = createBatch();
+    ((LongColumnVector) b2.cols[0]).vector[0] = 100;
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    fc.setBatch(b1);
+    validateF1Vector(fc.findColumnVector("f1"), 1);
+    // Change the batch
+    fc.setBatch(b2);
+    validateF1Vector(fc.findColumnVector("f1"), 100);
+  }
+
+  @Test
+  public void testMissingFieldTopLevel() {
+    VectorizedRowBatch b = createBatch();
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    fc.setBatch(b);
+
+    // Missing field at top level
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                      () -> fc.findColumnVector("f4"));
+    assertThat(exception.getMessage(), containsString("Field f4 not found in"));
+  }
+
+  @Test
+  public void testMissingFieldNestedLevel() {
+    VectorizedRowBatch b = createBatch();
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    fc.setBatch(b);
+
+    // Missing field at top level
+    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                      () -> fc.findColumnVector("f2.c"));
+    assertThat(exception.getMessage(),
+               containsString("Field c not found in struct<f2a:bigint,f2b:string>"));
+  }
+
+  @Test
+  public void testPropagations() {
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    assertNull(fc.batch);
+    fc.setBatch(schema.createRowBatch());
+    assertNotNull(fc.batch);
+    assertFalse(fc.isSelectedInUse());
+
+    // Set selections
+    fc.setSelectedInUse(true);
+    fc.getSelected()[0] = 5;
+    fc.setSelectedSize(1);
+    assertTrue(fc.isSelectedInUse());
+    assertEquals(1, fc.getSelectedSize());
+    assertEquals(fc.batch.getMaxSize(), fc.getSelected().length);
+    assertArrayEquals(new int[] {5}, Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
+    assertTrue(fc.validateSelected());
+    fc.setSelectedSize(2);
+    assertFalse(fc.validateSelected());
+
+    // Use a new selected vector
+    fc.setSelected(new int[fc.batch.getMaxSize()]);
+    assertArrayEquals(new int[] {0, 0}, Arrays.copyOf(fc.getSelected(), fc.getSelectedSize()));
+
+    // Increase the size of the vector
+    fc.reset();
+    assertFalse(fc.isSelectedInUse());
+    int currSize = fc.batch.getMaxSize();
+    assertEquals(currSize, fc.getSelected().length);
+    fc.updateSelected(currSize + 1);
+    assertEquals(currSize + 1, fc.getSelected().length);
+
+    // Set the filter context
+    fc.setFilterContext(true, new int[3], 1);
+    assertTrue(fc.isSelectedInUse());
+    assertEquals(3, fc.batch.getMaxSize());
+    assertEquals(1, fc.getSelectedSize());
+  }
+
+  private VectorizedRowBatch createBatch() {
+    VectorizedRowBatch b = schema.createRowBatch();
+    LongColumnVector v1 = (LongColumnVector) b.cols[0];
+    StructColumnVector v2 = (StructColumnVector) b.cols[1];
+    LongColumnVector v2a = (LongColumnVector) v2.fields[0];
+    BytesColumnVector v2b = (BytesColumnVector) v2.fields[1];
+    BytesColumnVector v3 = (BytesColumnVector) b.cols[2];
+
+    v1.vector[0] = 1;
+    v2a.vector[0] = 2;
+    v2b.setVal(0, "3".getBytes(StandardCharsets.UTF_8));
+    v3.setVal(0, "4".getBytes(StandardCharsets.UTF_8));
+    return b;
+  }
+
+  private void validateF1Vector(ColumnVector[] v, long headValue) {
+    assertEquals(1, v.length);
+    validateF1Vector(v[0], headValue);
+  }
+
+  private void validateF1Vector(ColumnVector v, long headValue) {
+    LongColumnVector l = (LongColumnVector) v;
+    assertEquals(headValue, l.vector[0]);
+  }
+
+  private void validateF2Vector(ColumnVector[] v) {
+    assertEquals(1, v.length);
+    validateF2Vector(v[0]);
+  }
+
+  private void validateF2Vector(ColumnVector v) {
+    StructColumnVector s = (StructColumnVector) v;
+    validateF2AVector(s.fields[0]);
+    validateF2BVector(s.fields[1]);
+  }
+
+  private void validateF2AVector(ColumnVector[] v) {
+    assertEquals(2, v.length);
+    validateF2Vector(v[0]);
+    validateF2AVector(v[1]);
+  }
+
+  private void validateF2AVector(ColumnVector v) {
+    LongColumnVector l = (LongColumnVector) v;
+    assertEquals(2, l.vector[0]);
+  }
+
+  private void validateF2BVector(ColumnVector[] v) {
+    assertEquals(2, v.length);
+    validateF2Vector(v[0]);
+    validateF2BVector(v[1]);
+  }
+
+  private void validateF2BVector(ColumnVector v) {
+    BytesColumnVector b = (BytesColumnVector) v;
+    assertEquals("3", b.toString(0));
+  }
+
+  private void validateF3Vector(ColumnVector[] v) {
+    assertEquals(1, v.length);
+    BytesColumnVector b = (BytesColumnVector) v[0];
+    assertEquals("4", b.toString(0));
+  }
+}


### PR DESCRIPTION
* Change the filter from Consumer<VectorizedRowBatch> to Consumer<OrcFilterContext>
* OrcFilterContext has findVector method that allows cached determination of ColumnVectors from name
* OrcFilterContext offers utility methods for null determination on the vector branch
* Refactors ParserUtils to introduce TypeWalker and VectorWalker to centralize the walk logic
* Tests have been modified to support the new interface

### What changes were proposed in this pull request?
* Change the filter from Consumer<VectorizedRowBatch> to Consumer<OrcFilterContext>
* Add the following convenience methods
  * OrcFilterContext has findVector method that allows cached determination of ColumnVectors from name
  * OrcFilterContext offers utility methods for null determination on the vector branch
* Refactors ParserUtils to introduce TypeWalker and VectorWalker to centralize the walk logic

### Why are the changes needed?
The changes are needed to allow easy access to ColumnVectors by name as part of [ORC-744]

### How was this patch tested?
Unit tests were added to the project.
