### PR TITLE
ORC-758: Avoid seeking and decompressing of compressed stream

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/InStream.java
+++ b/java/core/src/java/org/apache/orc/impl/InStream.java
@@ -404,7 +404,7 @@ public abstract class InStream extends InputStream {
     protected ByteBuffer compressed;
     protected DiskRangeList currentRange;
     private boolean isUncompressedOriginal;
-    protected long currentCompressedStart;
+    protected long currentCompressedStart = -1;
 
     /**
      * Create the stream without resetting the input stream.
@@ -558,9 +558,14 @@ public abstract class InStream extends InputStream {
     public void seek(PositionProvider index) throws IOException {
       boolean seeked = seek(index.getNext());
       long uncompressedBytes = index.getNext();
-      if (!seeked && uncompressed != null) {
-        // Only reposition uncompressed
-        uncompressed.position((int) uncompressedBytes);
+      if (!seeked) {
+        if (uncompressed != null) {
+          // Only reposition uncompressed
+          uncompressed.position((int) uncompressedBytes);
+        } else {
+          // Should not happen as !seeked would mean that a previous readHeader has taken place
+        }
+
       } else {
         if (uncompressedBytes != 0) {
           // Decompress compressed as a seek has taken place and position uncompressed

--- a/java/core/src/java/org/apache/orc/impl/InStream.java
+++ b/java/core/src/java/org/apache/orc/impl/InStream.java
@@ -397,7 +397,7 @@ public abstract class InStream extends InputStream {
     }
   }
 
-  static class CompressedStream extends InStream {
+  public static class CompressedStream extends InStream {
     private final int bufferSize;
     private ByteBuffer uncompressed;
     private final CompressionCodec codec;
@@ -472,7 +472,7 @@ public abstract class InStream extends InputStream {
     }
 
     private void readHeader() throws IOException {
-      currentCompressedStart = compressed.position();
+      currentCompressedStart = this.position;
       int b0 = readHeaderByte();
       int b1 = readHeaderByte();
       int b2 = readHeaderByte();
@@ -563,6 +563,7 @@ public abstract class InStream extends InputStream {
         uncompressed.position((int) uncompressedBytes);
       } else {
         if (uncompressedBytes != 0) {
+          // Decompress compressed as a seek has taken place and position uncompressed
           readHeader();
           uncompressed.position(uncompressed.position() +
                                 (int) uncompressedBytes);

--- a/java/core/src/java/org/apache/orc/impl/InStream.java
+++ b/java/core/src/java/org/apache/orc/impl/InStream.java
@@ -562,10 +562,9 @@ public abstract class InStream extends InputStream {
         if (uncompressed != null) {
           // Only reposition uncompressed
           uncompressed.position((int) uncompressedBytes);
-        } else {
-          // Should not happen as !seeked would mean that a previous readHeader has taken place
         }
-
+        // uncompressed == null should not happen as !seeked would mean that a previous
+        // readHeader has taken place
       } else {
         if (uncompressedBytes != 0) {
           // Decompress compressed as a seek has taken place and position uncompressed


### PR DESCRIPTION
### What changes were proposed in this pull request?
If the seek on a compressed stream is already satisfied by the current decompression then avoid seeking and decompressing the same block again.

### Why are the changes needed?
Seeks performed within the same compression block avoid the costs of decompression.

### How was this patch tested?
Modified an existing test to verify that the compressed buffer changes only when the seek is needed and not in other cases.
Additionally all of the existing tests pass.
