### PR TITLE
ORC-377: [c++] Add SnappyCompressionStream

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -1052,13 +1052,15 @@ DIAGNOSTIC_POP
     }
     
     virtual ~SnappyCompressionStream() override {
+      // PASS
     }
 
   protected:
     virtual uint64_t doBlockCompression() override;
 
     virtual uint64_t estimateMaxCompressionSize() override {
-      return static_cast<uint64_t>(snappy::MaxCompressedLength(static_cast<size_t>(bufferSize)));
+      return static_cast<uint64_t>
+        (snappy::MaxCompressedLength(static_cast<size_t>(bufferSize)));
     }
   };
 

--- a/c++/test/TestCompression.cc
+++ b/c++/test/TestCompression.cc
@@ -362,6 +362,30 @@ namespace orc {
     protobuff_compression(CompressionKind_LZ4, proto::LZ4);
   }
 
+  TEST(Compression, snappy_compress_original_string) {
+    compress_original_string(CompressionKind_SNAPPY);
+  }
+
+  TEST(Compression, snappy_compress_simple_repeated_string) {
+    compress_simple_repeated_string(CompressionKind_SNAPPY);
+  }
+
+  TEST(Compression, snappy_compress_two_blocks) {
+    compress_two_blocks(CompressionKind_SNAPPY);
+  }
+
+  TEST(Compression, snappy_compress_random_letters) {
+    compress_random_letters(CompressionKind_SNAPPY);
+  }
+
+  TEST(Compression, snappy_compress_random_bytes) {
+    compress_random_bytes(CompressionKind_SNAPPY);
+  }
+
+  TEST(Compression, snappy_protobuff_compression) {
+    protobuff_compression(CompressionKind_SNAPPY, proto::SNAPPY);
+  }
+
   void testSeekDecompressionStream(CompressionKind kind) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool * pool = getDefaultPool();
@@ -427,5 +451,6 @@ namespace orc {
     testSeekDecompressionStream(CompressionKind_ZSTD);
     testSeekDecompressionStream(CompressionKind_ZLIB);
     testSeekDecompressionStream(CompressionKind_LZ4);
+    testSeekDecompressionStream(CompressionKind_SNAPPY);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
A new BlockCompressionStream class was implemented for Snappy compression.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The C++ Writer doesn't support Snappy compression. This PR aims to fix that.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The existing compression tests were copied and changed to use Snappy compression.

PR #282 aims for the very same thing, but it's not complete and inactive for a while now. The BlockCompressionStream has been introduced since it was opened, thus it was easier for me to start over from the current state and open a new pull request.
I hope it's not a problem that I've stepped in to add the functionality.