### PR TITLE
ORC-882: Remove hamcrest-core test dependency

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -97,11 +97,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -775,12 +775,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest-core</artifactId>
-        <version>1.3</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>3.7.0</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `hamcrest-core` test dependency.

### Why are the changes needed?

This was added at ORC-60 and is not used now.
```
$ git show 08b854425 | grep hamcrest
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
```

### How was this patch tested?

Pass the CIs.

This closes #778 .