### PR TITLE
ORC-899: Archive Apache ORC 1.4.x in `releases` page

### DIFF
--- a/site/_data/releases.yml
+++ b/site/_data/releases.yml
@@ -221,7 +221,7 @@
 
 1.4.5:
   date: 2019-12-09
-  state: stable
+  state: archived
   tar: orc-1.4.5.tar.gz
   signed-by: Owen O’Malley (3D0C92B9)
   sha256: 6b30272d4c4cbccc4f019590aa0b770214ff154c8204018a640a61ae0b29e9cb


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to mark `Apache ORC 1.4.5` as `archived` instead of `stable`.
- http://orc.apache.org/docs/releases.html

### Why are the changes needed?

Most community are currently using Apache ORC 1.5.x and moved on Apache ORC 1.6.9 already.

- 2021-07-02 Apache ORC 1.6.9 is released.
- 2021-07-02 SPARK-35992: Upgrade ORC to 1.6.9
- 2021-07-16 ICEBERG: Upgrade ORC to 1.6.9
- 2021-07-26 HIVE-25384: Bump ORC to 1.6.9
- 2021-07-30 ARROW-13506: Upgrade ORC to 1.6.9
- 2021-07-31 Apache Druid: Upgrade ORC to 1.6.9
- (Under Review) FLINK-23551 Bump ORC to 1.6.9

Apache ORC 1.4 was released on 2019-12-09 and it's time to mark it `archived` because we are not going to maintain it.
Apache ORC 1.0/1.1/1.2/1.3 are marked as `archived` explicitly.

### How was this patch tested?

N/A
