### PR TITLE
ORC-770: Support ZSTD in Avro data benchmark

### DIFF
--- a/java/bench/core/pom.xml
+++ b/java/bench/core/pom.xml
@@ -59,7 +59,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>hadoop2</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/avro/AvroWriter.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/avro/AvroWriter.java
@@ -333,6 +333,9 @@ public class AvroWriter implements BatchWriter {
       case SNAPPY:
         writer.setCodec(CodecFactory.snappyCodec());
         break;
+      case ZSTD:
+        writer.setCodec(CodecFactory.zstandardCodec(CodecFactory.DEFAULT_ZSTANDARD_LEVEL));
+        break;
       default:
         throw new IllegalArgumentException("Compression unsupported " + compression);
     }

--- a/java/bench/hive/pom.xml
+++ b/java/bench/hive/pom.xml
@@ -52,7 +52,6 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro-mapred</artifactId>
-      <classifier>hadoop2</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -36,7 +36,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
 
-    <avro.version>1.8.2</avro.version>
+    <avro.version>1.10.2</avro.version>
     <hive.version>3.1.2</hive.version>
     <jmh.version>1.20</jmh.version>
     <orc.version>${project.version}</orc.version>
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.8.4</version>
+        <version>2.12.2</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>
@@ -103,14 +103,7 @@
       <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-mapred</artifactId>
-        <classifier>hadoop2</classifier>
         <version>${avro.version}</version>
-	<exclusions>
-	  <exclusion>
-	    <groupId>org.mortbay.jetty</groupId>
-	    <artifactId>servlet-api</artifactId>
-	  </exclusion>
-	</exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache Avro added ZSTD support. This PR aims to upgrade Apache Avro to 1.10.2 in benchmark.

### Why are the changes needed?

To support ZSTD comparison in benchmark.

### How was this patch tested?

```
$ cd java/bench
$ mvn package
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data -d sales -c zstd -f avro

$ ls -alh data/generated/sales
total 3.5G
drwxrwxr-x 2 dongjoon dongjoon 4.0K Mar 23 06:03 .
drwxrwxr-x 3 dongjoon dongjoon 4.0K Mar 23 06:03 ..
-rw-r--r-- 1 dongjoon dongjoon 3.5G Mar 23 06:08 avro.zstd
-rw-r--r-- 1 dongjoon dongjoon  28M Mar 23 06:08 .avro.zstd.crc

$ java -jar core/target/orc-benchmarks-core-*-uber.jar scan data -d sales -c zstd -f avro
data/generated/sales/avro.zstd rows: 25000000 batches: 24415
```