### PR TITLE
MINOR: Fix typo in make-release.md

### DIFF
--- a/site/develop/make-release.md
+++ b/site/develop/make-release.md
@@ -125,7 +125,7 @@ edit CMakeLists.txt to change version to X.Y.(Z+1)-SNAPSHOT
 
 Update the site with the new release.
 
-* Check out the master branch (git co apache/master)
+* Check out the master branch (git checkout apache/master)
 
 ~~~
 Change directory in to site.


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to fix a typo in make-release.md.


### Why are the changes needed?
`git co` is an incorrect command because co is from svn. We need to use git checkout instead. 


### How was this patch tested?
N/A.