### PR TITLE
ORC-895: Use snappy-java 1.1.8.4 in bench/core to support Apple Silicon

### DIFF
--- a/java/bench/core/pom.xml
+++ b/java/bench/core/pom.xml
@@ -92,6 +92,10 @@
       <artifactId>parquet-hadoop</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.openjdk.jmh</groupId>
       <artifactId>jmh-core</artifactId>
     </dependency>

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -343,6 +343,17 @@
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-hadoop</artifactId>
         <version>${parquet.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>1.1.8.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `snappy-java` 1.1.8.4 instead of the one (1.1.8) of `parquet-hadoop` dependency.

### Why are the changes needed?

To support benchmark in Apple Silicon, we need to use 1.1.8.2+.

- https://github.com/xerial/snappy-java/releases/tag/1.1.8.2
   Support Apple Silicon (M1, Mac-aarch64)

Otherwise, we hit the following error.
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data -d sales -f parquet
Processing sales [parquet]
[WARN ] Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Exception in thread "main" org.xerial.snappy.SnappyError: [FAILED_TO_LOAD_NATIVE_LIBRARY] no native library is found for os.name=Mac and os.arch=aarch64
```

### How was this patch tested?

Manually.
```
$ cd java
$ ./mvnw clean package -DskipTests -Pbenchmark
$ cd bench
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data -d sales -f parquet
```
