### PR TITLE
ORC-666: [C++] Add timestamp with local timezone

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -256,6 +256,16 @@ namespace orc {
      * Get search argument for predicate push down
      */
     std::shared_ptr<SearchArgument> getSearchArgument() const;
+
+    /**
+     * Set desired timezone to return data of timestamp type
+     */
+    RowReaderOptions& setReaderTimezone(const char* zoneName);
+
+    /**
+     * Get desired timezone to return data of timestamp type
+     */
+    const char* getReaderTimezone() const;
   };
 
 

--- a/c++/include/orc/Type.hh
+++ b/c++/include/orc/Type.hh
@@ -43,7 +43,8 @@ namespace orc {
     DECIMAL = 14,
     DATE = 15,
     VARCHAR = 16,
-    CHAR = 17
+    CHAR = 17,
+    TIMESTAMP_INSTANT = 18
   };
 
   class Type {

--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -217,6 +217,24 @@ namespace orc {
      * Get version of BloomFilter
      */
     BloomFilterVersion getBloomFilterVersion() const;
+
+    /**
+     * Get writer timezone
+     * @return writer timezone
+     */
+    const Timezone* getTimezone() const;
+
+    /**
+     * Get writer timezone name
+     * @return writer timezone name
+     */
+    const std::string& getTimezoneName() const;
+
+    /**
+     * Set writer timezone
+     * @param zone writer timezone name
+     */
+    WriterOptions& setTimezoneName(const std::string& zone);
   };
 
   class Writer {

--- a/c++/src/ColumnPrinter.cc
+++ b/c++/src/ColumnPrinter.cc
@@ -249,6 +249,7 @@ namespace orc {
         break;
 
       case TIMESTAMP:
+      case TIMESTAMP_INSTANT:
         result = new TimestampColumnPrinter(buffer);
         break;
 

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -305,10 +305,14 @@ namespace orc {
     std::unique_ptr<orc::RleDecoder> secondsRle;
     std::unique_ptr<orc::RleDecoder> nanoRle;
     const Timezone& writerTimezone;
+    const Timezone& readerTimezone;
     const int64_t epochOffset;
+    const bool sameTimezone;
 
   public:
-    TimestampColumnReader(const Type& type, StripeStreams& stripe);
+    TimestampColumnReader(const Type& type,
+                          StripeStreams& stripe,
+                          bool isInstantType);
     ~TimestampColumnReader() override;
 
     uint64_t skip(uint64_t numValues) override;
@@ -323,10 +327,17 @@ namespace orc {
 
 
   TimestampColumnReader::TimestampColumnReader(const Type& type,
-                                               StripeStreams& stripe
+                                               StripeStreams& stripe,
+                                               bool isInstantType
                                ): ColumnReader(type, stripe),
-                                  writerTimezone(stripe.getWriterTimezone()),
-                                  epochOffset(writerTimezone.getEpoch()) {
+                                  writerTimezone(isInstantType ?
+                                                 getTimezoneByName("GMT") :
+                                                 stripe.getWriterTimezone()),
+                                  readerTimezone(isInstantType ?
+                                                 getTimezoneByName("GMT") :
+                                                 stripe.getReaderTimezone()),
+                                  epochOffset(writerTimezone.getEpoch()),
+                                  sameTimezone(&writerTimezone == &readerTimezone) {
     RleVersion vers = convertRleVersion(stripe.getEncoding(columnId).kind());
     std::unique_ptr<SeekableInputStream> stream =
         stripe.getStream(columnId, proto::Stream_Kind_DATA, true);
@@ -373,7 +384,20 @@ namespace orc {
           }
         }
         int64_t writerTime = secsBuffer[i] + epochOffset;
-        secsBuffer[i] = writerTimezone.convertToUTC(writerTime);
+        if (!sameTimezone) {
+          // adjust timestamp value to same wall clock time if writer and reader
+          // time zones have different rules, which is required for Apache Orc.
+          const auto& wv = writerTimezone.getVariant(writerTime);
+          const auto& rv = readerTimezone.getVariant(writerTime);
+          if (!wv.hasSameTzRule(rv)) {
+            // If the timezone adjustment moves the millis across a DST boundary,
+            // we need to reevaluate the offsets.
+            int64_t adjustedTime = writerTime + wv.gmtOffset - rv.gmtOffset;
+            const auto& adjustedReader = readerTimezone.getVariant(adjustedTime);
+            writerTime = writerTime + wv.gmtOffset - adjustedReader.gmtOffset;
+          }
+        }
+        secsBuffer[i] = writerTime;
         if (secsBuffer[i] < 0 && nanoBuffer[i] > 999999) {
           secsBuffer[i] -= 1;
         }
@@ -1806,7 +1830,11 @@ namespace orc {
 
     case TIMESTAMP:
       return std::unique_ptr<ColumnReader>
-        (new TimestampColumnReader(type, stripe));
+        (new TimestampColumnReader(type, stripe, false));
+
+    case TIMESTAMP_INSTANT:
+      return std::unique_ptr<ColumnReader>
+        (new TimestampColumnReader(type, stripe, true));
 
     case DECIMAL:
       // is this a Hive 0.11 or 0.12 file?

--- a/c++/src/ColumnReader.hh
+++ b/c++/src/ColumnReader.hh
@@ -69,6 +69,11 @@ namespace orc {
     virtual const Timezone& getWriterTimezone() const = 0;
 
     /**
+     * Get the reader's timezone, so that we can convert their dates correctly.
+     */
+    virtual const Timezone& getReaderTimezone() const = 0;
+
+    /**
      * Get the error stream.
      * @return a pointer to the stream that should get error messages
      */

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1701,7 +1701,8 @@ namespace orc {
   public:
     TimestampColumnWriter(const Type& type,
                           const StreamsFactory& factory,
-                          const WriterOptions& options);
+                          const WriterOptions& options,
+                          bool isInstantType);
 
     virtual void add(ColumnVectorBatch& rowBatch,
                      uint64_t offset,
@@ -1722,16 +1723,22 @@ namespace orc {
 
   private:
     RleVersion rleVersion;
-    const Timezone& timezone;
+    const Timezone* timezone;
+    const bool isUTC;
   };
 
   TimestampColumnWriter::TimestampColumnWriter(
                              const Type& type,
                              const StreamsFactory& factory,
-                             const WriterOptions& options) :
+                             const WriterOptions& options,
+                             bool isInstantType) :
                                  ColumnWriter(type, factory, options),
                                  rleVersion(options.getRleVersion()),
-                                 timezone(getTimezoneByName("GMT")){
+                                 timezone(isInstantType ?
+                                          &getTimezoneByName("GMT") :
+                                          options.getTimezone()),
+                                 isUTC(isInstantType ||
+                                       options.getTimezoneName() == "GMT") {
     std::unique_ptr<BufferedOutputStream> dataStream =
         factory.createStream(proto::Stream_Kind_DATA);
     std::unique_ptr<BufferedOutputStream> secondaryStream =
@@ -1801,6 +1808,9 @@ namespace orc {
       if (notNull == nullptr || notNull[i]) {
         // TimestampVectorBatch already stores data in UTC
         int64_t millsUTC = secs[i] * 1000 + nanos[i] / 1000000;
+        if (!isUTC) {
+          millsUTC = timezone->convertToUTC(millsUTC);
+        }
         ++count;
         if (enableBloomFilter) {
           bloomFilter->addLong(millsUTC);
@@ -1811,7 +1821,7 @@ namespace orc {
           secs[i] += 1;
         }
 
-        secs[i] -= timezone.getEpoch();
+        secs[i] -= timezone->getEpoch();
         nanos[i] = formatNano(nanos[i]);
       }
     }
@@ -2958,7 +2968,15 @@ namespace orc {
           new TimestampColumnWriter(
                                     type,
                                     factory,
-                                    options));
+                                    options,
+                                    false));
+      case TIMESTAMP_INSTANT:
+        return std::unique_ptr<ColumnWriter>(
+          new TimestampColumnWriter(
+                                    type,
+                                    factory,
+                                    options,
+                                    true));
       case DECIMAL:
         if (type.getPrecision() <= Decimal64ColumnWriter::MAX_PRECISION_64) {
           return std::unique_ptr<ColumnWriter>(

--- a/c++/src/Options.hh
+++ b/c++/src/Options.hh
@@ -129,6 +129,7 @@ namespace orc {
     int32_t forcedScaleOnHive11Decimal;
     bool enableLazyDecoding;
     std::shared_ptr<SearchArgument> sargs;
+    const char* readerTimezone;
 
     RowReaderOptionsPrivate() {
       selection = ColumnSelection_NONE;
@@ -137,6 +138,7 @@ namespace orc {
       throwOnHive11DecimalOverflow = true;
       forcedScaleOnHive11Decimal = 6;
       enableLazyDecoding = false;
+      readerTimezone = "GMT";
     }
   };
 
@@ -258,6 +260,15 @@ namespace orc {
 
   std::shared_ptr<SearchArgument> RowReaderOptions::getSearchArgument() const {
     return privateBits->sargs;
+  }
+
+  RowReaderOptions& RowReaderOptions::setReaderTimezone(const char* zoneName) {
+    privateBits->readerTimezone = zoneName;
+    return *this;
+  }
+
+  const char* RowReaderOptions::getReaderTimezone() const {
+    return privateBits->readerTimezone;
   }
 }
 

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -195,7 +195,8 @@ namespace orc {
                             forcedScaleOnHive11Decimal(opts.getForcedScaleOnHive11Decimal()),
                             footer(contents->footer.get()),
                             firstRowOfStripe(*contents->pool, 0),
-                            enableEncodedBlock(opts.getEnableLazyDecoding()) {
+                            enableEncodedBlock(opts.getEnableLazyDecoding()),
+                            readerTimezone(getTimezoneByName(opts.getReaderTimezone())) {
     uint64_t numberOfStripes;
     numberOfStripes = static_cast<uint64_t>(footer->stripes_size());
     currentStripe = numberOfStripes;
@@ -783,6 +784,7 @@ namespace orc {
       case proto::Type_Kind_BINARY:
       case proto::Type_Kind_DECIMAL:
       case proto::Type_Kind_TIMESTAMP:
+      case proto::Type_Kind_TIMESTAMP_INSTANT:
         return 3;
       case proto::Type_Kind_CHAR:
       case proto::Type_Kind_STRING:
@@ -978,7 +980,8 @@ namespace orc {
                                       currentStripeFooter,
                                       currentStripeInfo.offset(),
                                       *contents->stream,
-                                      writerTimezone);
+                                      writerTimezone,
+                                      readerTimezone);
       reader = buildReader(*contents->schema, stripeStreams);
 
       if (sargsApplier) {

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -69,6 +69,7 @@ namespace orc {
                                       const FileContents& contents);
 
   class ReaderImpl;
+  class Timezone;
 
   class ColumnSelector {
    private:
@@ -146,6 +147,9 @@ namespace orc {
     std::map<uint32_t, BloomFilterIndex> bloomFilterIndex;
     std::shared_ptr<SearchArgument> sargs;
     std::unique_ptr<SargsApplier> sargsApplier;
+
+    // desired timezone to return data of timestamp types.
+    const Timezone& readerTimezone;
 
     // load stripe index if not done so
     void loadStripeIndex();

--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -415,6 +415,7 @@ namespace orc {
         return std::unique_ptr<MutableColumnStatistics>(
           new DateColumnStatisticsImpl());
       case TIMESTAMP:
+      case TIMESTAMP_INSTANT:
         return std::unique_ptr<MutableColumnStatistics>(
           new TimestampColumnStatisticsImpl());
       case DECIMAL:

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -30,14 +30,16 @@ namespace orc {
                                        const proto::StripeFooter& _footer,
                                        uint64_t _stripeStart,
                                        InputStream& _input,
-                                       const Timezone& _writerTimezone
+                                       const Timezone& _writerTimezone,
+                                       const Timezone& _readerTimezone
                                        ): reader(_reader),
                                           stripeInfo(_stripeInfo),
                                           footer(_footer),
                                           stripeIndex(_index),
                                           stripeStart(_stripeStart),
                                           input(_input),
-                                          writerTimezone(_writerTimezone) {
+                                          writerTimezone(_writerTimezone),
+                                          readerTimezone(_readerTimezone) {
     // PASS
   }
 
@@ -69,6 +71,10 @@ namespace orc {
 
   const Timezone& StripeStreamsImpl::getWriterTimezone() const {
     return writerTimezone;
+  }
+
+  const Timezone& StripeStreamsImpl::getReaderTimezone() const {
+    return readerTimezone;
   }
 
   std::ostream* StripeStreamsImpl::getErrorStream() const {

--- a/c++/src/StripeStream.hh
+++ b/c++/src/StripeStream.hh
@@ -43,6 +43,7 @@ namespace orc {
     const uint64_t stripeStart;
     InputStream& input;
     const Timezone& writerTimezone;
+    const Timezone& readerTimezone;
 
   public:
     StripeStreamsImpl(const RowReaderImpl& reader, uint64_t index,
@@ -50,7 +51,8 @@ namespace orc {
                       const proto::StripeFooter& footer,
                       uint64_t stripeStart,
                       InputStream& input,
-                      const Timezone& writerTimezone);
+                      const Timezone& writerTimezone,
+                      const Timezone& readerTimezone);
 
     virtual ~StripeStreamsImpl() override;
 
@@ -67,6 +69,8 @@ namespace orc {
     MemoryPool& getMemoryPool() const override;
 
     const Timezone& getWriterTimezone() const override;
+
+    const Timezone& getReaderTimezone() const override;
 
     std::ostream* getErrorStream() const override;
 

--- a/c++/src/Timezone.hh
+++ b/c++/src/Timezone.hh
@@ -42,6 +42,10 @@ namespace orc {
     bool isDst;
     std::string name;
 
+    bool hasSameTzRule(const TimezoneVariant& other) const {
+      return gmtOffset == other.gmtOffset && isDst == other.isDst;
+    }
+
     std::string toString() const;
   };
 

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -658,7 +658,7 @@ namespace orc {
       if (input[endPos] == ':') {
         fieldName = input.substr(pos, endPos - pos);
         pos = ++endPos;
-        while (endPos < end && isalpha(input[endPos])) {
+        while (endPos < end && (isalpha(input[endPos]) || input[endPos] == '_')) {
           ++endPos;
         }
       }

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -169,6 +169,8 @@ namespace orc {
       return "binary";
     case TIMESTAMP:
       return "timestamp";
+    case TIMESTAMP_INSTANT:
+      return "timestamp_with_local_time_zone";
     case LIST:
       return "array<" + (subTypes[0] ? subTypes[0]->toString() : "void") + ">";
     case MAP:
@@ -250,6 +252,7 @@ namespace orc {
         (new StringVectorBatch(capacity, memoryPool));
 
     case TIMESTAMP:
+    case TIMESTAMP_INSTANT:
       return std::unique_ptr<ColumnVectorBatch>
         (new TimestampVectorBatch(capacity, memoryPool));
 
@@ -364,6 +367,7 @@ namespace orc {
     case proto::Type_Kind_STRING:
     case proto::Type_Kind_BINARY:
     case proto::Type_Kind_TIMESTAMP:
+    case proto::Type_Kind_TIMESTAMP_INSTANT:
     case proto::Type_Kind_DATE:
       return std::unique_ptr<Type>
         (new TypeImpl(static_cast<TypeKind>(type.kind())));
@@ -439,6 +443,7 @@ namespace orc {
     case STRING:
     case BINARY:
     case TIMESTAMP:
+    case TIMESTAMP_INSTANT:
     case DATE:
       result = new TypeImpl(fileType->getKind());
       break;
@@ -609,6 +614,8 @@ namespace orc {
       return std::unique_ptr<Type>(new TypeImpl(BINARY));
     } else if (category == "timestamp") {
       return std::unique_ptr<Type>(new TypeImpl(TIMESTAMP));
+    } else if (category == "timestamp_with_local_time_zone") {
+      return std::unique_ptr<Type>(new TypeImpl(TIMESTAMP_INSTANT));
     } else if (category == "array") {
       return parseArrayType(input, start, end);
     } else if (category == "map") {

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -454,8 +454,7 @@ namespace orc {
       *stripeFooter.add_columns() = encodings[i];
     }
 
-    // use GMT to guarantee TimestampVectorBatch from reader can write
-    // same wall clock time
+    // use specified timezone to write wall clock time.
     stripeFooter.set_writertimezone(options.getTimezoneName());
 
     // add stripe statistics to metadata

--- a/c++/test/TestColumnReader.cc
+++ b/c++/test/TestColumnReader.cc
@@ -73,6 +73,10 @@ namespace orc {
     const Timezone &getWriterTimezone() const override {
       return getTimezoneByName("America/Los_Angeles");
     }
+
+    const Timezone& getReaderTimezone() const override {
+      return getTimezoneByName("GMT");
+    }
   };
 
   MockStripeStreams::~MockStripeStreams() {

--- a/c++/test/TestType.cc
+++ b/c++/test/TestType.cc
@@ -295,6 +295,11 @@ namespace orc {
     EXPECT_EQ(typeStr, type->toString());
 
     typeStr =
+      "struct<a:bigint,b:struct<a:binary,b:timestamp_with_local_time_zone>>";
+    type = Type::buildTypeFromString(typeStr);
+    EXPECT_EQ(typeStr, type->toString());
+
+    typeStr =
       "struct<a:bigint,b:struct<a:binary,b:timestamp>,c:map<double,tinyint>>";
     type = Type::buildTypeFromString(typeStr);
     EXPECT_EQ(typeStr, type->toString());

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -708,8 +708,7 @@ namespace orc {
                                       const char* writerTimezone,
                                       int64_t writerTime,
                                       const char* readerTimezone,
-                                      int64_t readerTime,
-                                      const std::string& tsStr) {
+                                      int64_t readerTime) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
     std::unique_ptr<Type> type(Type::buildTypeFromString("struct<col1:timestamp>"));
@@ -751,22 +750,24 @@ namespace orc {
   }
 
   TEST_P(WriterTest, writeTimestampWithTimezone) {
-    testWriteTimestampWithTimezone(fileVersion, "GMT", 1005589861, "GMT", 1005589861, "2001-11-12 18:31:01");
+    //use the time "2001-11-12 18:31:01" to generate readerTime and writerTime.
+    testWriteTimestampWithTimezone(fileVersion, "GMT", 1005589861, "GMT", 1005589861);
     // behavior for Apache Orc (writer & reader timezone can change)
-    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1005618661, "America/Los_Angeles", 1005618661, "2001-11-12 18:31:01");
-    testWriteTimestampWithTimezone(fileVersion, "Asia/Shanghai", 1005561061, "Asia/Shanghai", 1005561061, "2001-11-12 18:31:01");
-    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1005618661, "Asia/Shanghai", 1005561061, "2001-11-12 18:31:01");
-    testWriteTimestampWithTimezone(fileVersion, "Asia/Shanghai", 1005561061, "America/Los_Angeles", 1005618661, "2001-11-12 18:31:01");
+    //use the time "2001-11-12 18:31:01" to generate readerTime and writerTime.
+    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1005618661, "America/Los_Angeles", 1005618661);
+    testWriteTimestampWithTimezone(fileVersion, "Asia/Shanghai", 1005561061, "Asia/Shanghai", 1005561061);
+    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1005618661, "Asia/Shanghai", 1005561061);
+    testWriteTimestampWithTimezone(fileVersion, "Asia/Shanghai", 1005561061, "America/Los_Angeles", 1005618661);
     // daylight saving started at 2012-03-11 02:00:00 in Los Angeles
-    //set the dst of write time is 0
-    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1331459999, "Asia/Shanghai", 1331402399, "2012-03-11 01:59:59");
-    //set the dst of write time is 1
-    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1331460000, "Asia/Shanghai", 1331406000, "2012-03-11 03:00:00");
+    //use the time "2012-03-11 01:59:59" to generate readerTime and writerTime. And set the dst of write time is 0
+    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1331459999, "Asia/Shanghai", 1331402399);
+    //use the time "2012-03-11 03:00:00" to generate readerTime and writerTime. And set the dst of write time is 1
+    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1331460000, "Asia/Shanghai", 1331406000);
     // daylight saving ended at 2012-11-04 02:00:00 in Los Angeles
-    //set the dst of write time is 1
-    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1352019599, "Asia/Shanghai", 1351965599, "2012-11-04 01:59:59");
-    //set the dst of write time is 0
-    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1352023200, "Asia/Shanghai", 1351965600, "2012-11-04 02:00:00");
+    //use the time "2012-11-04 01:59:59" to generate readerTime and writerTime. And set the dst of write time is 1
+    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1352019599, "Asia/Shanghai", 1351965599);
+    //use the time "2012-11-04 02:00:00" to generate readerTime and writerTime. And set the dst of write time is 0
+    testWriteTimestampWithTimezone(fileVersion, "America/Los_Angeles", 1352023200, "Asia/Shanghai", 1351965600);
   }
 
   TEST_P(WriterTest, writeTimestampInstant) {

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -769,7 +769,7 @@ namespace orc {
     memset(&tm, 0, sizeof(struct tm));
     time_t ttime = tsBatch.data[0];
 #ifdef _WIN32
-    localtime_s(&ttime, &tm);
+    localtime_s(&tm, &ttime);
 #else
     localtime_r(&ttime, &tm);
 #endif
@@ -778,16 +778,20 @@ namespace orc {
     EXPECT_TRUE(strncmp(buf, tsStr.c_str(), tsStr.size()) == 0);
 
     // restore TZ env
-    if (tzBk) {
 #ifdef _WIN32
-      _putenv_s("TZ", tzBk, 1);
-#else
-      setenv("TZ", tzBk, 1);
-#endif
-      tzset();
+    if (tzBk) {
+      _putenv_s("TZ", tzBk);
     } else {
-      unsetenv("TZ");tzset();
+      _putenv("TZ=");
     }
+#else
+    if (tzBk) {
+      setenv("TZ", tzBk, 1);
+    } else {
+      unsetenv("TZ");
+    }
+#endif
+    tzset();
   }
 
   TEST_P(WriterTest, writeTimestampWithTimezone) {

--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -448,6 +448,7 @@ int main(int argc, char* argv[]) {
                            i);
             break;
           case orc::TIMESTAMP:
+          case orc::TIMESTAMP_INSTANT:
             fillTimestampValues(data,
                                 structBatch->fields[i],
                                 numValues,


### PR DESCRIPTION
### How was this patch tested?
The patch is tested through 
a. build type from string
b. write timestamp_instant column
c. read/write timestamp column with different timezone.
all test case already pass.

