### PR TITLE
MINOR: Add GitHub repo labels

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,3 +22,9 @@ github:
     merge: false
     squash: true
     rebase: true
+  labels:
+    - apache
+    - orc
+    - java
+    - cpp
+    - big-data


### PR DESCRIPTION


### What changes were proposed in this pull request?
This PR aims to add GitHub repo labels. 

### Why are the changes needed?
Apache ORC is incorrectly labeled as a database. 
<img width="299" alt="Screen Shot 2021-06-26 at 7 30 43 PM" src="https://user-images.githubusercontent.com/62487364/123530955-15e9ca80-d6b5-11eb-8dd9-2d8f3796aaf0.png">

### How was this patch tested?
N/A.