### PR TITLE
ORC-788: Update travis build status to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Releases:
 * Downloads: <a href="http://orc.apache.org/downloads">Apache ORC downloads</a>
 
 The current build status:
-* Master branch <a href="https://travis-ci.com/apache/orc/branches">
-![master build status](https://travis-ci.com/apache/orc.svg?branch=master)</a>
+* Main branch <a href="https://travis-ci.com/apache/orc/branches">
+![main build status](https://travis-ci.com/apache/orc.svg?branch=main)</a>
 * <a href="https://travis-ci.com/github/apache/orc/pull_requests">Pull Requests</a>
 
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update travis build status to `main`


### Why are the changes needed?
Change needed after INFRA-21723


### How was this patch tested?
N/A
