### PR TITLE
ORC-793: Invalid key provider configuration should not cause NPE

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionVariant.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionVariant.java
@@ -176,12 +176,12 @@ public class ReaderEncryptionVariant implements EncryptionVariant {
 
   @Override
   public Key getFileFooterKey() throws IOException {
-    return key == null ? null : getDecryptedKey(footerKey);
+    return (key == null || provider == null) ? null : getDecryptedKey(footerKey);
   }
 
   @Override
   public Key getStripeKey(long stripe) throws IOException {
-    return key == null ? null : getDecryptedKey(localKeys[(int) stripe]);
+    return (key == null || provider == null) ? null : getDecryptedKey(localKeys[(int) stripe]);
   }
 
   @Override

--- a/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
@@ -24,6 +24,7 @@ import org.apache.orc.EncryptionAlgorithm;
 import org.apache.orc.InMemoryKeystore;
 import org.apache.orc.OrcConf;
 import org.apache.orc.OrcProto;
+import org.apache.orc.impl.reader.ReaderEncryptionVariant;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class TestCryptoUtils {
 
@@ -85,5 +87,12 @@ public class TestCryptoUtils {
     Key key = provider.decryptLocalKey(meta, encrypted);
     assertEquals(new BytesWritable(localKey.getDecryptedKey().getEncoded()).toString(),
         new BytesWritable(key.getEncoded()).toString());
+  }
+
+  @Test
+  public void testInvalidKeyProvider() throws IOException {
+    Configuration conf = new Configuration();
+    OrcConf.KEY_PROVIDER.setString(conf, "");
+    assertNull(CryptoUtils.getKeyProvider(conf, new Random()));
   }
 }

--- a/java/core/src/test/org/apache/orc/impl/reader/TestReaderEncryptionVariant.java
+++ b/java/core/src/test/org/apache/orc/impl/reader/TestReaderEncryptionVariant.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.reader;
+
+import org.apache.orc.EncryptionAlgorithm;
+import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+
+import static org.junit.Assert.assertNull;
+
+public class TestReaderEncryptionVariant {
+
+  @Test
+  public void testInvalidKeyProvider() throws IOException {
+    OrcProto.EncryptionAlgorithm algorithm = OrcProto.EncryptionAlgorithm.AES_CTR_256;
+    ReaderEncryptionKey key =
+        new ReaderEncryptionKey(OrcProto.EncryptionKey.newBuilder().setAlgorithm(algorithm).build());
+    List<StripeInformation> strips = new ArrayList<>();
+    ReaderEncryptionVariant readerEncryptionVariant =
+        new ReaderEncryptionVariant(key, 0, null, null, strips, 0L, null, null);
+
+    assertNull(readerEncryptionVariant.getFileFooterKey());
+    assertNull(readerEncryptionVariant.getStripeKey(0L));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to prevent NPE due to the invalid key provider configuration.

### Why are the changes needed?

Invalid key provider configuration returns `null` for provider and causes NPE like the following.
```java
Caused by: java.lang.NullPointerException
	at org.apache.orc.impl.reader.ReaderEncryptionVariant.getDecryptedKey(ReaderEncryptionVariant.java:150)
	at org.apache.orc.impl.reader.ReaderEncryptionVariant.getFileFooterKey(ReaderEncryptionVariant.java:179)
	at org.apache.orc.impl.reader.ReaderEncryptionKey.isAvailable(ReaderEncryptionKey.java:142)
	at org.apache.orc.impl.reader.ReaderEncryption.getVariant(ReaderEncryption.java:139)
	at org.apache.orc.impl.reader.StripePlanner.buildEncodings(StripePlanner.java:222)
	at org.apache.orc.impl.reader.StripePlanner.parseStripe(StripePlanner.java:126)
	at org.apache.orc.impl.RecordReaderImpl.readStripe(RecordReaderImpl.java:1100)
	at org.apache.orc.impl.RecordReaderImpl.advanceStripe(RecordReaderImpl.java:1151)
	at org.apache.orc.impl.RecordReaderImpl.advanceToNextRow(RecordReaderImpl.java:1186)
	at org.apache.orc.impl.RecordReaderImpl.<init>(RecordReaderImpl.java:248)
	at org.apache.orc.impl.ReaderImpl.rows(ReaderImpl.java:840)
```

### How was this patch tested?

Pass the CIs with the newly added test cases.