### PR TITLE
ORC-891: Use assert methods without package name

### DIFF
--- a/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
+++ b/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.orc.impl.HadoopShims;
 import org.apache.orc.impl.LocalKey;
-import org.junit.Assert;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -60,9 +60,9 @@ public class TestInMemoryKeystore {
   @Test
   public void testGetKeyNames() {
 
-    Assert.assertTrue(memoryKeystore.getKeyNames().contains("key128"));
-    Assert.assertTrue(memoryKeystore.getKeyNames().contains("key256"));
-    Assert.assertTrue(memoryKeystore.getKeyNames().contains("key256short"));
+    assertTrue(memoryKeystore.getKeyNames().contains("key128"));
+    assertTrue(memoryKeystore.getKeyNames().contains("key256"));
+    assertTrue(memoryKeystore.getKeyNames().contains("key256short"));
 
   }
 
@@ -72,14 +72,14 @@ public class TestInMemoryKeystore {
     final HadoopShims.KeyMetadata metadata = memoryKeystore
         .getCurrentKeyVersion("key256");
 
-    Assert.assertEquals("key256", metadata.getKeyName());
+    assertEquals("key256", metadata.getKeyName());
     if (InMemoryKeystore.SUPPORTS_AES_256) {
-      Assert.assertEquals(EncryptionAlgorithm.AES_CTR_256, metadata.getAlgorithm());
+      assertEquals(EncryptionAlgorithm.AES_CTR_256, metadata.getAlgorithm());
     } else {
-      Assert.assertEquals(EncryptionAlgorithm.AES_CTR_128, metadata.getAlgorithm());
+      assertEquals(EncryptionAlgorithm.AES_CTR_128, metadata.getAlgorithm());
     }
 
-    Assert.assertEquals(0, metadata.getVersion());
+    assertEquals(0, metadata.getVersion());
 
   }
 
@@ -91,17 +91,17 @@ public class TestInMemoryKeystore {
 
     LocalKey key128 = memoryKeystore.createLocalKey(metadata128);
     // we are sure the key is the same because of the random generator.
-    Assert.assertEquals("39 72 2c bb f8 b9 1a 4b 90 45 c5 e6 17 5f 10 01",
+    assertEquals("39 72 2c bb f8 b9 1a 4b 90 45 c5 e6 17 5f 10 01",
         stringify(key128.getEncryptedKey()));
-    Assert.assertEquals("46 33 66 fd 79 57 66 9a ba 4a 28 df bf 16 f2 88",
+    assertEquals("46 33 66 fd 79 57 66 9a ba 4a 28 df bf 16 f2 88",
         stringify(key128.getDecryptedKey().getEncoded()));
     // used online aes/cbc calculator to encrypt key
-    Assert.assertEquals("AES", key128.getDecryptedKey().getAlgorithm());
+    assertEquals("AES", key128.getDecryptedKey().getAlgorithm());
 
     // now decrypt the key again
     Key decryptKey = memoryKeystore.decryptLocalKey(metadata128,
         key128.getEncryptedKey());
-    Assert.assertEquals(stringify(key128.getDecryptedKey().getEncoded()),
+    assertEquals(stringify(key128.getDecryptedKey().getEncoded()),
         stringify(decryptKey.getEncoded()));
 
     HadoopShims.KeyMetadata metadata256 = memoryKeystore
@@ -109,34 +109,34 @@ public class TestInMemoryKeystore {
     LocalKey key256 = memoryKeystore.createLocalKey(metadata256);
     // this is forced by the fixed Random in the keystore for this test
     if (InMemoryKeystore.SUPPORTS_AES_256) {
-      Assert.assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08 0f " +
+      assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08 0f " +
                               "7b 6c db 79 e5 51 ec 9c 9c c7 fc bd 60 ee 73",
           stringify(key256.getEncryptedKey()));
        // used online aes/cbc calculator to encrypt key
-      Assert.assertEquals("00 b0 1c 24 d9 03 bc 02 63 87 b3 f9 65 4e e7 a8 b8" +
+      assertEquals("00 b0 1c 24 d9 03 bc 02 63 87 b3 f9 65 4e e7 a8 b8" +
                               " 58 eb a0 81 06 b3 61 cf f8 06 ba 30 d4 c5 36",
           stringify(key256.getDecryptedKey().getEncoded()));
     } else {
-      Assert.assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08",
+      assertEquals("ea c3 2f 7f cd 5e cc da 5c 6e 62 fc 4e 63 85 08",
           stringify(key256.getEncryptedKey()));
-      Assert.assertEquals("6d 1c ff 55 a5 44 75 11 fb e6 8e 08 cd 2a 10 e8",
+      assertEquals("6d 1c ff 55 a5 44 75 11 fb e6 8e 08 cd 2a 10 e8",
           stringify(key256.getDecryptedKey().getEncoded()));
     }
-    Assert.assertEquals("AES", key256.getDecryptedKey().getAlgorithm());
+    assertEquals("AES", key256.getDecryptedKey().getAlgorithm());
 
     // now decrypt the key again
     decryptKey = memoryKeystore.decryptLocalKey(metadata256, key256.getEncryptedKey());
-    Assert.assertEquals(stringify(key256.getDecryptedKey().getEncoded()),
+    assertEquals(stringify(key256.getDecryptedKey().getEncoded()),
         stringify(decryptKey.getEncoded()));
   }
 
   @Test
   public void testRollNewVersion() throws IOException {
 
-    Assert.assertEquals(0,
+    assertEquals(0,
         memoryKeystore.getCurrentKeyVersion("key128").getVersion());
     memoryKeystore.addKey("key128", 1, EncryptionAlgorithm.AES_CTR_128, "NewSecret".getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals(1,
+    assertEquals(1,
         memoryKeystore.getCurrentKeyVersion("key128").getVersion());
   }
 
@@ -145,9 +145,9 @@ public class TestInMemoryKeystore {
     try {
       memoryKeystore.addKey("key128", 0, EncryptionAlgorithm.AES_CTR_128,
           "exception".getBytes(StandardCharsets.UTF_8));
-      Assert.fail("Keys with same name cannot be added.");
+      fail("Keys with same name cannot be added.");
     } catch (IOException e) {
-      Assert.assertTrue(e.toString().contains("equal or higher version"));
+      assertTrue(e.toString().contains("equal or higher version"));
     }
 
   }
@@ -161,24 +161,24 @@ public class TestInMemoryKeystore {
    */
   @Test
   public void testMultipleVersion() throws IOException {
-    Assert.assertEquals(0,
+    assertEquals(0,
         memoryKeystore.getCurrentKeyVersion("key256").getVersion());
     memoryKeystore.addKey("key256", 1, EncryptionAlgorithm.AES_CTR_256,
         "NewSecret".getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals(1,
+    assertEquals(1,
         memoryKeystore.getCurrentKeyVersion("key256").getVersion());
 
     try {
       memoryKeystore.addKey("key256", 1, EncryptionAlgorithm.AES_CTR_256,
           "BadSecret".getBytes(StandardCharsets.UTF_8));
-      Assert.fail("Keys with smaller version should not be added.");
+      fail("Keys with smaller version should not be added.");
     } catch (final IOException e) {
-      Assert.assertTrue(e.toString().contains("equal or higher version"));
+      assertTrue(e.toString().contains("equal or higher version"));
     }
 
     memoryKeystore.addKey("key256", 2, EncryptionAlgorithm.AES_CTR_256,
         "NewerSecret".getBytes(StandardCharsets.UTF_8));
-    Assert.assertEquals(2,
+    assertEquals(2,
         memoryKeystore.getCurrentKeyVersion("key256").getVersion());
 
     // make sure that all 3 versions of key256 exist and have different secrets
@@ -191,9 +191,9 @@ public class TestInMemoryKeystore {
     Key key2 = memoryKeystore.decryptLocalKey(
         new HadoopShims.KeyMetadata("key256", 2, EncryptionAlgorithm.AES_CTR_256),
         new byte[16]);
-    Assert.assertNotEquals(new BytesWritable(key0.getEncoded()).toString(),
+    assertNotEquals(new BytesWritable(key0.getEncoded()).toString(),
         new BytesWritable(key1.getEncoded()).toString());
-    Assert.assertNotEquals(new BytesWritable(key1.getEncoded()).toString(),
+    assertNotEquals(new BytesWritable(key1.getEncoded()).toString(),
         new BytesWritable(key2.getEncoded()).toString());
   }
 

--- a/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
+++ b/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
@@ -27,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
 
-import org.junit.Assert;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -276,7 +275,7 @@ public class TestOrcNullOptimization {
         stats[2].toString());
 
     // check the inspectors
-    Assert.assertEquals("struct<a:int,b:string,c:boolean,d:array<struct<z:int>>>",
+    assertEquals("struct<a:int,b:string,c:boolean,d:array<struct<z:int>>>",
         reader.getSchema().toString());
 
     RecordReader rows = reader.rows();
@@ -377,7 +376,7 @@ public class TestOrcNullOptimization {
     ListColumnVector dColumn = (ListColumnVector) batch.cols[3];
     LongColumnVector dElements =
         (LongColumnVector)(((StructColumnVector) dColumn.child).fields[0]);
-    Assert.assertEquals("struct<a:int,b:string,c:boolean,d:array<struct<z:int>>>",
+    assertEquals("struct<a:int,b:string,c:boolean,d:array<struct<z:int>>>",
         reader.getSchema().toString());
 
     RecordReader rows = reader.rows();

--- a/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentImpl;
 import org.apache.orc.impl.RecordReaderImpl;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -110,8 +109,8 @@ public class TestOrcTimestampPPD {
     times = (TimestampColumnVector) batch.cols[0];
     while (rows.nextBatch(batch)) {
       for (int r = 0; r < batch.size; ++r) {
-        Assert.assertEquals(tslist.get(0), times.asScratchTimestamp(r));
-        Assert.assertEquals(tslist.get(0).getNanos(), times.asScratchTimestamp(r).getNanos());
+        assertEquals(tslist.get(0), times.asScratchTimestamp(r));
+        assertEquals(tslist.get(0).getNanos(), times.asScratchTimestamp(r).getNanos());
       }
     }
     rows.close();
@@ -125,15 +124,15 @@ public class TestOrcTimestampPPD {
     PredicateLeaf pred = createPredicateLeaf(PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("1970-01-01 00:00:00.0005"), null);
     // Make sure PPD is now passing
-    Assert.assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("1970-01-01 00:00:00.0005"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("1970-01-01 00:00:00.0005"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
   }
 
   @Test
@@ -172,8 +171,8 @@ public class TestOrcTimestampPPD {
     times = (TimestampColumnVector) batch.cols[0];
     while (rows.nextBatch(batch)) {
       for (int r = 0; r < batch.size; ++r) {
-        Assert.assertEquals(tslist.get(r), times.asScratchTimestamp(r));
-        Assert.assertEquals(tslist.get(r).getNanos(), times.asScratchTimestamp(r).getNanos());
+        assertEquals(tslist.get(r), times.asScratchTimestamp(r));
+        assertEquals(tslist.get(r).getNanos(), times.asScratchTimestamp(r).getNanos());
       }
     }
     rows.close();
@@ -187,22 +186,22 @@ public class TestOrcTimestampPPD {
     // PPD EQUALS with nano precision passing
     PredicateLeaf pred = createPredicateLeaf(PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("2037-01-01 00:00:00.001109"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
 
     // PPD EQUALS with ms precision NOT passing
     pred = createPredicateLeaf(PredicateLeaf.Operator.EQUALS, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("2037-01-01 00:00:001"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
 
     // PPD LESS_THAN with ns precision passing
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("2037-01-01 00:00:00.006789"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
 
     // PPD LESS_THAN with ms precision passing
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.TIMESTAMP, "c",
         Timestamp.valueOf("2037-01-01 00:00:00.002"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0], pred, null));
   }
 }
 

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.TimeZone;
 
-import org.junit.Assert;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -182,7 +181,7 @@ public class TestOrcTimezone1 {
         ts.asScratchTimestamp(0));
 
     // handle the close up
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
     rows.close();
   }
 }

--- a/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
@@ -15,7 +15,7 @@
  */
 package org.apache.orc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 import java.io.File;
 import java.sql.Timestamp;
@@ -40,7 +40,6 @@ import org.apache.orc.impl.RecordReaderImpl;
 import org.apache.orc.impl.SerializationUtils;
 import org.apache.orc.util.BloomFilter;
 import org.apache.orc.util.BloomFilterIO;
-import static org.junit.Assert.assertNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;

--- a/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
@@ -40,8 +40,8 @@ import org.apache.orc.impl.RecordReaderImpl;
 import org.apache.orc.impl.SerializationUtils;
 import org.apache.orc.util.BloomFilter;
 import org.apache.orc.util.BloomFilterIO;
+import static org.junit.Assert.assertNull;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -168,35 +168,35 @@ public class TestOrcTimezonePPD {
     Timestamp gotMax = ((TimestampColumnStatistics) colStats[0]).getMaximum();
     assertEquals("2007-08-01 04:00:00.0", gotMax.toString());
 
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
       SearchArgumentFactory.newBuilder().equals
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0")).build().getLeaves().get(0),
       null));
 
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
       SearchArgumentFactory.newBuilder().equals
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0")).build().getLeaves().get(0),
       null));
 
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
       SearchArgumentFactory.newBuilder().between
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 05:00:00.0"),
           Timestamp.valueOf("2007-08-01 06:00:00.0")).build().getLeaves().get(0),
       null));
 
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
       SearchArgumentFactory.newBuilder().between
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0"),
           Timestamp.valueOf("2007-08-01 03:00:00.0")).build().getLeaves().get(0),
       null));
 
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[0],
       SearchArgumentFactory.newBuilder().in
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0"),
           Timestamp.valueOf("2007-08-01 03:00:00.0")).build().getLeaves().get(0),
       null));
 
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[0],
       SearchArgumentFactory.newBuilder().in
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0"),
           Timestamp.valueOf("2007-08-02 03:00:00.0")).build().getLeaves().get(0),
@@ -261,23 +261,23 @@ public class TestOrcTimezonePPD {
     BloomFilter bf = BloomFilterIO.deserialize(OrcProto.Stream.Kind.BLOOM_FILTER_UTF8,
         buildEncoding(), reader.getWriterVersion(),
       TypeDescription.Category.TIMESTAMP, bloomFilter);
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1],
       SearchArgumentFactory.newBuilder().equals
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0")).build().getLeaves().get(0),
       bf));
 
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1],
       SearchArgumentFactory.newBuilder().equals
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0")).build().getLeaves().get(0),
       bf));
 
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1],
       SearchArgumentFactory.newBuilder().in
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-01 00:00:00.0"),
           Timestamp.valueOf("2007-08-01 03:00:00.0")).build().getLeaves().get(0),
       bf));
 
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1],
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1],
       SearchArgumentFactory.newBuilder().in
         ("c", PredicateLeaf.Type.TIMESTAMP, Timestamp.valueOf("2007-08-02 00:00:00.0"),
           Timestamp.valueOf("2007-08-02 03:00:00.0")).build().getLeaves().get(0),
@@ -336,26 +336,26 @@ public class TestOrcTimezonePPD {
     PredicateLeaf pred = createPredicateLeaf(
       PredicateLeaf.Operator.NULL_SAFE_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
       Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.NULL_SAFE_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
       Timestamp.valueOf("2007-08-01 02:00:00.0"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
 
     bf.addLong(SerializationUtils.convertToUtc(TimeZone.getDefault(),
         Timestamp.valueOf("2007-08-01 02:00:00.0").getTime()));
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN, PredicateLeaf.Type.TIMESTAMP, "x",
       Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.LESS_THAN_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
       Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.YES_NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.IS_NULL, PredicateLeaf.Type.TIMESTAMP, "x", null, null);
-    Assert.assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.NO, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
   }
 
   @Test
@@ -386,10 +386,10 @@ public class TestOrcTimezonePPD {
     rows.close();
     ColumnStatistics[] colStats = reader.getStatistics();
     Timestamp gotMin = ((TimestampColumnStatistics) colStats[1]).getMinimum();
-    Assert.assertNull(gotMin);
+    assertNull(gotMin);
 
     Timestamp gotMax = ((TimestampColumnStatistics) colStats[1]).getMaximum();
-    Assert.assertNull(gotMax);
+    assertNull(gotMax);
 
     OrcProto.BloomFilterIndex[] bloomFilterIndices = indices.getBloomFilterIndex();
     OrcProto.BloomFilter bloomFilter = bloomFilterIndices[1].getBloomFilter(0);
@@ -399,9 +399,9 @@ public class TestOrcTimezonePPD {
     PredicateLeaf pred = createPredicateLeaf(
       PredicateLeaf.Operator.NULL_SAFE_EQUALS, PredicateLeaf.Type.TIMESTAMP, "x",
       Timestamp.valueOf("2007-08-01 00:00:00.0"), null);
-    Assert.assertEquals(SearchArgument.TruthValue.NULL, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.NULL, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
 
     pred = createPredicateLeaf(PredicateLeaf.Operator.IS_NULL, PredicateLeaf.Type.TIMESTAMP, "x", null, null);
-    Assert.assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
+    assertEquals(SearchArgument.TruthValue.YES, RecordReaderImpl.evaluatePredicate(colStats[1], pred, bf));
   }
 }

--- a/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypes.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypes.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.RecordReaderImpl;
-import org.junit.Assert;
+import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -107,8 +107,8 @@ public class TestRowFilteringComplexTypes {
 
             int noNullCnt = 0;
             while (rows.nextBatch(batch)) {
-                Assert.assertTrue(batch.selectedInUse);
-                Assert.assertEquals(ColumnBatchRows / 2, batch.size);
+                assertTrue(batch.selectedInUse);
+                assertEquals(ColumnBatchRows / 2, batch.size);
                 for (int r = 0; r < ColumnBatchRows; ++r) {
                     StringBuilder sb = new StringBuilder();
                     col2.stringifyValue(sb, r);
@@ -118,9 +118,9 @@ public class TestRowFilteringComplexTypes {
                 }
             }
             // Make sure that our filter worked
-            Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-            Assert.assertEquals(0, batch.selected[0]);
-            Assert.assertEquals(2, batch.selected[1]);
+            assertEquals(NUM_BATCHES * 512, noNullCnt);
+            assertEquals(0, batch.selected[0]);
+            assertEquals(2, batch.selected[1]);
         }
     }
 
@@ -172,19 +172,19 @@ public class TestRowFilteringComplexTypes {
 
             int previousBatchRows = 0;
             while (rows.nextBatch(batch)) {
-                Assert.assertTrue(batch.selectedInUse);
-                Assert.assertEquals(ColumnBatchRows / 2, batch.size);
+                assertTrue(batch.selectedInUse);
+                assertEquals(ColumnBatchRows / 2, batch.size);
                 for (int r = 0; r < batch.size; ++r) {
                     int row = batch.selected[r];
                     int originalRow = (r + previousBatchRows) * 2;
-                    Assert.assertEquals("row " + originalRow, originalRow, col1.vector[row]);
-                    Assert.assertEquals("row " + originalRow, 0, col2.tags[row]);
-                    Assert.assertEquals("row " + originalRow,
+                    assertEquals("row " + originalRow, originalRow, col1.vector[row]);
+                    assertEquals("row " + originalRow, 0, col2.tags[row]);
+                    assertEquals("row " + originalRow,
                         originalRow * 1000, innerCol1.vector[row]);
                 }
                 // check to make sure that we didn't read innerCol2
                 for(int r = 1; r < ColumnBatchRows; r += 2) {
-                    Assert.assertEquals("row " + r, 0, innerCol2.vector[r]);
+                    assertEquals("row " + r, 0, innerCol2.vector[r]);
                 }
                 previousBatchRows += batch.size;
             }
@@ -242,8 +242,8 @@ public class TestRowFilteringComplexTypes {
 
             int noNullCnt = 0;
             while (rows.nextBatch(batch)) {
-                Assert.assertTrue(batch.selectedInUse);
-                Assert.assertEquals(ColumnBatchRows / 2, batch.size);
+                assertTrue(batch.selectedInUse);
+                assertEquals(ColumnBatchRows / 2, batch.size);
                 for (int r = 0; r < ColumnBatchRows; ++r) {
                     StringBuilder sb = new StringBuilder();
                     col2.stringifyValue(sb, r);
@@ -253,10 +253,10 @@ public class TestRowFilteringComplexTypes {
                 }
             }
             // Make sure that we did NOT skip any rows
-            Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
+            assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
             // Even though selected Array is still used its not propagated
-            Assert.assertEquals(0, batch.selected[0]);
-            Assert.assertEquals(2, batch.selected[1]);
+            assertEquals(0, batch.selected[0]);
+            assertEquals(2, batch.selected[1]);
         }
     }
 
@@ -306,8 +306,8 @@ public class TestRowFilteringComplexTypes {
 
             int noNullCnt = 0;
             while (rows.nextBatch(batch)) {
-                Assert.assertTrue(batch.selectedInUse);
-                Assert.assertEquals(ColumnBatchRows / 2, batch.size);
+                assertTrue(batch.selectedInUse);
+                assertEquals(ColumnBatchRows / 2, batch.size);
                 for (int r = 0; r < ColumnBatchRows; ++r) {
                     StringBuilder sb = new StringBuilder();
                     col2.stringifyValue(sb, r);
@@ -317,10 +317,10 @@ public class TestRowFilteringComplexTypes {
                 }
             }
             // Make sure that we did NOT skip any rows
-            Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
+            assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
             // Even though selected Array is still used its not propagated
-            Assert.assertEquals(0, batch.selected[0]);
-            Assert.assertEquals(2, batch.selected[1]);
+            assertEquals(0, batch.selected[0]);
+            assertEquals(2, batch.selected[1]);
         }
     }
 }

--- a/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.OrcFilterContextImpl;
-import org.junit.Assert;
+import static org.junit.Assert.*;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -120,8 +120,8 @@ public class TestRowFilteringIOSkip {
   @Test
   public void writeIsSuccessful() throws IOException {
     Reader r = OrcFile.createReader(filePath, OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(RowCount, r.getNumberOfRows());
-    Assert.assertTrue(r.getStripes().size() > 1);
+    assertEquals(RowCount, r.getNumberOfRows());
+    assertTrue(r.getStripes().size() > 1);
   }
 
   @Test
@@ -132,14 +132,14 @@ public class TestRowFilteringIOSkip {
     long rowCount = 0;
     try (RecordReader rr = r.rows(r.options().include(FirstColumnOnly))) {
       while (rr.nextBatch(b)) {
-        Assert.assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
+        assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
         rowCount += b.size;
       }
     }
     FileSystem.Statistics stats = readEnd();
-    Assert.assertEquals(RowCount, rowCount);
+    assertEquals(RowCount, rowCount);
     // We should read less than half the length of the file
-    Assert.assertTrue(String.format("Bytes read %d is not half of file size %d",
+    assertTrue(String.format("Bytes read %d is not half of file size %d",
                                     stats.getBytesRead(),
                                     r.getContentLength()),
                       stats.getBytesRead() < r.getContentLength() / 2);
@@ -160,8 +160,8 @@ public class TestRowFilteringIOSkip {
       rowCount = validateFilteredRecordReader(rr, b);
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
-    Assert.assertEquals(RowCount, rowCount);
-    Assert.assertTrue(p >= 100);
+    assertEquals(RowCount, rowCount);
+    assertTrue(p >= 100);
   }
 
   private long validateFilteredRecordReader(RecordReader rr, VectorizedRowBatch b)
@@ -186,13 +186,13 @@ public class TestRowFilteringIOSkip {
       }
       long expValue = ((LongColumnVector) b.cols[0]).vector[rowIdx];
       d.setFromLongAndScale(expValue, scale);
-      Assert.assertEquals(d, ((DecimalColumnVector) b.cols[1]).vector[rowIdx]);
-      Assert.assertEquals(expValue, ((LongColumnVector) b.cols[2]).vector[rowIdx]);
+      assertEquals(d, ((DecimalColumnVector) b.cols[1]).vector[rowIdx]);
+      assertEquals(expValue, ((LongColumnVector) b.cols[2]).vector[rowIdx]);
       BytesColumnVector sv = (BytesColumnVector) b.cols[3];
-      Assert.assertEquals(String.valueOf(expValue),
+      assertEquals(String.valueOf(expValue),
                           sv.toString(rowIdx));
       if (expRowNum != -1) {
-        Assert.assertEquals(expRowNum + i, ((LongColumnVector) b.cols[4]).vector[rowIdx]);
+        assertEquals(expRowNum + i, ((LongColumnVector) b.cols[4]).vector[rowIdx]);
       }
     }
   }
@@ -207,16 +207,16 @@ public class TestRowFilteringIOSkip {
     long rowCount = 0;
     try (RecordReader rr = r.rows(options)) {
       while (rr.nextBatch(b)) {
-        Assert.assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
-        Assert.assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
+        assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
+        assertTrue(((LongColumnVector) b.cols[0]).vector[0] != 0);
         rowCount += b.size;
       }
     }
     FileSystem.Statistics stats = readEnd();
-    Assert.assertEquals(0, rowCount);
+    assertEquals(0, rowCount);
     // We should read less than half the length of the file
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    Assert.assertTrue(String.format("Bytes read %.2f%% should be less than 50%%",
+    assertTrue(String.format("Bytes read %.2f%% should be less than 50%%",
                                     readPercentage),
                       readPercentage < 50);
   }
@@ -231,8 +231,8 @@ public class TestRowFilteringIOSkip {
       rowCount = validateFilteredRecordReader(rr, b);
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
-    Assert.assertEquals(RowCount, rowCount);
-    Assert.assertTrue(p >= 100);
+    assertEquals(RowCount, rowCount);
+    assertTrue(p >= 100);
   }
 
   private double readPercentage(FileSystem.Statistics stats, long fileSize) {
@@ -255,8 +255,8 @@ public class TestRowFilteringIOSkip {
       rowCount = validateFilteredRecordReader(rr, b);
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
-    Assert.assertEquals(RowCount, rowCount);
-    Assert.assertTrue(p >= 100);
+    assertEquals(RowCount, rowCount);
+    assertTrue(p >= 100);
   }
 
   @Test
@@ -271,7 +271,7 @@ public class TestRowFilteringIOSkip {
       rowCount = validateFilteredRecordReader(rr, b);
     }
     readEnd();
-    Assert.assertTrue(RowCount > rowCount);
+    assertTrue(RowCount > rowCount);
   }
 
   @Test
@@ -284,14 +284,14 @@ public class TestRowFilteringIOSkip {
     long seekRow;
     try (RecordReader rr = r.rows(options)) {
       // Validate the first batch
-      Assert.assertTrue(rr.nextBatch(b));
+      assertTrue(rr.nextBatch(b));
       validateBatch(b, 0);
-      Assert.assertEquals(b.size, rr.getRowNumber());
+      assertEquals(b.size, rr.getRowNumber());
 
       // Read the next batch, will skip a batch that is filtered
-      Assert.assertTrue(rr.nextBatch(b));
+      assertTrue(rr.nextBatch(b));
       validateBatch(b, 2048);
-      Assert.assertEquals(2048 + 1024, rr.getRowNumber());
+      assertEquals(2048 + 1024, rr.getRowNumber());
 
       // Seek forward
       seekToRow(rr, b, 4096);
@@ -300,7 +300,7 @@ public class TestRowFilteringIOSkip {
       long bytesRead = readEnd().getBytesRead();
       seekToRow(rr, b, 1024);
       // No IO should have taken place
-      Assert.assertEquals(bytesRead, readEnd().getBytesRead());
+      assertEquals(bytesRead, readEnd().getBytesRead());
 
       // Seek forward to next row group, where the first batch is not filtered
       seekToRow(rr, b, 8192);
@@ -316,17 +316,17 @@ public class TestRowFilteringIOSkip {
       // stripe change
       bytesRead = readEnd().getBytesRead();
       seekToRow(rr, b, 1024);
-      Assert.assertTrue("Change of stripe should require more IO",
+      assertTrue("Change of stripe should require more IO",
                         readEnd().getBytesRead() > bytesRead);
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    Assert.assertTrue(readPercentage > 130);
+    assertTrue(readPercentage > 130);
   }
 
   private void seekToRow(RecordReader rr, VectorizedRowBatch b, long row) throws IOException {
     rr.seekToRow(row);
-    Assert.assertTrue(rr.nextBatch(b));
+    assertTrue(rr.nextBatch(b));
     long expRowNum;
     if ((row / b.getMaxSize()) % 2 == 0) {
       expRowNum = row;
@@ -335,7 +335,7 @@ public class TestRowFilteringIOSkip {
       expRowNum = row + b.getMaxSize();
     }
     validateBatch(b, expRowNum);
-    Assert.assertEquals(expRowNum + b.getMaxSize(), rr.getRowNumber());
+    assertEquals(expRowNum + b.getMaxSize(), rr.getRowNumber());
   }
 
   private static class InFilter implements Consumer<OrcFilterContext> {

--- a/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.impl.RecordReaderImpl;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,8 +32,7 @@ import org.junit.rules.TestName;
 import java.io.File;
 import java.sql.Timestamp;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Types that are not skipped at row-level include: Long, Short, Int, Date, Binary
@@ -110,10 +108,10 @@ public class TestRowFilteringNoSkip {
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertNotNull(batch.selected);
+        assertTrue(batch.selectedInUse);
+        assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
         assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
@@ -122,13 +120,13 @@ public class TestRowFilteringNoSkip {
         }
       }
       // For Int type ColumnVector filtering does not remove any data!
-      Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertEquals(col2.vector[0], 100);
-      Assert.assertEquals(col2.vector[511], 999);
-      Assert.assertEquals(col2.vector[1020],  100);
-      Assert.assertEquals(col2.vector[1021], 999);
+      assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertEquals(col2.vector[0], 100);
+      assertEquals(col2.vector[511], 999);
+      assertEquals(col2.vector[1020],  100);
+      assertEquals(col2.vector[1021], 999);
     }
   }
 
@@ -179,10 +177,10 @@ public class TestRowFilteringNoSkip {
       int noNullCount = 0;
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertNotNull(batch.selected);
+        assertTrue(batch.selectedInUse);
+        assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
         assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
@@ -193,11 +191,11 @@ public class TestRowFilteringNoSkip {
         }
       }
       // For Int type ColumnVector filtering does not remove any data!
-      Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCount);
+      assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCount);
       // check filter-selected output
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(0, batch.selected[1]);
-      Assert.assertEquals(0, batch.selected[1023]);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(0, batch.selected[1]);
+      assertEquals(0, batch.selected[1023]);
     }
   }
 
@@ -249,10 +247,10 @@ public class TestRowFilteringNoSkip {
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertNotNull(batch.selected);
+        assertTrue(batch.selectedInUse);
+        assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
         assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
@@ -261,14 +259,14 @@ public class TestRowFilteringNoSkip {
         }
       }
       // For Short type ColumnVector filtering does not remove any data!
-      Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
-      Assert.assertFalse(col2.isRepeating);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.vector[0] > 0);
-      Assert.assertTrue(col2.vector[511] < 0);
-      Assert.assertTrue(col2.vector[1020] > 0);
-      Assert.assertTrue(col2.vector[1021] < 0);
+      assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
+      assertFalse(col2.isRepeating);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.vector[0] > 0);
+      assertTrue(col2.vector[511] < 0);
+      assertTrue(col2.vector[1020] > 0);
+      assertTrue(col2.vector[1021] < 0);
     }
   }
 
@@ -319,10 +317,10 @@ public class TestRowFilteringNoSkip {
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertNotNull(batch.selected);
+        assertTrue(batch.selectedInUse);
+        assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
         assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
@@ -331,14 +329,14 @@ public class TestRowFilteringNoSkip {
         }
       }
       // For Date type ColumnVector filtering does not remove any data!
-      Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
-      Assert.assertFalse(col2.isRepeating);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.vector[0] != 0);
-      Assert.assertTrue(col2.vector[511] != 0);
-      Assert.assertTrue(col2.vector[1020] != 0);
-      Assert.assertTrue(col2.vector[1021] != 0);
+      assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
+      assertFalse(col2.isRepeating);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.vector[0] != 0);
+      assertTrue(col2.vector[511] != 0);
+      assertTrue(col2.vector[1020] != 0);
+      assertTrue(col2.vector[1021] != 0);
     }
   }
 
@@ -391,10 +389,10 @@ public class TestRowFilteringNoSkip {
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
         // We applied the given filter so selected is true
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertNotNull(batch.selected);
+        assertTrue(batch.selectedInUse);
+        assertNotNull(batch.selected);
         // Selected Arrays is propagated -- so size is never 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         // But since this Column type is not actually filtered there will be no nulls!
         assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
@@ -403,13 +401,13 @@ public class TestRowFilteringNoSkip {
         }
       }
       // For Binary type ColumnVector filtering does not remove any data!
-      Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertNotEquals(TestVectorOrcFile.getBinary(col2, 0), TestVectorOrcFile.bytes());
-      Assert.assertNotEquals(TestVectorOrcFile.getBinary(col2, 511), TestVectorOrcFile.bytes());
-      Assert.assertNotEquals(TestVectorOrcFile.getBinary(col2, 1020), TestVectorOrcFile.bytes());
-      Assert.assertNotEquals(TestVectorOrcFile.getBinary(col2, 1021), TestVectorOrcFile.bytes());
+      assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertNotEquals(TestVectorOrcFile.getBinary(col2, 0), TestVectorOrcFile.bytes());
+      assertNotEquals(TestVectorOrcFile.getBinary(col2, 511), TestVectorOrcFile.bytes());
+      assertNotEquals(TestVectorOrcFile.getBinary(col2, 1020), TestVectorOrcFile.bytes());
+      assertNotEquals(TestVectorOrcFile.getBinary(col2, 1021), TestVectorOrcFile.bytes());
     }
   }
 }

