### PR TITLE
ORC-796: Upgrade Apache parent pom to version 23

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -455,38 +455,6 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M1</version>
-          <executions>
-            <execution>
-              <id>enforce-maven</id>
-              <goals>
-                <goal>enforce</goal>
-              </goals>
-              <configuration>
-                <rules>
-                  <requireMavenVersion>
-                    <version>2.2.1</version>
-                  </requireMavenVersion>
-                </rules>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
-          <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
-	    <compilerArgs>
-	      <arg>-Xlint:unchecked</arg>
-	    </compilerArgs>
-          </configuration>
-        </plugin>
-        <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
           <configuration>
             <descriptors>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -165,7 +165,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -84,7 +84,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-	<version>3.1.0</version>
         <configuration>
           <archive>
             <manifest>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -92,7 +92,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>2.2.1</version>
+                  <version>${maven.version}</version>
                 </requireMavenVersion>
               </rules>
             </configuration>
@@ -102,7 +102,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
         <configuration>
           <links>
             <link>http://hadoop.apache.org/docs/r${hadoop.version}/api</link>
@@ -151,7 +150,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
         <configuration>
           <attach>true</attach>
         </configuration>
@@ -230,7 +228,6 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.13</version>
           <executions>
             <execution>
               <phase>package</phase>
@@ -340,7 +337,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
@@ -349,7 +345,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.4</version>
           <executions>
             <execution>
               <phase>package</phase>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -117,7 +117,6 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-	<version>3.1.0</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Parent pom to the latest version, 23.
- https://github.com/apache/maven-apache-parent/releases/tag/apache-23 

### Why are the changes needed?

We can remove the redundant information by using the versions from the parent pom.

### How was this patch tested?

Pass the CIs.