### PR TITLE
[ORC-756] Check null readerschema prior to setting readerSchemaIsAcid && readerColumnOffset

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -86,6 +86,7 @@ public class SchemaEvolution {
     this.isOnlyImplicitConversion = true;
     this.fileSchema = fileSchema;
     this.isAcid = checkAcidSchema(fileSchema);
+    if (null==readerSchema){readerSchema=fileSchema;};
     boolean readerSchemaIsAcid = readerSchema == null ? false : checkAcidSchema(readerSchema);
     this.includeAcidColumns = options.getIncludeAcidColumns();
     this.readerColumnOffset = isAcid && !readerSchemaIsAcid ? acidEventFieldNames.size() : 0;


### PR DESCRIPTION
-- Add a check for null readerSchema and using the fileschema before calculating readerSchemaIsAcid && readerColumnOffset
-- resolves "Include vector the wrong length" error for ACID files/tables that don't include OrcConf.MAPRED_INPUT_SCHEMA

### What changes were proposed in this pull request?
Setting readerSchema to the fileSchema prior to setting final properties for readerschema. 

### Why are the changes needed?
- Currently SchemaEvolution from a recordreader without OrcConf.MAPRED_INPUT_SCHEMA causes 
"Include vector the wrong length" error 

### How was this patch tested?
Limited Testing on local workstation. 
