### PR TITLE
ORC-853: Optimize writeDouble Implementation

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
@@ -173,7 +173,6 @@ public final class SerializationUtils {
     output.write(writeBuffer, 0, 8);
   }
 
-
   /**
    * Write the arbitrarily sized signed BigInteger in vint format.
    *

--- a/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
@@ -154,22 +154,25 @@ public final class SerializationUtils {
     IOUtils.skipFully(in, numOfDoubles * 8L);
   }
 
-  public void writeDouble(OutputStream output,
-                          double value) throws IOException {
-    writeLongLE(output, Double.doubleToLongBits(value));
-  }
-
-  private void writeLongLE(OutputStream output, long value) throws IOException {
-    writeBuffer[0] = (byte) ((value >> 0)  & 0xff);
-    writeBuffer[1] = (byte) ((value >> 8)  & 0xff);
-    writeBuffer[2] = (byte) ((value >> 16) & 0xff);
-    writeBuffer[3] = (byte) ((value >> 24) & 0xff);
-    writeBuffer[4] = (byte) ((value >> 32) & 0xff);
-    writeBuffer[5] = (byte) ((value >> 40) & 0xff);
-    writeBuffer[6] = (byte) ((value >> 48) & 0xff);
-    writeBuffer[7] = (byte) ((value >> 56) & 0xff);
+  public void writeDouble(OutputStream output, double value)
+      throws IOException {
+    final long bits = Double.doubleToLongBits(value);
+    final int first = (int) (bits & 0xFFFFFFFF);
+    final int second = (int) ((bits >>> 32) & 0xFFFFFFFF);
+    // Implementation taken from Apache Avro
+    // the compiler seems to execute this order the best, likely due to
+    // register allocation -- the lifetime of constants is minimized.
+    writeBuffer[0] = (byte) (first);
+    writeBuffer[4] = (byte) (second);
+    writeBuffer[5] = (byte) (second >>> 8);
+    writeBuffer[1] = (byte) (first >>> 8);
+    writeBuffer[2] = (byte) (first >>> 16);
+    writeBuffer[6] = (byte) (second >>> 16);
+    writeBuffer[7] = (byte) (second >>> 24);
+    writeBuffer[3] = (byte) (first >>> 24);
     output.write(writeBuffer, 0, 8);
   }
+
 
   /**
    * Write the arbitrarily sized signed BigInteger in vint format.

--- a/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
@@ -159,7 +159,7 @@ public final class SerializationUtils {
     final long bits = Double.doubleToLongBits(value);
     final int first = (int) (bits & 0xFFFFFFFF);
     final int second = (int) ((bits >>> 32) & 0xFFFFFFFF);
-    // Implementation taken from Apache Avro
+    // Implementation taken from Apache Avro (org.apache.avro.io.BinaryData)
     // the compiler seems to execute this order the best, likely due to
     // register allocation -- the lifetime of constants is minimized.
     writeBuffer[0] = (byte) (first);


### PR DESCRIPTION


### What changes were proposed in this pull request?
Use the optimized Apache Avro implementation of writing a `double` to a stream.  Remove extra method which supports this functionality; condense it into a single method.


### Why are the changes needed?
Performance. Had a measurable impact on the Driver performance harness for writing `double` values.


### How was this patch tested?
No change in functionality. Use existing unit tests.
