### PR TITLE
ORC-808: Update Spark to 3.1.2

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -41,7 +41,7 @@
     <jmh.version>1.20</jmh.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.0</parquet.version>
-    <spark.version>3.1.1</spark.version>
+    <spark.version>3.1.2</spark.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to update Spark to version 3.1.2.


### Why are the changes needed?
The latest version of Spark is 3.1.2.
This will bring the latest improvements. 

### How was this patch tested?
Pass the CIs.
