### PR TITLE
ORC-759: StructBatchReader should always skip processing on the rootReader

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/BatchReader.java
@@ -38,9 +38,7 @@ public abstract class BatchReader {
     this.rootType = rootType;
   }
 
-  public void startStripe(StripePlanner planner) throws IOException {
-    rootType.startStripe(planner);
-  }
+  public abstract void startStripe(StripePlanner planner) throws IOException;
 
   public void setVectorColumnCount(int vectorColumnCount) {
     this.vectorColumnCount = vectorColumnCount;
@@ -60,11 +58,7 @@ public abstract class BatchReader {
     batch.size = batchSize;
   }
 
-  public void skipRows(long rows) throws IOException {
-    rootType.skipRows(rows);
-  }
+  public abstract void skipRows(long rows) throws IOException;
 
-  public void seek(PositionProvider[] index) throws IOException {
-    rootType.seek(index);
-  }
+  public abstract void seek(PositionProvider[] index) throws IOException;
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/PrimitiveBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/PrimitiveBatchReader.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.orc.impl.reader.tree;
 
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/PrimitiveBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/PrimitiveBatchReader.java
@@ -15,10 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.orc.impl.reader.tree;
 
-import java.io.IOException;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.impl.PositionProvider;
+import org.apache.orc.impl.reader.StripePlanner;
+
+import java.io.IOException;
 
 public class PrimitiveBatchReader extends BatchReader {
 
@@ -29,9 +33,21 @@ public class PrimitiveBatchReader extends BatchReader {
   @Override
   public void nextBatch(VectorizedRowBatch batch,
                         int batchSize) throws IOException {
-  batch.cols[0].reset();
-  batch.cols[0].ensureSize(batchSize, false);
-  rootType.nextVector(batch.cols[0], null, batchSize, batch);
-  resetBatch(batch, batchSize);
+    batch.cols[0].reset();
+    batch.cols[0].ensureSize(batchSize, false);
+    rootType.nextVector(batch.cols[0], null, batchSize, batch);
+    resetBatch(batch, batchSize);
+  }
+
+  public void startStripe(StripePlanner planner) throws IOException {
+    rootType.startStripe(planner);
+  }
+
+  public void skipRows(long rows) throws IOException {
+    rootType.skipRows(rows);
+  }
+
+  public void seek(PositionProvider[] index) throws IOException {
+    rootType.seek(index);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
@@ -29,8 +29,8 @@ import java.util.Set;
 
 /**
  * Handles the Struct rootType for batch handling. The handling assumes that the root
- * {@link org.apache.orc.impl.TreeReaderFactory.StructTreeReader} has no nulls, this is required as
- * the {@link VectorizedRowBatch} does not represent the root Struct as a vector.
+ * {@link org.apache.orc.impl.TreeReaderFactory.StructTreeReader} no nulls. Root Struct vector is
+ * not represented as part of the final {@link org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch}.
  */
 public class StructBatchReader extends BatchReader {
   // The reader context including row-filtering details


### PR DESCRIPTION
### What changes were proposed in this pull request?
StructBatchReader assumes rootReader has no nulls and skips rootReader processing in the following methods:
* seek
* skip
* startStripe

This behavior will be consistent with the behavior of nextBatch which already makes this assumption.

### Why are the changes needed?
Make the behavior consistent on all the methods.


### How was this patch tested?
Regression test, none of the existing tests have failed.
