### PR TITLE
ORC-836: StringGroupFromDoubleTreeReader Use Double toString

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1101,8 +1101,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
     public void setConvertVectorElement(int elementNum) {
       double doubleValue = doubleColVector.vector[elementNum];
       if (!Double.isNaN(doubleValue)) {
-        String string = String.valueOf(doubleValue);
-        byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+        String string = Double.toString(doubleValue);
+        byte[] bytes = string.getBytes(StandardCharsets.US_ASCII);
         assignStringGroupVectorEntry(bytesColVector, elementNum, readerType, bytes);
       } else {
         bytesColVector.noNulls = false;


### PR DESCRIPTION
### What changes were proposed in this pull request?
When converting from Double to String, use the Double class methods directly. Lower overhead of encoding by using ASCII.


### Why are the changes needed?
Performance.


### How was this patch tested?
No change in functionality.  Use existing unit tests.