### PR TITLE
ORC-900: Update doap_orc.rdf for Apache Projects page

### DIFF
--- a/site/doap_orc.rdf
+++ b/site/doap_orc.rdf
@@ -44,9 +44,9 @@ the values that are required for the current query.</description>
     <category rdf:resource="http://projects.apache.org/category/library" />
     <release>
       <Version>
-        <name>Apache ORC 1.4.3</name>
-        <created>2018-02-09</created>
-        <revision>1.4.3</revision>
+        <name>Apache ORC 1.6.9</name>
+        <created>2021-07-02</created>
+        <revision>1.6.9</revision>
       </Version>
     </release>
     <repository>
@@ -57,8 +57,8 @@ the values that are required for the current query.</description>
     </repository>
     <maintainer>
       <foaf:Person>
-        <foaf:name>Owen O'Malley</foaf:name>
-          <foaf:mbox rdf:resource="mailto:omalley@apache.org"/>
+        <foaf:name>Dongjoon Hyun</foaf:name>
+          <foaf:mbox rdf:resource="mailto:dongjoon@apache.org"/>
       </foaf:Person>
     </maintainer>
   </Project>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `doap_orc.rdf` file.

### Why are the changes needed?

The following Apache Projects page is populated from `doap_orc.rdf`. We need to keep it up-to-date. For example, we need to show `1.6.9 (2021-07-02): Apache ORC 1.6.9` instead `1.4.3 (2018-02-09): Apache ORC 1.4.3`.
- https://projects.apache.org/project.html?orc

![Screen Shot 2021-08-02 at 9 54 06 AM](https://user-images.githubusercontent.com/9700541/127896944-4c9d3c4a-d349-4534-b4ee-2d915853d916.png)


### How was this patch tested?

N/A