### PR TITLE
ORC-901: Remove junit-vintage-engine from `mapreduce/tools` module

### DIFF
--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -75,8 +75,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -71,7 +71,7 @@
     <!-- test inter-project -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -82,16 +82,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.objenesis</groupId>
-      <artifactId>objenesis</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcList.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcList.java
@@ -24,12 +24,12 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.Writable;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestOrcList {
 

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcMap.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcMap.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestOrcMap {
 

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcOutputFormat.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcOutputFormat.java
@@ -49,13 +49,13 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestOrcOutputFormat {
 
@@ -187,9 +187,9 @@ public class TestOrcOutputFormat {
         } else {
           union.set((byte) 0, new OrcTimestamp("2011-12-25 12:34:56"));
         }
-        assertEquals("row " + r, struct, row.getFieldValue(11));
-        assertEquals("row " + r, new OrcTimestamp("1996-12-11 15:00:00"),
-            row.getFieldValue(12));
+        assertEquals(struct, row.getFieldValue(11), "row " + r);
+        assertEquals(new OrcTimestamp("1996-12-11 15:00:00"),
+            row.getFieldValue(12), "row " + r);
       }
     }
     assertEquals(false, reader.next(nada, row));

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcStruct.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcStruct.java
@@ -34,20 +34,14 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import com.google.common.io.Files;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class TestOrcStruct {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testRead() throws IOException {
@@ -167,16 +161,18 @@ public class TestOrcStruct {
   public void testBadFieldRead() {
     OrcStruct struct = new OrcStruct(TypeDescription.fromString
         ("struct<i:int,j:double,k:string>"));
-    thrown.expect(IllegalArgumentException.class);
-    struct.getFieldValue("bad");
+    assertThrows(IllegalArgumentException.class, () -> {
+      struct.getFieldValue("bad");
+    });
   }
 
   @Test
   public void testBadFieldWrite() {
     OrcStruct struct = new OrcStruct(TypeDescription.fromString
         ("struct<i:int,j:double,k:string>"));
-    thrown.expect(IllegalArgumentException.class);
-    struct.setFieldValue("bad", new Text("foobar"));
+    assertThrows(IllegalArgumentException.class, () -> {
+      struct.setFieldValue("bad", new Text("foobar"));
+    });
   }
 
   @Test

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcTimestamp.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcTimestamp.java
@@ -18,12 +18,11 @@
 
 package org.apache.orc.mapred;
 
-import org.junit.Test;
-
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestOrcTimestamp {
 

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcUnion.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestOrcUnion.java
@@ -22,12 +22,12 @@ import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestOrcUnion {
 

--- a/java/mapreduce/src/test/org/apache/orc/mapreduce/TestMapreduceOrcOutputFormat.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapreduce/TestMapreduceOrcOutputFormat.java
@@ -44,13 +44,13 @@ import org.apache.orc.Writer;
 import org.apache.orc.mapred.OrcKey;
 import org.apache.orc.mapred.OrcStruct;
 import org.apache.orc.mapred.OrcValue;
-import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 public class TestMapreduceOrcOutputFormat {
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -780,6 +780,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>5.7.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
         <version>5.7.2</version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -775,6 +775,12 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.7.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-engine</artifactId>
         <version>5.7.0</version>
         <scope>test</scope>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -91,11 +91,6 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -88,7 +88,7 @@
     <!-- test inter-project -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/tools/src/test/org/apache/orc/impl/TestHadoopKeyProvider.java
+++ b/java/tools/src/test/org/apache/orc/impl/TestHadoopKeyProvider.java
@@ -19,14 +19,14 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.BytesWritable;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.security.Key;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestHadoopKeyProvider {
 

--- a/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
+++ b/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
@@ -17,8 +17,8 @@
  */
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -43,10 +43,6 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.impl.writer.StreamOptions;
 import org.apache.orc.tools.FileDump;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 public class TestRLEv2 {
   Path workDir = new Path(System.getProperty("test.tmp.dir",
@@ -55,15 +51,12 @@ public class TestRLEv2 {
   Configuration conf;
   FileSystem fs;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem () throws Exception {
+  @BeforeEach
+  public void openFileSystem (TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestRLEv2." +
-        testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
@@ -375,7 +368,7 @@ public class TestRLEv2 {
     public void compareBytes(int... expected) {
       for(int i=0; i < expected.length; ++i) {
         ByteBuffer current = getCurrentBuffer();
-        assertEquals("position " + i, (byte) expected[i], current.get());
+        assertEquals((byte) expected[i], current.get(), "position " + i);
       }
       assertEquals(null, getCurrentBuffer());
     }

--- a/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestFileDump.java
@@ -18,8 +18,9 @@
 
 package org.apache.orc.tools;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+import org.junit.jupiter.api.*;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -59,8 +60,6 @@ import org.apache.orc.Reader;
 import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Before;
-import org.junit.Test;
 
 public class TestFileDump {
 
@@ -69,7 +68,7 @@ public class TestFileDump {
   FileSystem fs;
   Path testFilePath;
 
-  @Before
+  @BeforeEach
   public void openFileSystem () throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);

--- a/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
@@ -18,8 +18,8 @@
 
 package org.apache.orc.tools;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -41,8 +41,6 @@ import org.apache.orc.OrcConf;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Before;
-import org.junit.Test;
 
 public class TestJsonFileDump {
 
@@ -59,7 +57,7 @@ public class TestJsonFileDump {
   FileSystem fs;
   Path testFilePath;
 
-  @Before
+  @BeforeEach
   public void openFileSystem () throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestCsvReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestCsvReader.java
@@ -27,27 +27,26 @@ import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.StringReader;
 import java.util.Locale;
 
 import static org.apache.orc.tools.convert.ConvertTool.DEFAULT_TIMESTAMP_FORMAT;
-import static org.junit.Assert.assertEquals;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.*;
 
 public class TestCsvReader {
 
   Locale defaultLocale;
 
-  @Before
+  @BeforeEach
   public void storeDefaultLocale() {
     defaultLocale = Locale.getDefault();
     Locale.setDefault(Locale.US);
   }
 
-  @After
+  @AfterEach
   public void restoreDefaultLocale() {
     Locale.setDefault(defaultLocale);
   }
@@ -111,7 +110,7 @@ public class TestCsvReader {
     assertEquals(true, reader.nextBatch(batch));
     assertEquals(3, batch.size);
     for(int c=0; c < 4; ++c) {
-      assertEquals("column " + c, false, batch.cols[c].noNulls);
+      assertEquals(false, batch.cols[c].noNulls, "column " + c);
     }
 
     // check row 0
@@ -120,12 +119,12 @@ public class TestCsvReader {
     assertEquals("1", ((DecimalColumnVector) batch.cols[2]).vector[0].toString());
     assertEquals("a", ((BytesColumnVector) batch.cols[3]).toString(0));
     for(int c=0; c < 4; ++c) {
-      assertEquals("column " + c, false, batch.cols[c].isNull[0]);
+      assertEquals(false, batch.cols[c].isNull[0], "column " + c);
     }
 
     // row 1
     for(int c=0; c < 4; ++c) {
-      assertEquals("column " + c, true, batch.cols[c].isNull[1]);
+      assertEquals(true, batch.cols[c].isNull[1], "column " + c);
     }
 
     // check row 2
@@ -134,7 +133,7 @@ public class TestCsvReader {
     assertEquals("3", ((DecimalColumnVector) batch.cols[2]).vector[2].toString());
     assertEquals("row 3", ((BytesColumnVector) batch.cols[3]).toString(2));
     for(int c=0; c < 4; ++c) {
-      assertEquals("column " + c, false, batch.cols[c].isNull[2]);
+      assertEquals(false, batch.cols[c].isNull[2], "column " + c);
     }
   }
 
@@ -153,11 +152,11 @@ public class TestCsvReader {
     assertEquals(2, batch.size);
     int nextVal = 1;
     for(int r=0; r < 2; ++r) {
-      assertEquals("row " + r, nextVal++, ((LongColumnVector) batch.cols[0]).vector[r]);
+      assertEquals(nextVal++, ((LongColumnVector) batch.cols[0]).vector[r], "row " + r);
       StructColumnVector b = (StructColumnVector) batch.cols[1];
-      assertEquals("row " + r, nextVal++, ((LongColumnVector) b.fields[0]).vector[r]);
-      assertEquals("row " + r, nextVal++, ((LongColumnVector) b.fields[1]).vector[r]);
-      assertEquals("row " + r, nextVal++, ((LongColumnVector) batch.cols[2]).vector[r]);
+      assertEquals(nextVal++, ((LongColumnVector) b.fields[0]).vector[r], "row " + r);
+      assertEquals(nextVal++, ((LongColumnVector) b.fields[1]).vector[r], "row " + r);
+      assertEquals(nextVal++, ((LongColumnVector) batch.cols[2]).vector[r], "row " + r);
     }
     assertEquals(false, reader.nextBatch(batch));
   }

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hive.ql.exec.vector.DateColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -33,9 +32,8 @@ import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 
 public class TestJsonReader {
     @Test

--- a/java/tools/src/test/org/apache/orc/tools/json/TestJsonSchemaFinder.java
+++ b/java/tools/src/test/org/apache/orc/tools/json/TestJsonSchemaFinder.java
@@ -23,9 +23,9 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.internal.LazilyParsedNumber;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 public class TestJsonSchemaFinder {
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove old dependencies from `mapreduce` and `tools` modules by removing `junit-vintage-engine`.
- `junit-jupiter-api` is added.
- `junit-jupiter-params` is added to replace the JUnit4's parameterized test class.
- Remove unused `objenesis` and `net.bytebuddy` from `mapreduce` module.

### Why are the changes needed?

This will complete the JUnit5 migration in these modules.

### How was this patch tested?

Pass the CIs.