### PR TITLE
ORC-830: Do Not Copy String When Adding to StringHashTableDictionary

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -70,4 +70,27 @@ public class DictionaryUtils {
     byteArray.write(out, offset, length);
     return length;
   }
+  
+  /**
+   * Compare a UTF8 string from the byteArray using the offset in index-array.
+   *
+   * @param text Container for the UTF8 String
+   * @param position position in the keyOffsets
+   * @param keyOffsets starting offset of the key (in byte) in the byte array
+   * @param byteArray storing raw bytes of all key seen in dictionary
+   * @return true if the text is equal to the value within the byteArray; false
+   *         otherwise
+   */
+  public static boolean equalsTextInternal(Text text, int position,
+      DynamicIntArray keyOffsets, DynamicByteArray byteArray) {
+    final int offset = keyOffsets.get(position);
+    final int length;
+    if (position + 1 == keyOffsets.size()) {
+      length = byteArray.size() - offset;
+    } else {
+      length = keyOffsets.get(position + 1) - offset;
+    }
+    return 0 == byteArray.compare(text.getBytes(), 0, text.getLength(), offset,
+        length);
+  }
 }

--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -93,6 +93,6 @@ public class DictionaryUtils {
       keyLength = keyOffsets.get(position + 1) - byteArrayOffset;
     }
     return 0 == byteArray.compare(bytes, offset, length, byteArrayOffset,
-    	keyLength);
+      keyLength);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -74,23 +74,25 @@ public class DictionaryUtils {
   /**
    * Compare a UTF8 string from the byteArray using the offset in index-array.
    *
-   * @param text Container for the UTF8 String
+   * @param bytes an array containing bytes to search for
+   * @param offset the offset in the array
+   * @param length the number of bytes to search for
    * @param position position in the keyOffsets
    * @param keyOffsets starting offset of the key (in byte) in the byte array
    * @param byteArray storing raw bytes of all key seen in dictionary
    * @return true if the text is equal to the value within the byteArray; false
    *         otherwise
    */
-  public static boolean equalsTextInternal(Text text, int position,
+  public static boolean equalsInternal(byte[] bytes, int offset, int length, int position,
       DynamicIntArray keyOffsets, DynamicByteArray byteArray) {
-    final int offset = keyOffsets.get(position);
-    final int length;
+    final int byteArrayOffset = keyOffsets.get(position);
+    final int keyLength;
     if (position + 1 == keyOffsets.size()) {
-      length = byteArray.size() - offset;
+      keyLength = byteArray.size() - byteArrayOffset;
     } else {
-      length = keyOffsets.get(position + 1) - offset;
+      keyLength = keyOffsets.get(position + 1) - byteArrayOffset;
     }
-    return 0 == byteArray.compare(text.getBytes(), 0, text.getLength(), offset,
-        length);
+    return 0 == byteArray.compare(bytes, offset, length, byteArrayOffset,
+    	keyLength);
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -70,7 +70,7 @@ public class DictionaryUtils {
     byteArray.write(out, offset, length);
     return length;
   }
-  
+
   /**
    * Compare a UTF8 string from the byteArray using the offset in index-array.
    *

--- a/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
@@ -135,7 +135,7 @@ public class StringHashTableDictionary implements Dictionary {
 
     for (int i = 0; i < candidateArray.size(); i++) {
       final int candidateIndex = candidateArray.get(i);
-      if (DictionaryUtils.equalsTextInternal(newKey, candidateIndex,
+      if (DictionaryUtils.equalsInternal(bytes, offset, length, candidateIndex,
           this.keyOffsets, this.byteArray)) {
         return candidateIndex;
       }

--- a/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
@@ -133,11 +133,10 @@ public class StringHashTableDictionary implements Dictionary {
     int index = getIndex(bytes, offset, length);
     DynamicIntArray candidateArray = hashBuckets[index];
 
-    Text tmpText = new Text();
     for (int i = 0; i < candidateArray.size(); i++) {
       final int candidateIndex = candidateArray.get(i);
-      getText(tmpText, candidateIndex);
-      if (tmpText.compareTo(bytes, offset, length) == 0) {
+      if (DictionaryUtils.equalsTextInternal(newKey, candidateIndex,
+          this.keyOffsets, this.byteArray)) {
         return candidateIndex;
       }
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When there is a collision adding a value into a StringHashTableDictionary, a temp Text object is created and then each value in the byte array is copied into the temp Text until a match is found (or worst-case scenario, a match is not found and every value is loaded).

Instead of loading (copying) the values, just compare directly against the byte array without copying the data into a intermediate (temp) buffer.

### Why are the changes needed?
Performance.  StringTreeWriter#writeBatch() consumes some number the cycles, much of which is spent in getText().  By Changing this getText() implementation (removing the copy), the number of cycles consumed is decreased measurably.

### How was this patch tested?
No functionality change, utilized existing unit tests.