### PR TITLE
ORC-773: BinaryColumnWriter does not update Bloom filter

### DIFF
--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1683,6 +1683,9 @@ namespace orc {
       if (!notNull || notNull[i]) {
         directDataStream->write(data[i], unsignedLength);
 
+        if (enableBloomFilter) {
+          bloomFilter->addBytes(data[i], length[i]);
+        }
         binStats->update(unsignedLength);
         ++count;
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
Add missing Bloom filter update, when new item is added to a binary column.


### Why are the changes needed?
Even when the Bloom filter is enabled for a binary column, the filter won't be updated. 


### How was this patch tested?
Copied the logic from the string column in testBloomFilter.