--- a/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.OrcFilterContextImpl;
 import org.apache.orc.impl.RecordReaderImpl;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,10 +44,7 @@ import java.sql.Timestamp;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Types that are skipped at row-level include: Decimal, Decimal64, Double, Float, Char, VarChar, String, Boolean, Timestamp
@@ -180,10 +176,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r].compareTo(passDataVal) == 0)
@@ -191,13 +187,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertEquals(col2.vector[0], passDataVal);
-      Assert.assertEquals(col2.vector[511], nullDataVal);
-      Assert.assertEquals(col2.vector[1020],  passDataVal);
-      Assert.assertEquals(col2.vector[1021], nullDataVal);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertEquals(col2.vector[0], passDataVal);
+      assertEquals(col2.vector[511], nullDataVal);
+      assertEquals(col2.vector[1020],  passDataVal);
+      assertEquals(col2.vector[1021], nullDataVal);
     }
   }
 
@@ -251,10 +247,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r].getHiveDecimal().longValue() > 0)
@@ -262,13 +258,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertEquals(col2.vector[0].getHiveDecimal().longValue(), 1);
-      Assert.assertEquals(col2.vector[511], nullDataVal);
-      Assert.assertEquals(col2.vector[1020].getHiveDecimal().longValue(),  1021);
-      Assert.assertEquals(col2.vector[1021], nullDataVal);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertEquals(col2.vector[0].getHiveDecimal().longValue(), 1);
+      assertEquals(col2.vector[511], nullDataVal);
+      assertEquals(col2.vector[1020].getHiveDecimal().longValue(),  1021);
+      assertEquals(col2.vector[1021], nullDataVal);
     }
   }
 
