### PR TITLE
ORC-838: Simplify `compareTo/equals/putBuffer` of ByteBufferAllocatorPool

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -570,7 +570,7 @@ public class RecordReaderUtils {
       // If our key is not unique on the first try, try again
       do {
         key = new Key(buffer.capacity(), currentGeneration++);
-      while (tree.putIfAbsent(key, buffer) != null);
+      } while (tree.putIfAbsent(key, buffer) != null);
     }
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -504,13 +504,10 @@ public class RecordReaderUtils {
     private static final class Key implements Comparable<Key> {
       private final int capacity;
       private final long insertionGeneration;
-      private final int hash;
 
       Key(int capacity, long insertionGeneration) {
         this.capacity = capacity;
         this.insertionGeneration = insertionGeneration;
-        this.hash = new HashCodeBuilder().append(capacity).append(insertionGeneration)
-            .toHashCode();
       }
 
       @Override
@@ -530,7 +527,8 @@ public class RecordReaderUtils {
 
       @Override
       public int hashCode() {
-        return hash;
+        return new HashCodeBuilder().append(capacity).append(insertionGeneration)
+            .toHashCode();
       }
     }
 

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -506,7 +506,7 @@ public class RecordReaderUtils {
       private final long insertionGeneration;
       private final int hash;
 
-      Key (int capacity, long insertionGeneration) {
+      Key(int capacity, long insertionGeneration) {
         this.capacity = capacity;
         this.insertionGeneration = insertionGeneration;
         this.hash = new HashCodeBuilder().append(capacity).append(insertionGeneration)

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -504,38 +504,33 @@ public class RecordReaderUtils {
     private static final class Key implements Comparable<Key> {
       private final int capacity;
       private final long insertionGeneration;
+      private final int hash;
 
-      Key(int capacity, long insertionGeneration) {
+      Key (int capacity, long insertionGeneration) {
         this.capacity = capacity;
         this.insertionGeneration = insertionGeneration;
+        this.hash = new HashCodeBuilder().append(capacity).append(insertionGeneration)
+            .toHashCode();
       }
 
       @Override
       public int compareTo(Key other) {
-        if (capacity != other.capacity) {
-          return capacity - other.capacity;
-        } else {
-          return Long.compare(insertionGeneration, other.insertionGeneration);
-        }
+        final int c = Integer.compare(capacity, other.capacity);
+        return (c != 0) ? c : Long.compare(insertionGeneration, other.insertionGeneration);
       }
 
       @Override
       public boolean equals(Object rhs) {
-        if (rhs == null) {
-          return false;
-        }
-        try {
+        if (rhs instanceof Key) {
           Key o = (Key) rhs;
-          return (compareTo(o) == 0);
-        } catch (ClassCastException e) {
-          return false;
+          return 0 == compareTo(o);
         }
+        return false;
       }
 
       @Override
       public int hashCode() {
-        return new HashCodeBuilder().append(capacity).append(insertionGeneration)
-            .toHashCode();
+        return hash;
       }
     }
 
@@ -569,14 +564,13 @@ public class RecordReaderUtils {
     @Override
     public void putBuffer(ByteBuffer buffer) {
       TreeMap<Key, ByteBuffer> tree = getBufferTree(buffer.isDirect());
-      while (true) {
-        Key key = new Key(buffer.capacity(), currentGeneration++);
-        if (tree.putIfAbsent(key, buffer) == null) {
-          return;
-        }
-        // Buffers are indexed by (capacity, generation).
-        // If our key is not unique on the first try, we try again
-      }
+      Key key;
+
+      // Buffers are indexed by (capacity, generation).
+      // If our key is not unique on the first try, try again
+      do {
+        key = new Key(buffer.capacity(), currentGeneration++);
+      while (tree.putIfAbsent(key, buffer) != null);
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Simplify ByteBufferAllocatorPool Key class. Cache hash value for Key as it's computed more than once: putBuffer to insert into Tree and getBuffer to remove it from tree.

### Why are the changes needed?
Less code. Performance.

### How was this patch tested?
No changes to functionality. Use existing unit tests.