### PR TITLE
ORC-860: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/java"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `dependabot` with a weekly schedule.

This one makes PRs to us and we can pin the dependencies when they are incompatible.
For example, Apache Avro and Druid projects are using this like that.
- https://github.com/apache/avro/blob/master/.github/dependabot.yml
- https://github.com/apache/druid/blob/master/.github/dependabot.yml

### Why are the changes needed?

- This will keep ORC community up-to-date
- This will make the ORC community more efficiently by removing the burden of new dependency monitoring.
- This will convert the implicit knowledges about `incompability` to the community-wide explicit one.

### How was this patch tested?

N/A