### PR TITLE
ORC-769: Support ZSTD in ORC data benchmark

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/CompressionKind.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/CompressionKind.java
@@ -33,7 +33,8 @@ import java.util.zip.GZIPOutputStream;
 public enum CompressionKind {
   NONE("none"),
   ZLIB("gz"),
-  SNAPPY("snappy");
+  SNAPPY("snappy"),
+  ZSTD("zstd");
 
   CompressionKind(String extendsion) {
     this.extension = extendsion;

--- a/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
@@ -56,6 +56,8 @@ public class Utilities {
         return org.apache.orc.CompressionKind.ZLIB;
       case SNAPPY:
         return org.apache.orc.CompressionKind.SNAPPY;
+      case ZSTD:
+        return org.apache.orc.CompressionKind.ZSTD;
       default:
         throw new IllegalArgumentException("Unknown compression " + compression);
     }

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -81,13 +81,7 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>0.10</version>
-        <exclusions>
-          <exclusion>
-            <groupId>io.airlift</groupId>
-            <artifactId>slice</artifactId>
-          </exclusion>
-        </exclusions>
+        <version>0.16</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support ZSTD compression at benchmark ORC data.

### Why are the changes needed?

Apache ORC 1.6+ supports ZSTD compression.

### How was this patch tested?

Manually

**PREPARATION**
```
$ cd java/bench
$ mvn clean package
```

**ZSTD ORC DATA GENERATION**
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data -d sales -c zstd -f orc

$ ls -alhR data
data:
total 12K
drwxrwxr-x 3 dongjoon dongjoon 4.0K Mar 22 22:42 .
drwxrwxr-x 7 dongjoon dongjoon 4.0K Mar 22 22:42 ..
drwxrwxr-x 3 dongjoon dongjoon 4.0K Mar 22 22:42 generated

data/generated:
total 12K
drwxrwxr-x 3 dongjoon dongjoon 4.0K Mar 22 22:42 .
drwxrwxr-x 3 dongjoon dongjoon 4.0K Mar 22 22:42 ..
drwxrwxr-x 2 dongjoon dongjoon 4.0K Mar 22 22:42 sales

data/generated/sales:
total 2.5G
drwxrwxr-x 2 dongjoon dongjoon 4.0K Mar 22 22:42 .
drwxrwxr-x 3 dongjoon dongjoon 4.0K Mar 22 22:42 ..
-rw-r--r-- 1 dongjoon dongjoon 2.5G Mar 22 22:45 orc.zstd
-rw-r--r-- 1 dongjoon dongjoon  20M Mar 22 22:45 .orc.zstd.crc
```

**RUN TEST ON ZSTD ORC DATA**
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar scan data -d sales -c zstd -f orc
data/generated/sales/orc.zstd rows: 25000000 batches: 24415
```