### PR TITLE
ORC-906: Move to storage-api 2.7.3.

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
 
     <min.hadoop.version>2.2.0</min.hadoop.version>
     <hadoop.version>2.7.3</hadoop.version>
-    <storage-api.version>2.7.1</storage-api.version>
+    <storage-api.version>2.7.3</storage-api.version>
     <zookeeper.version>3.4.6</zookeeper.version>
     <maven.version>3.6.3</maven.version>
     <protoc.artifact>com.google.protobuf:protoc:2.5.0</protoc.artifact>


### PR DESCRIPTION
This is to get HIVE-25400 & HIVE-25190 fixed.