### PR TITLE
ORC-823: Upgrade maven-assembly-plugin to 3.3.0

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -467,6 +467,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven-assembly-plugin.version}</version>
           <configuration>
             <descriptors>
               <descriptor>src/assembly/uber.xml</descriptor>

--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -84,6 +84,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven-assembly-plugin.version}</version>
         <configuration>
           <archive>
             <manifest>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,6 +74,7 @@
     <storage-api.version>2.7.2</storage-api.version>
     <zookeeper.version>3.6.2</zookeeper.version>
     <maven.version>3.6.3</maven.version>
+    <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <slf4j.version>1.7.30</slf4j.version>
     <protoc.artifact>com.google.protobuf:protoc:2.5.0</protoc.artifact>
   </properties>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -117,6 +117,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
+        <version>${maven-assembly-plugin.version}</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade maven-assembly-plugin to 3.3.0.

### Why are the changes needed?
This is required to build with Java 17.

### How was this patch tested?
Pass the CIs. 