### PR TITLE
ORC-869: Pin jmh 1.20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,6 @@ updates:
       # Pin gson to 2.2.4 because of Hive
       - dependency-name: "com.google.code.gson:gson"
         versions: "[2.3,)"
+      # Pin jmh to 1.20
+      - dependency-name: "org.openjdk.jmh:jmh-core"
+        versions: "[1.21,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `jmh` to 1.20.

### Why are the changes needed?

As we see the test result (https://github.com/apache/orc/pull/769), the upgrade needs more efforts. ORC-870 will handle it later.

### How was this patch tested?

N/A

Closes #769