### PR TITLE
ORC-897: Optimization loop termination condition

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -1039,7 +1039,7 @@ public class OrcFile {
     if (first.length != next.length) {
       return false;
     }
-    for(int k = 0; k < first.length && k < next.length; ++k) {
+    for(int k = 0; k < first.length; ++k) {
       if (!first[k].getKeyName().equals(next[k].getKeyName()) ||
           first[k].getKeyVersion() != next[k].getKeyVersion() ||
           first[k].getAlgorithm() != next[k].getAlgorithm()) {
@@ -1054,7 +1054,7 @@ public class OrcFile {
     if (first.length != next.length) {
       return false;
     }
-    for(int k = 0; k < first.length && k < next.length; ++k) {
+    for(int k = 0; k < first.length; ++k) {
       if (!first[k].getName().equals(next[k].getName())) {
         return false;
       }
@@ -1063,7 +1063,7 @@ public class OrcFile {
       if (firstParam.length != nextParam.length) {
         return false;
       }
-      for(int p=0; p < firstParam.length && p < nextParam.length; ++p) {
+      for(int p=0; p < firstParam.length; ++p) {
         if (!firstParam[p].equals(nextParam[p])) {
           return false;
         }
@@ -1073,7 +1073,7 @@ public class OrcFile {
       if (firstRoots.length != nextRoots.length) {
         return false;
       }
-      for(int r=0; r < firstRoots.length && r < nextRoots.length; ++r) {
+      for(int r=0; r < firstRoots.length; ++r) {
         if (firstRoots[r].getId() != nextRoots[r].getId()) {
           return false;
         }
@@ -1087,7 +1087,7 @@ public class OrcFile {
     if (first.length != next.length) {
       return false;
     }
-    for(int k = 0; k < first.length && k < next.length; ++k) {
+    for(int k = 0; k < first.length; ++k) {
       if ((first[k].getKeyDescription() == null) !=
               (next[k].getKeyDescription() == null) ||
           !first[k].getKeyDescription().getKeyName().equals(


### PR DESCRIPTION
### What changes were proposed in this pull request?

```java
private static boolean sameKeys(EncryptionKey[] first,
                                  EncryptionKey[] next) {
    if (first.length != next.length) {
      return false;
    }
    for(int k = 0; k < first.length && k < next.length; ++k) {
      if (!first[k].getKeyName().equals(next[k].getKeyName()) ||
          first[k].getKeyVersion() != next[k].getKeyVersion() ||
          first[k].getAlgorithm() != next[k].getAlgorithm()) {
        return false;
      }
    }
    return true;
  }
```
There are five similar codes.
The length of `first` and `next` are the same, otherwise the loop is unreachable.
k <next.length is redundant conditions.
I think they can be removed.

### Why are the changes needed?

Optimization loop termination condition in readerIsCompatible method

### How was this patch tested?

Pass the CIs.