### PR TITLE
ORC-834: Do Not Convert to String in DecimalFromTimestampTreeReader

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -964,7 +964,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       }
       BigDecimal secondsBd = new BigDecimal(seconds);
       BigDecimal nanosBd = new BigDecimal(nanos).movePointLeft(9);
-      HiveDecimal value = HiveDecimal.create(secondsBd.add(nanosBd));
+      BigDecimal resultBd = (seconds >= 0L) ? secondsBd.add(nanosBd) : secondsBd.subtract(nanosBd);
+      HiveDecimal value = HiveDecimal.create(resultBd);
       if (value != null) {
         // The DecimalColumnVector will enforce precision and scale and set the entry to null when out of bounds.
         if (decimalColVector instanceof Decimal64ColumnVector) {

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -963,7 +963,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         nanos = 1_000_000_000 - nanos;
       }
       BigDecimal secondsBd = new BigDecimal(seconds);
-      BigDecimal nanosBd = new BigDecimal(nanos).movePointLeft(9));
+      BigDecimal nanosBd = new BigDecimal(nanos).movePointLeft(9);
       HiveDecimal value = HiveDecimal.create(secondsBd.add(nanosBd));
       if (value != null) {
         // The DecimalColumnVector will enforce precision and scale and set the entry to null when out of bounds.

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -963,7 +963,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         nanos = 1_000_000_000 - nanos;
       }
       BigDecimal secondsBd = new BigDecimal(seconds);
-	    BigDecimal nanosBd = new BigDecimal(nanos).movePointLeft(9));
+      BigDecimal nanosBd = new BigDecimal(nanos).movePointLeft(9));
       HiveDecimal value = HiveDecimal.create(secondsBd.add(nanosBd));
       if (value != null) {
         // The DecimalColumnVector will enforce precision and scale and set the entry to null when out of bounds.

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -38,6 +38,7 @@ import org.apache.orc.impl.reader.tree.TypeReader;
 import org.threeten.extra.chrono.HybridChronology;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -962,7 +962,9 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         seconds += 1;
         nanos = 1_000_000_000 - nanos;
       }
-      HiveDecimal value = HiveDecimal.create(String.format("%d.%09d", seconds, nanos));
+      BigDecimal secondsBd = new BigDecimal(seconds);
+	    BigDecimal nanosBd = new BigDecimal(nanos).movePointLeft(9));
+      HiveDecimal value = HiveDecimal.create(secondsBd.add(nanosBd));
       if (value != null) {
         // The DecimalColumnVector will enforce precision and scale and set the entry to null when out of bounds.
         if (decimalColVector instanceof Decimal64ColumnVector) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When converting Timestamp to Decimal type, do not use String operations.


### Why are the changes needed?
Performance.

A quick test (hardly definitive, but indicative) shows an order of magnitude (10x) performance improvement:

```java
    long t1 = System.nanoTime();
    long r = 0;
    for (long i = -100_000L; i < 100_000; i++) {
      BigDecimal secondsBd = new BigDecimal(i);
      BigDecimal nanosBd = new BigDecimal(i).movePointLeft(9);
      BigDecimal resultBd = (i >= 0L) ? secondsBd.add(nanosBd) : secondsBd.subtract(nanosBd);
      r += resultBd.longValue();
    }
    long t2 = System.nanoTime();

    System.out.println(r);
    System.out.println(t2 - t1);
```

### How was this patch tested?
No changes to functionality. Use existing unit tests.
