### PR TITLE
ORC-810: FIX expected Output Stats when using Hash Dictionary

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
@@ -208,6 +208,7 @@ public class TestFileDump {
   public void testDump() throws Exception {
     TypeDescription schema = getMyRecordType();
     conf.set(OrcConf.ENCODING_STRATEGY.getAttribute(), "COMPRESSION");
+    conf.set(OrcConf.DICTIONARY_IMPL.getAttribute(), "rbtree");
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
             .fileSystem(fs)
@@ -404,6 +405,7 @@ public class TestFileDump {
         .setAttribute("test2", "value2")
         .setAttribute("test3", "value3");
     conf.set(OrcConf.ENCODING_STRATEGY.getAttribute(), "COMPRESSION");
+    conf.set(OrcConf.DICTIONARY_IMPL.getAttribute(), "rbtree");
     OrcFile.WriterOptions options = OrcFile.writerOptions(conf)
         .fileSystem(fs)
         .setSchema(schema)
@@ -456,6 +458,7 @@ public class TestFileDump {
   public void testBloomFilter2() throws Exception {
     TypeDescription schema = getMyRecordType();
     conf.set(OrcConf.ENCODING_STRATEGY.getAttribute(), "COMPRESSION");
+    conf.set(OrcConf.DICTIONARY_IMPL.getAttribute(), "rbtree");
     OrcFile.WriterOptions options = OrcFile.writerOptions(conf)
         .fileSystem(fs)
         .setSchema(schema)

--- a/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
@@ -96,6 +96,7 @@ public class TestJsonFileDump {
         .setAttribute("test1", "value1")
         .setAttribute("test2","value2");
     conf.set(OrcConf.ENCODING_STRATEGY.getAttribute(), "COMPRESSION");
+    conf.set(OrcConf.DICTIONARY_IMPL.getAttribute(), "rbtree");
     OrcFile.WriterOptions options = OrcFile.writerOptions(conf)
         .fileSystem(fs)
         .setSchema(schema)


### PR DESCRIPTION
### What changes were proposed in this pull request?
ORC-757 introduced HT as the default string dictionary implementation.
testStripeLevelStats need to be updated and existing tests with ORC files written with RBTree dict should use the same dict to avoid size inconsistencies

### Why are the changes needed?
Fix tests upstream


### How was this patch tested?
Passed tests locally