### PR TITLE
ORC-862: Add libarchive to centos8 docker image.

### DIFF
--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -31,6 +31,7 @@ RUN yum install -y \
   gcc-c++ \
   gettext-devel \
   git \
+  libarchive \
   libtool \
   make \
   maven \


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to add libarchive to centos8 docker image. 


### Why are the changes needed?
```
% docker run -it --rm centos:8
[root@917a5c3b68ac /]# yum install -y -q cmake
Failed to set locale, defaulting to C.UTF-8
warning: /var/cache/dnf/appstream-02e86d1c976ab532/packages/cmake-3.18.2-11.el8_4.x86_64.rpm: Header V3 RSA/SHA256 Signature, key ID 8483c65d: NOKEY
Importing GPG key 0x8483C65D:
 Userid     : "CentOS (CentOS Official Signing Key) <security@centos.org>"
 Fingerprint: 99DB 70FA E1D7 CE22 7FB6 4882 05B5 55B3 8483 C65D
 From       : /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial

[root@917a5c3b68ac /]# cmake
cmake: symbol lookup error: cmake: undefined symbol: archive_write_add_filter_zstd

[root@917a5c3b68ac /]# yum install -y -q libarchive
Failed to set locale, defaulting to C.UTF-8

[root@917a5c3b68ac /]# cmake
Usage

  cmake [options] <path-to-source>
  cmake [options] <path-to-existing-build>
  cmake [options] -S <path-to-source> -B <path-to-build>
```


### How was this patch tested?
Manual.
