### PR TITLE
ORC-841: Remove Superfluous Array Fill in StringHashTableDictionary

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
@@ -19,7 +19,6 @@
 package org.apache.orc.impl;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.apache.hadoop.io.Text;
 
@@ -190,7 +189,6 @@ public class StringHashTableDictionary implements Dictionary {
       }
     }
 
-    Arrays.fill(hashBuckets, null);
     hashBuckets = resizedHashBuckets;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove Superfluous Array Fill in StringHashTableDictionary. Java GC will take care of this.

### Why are the changes needed?
Less code. Performance.


### How was this patch tested?
No changes to functionality. Uses existing unit tests.