### PR TITLE
ORC-840: Remove Superfluous Array Fill in RecordReaderImpl

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -173,8 +173,7 @@ public class RecordReaderImpl implements RecordReader {
                             List<PredicateLeaf> sargLeaves,
                             SchemaEvolution evolution) {
     int[] result = new int[sargLeaves.size()];
-    Arrays.fill(result, -1);
-    for(int i=0; i < result.length; ++i) {
+    for (int i = 0; i < sargLeaves.size(); ++i) {
       String colName = sargLeaves.get(i).getColumnName();
       result[i] = findColumns(evolution, colName);
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove Superfluous Array Fill in RecordReaderImpl.


### Why are the changes needed?
Less code. Performance.

### How was this patch tested?
No changes in functionality. Use existing unit tests.