@@ -320,10 +316,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r].getHiveDecimal().longValue() > 0)
@@ -331,13 +327,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertEquals(col2.vector[0].getHiveDecimal().longValue(), 1);
-      Assert.assertEquals(col2.vector[511], nullDataVal);
-      Assert.assertEquals(col2.vector[1020].getHiveDecimal().longValue(),  1021);
-      Assert.assertEquals(col2.vector[1021], nullDataVal);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertEquals(col2.vector[0].getHiveDecimal().longValue(), 1);
+      assertEquals(col2.vector[511], nullDataVal);
+      assertEquals(col2.vector[1020].getHiveDecimal().longValue(),  1021);
+      assertEquals(col2.vector[1021], nullDataVal);
     }
   }
 
@@ -400,10 +396,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r].compareTo(passDataVal) == 0 && col3.vector[r].compareTo(passDataVal) == 0)
@@ -411,20 +407,20 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 2, noNullCnt);
-      Assert.assertEquals(924, batch.selected[0]);
-      Assert.assertEquals(940, batch.selected[1]);
-      Assert.assertEquals(0, batch.selected[2]);
-      Assert.assertEquals(col2.vector[0],  nullDataVal);
-      Assert.assertEquals(col3.vector[0],  nullDataVal);
-      Assert.assertEquals(col2.vector[511], nullDataVal);
-      Assert.assertEquals(col3.vector[511], nullDataVal);
-      Assert.assertEquals(col2.vector[924], passDataVal);
-      Assert.assertEquals(col3.vector[940], passDataVal);
-      Assert.assertEquals(col2.vector[1020], nullDataVal);
-      Assert.assertEquals(col3.vector[1020], nullDataVal);
-      Assert.assertEquals(col2.vector[1021], nullDataVal);
-      Assert.assertEquals(col3.vector[1021], nullDataVal);
+      assertEquals(NUM_BATCHES * 2, noNullCnt);
+      assertEquals(924, batch.selected[0]);
+      assertEquals(940, batch.selected[1]);
+      assertEquals(0, batch.selected[2]);
+      assertEquals(col2.vector[0],  nullDataVal);
+      assertEquals(col3.vector[0],  nullDataVal);
+      assertEquals(col2.vector[511], nullDataVal);
+      assertEquals(col3.vector[511], nullDataVal);
+      assertEquals(col2.vector[924], passDataVal);
+      assertEquals(col3.vector[940], passDataVal);
+      assertEquals(col2.vector[1020], nullDataVal);
+      assertEquals(col3.vector[1020], nullDataVal);
+      assertEquals(col2.vector[1021], nullDataVal);
+      assertEquals(col3.vector[1021], nullDataVal);
     }
   }
 
