### PR TITLE
ORC-801: Clean up Logging

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/BufferChunk.java
+++ b/java/core/src/java/org/apache/orc/impl/BufferChunk.java
@@ -20,8 +20,6 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.hive.common.io.DiskRange;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.nio.ByteBuffer;
 
@@ -32,8 +30,6 @@ import java.nio.ByteBuffer;
  */
 public class BufferChunk extends DiskRangeList {
 
-  private static final Logger LOG =
-      LoggerFactory.getLogger(BufferChunk.class);
   private ByteBuffer chunk;
 
   public BufferChunk(long offset, int length) {
@@ -78,11 +74,10 @@ public class BufferChunk extends DiskRangeList {
       sliceBuf.position(newPos);
       sliceBuf.limit(newLimit);
     } catch (Throwable t) {
-      LOG.error("Failed to slice buffer chunk with range" + " [" + this.offset + ", " + this.end
-          + "), position: " + chunk.position() + " limit: " + chunk.limit() + ", "
-          + (chunk.isDirect() ? "direct" : "array") + "; to [" + offset + ", " + end + ") "
-          + t.getClass());
-      throw new RuntimeException(t);
+      throw new RuntimeException("Failed to slice buffer chunk with range" + " [" + this.offset + ", " + this.end
+              + "), position: " + chunk.position() + " limit: " + chunk.limit() + ", "
+              + (chunk.isDirect() ? "direct" : "array") + "; to [" + offset + ", " + end + ") "
+              + t.getClass(), t);
     }
     return new BufferChunk(sliceBuf, offset + shiftBy);
   }

--- a/java/core/src/java/org/apache/orc/impl/InStream.java
+++ b/java/core/src/java/org/apache/orc/impl/InStream.java
@@ -612,9 +612,7 @@ public abstract class InStream extends InputStream {
 
       while (currentRange.next != null) {
         setCurrent(currentRange.next, false);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug(String.format("Read slow-path, >1 cross block reads with %s", this.toString()));
-        }
+        LOG.debug("Read slow-path, >1 cross block reads with {}", this);
         if (compressed.remaining() >= len) {
           slice = compressed.slice();
           slice.limit(len);

--- a/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcCodecPool.java
@@ -53,7 +53,7 @@ public final class OrcCodecPool {
     }
     if (codec == null) {
       codec = WriterImpl.createCodec(kind);
-      LOG.debug("Got brand-new codec " + kind);
+      LOG.debug("Got brand-new codec {}", kind);
     } else {
       LOG.debug("Got recycled codec");
     }

--- a/java/core/src/java/org/apache/orc/impl/PhysicalFsWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/PhysicalFsWriter.java
@@ -503,8 +503,7 @@ public class PhysicalFsWriter implements PhysicalWriter {
     if (length < blockSize && length > availBlockSpace &&
         addBlockPadding) {
       byte[] pad = new byte[(int) Math.min(HDFS_BUFFER_SIZE, availBlockSpace)];
-      LOG.info(String.format("Padding ORC by %d bytes while merging..",
-          availBlockSpace));
+      LOG.info("Padding ORC by {} bytes while merging", availBlockSpace);
       start += availBlockSpace;
       while (availBlockSpace > 0) {
         int writeLen = (int) Math.min(availBlockSpace, pad.length);

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -962,7 +962,7 @@ public class ReaderImpl implements Reader {
     case LIST:
       return numVals * JavaDataModel.get().primitive1();
     default:
-      LOG.debug("Unknown primitive category: " + column.getCategory());
+      LOG.debug("Unknown primitive category: {}", column.getCategory());
       break;
     }
 

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -141,10 +141,8 @@ public class RecordReaderImpl implements RecordReader {
     OrcFile.WriterVersion writerVersion = fileReader.getWriterVersion();
     SchemaEvolution evolution;
     if (options.getSchema() == null) {
-      if (LOG.isInfoEnabled()) {
-        LOG.info("Reader schema not provided -- using file schema " +
-            fileReader.getSchema());
-      }
+      LOG.info("Reader schema not provided -- using file schema " +
+          fileReader.getSchema());
       evolution = new SchemaEvolution(fileReader.getSchema(), null, options);
     } else {
 
@@ -785,9 +783,7 @@ public class RecordReaderImpl implements RecordReader {
       result = TruthValue.YES_NO;
     }
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Bloom filter evaluation: " + result.toString());
-    }
+    LOG.debug("Bloom filter evaluation: {}", result);
 
     return result;
   }
@@ -1030,13 +1026,11 @@ public class RecordReaderImpl implements RecordReader {
                   LOG.info("Skipping ORC PPD - " + e.getMessage() + " on "
                       + predicate);
                 } else {
-                  if (LOG.isWarnEnabled()) {
-                    final String reason = e.getClass().getSimpleName() + " when evaluating predicate." +
-                        " Skipping ORC PPD." +
-                        " Stats: " + stats +
-                        " Predicate: " + predicate;
-                    LOG.warn(reason, e);
-                  }
+                  final String reason = e.getClass().getSimpleName() + " when evaluating predicate." +
+                      " Skipping ORC PPD." +
+                      " Stats: " + stats +
+                      " Predicate: " + predicate;
+                  LOG.warn(reason, e);
                 }
                 boolean hasNoNull = stats.hasHasNull() && !stats.getHasNull();
                 if (predicate.getOperator().equals(PredicateLeaf.Operator.NULL_SAFE_EQUALS)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Clean up some logging statements with the project. Remove instances of log-and-throw anti-pattern, remove superfluous logging guards, use anchors in debug statements instead of concatenation.


### Why are the changes needed?
Trivial performance increases, decrease in lines of code (readability), log-and-throw makes troubleshooting more difficult because the same error may be logged multiple times.


### How was this patch tested?
Existing unit tests, but should be no change in functionality.