### PR TITLE
ORC-820: Add Java 16 to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,7 +18,7 @@ jobs:
         java:
           - 1.8
           - 11
-          - 15
+          - 16
     env:
       MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add Java 16 to GitHub Action instead of Java 15 because Java 15 is EOL.

### Why are the changes needed?

To add Java 16 test coverage and prepare for Java 17 LTS.

### How was this patch tested?

Pass the CIs