@@ -475,10 +471,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] != 0)
@@ -486,13 +482,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertEquals(col2.vector[0], 1);
-      Assert.assertEquals(col2.vector[511], 0);
-      Assert.assertEquals(col2.vector[1020],  1021);
-      Assert.assertEquals(col2.vector[1021], 0);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertEquals(col2.vector[0], 1);
+      assertEquals(col2.vector[511], 0);
+      assertEquals(col2.vector[1020],  1021);
+      assertEquals(col2.vector[1021], 0);
     }
   }
 
@@ -541,10 +537,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] == 0)
@@ -552,13 +548,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertEquals(col2.vector[0], 1);
-      Assert.assertEquals(col2.vector[511], 0);
-      Assert.assertEquals(col2.vector[1020],  1021);
-      Assert.assertEquals(col2.vector[1021], 0);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertEquals(col2.vector[0], 1);
+      assertEquals(col2.vector[511], 0);
+      assertEquals(col2.vector[1020],  1021);
+      assertEquals(col2.vector[1021], 0);
     }
   }
 
@@ -609,10 +605,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] == 100)
@@ -620,13 +616,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.vector[0] == 100.0);
-      Assert.assertTrue(col2.vector[511] == 0.0);
-      Assert.assertTrue(col2.vector[1020] == 100);
-      Assert.assertTrue(col2.vector[1021] == 0);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.vector[0] == 100.0);
+      assertTrue(col2.vector[511] == 0.0);
+      assertTrue(col2.vector[1020] == 100);
+      assertTrue(col2.vector[1021] == 0);
     }
   }
 
@@ -677,10 +673,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] != 0)
@@ -688,13 +684,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.vector[0] != 999.0);
-      Assert.assertTrue(col2.vector[511] == 0.0);
-      Assert.assertTrue(col2.vector[1020] == 1120.0);
-      Assert.assertTrue(col2.vector[1021] == 0);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.vector[0] != 999.0);
+      assertTrue(col2.vector[511] == 0.0);
+      assertTrue(col2.vector[1020] == 1120.0);
+      assertTrue(col2.vector[1021] == 0);
     }
   }
 
@@ -748,10 +744,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (!col2.toString(r).isEmpty())
@@ -759,13 +755,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.toString(0).equals("p"));
-      Assert.assertTrue(col2.toString(511).isEmpty());
-      Assert.assertTrue(col2.toString(1020).equals("p"));
-      Assert.assertTrue(col2.toString(1021).isEmpty());
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.toString(0).equals("p"));
+      assertTrue(col2.toString(511).isEmpty());
+      assertTrue(col2.toString(1020).equals("p"));
+      assertTrue(col2.toString(1021).isEmpty());
     }
   }
 
@@ -819,10 +815,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (!col2.toString(r).isEmpty())
@@ -830,13 +826,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.toString(0).equals("p"));
-      Assert.assertTrue(col2.toString(511).isEmpty());
-      Assert.assertTrue(col2.toString(1020).equals("p"));
-      Assert.assertTrue(col2.toString(1021).isEmpty());
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.toString(0).equals("p"));
+      assertTrue(col2.toString(511).isEmpty());
+      assertTrue(col2.toString(1020).equals("p"));
+      assertTrue(col2.toString(1021).isEmpty());
     }
   }
 
@@ -888,10 +884,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (!col2.toString(r).isEmpty())
@@ -899,12 +895,12 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.toString(0).startsWith("pass"));
-      Assert.assertTrue(col2.toString(511).isEmpty());
-      Assert.assertTrue(col2.toString(1020).startsWith("pass"));
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.toString(0).startsWith("pass"));
+      assertTrue(col2.toString(511).isEmpty());
+      assertTrue(col2.toString(1020).startsWith("pass"));
     }
   }
 
@@ -955,10 +951,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (!col2.toString(r).isEmpty())
@@ -966,12 +962,12 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.toString(0).startsWith("pass"));
-      Assert.assertTrue(col2.toString(511).isEmpty());
-      Assert.assertTrue(col2.toString(1020).startsWith("pass"));
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.toString(0).startsWith("pass"));
+      assertTrue(col2.toString(511).isEmpty());
+      assertTrue(col2.toString(1020).startsWith("pass"));
     }
   }
 
@@ -1019,10 +1015,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] == 0)
@@ -1030,14 +1026,14 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
-      Assert.assertEquals(false, col2.isRepeating);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.vector[0] == 0);
-      Assert.assertTrue(col2.vector[511] == 0);
-      Assert.assertTrue(col2.vector[1020] == 0);
-      Assert.assertTrue(col2.vector[1021] == 0);
+      assertEquals(NUM_BATCHES * ColumnBatchRows, noNullCnt);
+      assertEquals(false, col2.isRepeating);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.vector[0] == 0);
+      assertTrue(col2.vector[511] == 0);
+      assertTrue(col2.vector[1020] == 0);
+      assertTrue(col2.vector[1021] == 0);
     }
   }
 
@@ -1085,10 +1081,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] == 0)
@@ -1096,13 +1092,13 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(col2.vector[0] == 1);
-      Assert.assertTrue(col2.vector[511] == 0);
-      Assert.assertTrue(col2.vector[1020] == 1);
-      Assert.assertTrue(col2.vector[1021] == 0);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(col2.vector[0] == 1);
+      assertTrue(col2.vector[511] == 0);
+      assertTrue(col2.vector[1020] == 1);
+      assertTrue(col2.vector[1021] == 0);
     }
   }
 
