### PR TITLE
ORC-791: Upgrade guava test dependency to 30.1.1-jre

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -748,7 +748,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>28.1-jre</version>
+        <version>30.1.1-jre</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to upgrade the guava test dependency to version 30.1.1-jre.


### Why are the changes needed?
This will use the latest version of guava during testing. 


### How was this patch tested?
Pass the CIs.
