### PR TITLE
ORC-800: Add `key` and `value` nullness check in `MapVectorBatch`

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -160,6 +160,7 @@ namespace orc {
       std::fill(selectedColumns.begin(), selectedColumns.end(), true);
     }
     selectParents(selectedColumns, *contents->schema.get());
+    selectMaps(selectedColumns, *contents->schema.get());
     selectedColumns[0] = true; // column 0 is selected by default
   }
 

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -100,6 +100,20 @@ namespace orc {
   }
 
   /**
+   * Recurses over a type tree and selects the map.key and map.value of every selected map type.
+   */
+  void ColumnSelector::selectMaps(std::vector<bool>& selectedColumns, const Type& type) {
+    size_t id = static_cast<size_t>(type.getColumnId());
+    for(uint64_t c=0; c < type.getSubtypeCount(); ++c) {
+      if (type.getKind() == MAP && selectedColumns[id]) {
+        selectChildren(selectedColumns, *type.getSubtype(c));
+      } else {
+        selectMaps(selectedColumns, *type.getSubtype(c));
+      }
+    }
+  }
+
+  /**
    * Recurses over a type tree and build two maps
    * map<TypeName, TypeId>, map<TypeId, Type>
    */

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -100,20 +100,6 @@ namespace orc {
   }
 
   /**
-   * Recurses over a type tree and selects the map.key and map.value of every selected map type.
-   */
-  void ColumnSelector::selectMaps(std::vector<bool>& selectedColumns, const Type& type) {
-    size_t id = static_cast<size_t>(type.getColumnId());
-    for(uint64_t c=0; c < type.getSubtypeCount(); ++c) {
-      if (type.getKind() == MAP && selectedColumns[id]) {
-        selectChildren(selectedColumns, *type.getSubtype(c));
-      } else {
-        selectMaps(selectedColumns, *type.getSubtype(c));
-      }
-    }
-  }
-
-  /**
    * Recurses over a type tree and build two maps
    * map<TypeName, TypeId>, map<TypeId, Type>
    */
@@ -160,7 +146,6 @@ namespace orc {
       std::fill(selectedColumns.begin(), selectedColumns.end(), true);
     }
     selectParents(selectedColumns, *contents->schema.get());
-    selectMaps(selectedColumns, *contents->schema.get());
     selectedColumns[0] = true; // column 0 is selected by default
   }
 

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -96,6 +96,9 @@ namespace orc {
     // For each child of type, select it if one of its children
     // is selected.
     bool selectParents(std::vector<bool>& selectedColumns, const Type& type);
+
+    // For selected map type, select its children, key and value
+    void selectMaps(std::vector<bool>& selectedColumns, const Type& type);
    /**
     * Constructor that selects columns.
     * @param contents of the file

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -97,8 +97,6 @@ namespace orc {
     // is selected.
     bool selectParents(std::vector<bool>& selectedColumns, const Type& type);
 
-    // For selected map type, select its children, key and value
-    void selectMaps(std::vector<bool>& selectedColumns, const Type& type);
    /**
     * Constructor that selects columns.
     * @param contents of the file

--- a/c++/src/Vector.cc
+++ b/c++/src/Vector.cc
@@ -294,8 +294,8 @@ namespace orc {
 
   std::string MapVectorBatch::toString() const {
     std::ostringstream buffer;
-    buffer << "Map vector <" << keys->toString() << ", "
-           << elements->toString() << " with "
+    buffer << "Map vector <" << (keys ? keys->toString(): "key not selected") << ", "
+           << (elements ? elements->toString(): "value not selected")  << " with "
            << numElements << " of " << capacity << ">";
     return buffer.str();
   }
@@ -316,8 +316,8 @@ namespace orc {
   uint64_t MapVectorBatch::getMemoryUsage() {
     return ColumnVectorBatch::getMemoryUsage()
            + static_cast<uint64_t>(offsets.capacity() * sizeof(int64_t))
-           + keys->getMemoryUsage()
-           + elements->getMemoryUsage();
+           + (keys ? keys->getMemoryUsage() : 0)
+           + (elements ? elements->getMemoryUsage() : 0);
   }
 
   bool MapVectorBatch::hasVariableLength() {

--- a/tools/test/TestMatch.cc
+++ b/tools/test/TestMatch.cc
@@ -1085,6 +1085,26 @@ TEST(TestMatch, selectColumns) {
         << "\"887336a7\"}}]}";
     EXPECT_EQ(expectedMapWithColumnId.str(), line);
 
+    // Map column #12 again, to test map key is automatically included
+    // two subtypes with column id:
+    // map<string(20),struct(21)<int1(22):int,string1(23):string>
+    cols.push_back(22);
+    cols.push_back(23);
+    rowReaderOpts.includeTypes(cols);
+    rowReader = reader->createRowReader(rowReaderOpts);
+    c = rowReader->getSelectedColumns();
+    for (unsigned int i=1; i < c.size(); i++) {
+      if (i>=19 && i<=23)
+        EXPECT_TRUE(c[i]);
+      else
+        EXPECT_TRUE(!c[i]);
+    }
+    batch = rowReader->createRowBatch(1);
+    std::ostringstream expectedMapSchema;
+    expectedMapSchema << "Struct vector <0 of 1; Map vector <Byte vector <0 of 1>, "
+        << "Struct vector <0 of 1; Long vector <0 of 1>; Byte vector <0 of 1>; > with 0 of 1>; >";
+    EXPECT_EQ(expectedMapSchema.str(), batch->toString());
+
     // Struct column #10, with field name: middle
     std::list<std::string> colNames;
     colNames.push_back("middle.list.int1");

--- a/tools/test/TestMatch.cc
+++ b/tools/test/TestMatch.cc
@@ -1095,16 +1095,17 @@ TEST(TestMatch, selectColumns) {
     rowReader = reader->createRowReader(rowReaderOpts);
     c = rowReader->getSelectedColumns();
     for (unsigned int i=1; i < c.size(); i++) {
-      if (i>=19 && i<=23)
+      if (i==19 || (i>=21 && i<=23))
         EXPECT_TRUE(c[i]);
       else
         EXPECT_TRUE(!c[i]);
     }
     batch = rowReader->createRowBatch(1);
     std::ostringstream expectedMapSchema;
-    expectedMapSchema << "Struct vector <0 of 1; Map vector <Byte vector <0 of 1>, "
+    expectedMapSchema << "Struct vector <0 of 1; Map vector <key not selected, "
         << "Struct vector <0 of 1; Long vector <0 of 1>; Byte vector <0 of 1>; > with 0 of 1>; >";
     EXPECT_EQ(expectedMapSchema.str(), batch->toString());
+    EXPECT_EQ(45, batch->getMemoryUsage());
 
     // Struct column #10, with field name: middle
     std::list<std::string> colNames;

--- a/tools/test/TestMatch.cc
+++ b/tools/test/TestMatch.cc
@@ -1088,6 +1088,7 @@ TEST(TestMatch, selectColumns) {
     // Map column #12 again, to test map key is automatically included
     // two subtypes with column id:
     // map<string(20),struct(21)<int1(22):int,string1(23):string>
+    cols.clear();
     cols.push_back(22);
     cols.push_back(23);
     rowReaderOpts.includeTypes(cols);


### PR DESCRIPTION
MapVectorBatch::toString will encounter segment fault if map.value is selected while map.key is not selected. 
