### PR TITLE
ORC-785: Update GitHub Action branch name to `main`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -3,10 +3,10 @@ name: Build and test
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
+    - main
 
 jobs:
   build:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -3,7 +3,7 @@ name: Publish Snapshot
 on:
   push:
     branches:
-    - master
+    - main
 
 jobs:
   publish-snapshot:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR updates the branch name from `master` to `main` in GitHub Action job. TravisCI and AppVeyor doesn't need this renaming.

### Why are the changes needed?

Apache ORC renames it via [INFRA-21723](https://issues.apache.org/jira/browse/INFRA-21723)

### How was this patch tested?

N/A