### PR TITLE
ORC-885: Update bench README.md and allow user env shell

### DIFF
--- a/java/bench/README.md
+++ b/java/bench/README.md
@@ -13,9 +13,12 @@ There are three sub-modules to try to mitigate dependency hell:
 * hive - the Hive benchmarks
 * spark - the Spark benchmarks
 
-To build this library:
+To build this library, run the following in the parent directory:
 
-```% ./mvnw clean package```
+```
+% ./mvnw clean package -Pbenchmark
+% cd bench
+```
 
 To fetch the source data:
 

--- a/java/bench/fetch-data.sh
+++ b/java/bench/fetch-data.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `READM.md` in bench submodule and allow user environment shell in `fetch-data.sh`.

### Why are the changes needed?

- ORC-821 added `mvnw` in the parent directory.
- Since ORC-354, `-Pbenchmark` is recommended.
- In some OS environments, `/bin/bash` is too old to run the script.

### How was this patch tested?

Pass the CIs.