### PR TITLE
ORC-887: Remove ORC Twitter link from news page

### DIFF
--- a/site/news/index.html
+++ b/site/news/index.html
@@ -8,12 +8,3 @@ author: all
 {% for post in site.posts %}
   {% include news_item.html %}
 {% endfor %}
-
-<p></p>
-
-<h2>ORC Twitter</h2>
-
-<p>The official <a href="https://twitter.com/apacheorc">@ApacheOrc</a>
-Twitter account pushes announcements about ORC. If you give a talk about
-ORC, let us know and we'll tweet it out and add it to the news section
-of the website.</p>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove ORC Twitter link from `news` page.

![Screen Shot 2021-07-29 at 10 09 16 PM](https://user-images.githubusercontent.com/9700541/127603546-5491287c-b3a9-436c-be53-5a823b05cde3.png)

### Why are the changes needed?

The twitter account has not used during last 3 years since 2018.

![Screen Shot 2021-07-29 at 10 09 51 PM](https://user-images.githubusercontent.com/9700541/127603585-c51603a0-607e-4ec4-9044-63508d1db5c6.png)

### How was this patch tested?

N/A (We need to update `asf-website` branch after merging)