### PR TITLE
ORC-868: Pin gson to 2.2.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,7 @@ updates:
     directory: "/java"
     schedule:
       interval: "weekly"
+    ignore:
+      # Pin gson to 2.2.4 because of Hive
+      - dependency-name: "com.google.code.gson:gson"
+        versions: "[2.3,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `gson` to 2.2.4 explicitly.

### Why are the changes needed?

Apache Hive 4.0 is still using 2.2.4 and Spark 3.1.2 distribution also has 2.2.4 due to that.
- https://github.com/apache/hive/blob/master/pom.xml#L219
```
<gson.version>2.2.4</gson.version>
```

### How was this patch tested?

N/A. This will inform `dependabot` to ignore son 2.3+.

This closes #766 .