### PR TITLE
ORC-816: Rename and enable aarch64 profile automatically

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -423,10 +423,15 @@
       </modules>
     </profile>
     <profile>
-      <id>applesilicon</id>
+      <id>aarch64</id>
       <properties>
         <protoc.artifact>com.google.protobuf:protoc:2.5.0:exe:osx-x86_64</protoc.artifact>
       </properties>
+      <activation>
+        <os>
+          <arch>aarch64</arch>
+        </os>
+      </activation>
     </profile>
   </profiles>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to rename and enable aarch64 profile automatically. 


### Why are the changes needed?
- First, we don't need to specify the profile. 
- Second, `make package` currently fails because it doesn't know the new profile. These changes will make it succeed.

### How was this patch tested?
Pass the CIs.