### PR TITLE
ORC-890: Pin minimum support Hadoop version to 2.2.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
       # Pin jmh to 1.20
       - dependency-name: "org.openjdk.jmh:jmh-core"
         versions: "[1.21,)"
+      # Pin minimum support Hadoop version to 2.2.0
+      - dependency-name: "org.apache.hadoop:hadoop-common"
+        versions: "[2.2.1,)"
+      - dependency-name: "org.apache.hadoop:hadoop-hdfs"
+        versions: "[2.2.1,)"
+      - dependency-name: "org.apache.hadoop:hadoop-mapreduce-client-core"
+        versions: "[2.2.1,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin the minimum support Hadoop version to 2.2.0.

### Why are the changes needed?

We have `min.hadoop.version` for three dependencies. We need to pin them all.
```
$ git grep -C1 min.hadoop.version
java/pom.xml-
java/pom.xml:    <min.hadoop.version>2.2.0</min.hadoop.version>
java/pom.xml-    <hadoop.version>2.7.3</hadoop.version>
--
java/pom.xml-        <artifactId>hadoop-common</artifactId>
java/pom.xml:        <version>${min.hadoop.version}</version>
java/pom.xml-        <scope>provided</scope>
--
java/pom.xml-        <artifactId>hadoop-hdfs</artifactId>
java/pom.xml:        <version>${min.hadoop.version}</version>
java/pom.xml-        <scope>provided</scope>
--
java/pom.xml-        <artifactId>hadoop-mapreduce-client-core</artifactId>
java/pom.xml:        <version>${min.hadoop.version}</version>
java/pom.xml-        <scope>provided</scope>
```

### How was this patch tested?

N/A. This affects only `Dependabot`.

This closes #782 .