### PR TITLE
ORC-797: Allow writers to get the stripe information.

### DIFF
--- a/java/core/src/java/org/apache/orc/Writer.java
+++ b/java/core/src/java/org/apache/orc/Writer.java
@@ -141,4 +141,15 @@ public interface Writer extends Closeable {
    * @return the information about the column
    */
   ColumnStatistics[] getStatistics() throws IOException;
+
+  /**
+   * Get the stripe information about the file. The output of this is based on the time at which it
+   * is called. It shall return stripes that have been completed.
+   *
+   * After the writer is closed this shall give the complete stripe information.
+   *
+   * @return stripe information
+   * @throws IOException
+   */
+  List<StripeInformation> getStripes() throws IOException;
 }

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.Key;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 import org.apache.orc.EncryptionAlgorithm;
@@ -116,6 +118,28 @@ public class ReaderImpl implements Reader {
       } else {
         encryptedKeys = previousKeys;
       }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      StripeInformationImpl that = (StripeInformationImpl) o;
+      return stripeId == that.stripeId
+             && originalStripeId == that.originalStripeId
+             && Arrays.deepEquals(encryptedKeys, that.encryptedKeys)
+             && stripe.equals(that.stripe);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = Objects.hash(stripeId, originalStripeId, stripe);
+      result = 31 * result + Arrays.hashCode(encryptedKeys);
+      return result;
     }
 
     @Override

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
@@ -857,6 +858,11 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     // Get the file statistics, preferring the encrypted one.
     treeWriter.getCurrentStatistics(result);
     return result;
+  }
+
+  @Override
+  public List<StripeInformation> getStripes() throws IOException {
+    return Collections.unmodifiableList(OrcUtils.convertProtoStripesToStripes(stripes));
   }
 
   public CompressionCodec getCompressionCodec() {


### PR DESCRIPTION

### What changes were proposed in this pull request?

It adds a new method to the Writer that lets the user get information about the stripes of the file.

### Why are the changes needed?

Currently Iceberg has to reopen the file after writing the file and we'd like to short circuit that.

### How was this patch tested?

Added a unit test.
