### PR TITLE
ORC-774: Support ZSTD in Parquet data benchmark

### DIFF
--- a/java/bench/core/pom.xml
+++ b/java/bench/core/pom.xml
@@ -73,6 +73,10 @@
       <artifactId>hadoop-hdfs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
     </dependency>

--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/parquet/ParquetWriter.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/parquet/ParquetWriter.java
@@ -48,6 +48,8 @@ public class ParquetWriter implements BatchWriter {
         return CompressionCodecName.GZIP;
       case SNAPPY:
         return CompressionCodecName.SNAPPY;
+      case ZSTD:
+        return CompressionCodecName.ZSTD;
       default:
         throw new IllegalArgumentException("Unhandled compression type " + kind);
     }

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,7 +40,7 @@
     <hive.version>3.1.2</hive.version>
     <jmh.version>1.20</jmh.version>
     <orc.version>${project.version}</orc.version>
-    <parquet.version>1.8.3</parquet.version>
+    <parquet.version>1.12.0</parquet.version>
     <slf4j.version>1.7.25</slf4j.version>
     <spark.version>3.1.1</spark.version>
   </properties>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache Parquet 1.12.0 starts to support ZSTD. This PR aims to support ZSTD in Parquet data benchmark.

### Why are the changes needed?

For comparision.

### How was this patch tested?

Manually.
```
$ cd java/bench
$ mvn package
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data -d sales -c zstd -f parquet

$ ls -alh data/generated/sales
total 5417216
drwxr-xr-x  4 dongjoon  staff   128B Mar 25 09:53 .
drwxr-xr-x  3 dongjoon  staff    96B Mar 25 09:53 ..
-rw-r--r--  1 dongjoon  staff    20M Mar 25 09:56 .parquet.zstd.crc
-rw-r--r--  1 dongjoon  staff   2.6G Mar 25 09:56 parquet.zstd

$ java -jar core/target/orc-benchmarks-core-*-uber.jar scan data -d sales -c zstd -f parquet
data/generated/sales/parquet.zstd rows: 25000000 batches: 24415
```
