### PR TITLE
ORC-772: Fix Spark benchmark jar creation

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -174,6 +174,13 @@
             </goals>
             <configuration>
 	      <createDependencyReducedPom>false</createDependencyReducedPom>
+              <artifactSet>
+                <includes>
+                  <include>*:*</include>
+                </includes>
+              </artifactSet>
+              <shadedArtifactAttached>false</shadedArtifactAttached>
+              <shadedClassifierName>shaded</shadedClassifierName>
               <filters>
                 <filter>
                   <artifact>org.codehaus.janino:janino</artifact>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix Spark benchmark jar creation by using the default Maven shade plugin configurations explicitly. Otherwise, the parent pom's configuration is applied.

### Why are the changes needed?

Since ORC-750, it builds incorrect uber jar. 
```
$ cd java/bench

$ mvn clean package -pl spark --am

$ ls -alh spark/target/*.jar      
-rw-rw-r-- 1 dongjoon dongjoon  62K Mar 23 05:28 spark/target/orc-benchmarks-spark-1.7.0-SNAPSHOT.jar
-rw-rw-r-- 1 dongjoon dongjoon 808K Mar 23 05:28 spark/target/orc-benchmarks-spark-1.7.0-SNAPSHOT-nohive.jar
```

### How was this patch tested?

Manually.
```
$ cd java/bench

$ mvn clean package -pl spark --am

$ ls -alh spark/target/*.jar
-rw-rw-r-- 1 dongjoon dongjoon 130M Mar 23 05:56 spark/target/orc-benchmarks-spark-1.7.0-SNAPSHOT.jar
-rw-rw-r-- 1 dongjoon dongjoon  62K Mar 23 05:55 spark/target/original-orc-benchmarks-spark-1.7.0-SNAPSHOT.jar
```