### PR TITLE
ORC-889: Remove orc-mapreduce build warnings due to overlapping resources

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -382,6 +382,17 @@
                     <shadedPattern>org.apache.orc.storage</shadedPattern>
                   </relocation>
                 </relocations>
+                <filters>
+                  <filter>
+                    <artifact>*:*</artifact>
+                    <excludes>
+                      <exclude>META-INF/MANIFEST.MF</exclude>
+                      <exclude>META-INF/DEPENDENCIES</exclude>
+                      <exclude>META-INF/LICENSE</exclude>
+                      <exclude>META-INF/NOTICE</exclude>
+                    </excludes>
+                  </filter>
+                </filters>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a filtering rule at `maven-shade-plugin` to remove a build warning due to the overlapping resources.

### Why are the changes needed?

We had better remove this warnings on `orc-mapreduce` module before Apache ORC 1.7.0 release.
```
[INFO] --- maven-shade-plugin:3.2.4:shade (default) @ orc-mapreduce ---
[INFO] Including com.google.protobuf:protobuf-java:jar:2.5.0 in the shaded jar.
[INFO] Including org.apache.hive:hive-storage-api:jar:2.7.2 in the shaded jar.
[INFO] Excluding org.apache.orc:orc-core:jar:1.8.0-SNAPSHOT from the shaded jar.
[INFO] Excluding org.apache.orc:orc-shims:jar:1.8.0-SNAPSHOT from the shaded jar.
[INFO] Excluding io.airlift:aircompressor:jar:0.19 from the shaded jar.
[INFO] Excluding javax.xml.bind:jaxb-api:jar:2.2.11 from the shaded jar.
[INFO] Excluding org.jetbrains:annotations:jar:17.0.0 from the shaded jar.
[INFO] Excluding org.slf4j:slf4j-api:jar:1.7.32 from the shaded jar.
[INFO] Excluding org.threeten:threeten-extra:jar:1.5.0 from the shaded jar.
[INFO] Excluding com.esotericsoftware:kryo-shaded:jar:4.0.2 from the shaded jar.
[INFO] Excluding com.esotericsoftware:minlog:jar:1.3.0 from the shaded jar.
[INFO] Excluding commons-codec:commons-codec:jar:1.15 from the shaded jar.
[INFO] Excluding org.apache.commons:commons-lang3:jar:3.12.0 from the shaded jar.
[INFO] Excluding log4j:log4j:jar:1.2.17 from the shaded jar.
[INFO] Excluding commons-lang:commons-lang:jar:2.5 from the shaded jar.
[INFO] Excluding org.slf4j:slf4j-log4j12:jar:1.7.5 from the shaded jar.
[INFO] Excluding org.apache.zookeeper:zookeeper:jar:3.7.0 from the shaded jar.
[INFO] Excluding org.apache.zookeeper:zookeeper-jute:jar:3.7.0 from the shaded jar.
[INFO] Excluding org.apache.yetus:audience-annotations:jar:0.12.0 from the shaded jar.
[WARNING] hive-storage-api-2.7.2.jar, orc-mapreduce-1.8.0-SNAPSHOT.jar, protobuf-java-2.5.0.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] hive-storage-api-2.7.2.jar, orc-mapreduce-1.8.0-SNAPSHOT.jar define 3 overlapping resources:
[WARNING]   - META-INF/DEPENDENCIES
[WARNING]   - META-INF/LICENSE
[WARNING]   - META-INF/NOTICE
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://maven.apache.org/plugins/maven-shade-plugin/
```

### How was this patch tested?

Manually check because this is a warning.

**BEFORE**
```
$ cd java
$ mvn package -pl mapreduce -DskipTests | grep WARNING
Using `mvn` from path: /opt/homebrew/bin/mvn
[WARNING] hive-storage-api-2.7.2.jar, orc-mapreduce-1.8.0-SNAPSHOT.jar, protobuf-java-2.5.0.jar define 1 overlapping resource:
[WARNING]   - META-INF/MANIFEST.MF
[WARNING] hive-storage-api-2.7.2.jar, orc-mapreduce-1.8.0-SNAPSHOT.jar define 3 overlapping resources:
[WARNING]   - META-INF/DEPENDENCIES
[WARNING]   - META-INF/LICENSE
[WARNING]   - META-INF/NOTICE
[WARNING] maven-shade-plugin has detected that some class files are
[WARNING] present in two or more JARs. When this happens, only one
[WARNING] single version of the class is copied to the uber jar.
[WARNING] Usually this is not harmful and you can skip these warnings,
[WARNING] otherwise try to manually exclude artifacts based on
[WARNING] mvn dependency:tree -Ddetail=true and the above output.
[WARNING] See http://maven.apache.org/plugins/maven-shade-plugin/
```

**AFTER**
```
$ mvn package -pl mapreduce -DskipTests | grep WARNING
Using `mvn` from path: /opt/homebrew/bin/mvn
```