### PR TITLE
ORC-792: Upgrade commons-lang3 to 3.12.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -499,7 +499,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.11</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>io.airlift</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade commons-lang3 to version 3.12.0.


### Why are the changes needed?
This will bring the following features and bug fixes. 
- https://commons.apache.org/proper/commons-lang/changes-report.html#a3.12.0
    - Add JavaVersion.JAVA_17

### How was this patch tested?

Pass the CIs.
