### PR TITLE
ORC-873: Fix FindCyrusSASL to use the package name CyrusSASL

### DIFF
--- a/cmake_modules/FindCyrusSASL.cmake
+++ b/cmake_modules/FindCyrusSASL.cmake
@@ -43,7 +43,7 @@ find_path(CYRUS_SASL_INCLUDE_DIR sasl/sasl.h)
 find_library(CYRUS_SASL_SHARED_LIB sasl2)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(CYRUS_SASL DEFAULT_MSG
+find_package_handle_standard_args(CyrusSASL DEFAULT_MSG
   CYRUS_SASL_SHARED_LIB CYRUS_SASL_INCLUDE_DIR)
 
 MARK_AS_ADVANCED(CYRUS_SASL_INCLUDE_DIR CYRUS_SASL_SHARED_LIB)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the package name `CyprusSASL` at `find_package_handle_standard_args`.
```cmake
-find_package_handle_standard_args(CYRUS_SASL DEFAULT_MSG
+find_package_handle_standard_args(CyrusSASL DEFAULT_MSG
```

### Why are the changes needed?

Currently, it shows a warning like the following.
```
CMake Warning (dev) at /opt/homebrew/Cellar/cmake/3.21.0/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:438 (message):
  The package name passed to `find_package_handle_standard_args` (CYRUS_SASL)
  does not match the name of the calling package (CyrusSASL).  This can lead
  to problems in calling code that expects `find_package` result variables
  (e.g., `_FOUND`) to follow a certain pattern.
Call Stack (most recent call first):
  cmake_modules/FindCyrusSASL.cmake:46 (find_package_handle_standard_args)
  cmake_modules/ThirdpartyToolchain.cmake:432 (find_package)
  CMakeLists.txt:130 (INCLUDE)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

### How was this patch tested?

After passing the CIs, manually check the C++ build.