### PR TITLE
ORC-893: Remove junit-vintage-engine from shims module

### DIFF
--- a/java/shims/pom.xml
+++ b/java/shims/pom.xml
@@ -59,11 +59,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
+++ b/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPre2_7.java
@@ -21,21 +21,24 @@ package org.apache.orc.impl;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.kms.KMSClientProvider;
 import org.apache.orc.EncryptionAlgorithm;
-import org.junit.Test;
 
 import java.sql.Date;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.junit.jupiter.api.Test;
 
 public class TestHadoopShimsPre2_7 {
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFindingUnknownEncryption() {
-    KeyProvider.Metadata meta = new KMSClientProvider.KMSMetadata(
-        "XXX/CTR/NoPadding", 128, "", new HashMap<String, String>(),
-        new Date(0), 1);
-    HadoopShimsPre2_7.findAlgorithm(meta);
+    assertThrows(IllegalArgumentException.class, () -> {
+      KeyProvider.Metadata meta = new KMSClientProvider.KMSMetadata(
+          "XXX/CTR/NoPadding", 128, "", new HashMap<String, String>(),
+          new Date(0), 1);
+      HadoopShimsPre2_7.findAlgorithm(meta);
+    });
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove junit-vintage-engine from shims module. 


### Why are the changes needed?
This will complete the migration to JUnit 5 in `shims` module. 


### How was this patch tested?
Pass the CIs. 
