### PR TITLE
ORC-833: Calculate nextVector Batch Size Once

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
@@ -397,7 +397,7 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
         data[r] = (int) next();
       }
     } else if (!(vector.isRepeating && vector.isNull[0])) {
-      for (int r = 0; r < batchSize ++r) {
+      for (int r = 0; r < batchSize; ++r) {
           data[r] = (vector.isNull[r]) ? 1 : (int) next();
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
@@ -390,20 +390,15 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
   }
 
   @Override
-  public void nextVector(ColumnVector vector,
-                         int[] data,
-                         int size) throws IOException {
+  public void nextVector(ColumnVector vector, int[] data, int size) throws IOException {
+    final int batchSize = Math.min(data.length, size);
     if (vector.noNulls) {
-      for(int r=0; r < data.length && r < size; ++r) {
+      for (int r = 0; r < batchSize; ++r) {
         data[r] = (int) next();
       }
     } else if (!(vector.isRepeating && vector.isNull[0])) {
-      for(int r=0; r < data.length && r < size; ++r) {
-        if (!vector.isNull[r]) {
-          data[r] = (int) next();
-        } else {
-          data[r] = 1;
-        }
+      for (int r = 0; r < batchSize ++r) {
+          data[r] = (vector.isNull[r]) ? 1 : (int) next();
       }
     }
   }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
@@ -398,7 +398,7 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
       }
     } else if (!(vector.isRepeating && vector.isNull[0])) {
       for (int r = 0; r < batchSize; ++r) {
-          data[r] = (vector.isNull[r]) ? 1 : (int) next();
+        data[r] = (vector.isNull[r]) ? 1 : (int) next();
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

The number of iterations of the loops in RunLengthIntegerReaderV2 nextVector look at two distinct, but known, values. Instead of check each value in each loop, pre-compute the batch size.


### Why are the changes needed?
Code clarity, and if the optimizer doesn't already do it automagically, saves a few branches.


### How was this patch tested?
No changes in functionality.  Uses existing unit tests.