### PR TITLE
ORC-782: Update slf4j to 1.7.30

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -41,7 +41,6 @@
     <jmh.version>1.20</jmh.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.0</parquet.version>
-    <slf4j.version>1.7.25</slf4j.version>
     <spark.version>3.1.1</spark.version>
   </properties>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,6 +74,7 @@
     <storage-api.version>2.7.2</storage-api.version>
     <zookeeper.version>3.6.2</zookeeper.version>
     <maven.version>3.6.3</maven.version>
+    <slf4j.version>1.7.30</slf4j.version>
   </properties>
 
   <build>
@@ -718,12 +719,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.5</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>1.7.5</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.threeten</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to update the slf4j version to 1.7.30.


### Why are the changes needed?
We are currently using 1.7.5 and 1.7.25, unifying the versions into the latest stable 1.7.30 will bring the latest bug fixes. 
- http://www.slf4j.org/news.html

### How was this patch tested?
Pass the CIs.