### PR TITLE
ORC-806: Upgrade to Apache POM 23

### DIFF
--- a/java/bench/core/pom.xml
+++ b/java/bench/core/pom.xml
@@ -24,7 +24,6 @@
   </parent>
 
   <artifactId>orc-benchmarks-core</artifactId>
-  <version>1.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>ORC Benchmarks Core</name>
   <description>

--- a/java/bench/hive/pom.xml
+++ b/java/bench/hive/pom.xml
@@ -23,9 +23,7 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <groupId>org.apache.orc</groupId>
   <artifactId>orc-benchmarks-hive</artifactId>
-  <version>1.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>ORC Benchmarks Hive</name>
   <description>
@@ -77,7 +75,6 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
-      <version>${storage-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.orc</groupId>
@@ -113,10 +110,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -23,9 +23,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <groupId>org.apache.orc</groupId>
   <artifactId>orc-benchmarks</artifactId>
-  <version>1.8.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>ORC Benchmarks</name>
   <description>
@@ -33,9 +31,6 @@
   </description>
 
   <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-
     <avro.version>1.10.2</avro.version>
     <hive.version>3.1.2</hive.version>
     <jmh.version>1.20</jmh.version>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -23,9 +23,7 @@
     <relativePath>..</relativePath>
   </parent>
 
-  <groupId>org.apache.orc</groupId>
   <artifactId>orc-benchmarks-spark</artifactId>
-  <version>1.8.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>ORC Benchmarks Spark</name>
   <description>
@@ -106,7 +104,6 @@
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hadoop</artifactId>
-      <version>1.10.1</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -50,14 +50,10 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <version>${hadoop.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
-      <version>${hadoop.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,6 +76,7 @@
     <zookeeper.version>3.6.2</zookeeper.version>
     <maven.version>3.6.3</maven.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
+    <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <slf4j.version>1.7.30</slf4j.version>
     <protoc.artifact>com.google.protobuf:protoc:2.5.0</protoc.artifact>
     <surefire.version>3.0.0-M5</surefire.version>
@@ -336,6 +337,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
+          <version>${maven-shade-plugin.version}</version>
           <executions>
             <execution>
               <phase>package</phase>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>18</version>
+    <version>23</version>
   </parent>
   <groupId>org.apache.orc</groupId>
   <artifactId>orc</artifactId>
@@ -63,7 +63,8 @@
 
   <properties>
     <!-- Build Properties -->
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
     <example.dir>${project.basedir}/../../examples</example.dir>
@@ -77,6 +78,7 @@
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <slf4j.version>1.7.30</slf4j.version>
     <protoc.artifact>com.google.protobuf:protoc:2.5.0</protoc.artifact>
+    <surefire.version>3.0.0-M5</surefire.version>
   </properties>
 
   <build>
@@ -84,7 +86,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -132,7 +133,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>3.0.0</version>
         <executions>
           <execution>
             <id>setup-test-dirs</id>
@@ -168,7 +168,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.0.0-M5</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
           <reuseForks>false</reuseForks>
@@ -188,12 +187,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>3.1.1</version>
       </plugin>
       <plugin>
         <groupId>io.github.zlika</groupId>
         <artifactId>reproducible-build-maven-plugin</artifactId>
-        <version>0.13</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -335,14 +332,6 @@
               </configuration>
             </execution>
           </executions>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <configuration>
-            <source>1.8</source>
-            <target>1.8</target>
-          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -58,13 +58,11 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${tools.hadoop.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <version>${tools.hadoop.version}</version>
-      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
@@ -82,7 +80,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <scope>compile</scope>
     </dependency>
 
     <!-- test inter-project -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade Apache Parent POM to version 23 and clean up superfluous Maven POM elements


### Why are the changes needed?
Get benefits from upgraded maven plugins. Simplification.


### How was this patch tested?
Existing unit tests.