### PR TITLE
ORC-793: Deprecate the incorrect getInt method and add a new setInt within OrcConf

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -244,7 +244,7 @@ public enum OrcConf {
     return getInt(null, conf);
   }
 
-  public void getInt(Configuration conf, int value) {
+  public void setInt(Configuration conf, int value) {
     conf.setInt(attribute, value);
   }
 

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -244,6 +244,15 @@ public enum OrcConf {
     return getInt(null, conf);
   }
 
+  /**
+   * @deprecated Use {@link #getInt(Configuration)} instead. This method was
+   * incorrectly added and shouldn't be used anymore.
+   */
+  @Deprecated
+  public void getInt(Configuration conf, int value) {
+    // noop
+  }
+
   public void setInt(Configuration conf, int value) {
     conf.setInt(attribute, value);
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
There was two duplicated `getInt` method existed in `OrcConf` but no `setInt`. From the existing implementation it is obvious that the method `getInt` is a typo and it should `setInt` instead.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
This patch is rather straightforward, running through existing unit tests. 