### PR TITLE
MINOR: Add GitHub Action status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Releases:
 * Downloads: <a href="http://orc.apache.org/downloads">Apache ORC downloads</a>
 
 The current build status:
-* Main branch <a href="https://travis-ci.com/apache/orc/branches">
+* Main branch <a href="https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain">
+![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)</a> <a href="https://travis-ci.com/apache/orc/branches">
 ![main build status](https://travis-ci.com/apache/orc.svg?branch=main)</a>
 * <a href="https://travis-ci.com/github/apache/orc/pull_requests">Pull Requests</a>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add the GitHub action status badge to README.md.
- https://github.com/williamhyun/orc/blob/badge/README.md#orc-file-library

### Why are the changes needed?
This will increase the visibility of the build status. 

### How was this patch tested?
N/A
