### PR TITLE
ORC-852: Allow DynamicByteArray to return a ByteBuffer

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/Dictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/Dictionary.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 
 
 /**
@@ -51,6 +52,8 @@ public interface Dictionary {
    * @param position the position where the key was added
    */
   void getText(Text result, int position);
+
+  ByteBuffer getText(int position);
 
   /**
    * Given the position index, write the original string, before being encoded,

--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -47,6 +47,15 @@ public class DictionaryUtils {
     byteArray.setText(result, offset, length);
   }
 
+  /**
+   * Return a {@code ByteBuffer} containing the data at a certain offset within a
+   * {@code DynamicByteArray}.
+   *
+   * @param position position in the keyOffsets
+   * @param keyOffsets starting offset of the key (in byte) in the byte array
+   * @param byteArray storing raw bytes of all keys seen in dictionary
+   * @return the number of bytes written to the output stream
+   */
   public static ByteBuffer getTextInternal(int position, DynamicIntArray keyOffsets,
       DynamicByteArray byteArray) {
     final int offset = keyOffsets.get(position);

--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 
 public class DictionaryUtils {
   private DictionaryUtils() {
@@ -44,6 +45,17 @@ public class DictionaryUtils {
       length = keyOffsets.get(position + 1) - offset;
     }
     byteArray.setText(result, offset, length);
+  }
+
+  public static ByteBuffer getTextInternal(int position, DynamicIntArray keyOffsets, DynamicByteArray byteArray) {
+    final int offset = keyOffsets.get(position);
+    final int length;
+    if (position + 1 == keyOffsets.size()) {
+      length = byteArray.size() - offset;
+    } else {
+      length = keyOffsets.get(position + 1) - offset;
+    }
+    return byteArray.get(offset, length);
   }
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -47,7 +47,8 @@ public class DictionaryUtils {
     byteArray.setText(result, offset, length);
   }
 
-  public static ByteBuffer getTextInternal(int position, DynamicIntArray keyOffsets, DynamicByteArray byteArray) {
+  public static ByteBuffer getTextInternal(int position, DynamicIntArray keyOffsets,
+      DynamicByteArray byteArray) {
     final int offset = keyOffsets.get(position);
     final int length;
     if (position + 1 == keyOffsets.size()) {

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -254,7 +254,7 @@ public final class DynamicByteArray {
     return sb.toString();
   }
 
-  public ByteBuffer setByteBuffer(ByteBuffer result, int offset, int length) {
+  public void setByteBuffer(ByteBuffer result, int offset, int length) {
     result.clear();
     int currentChunk = offset / chunkSize;
     int currentOffset = offset % chunkSize;
@@ -266,7 +266,6 @@ public final class DynamicByteArray {
       currentOffset = 0;
       currentLength = Math.min(length, chunkSize - currentOffset);
     }
-    return result;
   }
 
   /**
@@ -302,7 +301,9 @@ public final class DynamicByteArray {
     if (currentLength == length) {
       return ByteBuffer.wrap(data[currentChunk], currentOffset, length);
     }
-    return (ByteBuffer) this.setByteBuffer(ByteBuffer.allocate(length), offset, length).flip();
+    ByteBuffer bb = ByteBuffer.allocate(length);
+    setByteBuffer(bb, offset, length);
+    return (ByteBuffer) bb.flip();
   }
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -254,7 +254,7 @@ public final class DynamicByteArray {
     return sb.toString();
   }
 
-  public void setByteBuffer(ByteBuffer result, int offset, int length) {
+  public ByteBuffer setByteBuffer(ByteBuffer result, int offset, int length) {
     result.clear();
     int currentChunk = offset / chunkSize;
     int currentOffset = offset % chunkSize;
@@ -266,6 +266,7 @@ public final class DynamicByteArray {
       currentOffset = 0;
       currentLength = Math.min(length, chunkSize - currentOffset);
     }
+    return result;
   }
 
   /**
@@ -292,6 +293,16 @@ public final class DynamicByteArray {
       }
     }
     return result;
+  }
+
+  public ByteBuffer get(int offset, int length) {
+    final int currentChunk = offset / chunkSize;
+    final int currentOffset = offset % chunkSize;
+    final int currentLength = Math.min(length, chunkSize - currentOffset);
+    if (currentLength == length) {
+      return ByteBuffer.wrap(data[currentChunk], currentOffset, length);
+    }
+    return (ByteBuffer) this.setByteBuffer(ByteBuffer.allocate(length), offset, length).flip();
   }
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
@@ -19,12 +19,11 @@
 package org.apache.orc.impl;
 
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.WritableComparator;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-
-import org.apache.hadoop.io.WritableComparator;
 
 /**
  * Using HashTable to represent a dictionary. The strings are stored as UTF-8 bytes

--- a/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/StringHashTableDictionary.java
@@ -19,7 +19,6 @@
 package org.apache.orc.impl;
 
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.WritableComparator;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -189,11 +188,6 @@ public class StringHashTableDictionary implements Dictionary {
     return Math.floorMod(hash, capacity);
   }
 
-  int getIndex(ByteBuffer text) {
-    return Math.floorMod(WritableComparator.hashBytes(text.array(),
-        text.position(), text.remaining()), capacity);
-  }
-
   // Resize the hash table, re-hash all the existing keys.
   // byteArray and keyOffsetsArray don't have to be re-filled.
   private void doResize(int newCapacity, int oldCapacity) {
@@ -207,7 +201,8 @@ public class StringHashTableDictionary implements Dictionary {
       for (int j = 0; j < oldBucket.size(); j++) {
         final int offset = oldBucket.get(j);
         ByteBuffer text = getText(offset);
-        resizedHashBuckets[getIndex(text)].add(oldBucket.get(j));
+        resizedHashBuckets[getIndex(text.array(),
+                text.position(), text.remaining())].add(oldBucket.get(j));
       }
     }
 

--- a/java/core/src/java/org/apache/orc/impl/StringRedBlackTree.java
+++ b/java/core/src/java/org/apache/orc/impl/StringRedBlackTree.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 
 /**
  * A red-black tree that stores strings. The strings are stored as UTF-8 bytes
@@ -110,6 +111,11 @@ public class StringRedBlackTree extends RedBlackTree implements Dictionary {
   @Override
   public void getText(Text result, int originalPosition) {
     DictionaryUtils.getTextInternal(result, originalPosition, this.keyOffsets, this.byteArray);
+  }
+
+  @Override
+  public ByteBuffer getText(int positionInKeyOffset) {
+    return DictionaryUtils.getTextInternal(positionInKeyOffset, this.keyOffsets, this.byteArray);
   }
 
   @Override

--- a/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
@@ -102,7 +102,6 @@ public class TestStringHashTableDictionary {
     int getIndex(byte[] bytes, int offset, int length) {
       return (char) bytes[0] - '0';
     }
-
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.orc.StringDictTestingUtils;
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -104,10 +103,6 @@ public class TestStringHashTableDictionary {
       return (char) bytes[0] - '0';
     }
 
-    @Override
-    int getIndex(ByteBuffer text) {
-      return (char)text.array()[text.position()] - '0';
-    }
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.orc.StringDictTestingUtils;
 import org.junit.jupiter.api.Test;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -101,6 +102,11 @@ public class TestStringHashTableDictionary {
     @Override
     int getIndex(byte[] bytes, int offset, int length) {
       return (char) bytes[0] - '0';
+    }
+
+    @Override
+    int getIndex(ByteBuffer text) {
+      return (char)text.array()[text.position()] - '0';
     }
   }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
Allow `DyanmicByteArray` and `Dictionary` to return a ByteBuffer of its content.


### Why are the changes needed?
Performance.

### How was this patch tested?
No change to functionality. Existing unit tests used.
