### PR TITLE
ORC-780: Add LZ4 Compression to the C++ Writer

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -36,6 +36,11 @@
 #define ZSTD_CLEVEL_DEFAULT 3
 #endif
 
+/* These macros are defined in lz4.c */
+#ifndef LZ4_ACCELERATION_DEFAULT
+#define LZ4_ACCELERATION_DEFAULT 1
+#endif
+
 #ifndef LZ4_ACCELERATION_MAX
 #define LZ4_ACCELERATION_MAX 65537
 #endif
@@ -1134,7 +1139,7 @@ DIAGNOSTIC_PUSH
     }
     case CompressionKind_LZ4: {
       int level = (strategy == CompressionStrategy_SPEED) ?
-              LZ4_ACCELERATION_MAX : 1;
+              LZ4_ACCELERATION_MAX : LZ4_ACCELERATION_DEFAULT;
       return std::unique_ptr<BufferedOutputStream>
         (new Lz4CompressionSteam(
           outStream, level, bufferCapacity, compressionBlockSize, pool));

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -954,14 +954,14 @@ DIAGNOSTIC_POP
   }
 
   void Lz4CompressionSteam::init() {
-    state = static_cast<LZ4_stream_t*>(malloc(static_cast<size_t>(LZ4_sizeofState())));
+    state = LZ4_createStream();
     if (!state) {
       throw std::runtime_error("Error while allocating state for lz4.");
     }
   }
 
   void Lz4CompressionSteam::end() {
-    free(state);
+    (void)LZ4_freeStream(state);
     state = nullptr;
   }
 

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -931,7 +931,7 @@ DIAGNOSTIC_POP
     virtual uint64_t doBlockCompression() override;
 
     virtual uint64_t estimateMaxCompressionSize() override {
-      return LZ4_compressBound(bufferSize);
+      return static_cast<uint64_t>(LZ4_compressBound(bufferSize));
     }
 
   private:
@@ -954,7 +954,7 @@ DIAGNOSTIC_POP
   }
 
   void Lz4CompressionSteam::init() {
-    state = static_cast<LZ4_stream_t*>(malloc(LZ4_sizeofState()));
+    state = static_cast<LZ4_stream_t*>(malloc(static_cast<size_t>(LZ4_sizeofState())));
     if (!state) {
       throw std::runtime_error("Error while allocating state for lz4.");
     }

--- a/c++/test/TestCompression.cc
+++ b/c++/test/TestCompression.cc
@@ -338,6 +338,30 @@ namespace orc {
     protobuff_compression(CompressionKind_ZSTD, proto::ZSTD);
   }
 
+  TEST(Compression, lz4_compress_original_string) {
+    compress_original_string(CompressionKind_LZ4);
+  }
+
+  TEST(Compression, lz4_compress_simple_repeated_string) {
+    compress_simple_repeated_string(CompressionKind_LZ4);
+  }
+
+  TEST(Compression, lz4_compress_two_blocks) {
+    compress_two_blocks(CompressionKind_LZ4);
+  }
+
+  TEST(Compression, lz4_compress_random_letters) {
+    compress_random_letters(CompressionKind_LZ4);
+  }
+
+  TEST(Compression, lz4_compress_random_bytes) {
+    compress_random_bytes(CompressionKind_LZ4);
+  }
+
+  TEST(Compression, lz4_protobuff_compression) {
+    protobuff_compression(CompressionKind_LZ4, proto::LZ4);
+  }
+
   void testSeekDecompressionStream(CompressionKind kind) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool * pool = getDefaultPool();
@@ -402,5 +426,6 @@ namespace orc {
   TEST(Compression, seekDecompressionStream) {
     testSeekDecompressionStream(CompressionKind_ZSTD);
     testSeekDecompressionStream(CompressionKind_ZLIB);
+    testSeekDecompressionStream(CompressionKind_LZ4);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?

A new BlockCompressionStream class was implemented, that can be used for LZ4 compression kind.


### Why are the changes needed?

The C++ Writer doesn't support LZ4 compression. This PR aims to fix that.

### How was this patch tested?

The existing compression tests were copied and changed to use LZ4 compression,
