### PR TITLE
ORC-892: Pin scala-library to 2.12.10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,3 +33,6 @@ updates:
         versions: "[2.2.1,)"
       - dependency-name: "org.apache.hadoop:hadoop-mapreduce-client-core"
         versions: "[2.2.1,)"
+      # Pin scala-library to 2.12.10
+      - dependency-name: "org.scala-lang:scala-library"
+        versions: "[2.12.11,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to pin scala-library to 2.12.10.


### Why are the changes needed?
Apache Spark 3.1 uses 2.12.10 


### How was this patch tested?
N/A

This closes #796 .