### PR TITLE
ORC-763: [C++] Fix ORC timestamp inconsistencies with Java ORC

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -374,7 +374,7 @@ namespace orc {
         }
         int64_t writerTime = secsBuffer[i] + epochOffset;
         secsBuffer[i] = writerTimezone.convertToUTC(writerTime);
-        if (secsBuffer[i] < 0 && nanoBuffer[i] != 0) {
+        if (secsBuffer[i] < 0 && nanoBuffer[i] > 999999) {
           secsBuffer[i] -= 1;
         }
       }

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1804,7 +1804,7 @@ namespace orc {
         }
         tsStats->update(millsUTC, static_cast<int32_t>(nanos[i] % 1000000));
 
-        if (secs[i] < 0 && nanos[i] != 0) {
+        if (secs[i] < 0 && nanos[i] > 999999) {
           secs[i] += 1;
         }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The Java ORC reader takes one second off from timestamp values with negative second and nanosecond greater than 999999. The C++ ORC reader/writer should use same logic to be consistent.

### Why are the changes needed?
WIthout this fix, we may see data inconsistency of timestamp values from different ORC readers.

### How was this patch tested?
It can be tested manually by C++/Java ORC tools.
