### PR TITLE
ORC-805: Add .asf.yaml for Apache ORC website publishing

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,25 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+
+staging:
+  profile: ~
+  whoami:  asf-site
+
+publish:
+  whoami:  asf-site


### PR DESCRIPTION
### What changes were proposed in this pull request?

According to the announcement, we need to add this to our website branch before July 1st.
- https://github.com/apache/infrastructure-website/blob/asf-site/.asf.yaml

### Why are the changes needed?

To comply ASF Git Web site publishing change.

### How was this patch tested?

N/A