### PR TITLE
ORC-821: Use mvnw instead of mvn

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         cd java
         echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
-        mvn --settings settings.xml -DskipTests deploy
+        ./mvnw --settings settings.xml -DskipTests deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ matrix:
     - MAVEN_OPTS=-Xmx2g MAVEN_SKIP_RC=true
     script:
     - cd java
-    - mvn -Panalyze clean package
-    - mvn apache-rat:check
+    - ./mvnw -Panalyze clean package
+    - ./mvnw apache-rat:check
 
   - language: cpp
     compiler: gcc

--- a/README.md
+++ b/README.md
@@ -82,10 +82,8 @@ To build a release version without debug information:
 To build only the Java library:
 ```shell
 % cd java
-% mvn package
+% ./mvnw package
 
-# If you do not have a supported version of Maven installed locally
-% mvnw package
 ```
 
 To build only the C++ library:

--- a/java/bench/README.md
+++ b/java/bench/README.md
@@ -15,7 +15,7 @@ There are three sub-modules to try to mitigate dependency hell:
 
 To build this library:
 
-```% mvn clean package```
+```% ./mvnw clean package```
 
 To fetch the source data:
 

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -60,7 +60,7 @@ is invoking:
 You'll need to install:
 
 * java (>= 1.8)
-* maven (>= 3.8.1)
+* maven (>= 3)
 
 To build:
 

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -59,14 +59,14 @@ is invoking:
 
 You'll need to install:
 
-* java (>= 1.7)
-* maven (>= 3)
+* java (>= 1.8)
+* maven (>= 3.8.1)
 
 To build:
 
 ~~~ shell
 % cd java
-% mvn package
+% ./mvnw package
 ~~~
 
 ## Building just C++

--- a/site/develop/make-release.md
+++ b/site/develop/make-release.md
@@ -85,7 +85,7 @@ Publish the artifacts to Maven central staging. Make sure to have this [setup](h
 
 ~~~
 % cd java
-% mvn -Papache-release clean deploy
+% ./mvnw -Papache-release clean deploy
 ~~~
 
 Publish from the staging area:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR uses `mvnw` instead of `mvn` in our build system and documentation.

### Why are the changes needed?

For consistency.

### How was this patch tested?

Pass the CIs.