### PR TITLE
ORC-825: Use Empty Array For Collections toArray

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/MaskDescriptionImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/MaskDescriptionImpl.java
@@ -82,7 +82,7 @@ public class MaskDescriptionImpl implements DataMaskDescription,
 
   @Override
   public TypeDescription[] getColumns() {
-    TypeDescription[] result = columns.toArray(new TypeDescription[columns.size()]);
+    TypeDescription[] result = columns.toArray(new TypeDescription[0]);
     // sort the columns by their ids
     Arrays.sort(result, Comparator.comparingInt(TypeDescription::getId));
     return result;

--- a/java/core/src/java/org/apache/orc/impl/ParserUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/ParserUtils.java
@@ -580,7 +580,6 @@ public class ParserUtils {
     while (consumeChar(source, ',')) {
       params.add(parseName(source));
     }
-    return new MaskDescriptionImpl(maskName,
-        params.toArray(new String[params.size()]));
+    return new MaskDescriptionImpl(maskName, params.toArray(new String[0]));
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionKey.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/ReaderEncryptionKey.java
@@ -75,7 +75,7 @@ public class ReaderEncryptionKey implements EncryptionKey {
 
   @Override
   public ReaderEncryptionVariant[] getEncryptionRoots() {
-    return roots.toArray(new ReaderEncryptionVariant[roots.size()]);
+    return roots.toArray(new ReaderEncryptionVariant[0]);
   }
 
   public HadoopShims.KeyMetadata getMetadata() {

--- a/java/core/src/java/org/apache/orc/impl/writer/WriterEncryptionKey.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/WriterEncryptionKey.java
@@ -65,7 +65,7 @@ public class WriterEncryptionKey implements EncryptionKey {
 
   @Override
   public WriterEncryptionVariant[] getEncryptionRoots() {
-    return roots.toArray(new WriterEncryptionVariant[roots.size()]);
+    return roots.toArray(new WriterEncryptionVariant[0]);
   }
 
   @Override

--- a/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
+++ b/java/mapreduce/src/java/org/apache/orc/mapred/OrcInputFormat.java
@@ -176,7 +176,7 @@ public class OrcInputFormat<V extends WritableComparable>
     if (ok.size() == result.length) {
       return result;
     } else {
-      return ok.toArray(new FileStatus[ok.size()]);
+      return ok.toArray(new FileStatus[0]);
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For Java, use Empty Array For Collections toArray

### Why are the changes needed?
JDK recommended, faster, less code.
- https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#toArray-T:A-

### How was this patch tested?
Existing unit test