### PR TITLE
Update ORCv1.md: Fix documentation about bitset in bloom filter section

### DIFF
--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -1297,7 +1297,7 @@ in a bloom filter is as follows:
   * position = combinedHash % m
 6. Set the position in bit set. The LSB 6 bits identifies the long index
    within bitset and bit position within the long uses little endian order.
-  * bitset[position >> 6] \|= (1L << (position & 0x3f));
+  * bitset[position >> 6] \|= (1L << (position % 64));
 
 Bloom filter streams are interlaced with row group indexes. This placement
 makes it convenient to read the bloom filter stream and row index stream

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -1297,7 +1297,7 @@ in a bloom filter is as follows:
   * position = combinedHash % m
 6. Set the position in bit set. The LSB 6 bits identifies the long index
    within bitset and bit position within the long uses little endian order.
-  * bitset[position >>> 6] \|= (1L << position);
+  * bitset[position >> 6] \|= (1L << (position & 0x3f));
 
 Bloom filter streams are interlaced with row group indexes. This placement
 makes it convenient to read the bloom filter stream and row index stream


### PR DESCRIPTION
The corresponding code is https://github.com/apache/orc/blob/master/c%2B%2B/src/BloomFilter.cc#L47.

The code is correct, but the documentation is not. The code is to use `index % 64` which has the same effect as `index & 0x3f`.
```
  constexpr uint64_t BITS_OF_LONG = 64;
  constexpr uint8_t  SHIFT_6_BITS = 6;
  void BitSet::set(uint64_t index) {
    mData[index >> SHIFT_6_BITS] |= (1ULL << (index % BITS_OF_LONG));
  }
```

The fixes on documentation are
1. There is no need to use `>>>`. We have already flip `combinedHash` if it's negative and `position`  sign bit will be always zero.
2. To set bit we have to mask `position` with 0x3f to keep the least 6 bits.
