### PR TITLE
ORC-866: Reduce LineLength from 125 to 120

### DIFF
--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
@@ -162,7 +162,8 @@ public class TimestampRowFilterBenchmark extends org.openjdk.jmh.Main {
 
   /*
    * Run this test:
-   *  java -cp hive/target/orc-benchmarks-hive-*-uber.jar org.apache.orc.bench.hive.rowfilter.TimestampRowFilterBenchmark
+   *  java -cp hive/target/orc-benchmarks-hive-*-uber.jar \
+   *    org.apache.orc.bench.hive.rowfilter.TimestampRowFilterBenchmark
    */
   public static void main(String[] args) throws RunnerException {
     new Runner(new OptionsBuilder()

--- a/java/core/src/java/org/apache/orc/impl/Dictionary.java
+++ b/java/core/src/java/org/apache/orc/impl/Dictionary.java
@@ -25,7 +25,8 @@ import org.apache.hadoop.io.Text;
 
 
 /**
- * Interface to define the dictionary used for encoding value in columns of specific types like string, char, varchar, etc.
+ * Interface to define the dictionary used for encoding value in columns
+ * of specific types like string, char, varchar, etc.
  */
 public interface Dictionary {
   enum IMPL {

--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -34,7 +34,8 @@ public class DictionaryUtils {
    * @param keyOffsets starting offset of the key (in byte) in the byte array.
    * @param byteArray storing raw bytes of all keys seen in dictionary
    */
-  public static void getTextInternal(Text result, int position, DynamicIntArray keyOffsets, DynamicByteArray byteArray) {
+  public static void getTextInternal(Text result, int position,
+      DynamicIntArray keyOffsets, DynamicByteArray byteArray) {
     int offset = keyOffsets.get(position);
     int length;
     if (position + 1 == keyOffsets.size()) {

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -735,7 +735,8 @@ public class ReaderImpl implements Reader {
       OrcProto.Footer footer =
           OrcProto.Footer.parseFrom(
               InStream.createCodedInputStream(
-                  InStream.create("footer", new BufferChunk(buffer, 0), psOffset - footerSize, footerSize, compression)));
+                  InStream.create("footer", new BufferChunk(buffer, 0),
+                                  psOffset - footerSize, footerSize, compression)));
       fileTailBuilder.setPostscriptLength(psLen).setFooter(footer);
     }
     // clear does not clear the contents but sets position to 0 and limit = capacity

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
@@ -50,7 +50,8 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
     this.utils = new SerializationUtils();
   }
 
-  private final static RunLengthIntegerWriterV2.EncodingType[] encodings = RunLengthIntegerWriterV2.EncodingType.values();
+  private final static RunLengthIntegerWriterV2.EncodingType[] encodings =
+    RunLengthIntegerWriterV2.EncodingType.values();
   private void readValues(boolean ignoreEof) throws IOException {
     // read the first 2 bits and determine the encoding type
     int firstByte = input.read();

--- a/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
@@ -767,7 +767,8 @@ public final class SerializationUtils {
     output.write(writeBuffer, 0, toWrite);
   }
 
-  private void writeLongBE(OutputStream output, long[] input, int offset, int numHops, int numBytes) throws IOException {
+  private void writeLongBE(OutputStream output, long[] input, int offset,
+                           int numHops, int numBytes) throws IOException {
 
     switch (numBytes) {
     case 1:

--- a/java/core/src/java/org/threeten/extra/chrono/HybridDate.java
+++ b/java/core/src/java/org/threeten/extra/chrono/HybridDate.java
@@ -264,7 +264,8 @@ public final class HybridDate
     }
 
     private boolean isCutoverMonth() {
-        return isoDate.getYear() == CUTOVER_YEAR && isoDate.getMonthValue() == 9 && isoDate.getDayOfMonth() > CUTOVER_DAYS;
+        return isoDate.getYear() == CUTOVER_YEAR &&
+            isoDate.getMonthValue() == 9 && isoDate.getDayOfMonth() > CUTOVER_DAYS;
     }
 
     //-------------------------------------------------------------------------

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -284,7 +284,7 @@
                 <module name="NewlineAtEndOfFile">
                 </module>
                 <module name="LineLength">
-                  <property name="max" value="125"/>
+                  <property name="max" value="120"/>
                 </module>
                 <module name="RegexpSingleline">
                   <property name="format" value="\s+$"/>

--- a/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
@@ -83,8 +83,8 @@ class ZeroCopyShims {
     }
   }
 
-  public static HadoopShims.ZeroCopyReaderShim getZeroCopyReader(FSDataInputStream in,
-                                                                 HadoopShims.ByteBufferPoolShim pool) throws IOException {
+  public static HadoopShims.ZeroCopyReaderShim getZeroCopyReader(
+      FSDataInputStream in, HadoopShims.ByteBufferPoolShim pool) throws IOException {
     return new ZeroCopyAdapter(in, pool);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enforce the maximum line length in Java file from 125 to 120.

### Why are the changes needed?

ORC-795 started LineLength rule with 125 maximum at Apache ORC 1.6.8.
This issue aims to enforce it with 120 at Apache ORC 1.7.0.

### How was this patch tested?

Pass the CIs with the new 120 limit.