@@ -1150,10 +1146,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.vector[r] == 1)
@@ -1161,14 +1157,14 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 2, noNullCnt);
-      Assert.assertEquals(924, batch.selected[0]);
-      Assert.assertEquals(940, batch.selected[1]);
-      Assert.assertTrue(col2.vector[0] == 0);
-      Assert.assertTrue(col2.vector[511] == 0);
-      Assert.assertTrue(col2.vector[1020] == 0);
-      Assert.assertTrue(col2.vector[924] == 1);
-      Assert.assertTrue(col2.vector[940] == 1);
+      assertEquals(NUM_BATCHES * 2, noNullCnt);
+      assertEquals(924, batch.selected[0]);
+      assertEquals(940, batch.selected[1]);
+      assertTrue(col2.vector[0] == 0);
+      assertTrue(col2.vector[511] == 0);
+      assertTrue(col2.vector[1020] == 0);
+      assertTrue(col2.vector[924] == 1);
+      assertTrue(col2.vector[940] == 1);
     }
   }
 
@@ -1222,10 +1218,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertTrue(batch.selected != null);
+        assertTrue(batch.selectedInUse);
+        assertTrue(batch.selected != null);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertEquals( true, col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col2.getTime(r) == 0)
@@ -1233,14 +1229,14 @@ public class TestRowFilteringSkip {
         }
       }
       // Make sure that our filter worked
-      Assert.assertEquals(NUM_BATCHES * 512, noNullCnt);
-      Assert.assertEquals(false, col2.isRepeating);
-      Assert.assertEquals(0, batch.selected[0]);
-      Assert.assertEquals(2, batch.selected[1]);
-      Assert.assertTrue(convertTime(col2.getTime(0)).compareTo("1900-04-1 12:34:56.900") == 0);
-      Assert.assertTrue(col2.getTime(511) == 0);
-      Assert.assertTrue(convertTime(col2.getTime(1020)).compareTo("2920-04-1 12:34:56.900") == 0);
-      Assert.assertTrue(col2.getTime(1021) == 0);
+      assertEquals(NUM_BATCHES * 512, noNullCnt);
+      assertEquals(false, col2.isRepeating);
+      assertEquals(0, batch.selected[0]);
+      assertEquals(2, batch.selected[1]);
+      assertTrue(convertTime(col2.getTime(0)).compareTo("1900-04-1 12:34:56.900") == 0);
+      assertTrue(col2.getTime(511) == 0);
+      assertTrue(convertTime(col2.getTime(1020)).compareTo("2920-04-1 12:34:56.900") == 0);
+      assertTrue(col2.getTime(1021) == 0);
     }
   }
 
@@ -1560,10 +1556,10 @@ public class TestRowFilteringSkip {
 
       int noNullCnt = 0;
       while (rows.nextBatch(batch)) {
-        Assert.assertTrue(batch.selectedInUse);
-        Assert.assertNotNull(batch.selected);
+        assertTrue(batch.selectedInUse);
+        assertNotNull(batch.selected);
         // Rows are filtered so it should never be 1024
-        Assert.assertTrue(batch.size != ColumnBatchRows);
+        assertTrue(batch.size != ColumnBatchRows);
         assertTrue(col1.noNulls);
         for (int r = 0; r < ColumnBatchRows; ++r) {
           if (col1.vector[r] != 100) noNullCnt ++;
@@ -1573,24 +1569,24 @@ public class TestRowFilteringSkip {
         if (batch.size == 0) {
           continue;
         }
-        Assert.assertEquals(1, batch.size);
+        assertEquals(1, batch.size);
         long val = col1.vector[batch.selected[0]] ;
         // Check that we have read the valid value
-        Assert.assertTrue((val == 2) || (val == 5) || (val == 13) || (val == 29) || (val == 70));
+        assertTrue((val == 2) || (val == 5) || (val == 13) || (val == 29) || (val == 70));
         if (val == 2) {
-          Assert.assertEquals(0, col5.getTime(batch.selected[0]));
+          assertEquals(0, col5.getTime(batch.selected[0]));
         } else {
-          Assert.assertNotEquals(0, col5.getTime(batch.selected[0]));
+          assertNotEquals(0, col5.getTime(batch.selected[0]));
         }
 
         // Check that unselected is not populated
-        Assert.assertEquals(0, batch.selected[1]);
+        assertEquals(0, batch.selected[1]);
       }
 
       // Total rows of the file should be 25k
-      Assert.assertEquals(25000, rowCount);
+      assertEquals(25000, rowCount);
       // Make sure that our filter worked ( 5 rows with userId != 100)
-      Assert.assertEquals(5, noNullCnt);
+      assertEquals(5, noNullCnt);
     }
   }
 }

--- a/java/core/src/test/org/apache/orc/TestStringDictionary.java
+++ b/java/core/src/test/org/apache/orc/TestStringDictionary.java
@@ -46,7 +46,6 @@ import org.apache.orc.impl.writer.StringTreeWriter;
 import org.apache.orc.impl.writer.TreeWriter;
 import org.apache.orc.impl.writer.WriterContext;
 import org.apache.orc.impl.writer.WriterEncryptionVariant;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/java/core/src/test/org/apache/orc/TestStringDictionary.java
