### PR TITLE
ORC-827: Utilize Array copyOf

### DIFF
--- a/java/core/src/java/org/apache/orc/InMemoryKeystore.java
+++ b/java/core/src/java/org/apache/orc/InMemoryKeystore.java
@@ -276,7 +276,16 @@ public class InMemoryKeystore implements KeyProvider {
       algorithm = EncryptionAlgorithm.AES_CTR_128;
     }
 
-    final byte[] buffer = Arrays.copyOf(masterKey, algorithm.keyLength());
+    final byte[] buffer = new byte[algorithm.keyLength()];
+    if (algorithm.keyLength() > masterKey.length) {
+
+      System.arraycopy(masterKey, 0, buffer, 0, masterKey.length);
+      /* fill with zeros */
+      Arrays.fill(buffer, masterKey.length, buffer.length - 1, (byte) 0);
+
+    } else {
+      System.arraycopy(masterKey, 0, buffer, 0, algorithm.keyLength());
+    }
 
     final KeyVersion key = new KeyVersion(keyName, version, algorithm,
         buffer);

--- a/java/core/src/java/org/apache/orc/InMemoryKeystore.java
+++ b/java/core/src/java/org/apache/orc/InMemoryKeystore.java
@@ -151,8 +151,7 @@ public class InMemoryKeystore implements KeyProvider {
     final EncryptionAlgorithm algorithm = secret.getAlgorithm();
     byte[] encryptedKey = new byte[algorithm.keyLength()];
     random.nextBytes(encryptedKey);
-    byte[] iv = new byte[algorithm.getIvLength()];
-    System.arraycopy(encryptedKey, 0, iv, 0, iv.length);
+    byte[] iv = Arrays.copyOf(encryptedKey, algorithm.getIvLength());
     Cipher localCipher = algorithm.createCipher();
 
     try {
@@ -202,8 +201,7 @@ public class InMemoryKeystore implements KeyProvider {
     }
     final KeyVersion secret = keys.get(keyVersion);
     final EncryptionAlgorithm algorithm = secret.getAlgorithm();
-    byte[] iv = new byte[algorithm.getIvLength()];
-    System.arraycopy(encryptedKey, 0, iv, 0, iv.length);
+    byte[] iv = Arrays.copyOf(encryptedKey, algorithm.getIvLength());
     Cipher localCipher = algorithm.createCipher();
 
     try {
@@ -278,16 +276,7 @@ public class InMemoryKeystore implements KeyProvider {
       algorithm = EncryptionAlgorithm.AES_CTR_128;
     }
 
-    final byte[] buffer = new byte[algorithm.keyLength()];
-    if (algorithm.keyLength() > masterKey.length) {
-
-      System.arraycopy(masterKey, 0, buffer, 0, masterKey.length);
-      /* fill with zeros */
-      Arrays.fill(buffer, masterKey.length, buffer.length - 1, (byte) 0);
-
-    } else {
-      System.arraycopy(masterKey, 0, buffer, 0, algorithm.keyLength());
-    }
+    final byte[] buffer = Arrays.copyOf(masterKey, algorithm.keyLength());
 
     final KeyVersion key = new KeyVersion(keyName, version, algorithm,
         buffer);

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.apache.hadoop.io.Text;
 
@@ -56,9 +57,7 @@ public final class DynamicByteArray {
     if (chunkIndex >= initializedChunks) {
       if (chunkIndex >= data.length) {
         int newSize = Math.max(chunkIndex + 1, 2 * data.length);
-        byte[][] newChunk = new byte[newSize][];
-        System.arraycopy(data, 0, newChunk, 0, data.length);
-        data = newChunk;
+        data = Arrays.copyOf(data, newSize);
       }
       for(int i=initializedChunks; i <= chunkIndex; ++i) {
         data[i] = new byte[chunkSize];

--- a/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
@@ -17,6 +17,8 @@
  */
 package org.apache.orc.impl;
 
+import java.util.Arrays;
+
 /**
  * Dynamic int array that uses primitive types and chunks to avoid copying
  * large number of integers when it resizes.
@@ -57,9 +59,7 @@ public final class DynamicIntArray {
     if (chunkIndex >= initializedChunks) {
       if (chunkIndex >= data.length) {
         int newSize = Math.max(chunkIndex + 1, 2 * data.length);
-        int[][] newChunk = new int[newSize][];
-        System.arraycopy(data, 0, newChunk, 0, data.length);
-        data = newChunk;
+        data = Arrays.copyOf(data, newSize);
       }
       for (int i=initializedChunks; i <= chunkIndex; ++i) {
         data[i] = new int[chunkSize];

--- a/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
@@ -108,8 +108,7 @@ public class SHA256MaskFactory extends MaskFactory {
         targetLength = schema.getMaxLength();
         /* pad the hash with blank char if targetlength is greater than hash */
         if (targetLength > hash.length) {
-          byte[] tmp = new byte[targetLength];
-          System.arraycopy(hash, 0, tmp, 0, hash.length);
+          byte[] tmp = Arrays.copyOf(hash, targetLength);
           Arrays.fill(tmp, hash.length, tmp.length - 1, (byte) ' ');
           hash = tmp;
         }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Utilize JDK Array copyOf


### Why are the changes needed?
Less code, small performance boost perhaps


### How was this patch tested?
Existing unit tests as functionality has not changed.
