### PR TITLE
ORC-861: Bump CMake minimum requirement to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required (VERSION 2.6)
+cmake_minimum_required (VERSION 2.8.12)
 if (POLICY CMP0048)
     cmake_policy(SET CMP0048 NEW)
 endif ()


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump CMake minimum requirement from 2.6 to 2.8.12.

### Why are the changes needed?

As of today, we are currently using CMake 3.21.0 and hitting this warning because our minimum requirement is 2.6.
```
$ cmake --version
cmake version 3.21.0

$ cmake ..
CMake Deprecation Warning at CMakeLists.txt:13 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

### How was this patch tested?

Pass the CIs