+++ b/java/core/src/test/org/apache/orc/TestStringDictionary.java
@@ -517,18 +517,18 @@ public class TestStringDictionary {
       // within the same package as ORC reader
       OrcProto.StripeFooter footer = ((RecordReaderImpl) recordReader).readStripeFooter(stripe);
       for (int i = 0; i < footer.getColumnsCount(); ++i) {
-        Assert.assertEquals(
+        assertEquals(
             "Expected 3 columns in the footer: One for the Orc Struct, and two for its members.",
             3, footer.getColumnsCount());
-        Assert.assertEquals(
+        assertEquals(
             "The ORC schema struct should be DIRECT encoded.",
             OrcProto.ColumnEncoding.Kind.DIRECT, footer.getColumns(0).getKind()
         );
-        Assert.assertEquals(
+        assertEquals(
             "The shortString column must be DICTIONARY_V2 encoded",
             OrcProto.ColumnEncoding.Kind.DICTIONARY_V2, footer.getColumns(1).getKind()
         );
-        Assert.assertEquals(
+        assertEquals(
             "The longString column must be DIRECT_V2 encoded",
             OrcProto.ColumnEncoding.Kind.DIRECT_V2, footer.getColumns(2).getKind()
         );

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -32,7 +32,6 @@ import com.google.common.collect.Lists;
 import org.apache.orc.impl.ReaderImpl;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
-import org.junit.Assert;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -238,7 +237,7 @@ public class TestVectorOrcFile {
             + stripe.getFooterLength();
       }
     }
-    Assert.assertEquals(reader.getNumberOfRows(), rowCount);
+    assertEquals(reader.getNumberOfRows(), rowCount);
     assertEquals(2, stripeCount);
 
     // check the stats
@@ -285,7 +284,7 @@ public class TestVectorOrcFile {
     VectorizedRowBatch batch = schema.createRowBatch();
 
     RecordReader rows = reader.rows();
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
 
     // check the contents of the first row
@@ -338,7 +337,7 @@ public class TestVectorOrcFile {
 
     // check the contents of row 7499
     rows.seekToRow(7499);
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(true, getBoolean(batch, 0));
     assertEquals(100, getByte(batch, 0));
     assertEquals(2048, getShort(batch, 0));
@@ -377,7 +376,7 @@ public class TestVectorOrcFile {
         decs.vector[0]);
 
     // handle the close up
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
     rows.close();
   }
 
@@ -481,7 +480,7 @@ public class TestVectorOrcFile {
             timestamps.asScratchTimestamp(r).getNanos());
       }
     }
-    Assert.assertEquals(tslist.size(), rows.getRowNumber());
+    assertEquals(tslist.size(), rows.getRowNumber());
     assertEquals(0, writer.getSchema().getMaximumId());
     boolean[] expected = new boolean[] {false};
     boolean[] included = OrcUtils.includeColumns("", writer.getSchema());
@@ -558,7 +557,7 @@ public class TestVectorOrcFile {
     BytesColumnVector bytes = (BytesColumnVector) batch.cols[0];
     BytesColumnVector strs = (BytesColumnVector) batch.cols[1];
     RecordReader rows = reader.rows();
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(4, batch.size);
 
     // check the contents of the first row
@@ -578,7 +577,7 @@ public class TestVectorOrcFile {
     assertEquals("hi", strs.toString(3));
 
     // handle the close up
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
     rows.close();
   }
 
@@ -605,12 +604,12 @@ public class TestVectorOrcFile {
       OrcFile.readerOptions(conf).filesystem(fs));
     // check the stats
     ColumnStatistics[] stats = reader.getStatistics();
-    Assert.assertEquals(4, stats[0].getNumberOfValues());
-    Assert.assertEquals(0, stats[1].getNumberOfValues());
-    Assert.assertEquals(true, stats[1].hasNull());
-    Assert.assertNull(((DecimalColumnStatistics)stats[1]).getMinimum());
-    Assert.assertNull(((DecimalColumnStatistics)stats[1]).getMaximum());
-    Assert.assertEquals(new HiveDecimalWritable(0).getHiveDecimal(), ((DecimalColumnStatistics)stats[1]).getSum());
+    assertEquals(4, stats[0].getNumberOfValues());
+    assertEquals(0, stats[1].getNumberOfValues());
+    assertEquals(true, stats[1].hasNull());
+    assertNull(((DecimalColumnStatistics)stats[1]).getMinimum());
+    assertNull(((DecimalColumnStatistics)stats[1]).getMaximum());
+    assertEquals(new HiveDecimalWritable(0).getHiveDecimal(), ((DecimalColumnStatistics)stats[1]).getSum());
   }
 
   @Test
@@ -1299,9 +1298,9 @@ public class TestVectorOrcFile {
     RecordReader rows = reader.rows();
     // create a new batch
     batch = readerSchema.createRowBatch();
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(2, batch.size);
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
 
     // check the contents of the first row
     assertEquals(false, getBoolean(batch, 0));
@@ -1364,7 +1363,7 @@ public class TestVectorOrcFile {
     assertEquals("mauddib", value.string1.toString());
 
     // handle the close up
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
     rows.close();
   }
 
@@ -1455,8 +1454,8 @@ public class TestVectorOrcFile {
     VectorizedRowBatch batch1 = reader.getSchema().createRowBatch(1000);
     VectorizedRowBatch batch2 = reader.getSchema().createRowBatch(1000);
     for(int i = 0; i < 21000; i += 1000) {
-      Assert.assertEquals(true, rows1.nextBatch(batch1));
-      Assert.assertEquals(true, rows2.nextBatch(batch2));
+      assertEquals(true, rows1.nextBatch(batch1));
+      assertEquals(true, rows2.nextBatch(batch2));
       assertEquals(1000, batch1.size);
       assertEquals(1000, batch2.size);
       for(int j=0; j < 1000; ++j) {
@@ -1466,8 +1465,8 @@ public class TestVectorOrcFile {
             ((BytesColumnVector) batch2.cols[1]).toString(j));
       }
     }
-    Assert.assertEquals(false, rows1.nextBatch(batch1));
-    Assert.assertEquals(false, rows2.nextBatch(batch2));
+    assertEquals(false, rows1.nextBatch(batch1));
+    assertEquals(false, rows2.nextBatch(batch2));
     rows1.close();
     rows2.close();
   }
@@ -1486,13 +1485,13 @@ public class TestVectorOrcFile {
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
     VectorizedRowBatch batch = reader.getSchema().createRowBatch();
-    Assert.assertEquals(false, reader.rows().nextBatch(batch));
-    Assert.assertEquals(CompressionKind.NONE, reader.getCompressionKind());
-    Assert.assertEquals(0, reader.getNumberOfRows());
-    Assert.assertEquals(0, reader.getCompressionSize());
-    Assert.assertEquals(false, reader.getMetadataKeys().iterator().hasNext());
-    Assert.assertEquals(3, reader.getContentLength());
-    Assert.assertEquals(false, reader.getStripes().iterator().hasNext());
+    assertEquals(false, reader.rows().nextBatch(batch));
+    assertEquals(CompressionKind.NONE, reader.getCompressionKind());
+    assertEquals(0, reader.getNumberOfRows());
+    assertEquals(0, reader.getCompressionSize());
+    assertEquals(false, reader.getMetadataKeys().iterator().hasNext());
+    assertEquals(3, reader.getContentLength());
+    assertEquals(false, reader.getStripes().iterator().hasNext());
   }
 
   @Test
@@ -1525,10 +1524,10 @@ public class TestVectorOrcFile {
 
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(byteBuf(5, 7, 11, 13, 17, 19), reader.getMetadataValue("clobber"));
-    Assert.assertEquals(byteBuf(1, 2, 3, 4, 5, 6, 7, -1, -2, 127, -128),
+    assertEquals(byteBuf(5, 7, 11, 13, 17, 19), reader.getMetadataValue("clobber"));
+    assertEquals(byteBuf(1, 2, 3, 4, 5, 6, 7, -1, -2, 127, -128),
         reader.getMetadataValue("my.meta"));
-    Assert.assertEquals(bigBuf, reader.getMetadataValue("big"));
+    assertEquals(bigBuf, reader.getMetadataValue("big"));
     try {
       reader.getMetadataValue("unknown");
       assertTrue(false);
@@ -1968,8 +1967,8 @@ public class TestVectorOrcFile {
     included = OrcUtils.includeColumns("union", schema);
     assertEquals(true, Arrays.equals(expected, included));
 
-    Assert.assertEquals(false, reader.getMetadataKeys().iterator().hasNext());
-    Assert.assertEquals(5077, reader.getNumberOfRows());
+    assertEquals(false, reader.getMetadataKeys().iterator().hasNext());
+    assertEquals(5077, reader.getNumberOfRows());
     DecimalColumnStatistics decStats =
         (DecimalColumnStatistics) reader.getStatistics()[5];
     assertEquals(71, decStats.getNumberOfValues());
@@ -1990,19 +1989,19 @@ public class TestVectorOrcFile {
         currentOffset += stripe.getLength();
       }
     }
-    Assert.assertEquals(reader.getNumberOfRows(), rowCount);
+    assertEquals(reader.getNumberOfRows(), rowCount);
     assertEquals(2, stripeCount);
-    Assert.assertEquals(reader.getContentLength(), currentOffset);
+    assertEquals(reader.getContentLength(), currentOffset);
     RecordReader rows = reader.rows();
-    Assert.assertEquals(0, rows.getRowNumber());
-    Assert.assertEquals(0.0, rows.getProgress(), 0.000001);
+    assertEquals(0, rows.getRowNumber());
+    assertEquals(0.0, rows.getProgress(), 0.000001);
 
     schema = reader.getSchema();
     batch = schema.createRowBatch(74);
-    Assert.assertEquals(0, rows.getRowNumber());
+    assertEquals(0, rows.getRowNumber());
     rows.nextBatch(batch);
     assertEquals(74, batch.size);
-    Assert.assertEquals(74, rows.getRowNumber());
+    assertEquals(74, rows.getRowNumber());
     TimestampColumnVector ts = (TimestampColumnVector) batch.cols[0];
     UnionColumnVector union = (UnionColumnVector) batch.cols[1];
     LongColumnVector longs = (LongColumnVector) union.fields[0];
@@ -2101,8 +2100,8 @@ public class TestVectorOrcFile {
 
     rows.nextBatch(batch);
     assertEquals(0, batch.size);
-    Assert.assertEquals(1.0, rows.getProgress(), 0.00001);
-    Assert.assertEquals(reader.getNumberOfRows(), rows.getRowNumber());
+    assertEquals(1.0, rows.getProgress(), 0.00001);
+    assertEquals(reader.getNumberOfRows(), rows.getRowNumber());
     rows.seekToRow(1);
     rows.nextBatch(batch);
     assertEquals(1000, batch.size);
@@ -2134,7 +2133,7 @@ public class TestVectorOrcFile {
     writer.close();
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
+    assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
     RecordReader rows = reader.rows();
     batch = reader.getSchema().createRowBatch(1000);
     rand = new Random(12);
@@ -2317,13 +2316,13 @@ public class TestVectorOrcFile {
     snappyCodec = writeBatchesAndGetCodec(10, 1000, opts.compress(CompressionKind.SNAPPY), batch);
     assertEquals(1, OrcCodecPool.getPoolSize(CompressionKind.SNAPPY));
     Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
+    assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
     CompressionCodec codec = readBatchesAndGetCodec(reader, 10, 1000);
     assertEquals(1, OrcCodecPool.getPoolSize(CompressionKind.SNAPPY));
     assertSame(snappyCodec, codec);
 
     reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
+    assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
     codec = readBatchesAndGetCodec(reader, 10, 1000);
     assertSame(snappyCodec, codec);
     assertEquals(1, OrcCodecPool.getPoolSize(CompressionKind.SNAPPY));
@@ -2341,7 +2340,7 @@ public class TestVectorOrcFile {
     assertNotSame(snappyCodec, snappyCodec2);
     OrcCodecPool.returnCodec(CompressionKind.SNAPPY, snappyCodec);
     reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
+    assertEquals(CompressionKind.SNAPPY, reader.getCompressionKind());
     codec = readBatchesAndGetCodec(reader, 10, 1000);
     assertEquals(2, OrcCodecPool.getPoolSize(CompressionKind.SNAPPY));
     assertTrue(snappyCodec == codec || snappyCodec2 == codec);
@@ -2421,8 +2420,8 @@ public class TestVectorOrcFile {
     writer.close();
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(50000, reader.getNumberOfRows());
-    Assert.assertEquals(0, reader.getRowIndexStride());
+    assertEquals(50000, reader.getNumberOfRows());
+    assertEquals(0, reader.getRowIndexStride());
     StripeInformation stripe = reader.getStripes().iterator().next();
     assertEquals(true, stripe.getDataLength() != 0);
     assertEquals(0, stripe.getIndexLength());
@@ -2495,7 +2494,7 @@ public class TestVectorOrcFile {
     writer.close();
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
-    Assert.assertEquals(COUNT, reader.getNumberOfRows());
+    assertEquals(COUNT, reader.getNumberOfRows());
     RecordReader rows = reader.rows();
     // get the row index
     InStream.StreamOptions options = InStream.options();
@@ -2530,7 +2529,7 @@ public class TestVectorOrcFile {
       if (nextRowInBatch < 0) {
         long base = Math.max(i - 1023, 0);
         rows.seekToRow(base);
-        Assert.assertEquals("row " + i, true, rows.nextBatch(batch));
+        assertEquals("row " + i, true, rows.nextBatch(batch));
         nextRowInBatch = batch.size - 1;
       }
       checkRandomRow(batch, intValues, doubleValues,
@@ -2562,12 +2561,12 @@ public class TestVectorOrcFile {
     rows.seekToRow(lastRowOfStripe2);
     // we only want two rows
     batch = reader.getSchema().createRowBatch(2);
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1, batch.size);
     assertEquals(intValues[(int) lastRowOfStripe2], getLong(batch, 0));
     assertEquals(stringValues[(int) lastRowOfStripe2],
         getText(batch, 0).toString());
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(intValues[(int) lastRowOfStripe2 + 1], getLong(batch, 0));
     assertEquals(stringValues[(int) lastRowOfStripe2 + 1],
         getText(batch, 0).toString());
@@ -2690,16 +2689,16 @@ public class TestVectorOrcFile {
     LongColumnVector ints = (LongColumnVector) batch.cols[0];
     BytesColumnVector strs = (BytesColumnVector) batch.cols[1];
 
-    Assert.assertEquals(1000L, rows.getRowNumber());
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(1000L, rows.getRowNumber());
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1000, batch.size);
 
     for(int i=1000; i < 2000; ++i) {
       assertEquals(300 * i, ints.vector[i - 1000]);
       assertEquals(Integer.toHexString(10*i), strs.toString(i - 1000));
     }
-    Assert.assertEquals(false, rows.nextBatch(batch));
-    Assert.assertEquals(3500, rows.getRowNumber());
+    assertEquals(false, rows.nextBatch(batch));
+    assertEquals(3500, rows.getRowNumber());
 
     // look through the file with no rows selected
     sarg = SearchArgumentFactory.newBuilder()
@@ -2711,7 +2710,7 @@ public class TestVectorOrcFile {
         .range(0L, Long.MAX_VALUE)
         .include(new boolean[]{true, true, true})
         .searchArgument(sarg, new String[]{null, "int1", "string1"}));
-    Assert.assertEquals(3500L, rows.getRowNumber());
+    assertEquals(3500L, rows.getRowNumber());
     assertTrue(!rows.nextBatch(batch));
 
     // select first 100 and last 100 rows
@@ -2727,24 +2726,24 @@ public class TestVectorOrcFile {
         .range(0L, Long.MAX_VALUE)
         .include(new boolean[]{true, true, true})
         .searchArgument(sarg, new String[]{null, "int1", "string1"}));
-    Assert.assertEquals(0, rows.getRowNumber());
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(0, rows.getRowNumber());
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1000, batch.size);
-    Assert.assertEquals(3000, rows.getRowNumber());
+    assertEquals(3000, rows.getRowNumber());
     for(int i=0; i < 1000; ++i) {
       assertEquals(300 * i, ints.vector[i]);
       assertEquals(Integer.toHexString(10*i), strs.toString(i));
     }
 
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(500, batch.size);
-    Assert.assertEquals(3500, rows.getRowNumber());
+    assertEquals(3500, rows.getRowNumber());
     for(int i=3000; i < 3500; ++i) {
       assertEquals(300 * i, ints.vector[i - 3000]);
       assertEquals(Integer.toHexString(10*i), strs.toString(i - 3000));
     }
-    Assert.assertEquals(false, rows.nextBatch(batch));
-    Assert.assertEquals(3500, rows.getRowNumber());
+    assertEquals(false, rows.nextBatch(batch));
+    assertEquals(3500, rows.getRowNumber());
   }
 
   @Test
@@ -2786,8 +2785,8 @@ public class TestVectorOrcFile {
         .searchArgument(sarg, new String[]{null, "`int1`", "string1"}));
     batch = reader.getSchema().createRowBatch(2000);
 
-    Assert.assertEquals(1000L, rows.getRowNumber());
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(1000L, rows.getRowNumber());
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1000, batch.size);
 
     // Validate the same behaviour with schemaFromString
@@ -2832,8 +2831,8 @@ public class TestVectorOrcFile {
         .searchArgument(sarg, new String[]{null, "`int1`", "string1"}));
     batch = readerSchemaFromStr.getSchema().createRowBatch(2000);
 
-    Assert.assertEquals(1000L, rows.getRowNumber());
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(1000L, rows.getRowNumber());
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1000, batch.size);
 
     assertEquals(reader.getSchema(), readerSchemaFromStr.getSchema());
@@ -3050,7 +3049,7 @@ public class TestVectorOrcFile {
     BytesColumnVector mapKeys = (BytesColumnVector) maps.keys;
     BytesColumnVector mapValues = (BytesColumnVector) maps.values;
 
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
 
     // read the 1024 nulls
@@ -3064,7 +3063,7 @@ public class TestVectorOrcFile {
     }
 
     // read the 1024 repeat values
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
     for(int r=0; r < 1024; ++r) {
       assertEquals("row " + r, "Horton", bins.toString(r));
@@ -3097,7 +3096,7 @@ public class TestVectorOrcFile {
     }
 
     // read the second set of 1024 nulls
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
     for(int f=0; f < batch.cols.length; ++f) {
       assertEquals("field " + f,
@@ -3108,7 +3107,7 @@ public class TestVectorOrcFile {
           true, batch.cols[f].isNull[0]);
     }
 
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
     for(int r=0; r < 1024; ++r) {
       String hex = Integer.toHexString(r);
@@ -3145,7 +3144,7 @@ public class TestVectorOrcFile {
     }
 
     // should have no more rows
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
   }
 
   private static String makeString(BytesColumnVector vector, int row) {
@@ -3187,7 +3186,7 @@ public class TestVectorOrcFile {
         OrcFile.readerOptions(conf));
     RecordReader rows = reader.rows();
     batch = reader.getSchema().createRowBatch();
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(4, batch.size);
     // ORC currently trims the output strings. See HIVE-12286
     assertEquals("",
@@ -3239,19 +3238,19 @@ public class TestVectorOrcFile {
         OrcFile.readerOptions(conf));
     RecordReader rows = reader.rows();
     batch = reader.getSchema().createRowBatch();
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
     for(int r=0; r < 1024; ++r) {
       assertEquals(Integer.toString(r * 10001),
           makeString((BytesColumnVector) batch.cols[0], r));
     }
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
     for(int r=0; r < 1024; ++r) {
       assertEquals("Halloween",
           makeString((BytesColumnVector) batch.cols[0], r));
     }
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
   }
 
   @Test
@@ -3337,7 +3336,7 @@ public class TestVectorOrcFile {
     UnionColumnVector union = (UnionColumnVector) batch.cols[0];
     LongColumnVector ints = (LongColumnVector) union.fields[0];
     LongColumnVector longs = (LongColumnVector) union.fields[1];
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1024, batch.size);
     for(int r=0; r < 1024; ++r) {
       if (r < 200) {
@@ -3364,7 +3363,7 @@ public class TestVectorOrcFile {
         assertEquals("row " + r, -r, longs.vector[r]);
       }
     }
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
   }
 
   /**
@@ -3437,7 +3436,7 @@ public class TestVectorOrcFile {
         assertEquals("row " + r, "null", actual.toString());
       }
     }
-    Assert.assertEquals(false, rows.nextBatch(batch));
+    assertEquals(false, rows.nextBatch(batch));
   }
 
   /**
@@ -4197,8 +4196,8 @@ public class TestVectorOrcFile {
     LongColumnVector ints2 = (LongColumnVector) struct1.fields[0];
     BytesColumnVector strs = (BytesColumnVector) struct1.fields[1];
 
-    Assert.assertEquals(1000L, rows.getRowNumber());
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(1000L, rows.getRowNumber());
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1000, batch.size);
 
     for(int i=1000; i < 2000; ++i) {
@@ -4206,8 +4205,8 @@ public class TestVectorOrcFile {
       assertEquals(300 * i, ints2.vector[i - 1000]);
       assertEquals(Integer.toHexString(10*i), strs.toString(i - 1000));
     }
-    Assert.assertEquals(false, rows.nextBatch(batch));
-    Assert.assertEquals(3500, rows.getRowNumber());
+    assertEquals(false, rows.nextBatch(batch));
+    assertEquals(3500, rows.getRowNumber());
 
 
     // look through the file with no rows selected
@@ -4220,7 +4219,7 @@ public class TestVectorOrcFile {
             .range(0L, Long.MAX_VALUE)
             .include(new boolean[]{true, true, true, true, true})
             .searchArgument(sarg, new String[]{null, "int1",null,"int2","string1"}));
-    Assert.assertEquals(3500L, rows.getRowNumber());
+    assertEquals(3500L, rows.getRowNumber());
     assertTrue(!rows.nextBatch(batch));
 
     // select first 100 and last 100 rows
@@ -4236,25 +4235,25 @@ public class TestVectorOrcFile {
             .range(0L, Long.MAX_VALUE)
             .include(new boolean[]{true, true,true,true, true})
             .searchArgument(sarg, new String[]{null, "int1",null, "int2","string1"}));
-    Assert.assertEquals(0, rows.getRowNumber());
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(0, rows.getRowNumber());
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(1000, batch.size);
-    Assert.assertEquals(3000, rows.getRowNumber());
+    assertEquals(3000, rows.getRowNumber());
 
     for(int i=0; i < 1000; ++i) {
       assertEquals(300 * i, ints2.vector[i]);
       assertEquals(Integer.toHexString(10*i), strs.toString(i));
     }
 
-    Assert.assertEquals(true, rows.nextBatch(batch));
+    assertEquals(true, rows.nextBatch(batch));
     assertEquals(500, batch.size);
-    Assert.assertEquals(3500, rows.getRowNumber());
+    assertEquals(3500, rows.getRowNumber());
     for(int i=3000; i < 3500; ++i) {
       assertEquals(300 * i, ints2.vector[i - 3000]);
       assertEquals(Integer.toHexString(10*i), strs.toString(i - 3000));
     }
-    Assert.assertEquals(false, rows.nextBatch(batch));
-    Assert.assertEquals(3500, rows.getRowNumber());
+    assertEquals(false, rows.nextBatch(batch));
+    assertEquals(3500, rows.getRowNumber());
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
 import org.apache.orc.IntegerColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.util.BloomFilter;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -340,8 +339,8 @@ public class TestPredicatePushDownBounds {
     stat.updateInteger(3, 100);
 
     IntegerColumnStatistics typed = (IntegerColumnStatistics) stat;
-    Assert.assertEquals(1, typed.getMinimum());
-    Assert.assertEquals(3, typed.getMaximum());
+    assertEquals(1, typed.getMinimum());
+    assertEquals(3, typed.getMaximum());
 
     SearchArgument sArg = SearchArgumentFactory.newBuilder()
         .startAnd()
@@ -359,8 +358,8 @@ public class TestPredicatePushDownBounds {
     newStat.updateInteger(3, 100);
 
     typed = (IntegerColumnStatistics) newStat;
-    Assert.assertEquals(3, typed.getMinimum());
-    Assert.assertEquals(3, typed.getMaximum());
+    assertEquals(3, typed.getMinimum());
+    assertEquals(3, typed.getMaximum());
 
     sArg = SearchArgumentFactory.newBuilder()
         .startAnd()

--- a/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
@@ -24,7 +24,7 @@ import java.util.stream.Stream;
 
 import org.apache.hadoop.io.Text;
 import org.apache.orc.StringDictTestingUtils;
-import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 
@@ -42,46 +42,46 @@ public class TestStringHashTableDictionary {
         Stream.of(new String[]{"Alice", "Bob", "Cindy", "David", "Eason"}).map(Text::new).collect(Collectors.toList());
     List<byte[]> testBytes = testTexts.stream().map(Text::getBytes).collect(Collectors.toList());
 
-    Assert.assertEquals(0, htDict.getSizeInBytes());
-    Assert.assertEquals(0, htDict.add(testBytes.get(0), 0, testBytes.get(0).length));
-    Assert.assertEquals(1, htDict.add(testBytes.get(1), 0, testBytes.get(1).length));
-    Assert.assertEquals(0, htDict.add(testBytes.get(0), 0, testBytes.get(0).length));
-    Assert.assertEquals(1, htDict.add(testBytes.get(1), 0, testBytes.get(1).length));
-    Assert.assertEquals(2, htDict.add(testBytes.get(2), 0, testBytes.get(2).length));
+    assertEquals(0, htDict.getSizeInBytes());
+    assertEquals(0, htDict.add(testBytes.get(0), 0, testBytes.get(0).length));
+    assertEquals(1, htDict.add(testBytes.get(1), 0, testBytes.get(1).length));
+    assertEquals(0, htDict.add(testBytes.get(0), 0, testBytes.get(0).length));
+    assertEquals(1, htDict.add(testBytes.get(1), 0, testBytes.get(1).length));
+    assertEquals(2, htDict.add(testBytes.get(2), 0, testBytes.get(2).length));
 
     Text text = new Text();
     htDict.getText(text, 0);
-    Assert.assertEquals("Alice", text.toString());
+    assertEquals("Alice", text.toString());
     htDict.getText(text, 1);
-    Assert.assertEquals("Bob", text.toString());
+    assertEquals("Bob", text.toString());
     htDict.getText(text, 2);
-    Assert.assertEquals("Cindy", text.toString());
+    assertEquals("Cindy", text.toString());
 
-    Assert.assertEquals(htDict.size(), 3);
+    assertEquals(htDict.size(), 3);
 
     // entering the fourth and fifth element which triggers rehash
-    Assert.assertEquals(3, htDict.add(testBytes.get(3), 0, testBytes.get(3).length));
+    assertEquals(3, htDict.add(testBytes.get(3), 0, testBytes.get(3).length));
     htDict.getText(text, 3);
-    Assert.assertEquals("David", text.toString());
-    Assert.assertEquals(4, htDict.add(testBytes.get(4), 0, testBytes.get(4).length));
+    assertEquals("David", text.toString());
+    assertEquals(4, htDict.add(testBytes.get(4), 0, testBytes.get(4).length));
     htDict.getText(text, 4);
-    Assert.assertEquals("Eason", text.toString());
+    assertEquals("Eason", text.toString());
 
-    Assert.assertEquals(htDict.size(), 5);
+    assertEquals(htDict.size(), 5);
 
     // Re-ensure no all previously existed string still have correct encoded value
     htDict.getText(text, 0);
-    Assert.assertEquals("Alice", text.toString());
+    assertEquals("Alice", text.toString());
     htDict.getText(text, 1);
-    Assert.assertEquals("Bob", text.toString());
+    assertEquals("Bob", text.toString());
     htDict.getText(text, 2);
-    Assert.assertEquals("Cindy", text.toString());
+    assertEquals("Cindy", text.toString());
 
     // Peaking the hashtable and obtain the order sequence since the hashArray object needs to be private.
     StringDictTestingUtils.checkContents(htDict, new int[]{1, 2, 3, 0 ,4}, "Bob", "Cindy", "David", "Alice", "Eason");
 
     htDict.clear();
-    Assert.assertEquals(0, htDict.size());
+    assertEquals(0, htDict.size());
   }
 
   /**
@@ -109,36 +109,36 @@ public class TestStringHashTableDictionary {
       throws Exception {
     SimpleHashDictionary hashTableDictionary = new SimpleHashDictionary(5);
     // Non-resize trivial cases
-    Assert.assertEquals(0, hashTableDictionary.getSizeInBytes());
-    Assert.assertEquals(0, hashTableDictionary.add(new Text("2_Alice")));
-    Assert.assertEquals(1, hashTableDictionary.add(new Text("3_Bob")));
-    Assert.assertEquals(0, hashTableDictionary.add(new Text("2_Alice")));
-    Assert.assertEquals(1, hashTableDictionary.add(new Text("3_Bob")));
-    Assert.assertEquals(2, hashTableDictionary.add(new Text("1_Cindy")));
+    assertEquals(0, hashTableDictionary.getSizeInBytes());
+    assertEquals(0, hashTableDictionary.add(new Text("2_Alice")));
+    assertEquals(1, hashTableDictionary.add(new Text("3_Bob")));
+    assertEquals(0, hashTableDictionary.add(new Text("2_Alice")));
+    assertEquals(1, hashTableDictionary.add(new Text("3_Bob")));
+    assertEquals(2, hashTableDictionary.add(new Text("1_Cindy")));
 
     Text text = new Text();
     hashTableDictionary.getText(text, 0);
-    Assert.assertEquals("2_Alice", text.toString());
+    assertEquals("2_Alice", text.toString());
     hashTableDictionary.getText(text, 1);
-    Assert.assertEquals("3_Bob", text.toString());
+    assertEquals("3_Bob", text.toString());
     hashTableDictionary.getText(text, 2);
-    Assert.assertEquals("1_Cindy", text.toString());
+    assertEquals("1_Cindy", text.toString());
 
     // entering the fourth and fifth element which triggers rehash
-    Assert.assertEquals(3, hashTableDictionary.add(new Text("0_David")));
+    assertEquals(3, hashTableDictionary.add(new Text("0_David")));
     hashTableDictionary.getText(text, 3);
-    Assert.assertEquals("0_David", text.toString());
-    Assert.assertEquals(4, hashTableDictionary.add(new Text("4_Eason")));
+    assertEquals("0_David", text.toString());
+    assertEquals(4, hashTableDictionary.add(new Text("4_Eason")));
     hashTableDictionary.getText(text, 4);
-    Assert.assertEquals("4_Eason", text.toString());
+    assertEquals("4_Eason", text.toString());
 
     // Re-ensure no all previously existed string still have correct encoded value
     hashTableDictionary.getText(text, 0);
-    Assert.assertEquals("2_Alice", text.toString());
+    assertEquals("2_Alice", text.toString());
     hashTableDictionary.getText(text, 1);
-    Assert.assertEquals("3_Bob", text.toString());
+    assertEquals("3_Bob", text.toString());
     hashTableDictionary.getText(text, 2);
-    Assert.assertEquals("1_Cindy", text.toString());
+    assertEquals("1_Cindy", text.toString());
 
     // The order of words are based on each string's prefix given their index in the hashArray will be based on that.
     StringDictTestingUtils
@@ -146,6 +146,6 @@ public class TestStringHashTableDictionary {
             "4_Eason");
 
     hashTableDictionary.clear();
-    Assert.assertEquals(0, hashTableDictionary.size());
+    assertEquals(0, hashTableDictionary.size());
   }
 }

--- a/java/core/src/test/org/apache/orc/util/TestOrcUtils.java
+++ b/java/core/src/test/org/apache/orc/util/TestOrcUtils.java
@@ -23,7 +23,7 @@ import java.util.Arrays;
 import org.apache.orc.OrcUtils;
 import org.apache.orc.TypeDescription;
 
-import org.junit.Assert;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 /**
@@ -42,7 +42,7 @@ public class TestOrcUtils {
     includeColumns[1] = true;
     includeColumns[3] = true;
 
-    Assert.assertTrue(Arrays.equals(includeColumns,
+    assertTrue(Arrays.equals(includeColumns,
         OrcUtils.includeColumns("msisdn, imei", schema)));
   }
 
@@ -63,7 +63,7 @@ public class TestOrcUtils {
     boolean[] includeColumns = new boolean[8+1];
     includeColumns[7] = true;
 
-    Assert.assertTrue(Arrays.equals(includeColumns,
+    assertTrue(Arrays.equals(includeColumns,
         OrcUtils.includeColumns("msisdn", schema)));
   }
 
@@ -79,7 +79,7 @@ public class TestOrcUtils {
     boolean[] includeColumns = new boolean[3+1];
     includeColumns[2] = true;
 
-    Assert.assertTrue(Arrays.equals(includeColumns,
+    assertTrue(Arrays.equals(includeColumns,
         OrcUtils.includeColumns("row.msisdn", schema)));
   }
 
@@ -94,7 +94,7 @@ public class TestOrcUtils {
 
     boolean[] includeColumns = new boolean[3+1];
 
-    Assert.assertTrue(Arrays.equals(includeColumns,
+    assertTrue(Arrays.equals(includeColumns,
         OrcUtils.includeColumns("msisdn, row.msisdn2", schema)));
   }
 }

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcFileEvolution.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.orc.*;
 import org.apache.orc.TypeDescription.Category;
 import org.apache.orc.impl.SchemaEvolution;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +42,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -237,7 +236,7 @@ public class TestOrcFileEvolution {
   public void testMissingColumnFromReaderSchema() {
     // Expect failure if the column is missing from the reader schema, as column a that is added
     // by the SArg is missing from the reader schema
-    Assert.assertThrows("Field a not found in", IllegalArgumentException.class,
+    assertThrows("Field a not found in", IllegalArgumentException.class,
                         () -> checkEvolution("struct<b:int,c:string>",
                                        "struct<b:int,c:string>",
                                        struct(1, "foo"),

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcStruct.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcStruct.java
@@ -34,7 +34,6 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -138,13 +137,13 @@ public class TestOrcStruct {
     OrcMapredRecordReader<OrcUnion> recordReader = new OrcMapredRecordReader<>(reader,options);
     OrcUnion result = recordReader.createValue();
     recordReader.next(recordReader.createKey(), result);
-    Assert.assertEquals(result, u1);
+    assertEquals(result, u1);
     recordReader.next(recordReader.createKey(), result);
-    Assert.assertEquals(result, u2);
+    assertEquals(result, u2);
     recordReader.next(recordReader.createKey(), result);
-    Assert.assertEquals(result, u3);
+    assertEquals(result, u3);
     recordReader.next(recordReader.createKey(), result);
-    Assert.assertEquals(result, u4);
+    assertEquals(result, u4);
   }
 
   @Test

--- a/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
@@ -18,7 +18,7 @@
 
 package org.apache.orc.tools;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.BufferedReader;
@@ -59,7 +59,6 @@ import org.apache.orc.Reader;
 import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -194,12 +193,12 @@ public class TestFileDump {
       if (actualLine != null) {
         actualLine = actualLine.trim();
       }
-      Assert.assertEquals(expectedLine, actualLine);
+      assertEquals(expectedLine, actualLine);
       expectedLine = eStream.readLine();
       expectedLine = expectedLine == null ? null : expectedLine.trim();
     }
-    Assert.assertNull(eStream.readLine());
-    Assert.assertNull(aStream.readLine());
+    assertNull(eStream.readLine());
+    assertNull(aStream.readLine());
     eStream.close();
     aStream.close();
   }
@@ -330,8 +329,8 @@ public class TestFileDump {
     System.out.flush();
     System.setOut(origOut);
     String[] lines = myOut.toString(StandardCharsets.UTF_8.toString()).split("\n");
-    Assert.assertEquals("{\"b\":true,\"bt\":10,\"s\":100,\"i\":1000,\"l\":10000,\"f\":4,\"d\":20,\"de\":\"4.2222\",\"t\":\"2014-11-25 18:09:24.0\",\"dt\":\"2014-11-25\",\"str\":\"string\",\"c\":\"hello\",\"vc\":\"hello\",\"m\":[{\"_key\":\"k1\",\"_value\":\"v1\"}],\"a\":[100,200],\"st\":{\"i\":10,\"s\":\"foo\"}}", lines[0]);
-    Assert.assertEquals("{\"b\":false,\"bt\":20,\"s\":200,\"i\":2000,\"l\":20000,\"f\":8,\"d\":40,\"de\":\"2.2222\",\"t\":\"2014-11-25 18:02:44.0\",\"dt\":\"2014-09-28\",\"str\":\"abcd\",\"c\":\"world\",\"vc\":\"world\",\"m\":[{\"_key\":\"k3\",\"_value\":\"v3\"}],\"a\":[200,300],\"st\":{\"i\":20,\"s\":\"bar\"}}", lines[1]);
+    assertEquals("{\"b\":true,\"bt\":10,\"s\":100,\"i\":1000,\"l\":10000,\"f\":4,\"d\":20,\"de\":\"4.2222\",\"t\":\"2014-11-25 18:09:24.0\",\"dt\":\"2014-11-25\",\"str\":\"string\",\"c\":\"hello\",\"vc\":\"hello\",\"m\":[{\"_key\":\"k1\",\"_value\":\"v1\"}],\"a\":[100,200],\"st\":{\"i\":10,\"s\":\"foo\"}}", lines[0]);
+    assertEquals("{\"b\":false,\"bt\":20,\"s\":200,\"i\":2000,\"l\":20000,\"f\":8,\"d\":40,\"de\":\"2.2222\",\"t\":\"2014-11-25 18:02:44.0\",\"dt\":\"2014-09-28\",\"str\":\"abcd\",\"c\":\"world\",\"vc\":\"world\",\"m\":[{\"_key\":\"k3\",\"_value\":\"v3\"}],\"a\":[200,300],\"st\":{\"i\":20,\"s\":\"bar\"}}", lines[1]);
   }
 
   // Test that if the fraction of rows that have distinct strings is greater than the configured


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `assertXXX` methods directly without their package name, `Assert`.

```java
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -194,12 +193,12 @@ public class TestFileDump {
       if (actualLine != null) {
         actualLine = actualLine.trim();
       }
-      Assert.assertEquals(expectedLine, actualLine);
+      assertEquals(expectedLine, actualLine);
```

### Why are the changes needed?

There are three benefits after this PR.
- This reduces the heterogeneity in the test suites which uses both `assertEquals` and `Assert.assertEquals` at the same time currently.
- It's easy to remove the JUnit5 `vintage` engine and migrate to the real JUnit5. Although ORC-687 upgraded to JUnit5, our test cases are still using JUnit5 engine.
- It reduces the length of lines. We are gradually reducing the maximum limit of length by the checkstyle rule to 80 which is [the ORC coding guideline](https://orc.apache.org/develop/coding/). So far, ORC-795 revised our codebase to 125 and ORC-866 did to 120.

### How was this patch tested?

Pass the CIs.