### PR TITLE
ORC-804: MaskDescriptionImpl should use List instead of Set

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/MaskDescriptionImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/MaskDescriptionImpl.java
@@ -24,17 +24,17 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.DataMask;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.List;
 
 public class MaskDescriptionImpl implements DataMaskDescription,
                                             Comparable<MaskDescriptionImpl> {
   private int id;
   private final String name;
   private final String[] parameters;
-  private final Set<TypeDescription> columns = new HashSet<>();
+  private final List<TypeDescription> columns = new ArrayList<>();
 
   public MaskDescriptionImpl(String name,
                              String... parameters) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `List` instead of `Set` in `MaskDescriptionImpl`.

### Why are the changes needed?

If there are multiple encrypted columns with the same types for a single key, only the first column is masked.

### How was this patch tested?

Pass the CIs with the newly added test cases.
