### PR TITLE
ORC-842: Remove newKey from StringHashTableDictionary

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
@@ -23,7 +23,6 @@ import java.io.OutputStream;
 import java.util.Arrays;
 
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.WritableComparator;
 
 
 /**
@@ -176,12 +175,14 @@ public class StringHashTableDictionary implements Dictionary {
   }
 
   /**
-   * Compute the hash value and find the corresponding index. Uses same
-   * implementation as {@code Text#hashCode()}.
+   * Compute the hash value and find the corresponding index.
    */
   int getIndex(final byte[] bytes, final int offset, final int length) {
-    return Math.floorMod(WritableComparator.hashBytes(bytes, offset, length),
-        capacity);
+    int hash = 1;
+    for (int i = offset; i < offset + length; i++) {
+      hash = (31 * hash) + bytes[i];
+    }
+    return Math.floorMod(hash, capacity);
   }
 
   // Resize the hash table, re-hash all the existing keys.

--- a/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableComparator;
 
 
 /**
@@ -37,8 +38,6 @@ public class StringHashTableDictionary implements Dictionary {
   private final DynamicByteArray byteArray = new DynamicByteArray();
   // containing starting offset of the key (in byte) in the byte array.
   private final DynamicIntArray keyOffsets;
-
-  private final Text newKey = new Text();
 
   private DynamicIntArray[] hashBuckets;
 
@@ -125,31 +124,29 @@ public class StringHashTableDictionary implements Dictionary {
     return DictionaryUtils.writeToTextInternal(out, position, this.keyOffsets, this.byteArray);
   }
 
-  @Override
-  public int add(byte[] bytes, int offset, int length) {
-    newKey.set(bytes, offset, length);
-    return add(newKey);
+  public int add(Text text) {
+    return add(text.getBytes(), 0, text.getLength());
   }
 
-  public int add(Text text) {
+  @Override
+  public int add(final byte[] bytes, final int offset, final int length) {
     resizeIfNeeded();
-    newKey.set(text);
 
-    int index = getIndex(text);
+    int index = getIndex(bytes, offset, length);
     DynamicIntArray candidateArray = hashBuckets[index];
 
     Text tmpText = new Text();
     for (int i = 0; i < candidateArray.size(); i++) {
-      getText(tmpText, candidateArray.get(i));
-      if (tmpText.equals(newKey)) {
-        return candidateArray.get(i);
+      final int candidateIndex = candidateArray.get(i);
+      getText(tmpText, candidateIndex);
+      if (tmpText.compareTo(bytes, offset, length) == 0) {
+        return candidateIndex;
       }
     }
 
     // if making it here, it means no match.
-    int len = newKey.getLength();
     int currIdx = keyOffsets.size();
-    keyOffsets.add(byteArray.add(newKey.getBytes(), 0, len));
+    keyOffsets.add(byteArray.add(bytes, offset, length));
     candidateArray.add(currIdx);
     return currIdx;
   }
@@ -173,10 +170,18 @@ public class StringHashTableDictionary implements Dictionary {
 
   /**
    * Compute the hash value and find the corresponding index.
-   *
    */
   int getIndex(Text text) {
-    return Math.floorMod(text.hashCode(), capacity);
+    return getIndex(text.getBytes(), 0, text.getLength());
+  }
+
+  /**
+   * Compute the hash value and find the corresponding index. Uses same
+   * implementation as {@code Text#hashCode()}.
+   */
+  int getIndex(final byte[] bytes, final int offset, final int length) {
+    return Math.floorMod(WritableComparator.hashBytes(bytes, offset, length),
+        capacity);
   }
 
   // Resize the hash table, re-hash all the existing keys.

--- a/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
@@ -99,10 +99,8 @@ public class TestStringHashTableDictionary {
      * this way we know the order of the traverse() method.
      */
     @Override
-    int getIndex(Text text) {
-      String s = text.toString();
-      int underscore = s.indexOf("_");
-      return Integer.parseInt(text.toString().substring(0, underscore));
+    int getIndex(byte[] bytes, int offset, int length) {
+      return (char) bytes[0] - '0';
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When adding keys to `StringHashTableDictionary`, do not copy data into intermediate container.


### Why are the changes needed?
Performance.


### How was this patch tested?
No changes to functionality. Use existing unit tests. Existing unit test was updated to use new internal mechanism for testing.
