### PR TITLE
ORC-903: Migrate TestVectorOrcFile to JUnit5

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -92,6 +92,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to migrate `TestVectorOrcFile` to JUnit5.

### Why are the changes needed?

`TestVectorOrcFile` is one of the largest test file in ORC which has 4768 lines.
This is the first step to migrate `core` module. The others are smaller than this.

### How was this patch tested?

Pass the CIs.

**BEFORE**
```
$ mvn test -pl core -Dtest=org.apache.orc.TestVectorOrcFile
[WARNING] Tests run: 147, Failures: 0, Errors: 0, Skipped: 18, Time elapsed: 6.669 s - in org.apache.orc.TestVectorOrcFile
```

**AFTER**
```
$ mvn test -pl core -Dtest=org.apache.orc.TestVectorOrcFile
[WARNING] Tests run: 147, Failures: 0, Errors: 0, Skipped: 18, Time elapsed: 6.844 s - in org.apache.orc.TestVectorOrcFile
```
