### PR TITLE
ORC-843: Enforce Non-Null Fields in TypeDescription

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcUtils.java
+++ b/java/core/src/java/org/apache/orc/OrcUtils.java
@@ -199,10 +199,8 @@ public class OrcUtils {
           typeDescr.getCategory());
     }
     result.add(type.build());
-    if (children != null) {
-      for(TypeDescription child: children) {
-        appendOrcTypes(result, child);
-      }
+    for (TypeDescription child : children) {
+      appendOrcTypes(result, child);
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -329,14 +329,12 @@ public class SchemaEvolution {
                         boolean[] ppdSafeConversion,
                         List<TypeDescription> children) {
     boolean safePpd;
-    if (children != null) {
-      for (TypeDescription child : children) {
-        TypeDescription fileType = getFileType(child.getId());
-        safePpd = validatePPDConversion(fileType, child);
-        ppdSafeConversion[child.getId()] = safePpd;
-        populatePpdSafeConversionForChildern(ppdSafeConversion,
-            child.getChildren());
-      }
+    for (TypeDescription child : children) {
+      TypeDescription fileType = getFileType(child.getId());
+      safePpd = validatePPDConversion(fileType, child);
+      ppdSafeConversion[child.getId()] = safePpd;
+      populatePpdSafeConversionForChildern(ppdSafeConversion,
+          child.getChildren());
     }
     return  ppdSafeConversion;
   }

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -203,7 +203,7 @@ public class TreeReaderFactory {
         TypeDescription col = columnId == -1 ? null : getSchemaEvolution()
           .getFileSchema()
           .findSubtype(columnId);
-        if (col == null || col.getChildren() == null || col.getChildren().isEmpty()) {
+        if (col == null || col.getChildren().isEmpty()) {
           result = TypeReader.ReaderCategory.FILTER_CHILD;
         } else {
           result = TypeReader.ReaderCategory.FILTER_PARENT;

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -863,11 +863,9 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
       return true;
     }
     List<TypeDescription> children = schema.getChildren();
-    if (children != null) {
-      for (TypeDescription child : children) {
-        if (hasTimestamp(child)) {
-          return true;
-        }
+    for (TypeDescription child : children) {
+      if (hasTimestamp(child)) {
+        return true;
       }
     }
     return false;
@@ -919,10 +917,8 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
       mask.addColumn(schema);
     }
     List<TypeDescription> children = schema.getChildren();
-    if (children != null) {
-      for(TypeDescription child: children) {
-        result += visitTypeTree(child, encrypted, provider);
-      }
+    for (TypeDescription child : children) {
+      result += visitTypeTree(child, encrypted, provider);
     }
     return result;
   }

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -411,10 +411,8 @@ public class TestTypeDescription {
       result += 1;
     }
     List<TypeDescription> children = schema.getChildren();
-    if (children != null) {
-      for (TypeDescription child : children) {
-        result += clearAttributes(child);
-      }
+    for (TypeDescription child : children) {
+      result += clearAttributes(child);
     }
     return result;
   }

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -303,7 +303,7 @@ public final class FileDump {
       }
     }
     List<TypeDescription> children = type.getChildren();
-    if (children != null) {
+    if (!children.isEmpty()) {
       switch (type.getCategory()) {
         case STRUCT:
           List<String> fields = type.getFieldNames();

--- a/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
@@ -271,7 +271,7 @@ public class JsonFileDump {
         break;
     }
     List<TypeDescription> children = type.getChildren();
-    if (children != null) {
+    if (!children.isEmpty()) {
       writer.key("children");
       switch (type.getCategory()) {
         case STRUCT:

--- a/java/tools/src/java/org/apache/orc/tools/ScanData.java
+++ b/java/tools/src/java/org/apache/orc/tools/ScanData.java
@@ -126,7 +126,7 @@ public class ScanData {
     include[column.getId()] = true;
     TypeDescription schema = reader.getSchema();
     boolean result = false;
-    if (column.getChildren() == null) {
+    if (column.getChildren().isEmpty()) {
       int row = 0;
       try (RecordReader rows = reader.rows(reader.options().include(include))) {
         rows.seekToRow(current.row);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Enforce fields in `TypeDescription` not be `null`.


### Why are the changes needed?
Makes code less error-prone and removes the need to remember to check for `null` especially since it's not documented.


### How was this patch tested?
No change in functionality. Use existing unit tests.