### PR TITLE
ORC-859: Update maven-checkstyle-plugin to 3.1.2 and checkstyle to 8.44

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -256,7 +256,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
           <executions>
             <execution>
               <phase>package</phase>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -257,6 +257,13 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
           <version>3.1.2</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.puppycrawl.tools</groupId>
+              <artifactId>checkstyle</artifactId>
+              <version>8.44</version>
+            </dependency>
+          </dependencies>
           <executions>
             <execution>
               <phase>package</phase>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to update maven-checkstyle-plugin to 3.1.2 and checkstyle to 8.44.

### Why are the changes needed?
This will bring the bug fixes of 8.30 ~ 8.44.
- https://checkstyle.sourceforge.io/releasenotes.html

### How was this patch tested?
Pass the GHA.
