### PR TITLE
ORC-867: Upgrade hive-storage-api to 2.8.1

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -311,6 +311,9 @@ public class TestRecordReaderImpl {
     }
 
     @Override
+    public int getId() { return -1; }
+
+    @Override
     public List<Object> getLiteralList() {
       return null;
     }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
     <min.hadoop.version>2.2.0</min.hadoop.version>
     <hadoop.version>2.7.3</hadoop.version>
     <tools.hadoop.version>2.10.1</tools.hadoop.version>
-    <storage-api.version>2.7.2</storage-api.version>
+    <storage-api.version>2.8.1</storage-api.version>
     <zookeeper.version>3.7.0</zookeeper.version>
     <maven.version>3.6.3</maven.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `hive-storage-api` from 2.7.2 to 2.8.1.

### Why are the changes needed?

This will bring the latest improvement and bug fixes.

### How was this patch tested?

Pass the CIs.