### PR TITLE
ORC-826: Do Not Use Collection Contains/Get

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -1144,8 +1144,8 @@ public class OrcFile {
       return false;
     }
     for(String key: reader.getMetadataKeys()) {
-      if (userMetadata.containsKey(key)) {
-        ByteBuffer currentValue = userMetadata.get(key);
+      ByteBuffer currentValue = userMetadata.get(key);
+      if (currentValue != null) {
         ByteBuffer newValue = reader.getMetadataValue(key);
         if (!newValue.equals(currentValue)) {
           LOG.info("Can't merge {} because of different user metadata {}", path,

--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -564,8 +564,7 @@ public class TypeDescription
    * @return a list of sorted attribute names
    */
   public List<String> getAttributeNames() {
-    List<String> result = new ArrayList<>(attributes.size());
-    result.addAll(attributes.keySet());
+    List<String> result = new ArrayList<>(attributes.keySet());
     Collections.sort(result);
     return result;
   }

--- a/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
@@ -118,13 +118,8 @@ public class OrcFilterContextImpl implements OrcFilterContext {
 
   @Override
   public ColumnVector[] findColumnVector(String name) {
-    if (!vectors.containsKey(name)) {
-      vectors.put(name,
-                  ParserUtils.findColumnVectors(readSchema,
-                                                new ParserUtils.StringPosition(name),
-                                                true,
-                                                batch));
-    }
-    return vectors.get(name);
+    return vectors.computeIfAbsent(name,
+        key -> ParserUtils.findColumnVectors(readSchema,
+            new ParserUtils.StringPosition(key), true, batch));
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -571,8 +571,7 @@ public class RecordReaderUtils {
       TreeMap<Key, ByteBuffer> tree = getBufferTree(buffer.isDirect());
       while (true) {
         Key key = new Key(buffer.capacity(), currentGeneration++);
-        if (!tree.containsKey(key)) {
-          tree.put(key, buffer);
+        if (tree.putIfAbsent(key, buffer) == null) {
           return;
         }
         // Buffers are indexed by (capacity, generation).


### PR DESCRIPTION
### What changes were proposed in this pull request?

Discovered multiple places in the code where a Collection is accessed with a 'contains' and a 'get'.  However, this is superfluous as a 'get' will return a `null` value if the Collection doesn't contain the item.  This can be utilized to save multiple trips into the same map.

### Why are the changes needed?
Small performance, less code

### How was this patch tested?
No change in behavior so existing unit test suffice.