### PR TITLE
ORC-807: Separate Jackson Versions in benchmark module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -42,6 +42,7 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.0</parquet.version>
     <spark.version>3.1.2</spark.version>
+    <jackson.version>2.12.2</jackson.version>
   </properties>
 
   <modules>
@@ -55,7 +56,17 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.12.2</version>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-annotations</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -36,7 +36,6 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-    <jackson.version>2.10.0</jackson.version>
   </properties>
 
   <dependencies>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
+
+    <!-- Spark Jackson version may not be same as ORC -->
+    <spark.jackson.version>2.10.0</spark.jackson.version>
   </properties>
 
   <dependencies>
@@ -137,14 +140,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
+      <version>${spark.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${spark.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+      <version>${spark.jackson.version}</version>
     </dependency>
   </dependencies>
 

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -138,17 +138,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${jackson.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Be explicit about Jackson versioning for the various modules.

### Why are the changes needed?

Allow main ORC components to use different Jackson version than bench-spark.

### How was this patch tested?

Manually build and test benchmark module.