### PR TITLE
ORC-907: Remove junit-vintage-engine from core module

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -88,7 +88,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -97,23 +97,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.objenesis</groupId>
-      <artifactId>objenesis</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>net.bytebuddy</groupId>
-      <artifactId>byte-buddy</artifactId>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/java/core/src/test/org/apache/orc/StringDictTestingUtils.java
+++ b/java/core/src/test/org/apache/orc/StringDictTestingUtils.java
@@ -23,7 +23,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.orc.impl.Dictionary;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 /**
@@ -54,8 +54,8 @@ public class StringDictTestingUtils {
     public void visit(Dictionary.VisitorContext context)
         throws IOException {
       String word = context.getText().toString();
-      assertEquals("in word " + current, words[current], word);
-      assertEquals("in word " + current, order[current], context.getOriginalPosition());
+      assertEquals(words[current], word, "in word " + current);
+      assertEquals(order[current], context.getOriginalPosition(), "in word " + current);
       buffer.reset();
       context.writeBytes(buffer);
       assertEquals(word, new String(buffer.getData(), 0, buffer.getLength(), StandardCharsets.UTF_8));

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -29,10 +29,6 @@ import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.orc.impl.ColumnStatisticsImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -42,8 +38,8 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test ColumnStatisticsImpl for ORC.
@@ -143,9 +139,10 @@ public class TestColumnStatistics {
     final StringColumnStatistics typed = (StringColumnStatistics) stats1;
     final StringColumnStatistics typed2 = (StringColumnStatistics) stats2;
 
-    assertTrue("Upperbound cannot be more than 1024 bytes",
-        1024 >= typed.getUpperBound().getBytes(StandardCharsets.UTF_8).length);
-    assertTrue("Lowerbound cannot be more than 1024 bytes",1024 >= typed.getLowerBound().getBytes(StandardCharsets.UTF_8).length);
+    assertTrue(1024 >= typed.getUpperBound().getBytes(StandardCharsets.UTF_8).length,
+        "Upperbound cannot be more than 1024 bytes");
+    assertTrue(1024 >= typed.getLowerBound().getBytes(StandardCharsets.UTF_8).length,
+        "Lowerbound cannot be more than 1024 bytes");
 
     assertEquals(null, typed.getMinimum());
     assertEquals(null, typed.getMaximum());
@@ -157,8 +154,10 @@ public class TestColumnStatistics {
     stats1.updateString(test.getBytes(StandardCharsets.UTF_8), 0,
         test.getBytes(StandardCharsets.UTF_8).length, 0);
 
-    assertTrue("Lowerbound cannot be more than 1024 bytes", 1024 >= typed.getLowerBound().getBytes(StandardCharsets.UTF_8).length);
-    assertTrue("Upperbound cannot be more than 1024 bytes", 1024 >= typed.getUpperBound().getBytes(StandardCharsets.UTF_8).length);
+    assertTrue(1024 >= typed.getLowerBound().getBytes(StandardCharsets.UTF_8).length,
+        "Lowerbound cannot be more than 1024 bytes");
+    assertTrue(1024 >= typed.getUpperBound().getBytes(StandardCharsets.UTF_8).length,
+            "Upperbound cannot be more than 1024 bytes");
 
     assertEquals(null, typed.getMinimum());
     assertEquals(null, typed.getMaximum());
@@ -679,8 +678,10 @@ public class TestColumnStatistics {
     Reader reader = OrcFile.createReader(testFilePath,
         OrcFile.readerOptions(conf).filesystem(fs));
     DecimalColumnStatistics statistics = (DecimalColumnStatistics) reader.getStatistics()[0];
-    assertEquals("Incorrect maximum value", new BigDecimal("-99999.99"), statistics.getMinimum().bigDecimalValue());
-    assertEquals("Incorrect minimum value", new BigDecimal("-88888.88"), statistics.getMaximum().bigDecimalValue());
+    assertEquals(new BigDecimal("-99999.99"), statistics.getMinimum().bigDecimalValue(),
+        "Incorrect maximum value");
+    assertEquals(new BigDecimal("-88888.88"), statistics.getMaximum().bigDecimalValue(),
+        "Incorrect minimum value");
   }
 
 
@@ -691,15 +692,13 @@ public class TestColumnStatistics {
   FileSystem fs;
   Path testFilePath;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     fs.setWorkingDirectory(workDir);
-    testFilePath = new Path("TestOrcFile." + testCaseName.getMethodName() + ".orc");
+    testFilePath = new Path(
+        "TestOrcFile." + testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 }

--- a/java/core/src/test/org/apache/orc/TestCorruptTypes.java
+++ b/java/core/src/test/org/apache/orc/TestCorruptTypes.java
@@ -17,13 +17,11 @@
  */
 package org.apache.orc;
 
-import org.junit.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCorruptTypes {
 

--- a/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
+++ b/java/core/src/test/org/apache/orc/TestInMemoryKeystore.java
@@ -21,9 +21,8 @@ import java.nio.charset.StandardCharsets;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.orc.impl.HadoopShims;
 import org.apache.orc.impl.LocalKey;
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.security.Key;
@@ -40,7 +39,7 @@ public class TestInMemoryKeystore {
     super();
   }
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     // For testing, use a fixed random number generator so that everything
     // is repeatable.

--- a/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
+++ b/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
@@ -17,14 +17,16 @@
  */
 package org.apache.orc;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
 
 import java.io.File;
 import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Random;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -32,31 +34,16 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 
-@RunWith(value = Parameterized.class)
 public class TestNewIntegerEncoding {
 
-  private OrcFile.EncodingStrategy encodingStrategy;
-
-  public TestNewIntegerEncoding( OrcFile.EncodingStrategy es) {
-    this.encodingStrategy = es;
-  }
-
-  @Parameters
-  public static Collection<Object[]> data() {
-    Object[][] data = new Object[][] { {  OrcFile.EncodingStrategy.COMPRESSION },
-        {  OrcFile.EncodingStrategy.SPEED } };
-    return Arrays.asList(data);
+  private static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(OrcFile.EncodingStrategy.COMPRESSION),
+        Arguments.of(OrcFile.EncodingStrategy.SPEED));
   }
 
   public static TypeDescription getRowSchema() {
@@ -85,20 +72,18 @@ public class TestNewIntegerEncoding {
   FileSystem fs;
   Path testFilePath;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestOrcFile."
-        + testCaseName.getMethodName() + ".orc");
+        + testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
-  @Test
-  public void testBasicRow() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testBasicRow(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema= getRowSchema();
     Writer writer = OrcFile.createWriter(testFilePath,
                                          OrcFile.writerOptions(conf)
@@ -126,8 +111,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testBasicOld() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testBasicOld(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
     long[] inp = new long[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5, 6,
         7, 8, 9, 10, 1, 1, 1, 1, 1, 1, 10, 9, 7, 6, 5, 4, 3, 2, 1, 1, 1, 1, 1,
@@ -162,8 +148,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testBasicNew() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testBasicNew(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 3, 4, 5, 6,
@@ -200,8 +187,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testBasicDelta1() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testBasicDelta1(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { -500, -400, -350, -325, -310 };
@@ -234,8 +222,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testBasicDelta2() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testBasicDelta2(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { -500, -600, -650, -675, -710 };
@@ -268,8 +257,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testBasicDelta3() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testBasicDelta3(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 500, 400, 350, 325, 310 };
@@ -302,8 +292,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testBasicDelta4() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testBasicDelta4(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 500, 600, 650, 675, 710 };
@@ -434,8 +425,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testIntegerMin() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testIntegerMin(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -467,8 +459,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testIntegerMax() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testIntegerMax(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -501,8 +494,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testLongMin() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testLongMin(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -535,8 +529,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testLongMax() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testLongMax(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -569,8 +564,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testRandomInt() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testRandomInt(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -606,8 +602,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testRandomLong() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testRandomLong(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -643,8 +640,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseNegativeMin() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseNegativeMin(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 20, 2, 3, 2, 1, 3, 17, 71, 35, 2, 1, 139, 2, 2,
@@ -688,8 +686,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseNegativeMin2() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseNegativeMin2(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 20, 2, 3, 2, 1, 3, 17, 71, 35, 2, 1, 139, 2, 2,
@@ -733,8 +732,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseNegativeMin3() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseNegativeMin3(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 20, 2, 3, 2, 1, 3, 17, 71, 35, 2, 1, 139, 2, 2,
@@ -778,8 +778,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseNegativeMin4() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseNegativeMin4(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 13, 13, 11, 8, 13, 10, 10, 11, 11, 14, 11, 7, 13,
@@ -814,8 +815,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseAt0() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseAt0(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -852,8 +854,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseAt1() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseAt1(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -889,8 +892,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseAt255() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseAt255(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -926,8 +930,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseAt256() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseAt256(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -963,8 +968,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBase510() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBase510(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -1000,8 +1006,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBase511() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBase511(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -1037,8 +1044,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseMax1() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseMax1(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -1074,8 +1082,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseMax2() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseMax2(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -1113,8 +1122,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseMax3() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseMax3(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -1164,8 +1174,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseMax4() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseMax4(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();
@@ -1219,8 +1230,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testPatchedBaseTimestamp() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testPatchedBaseTimestamp(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createStruct()
         .addField("ts", TypeDescription.createTimestamp());
 
@@ -1288,8 +1300,9 @@ public class TestNewIntegerEncoding {
     }
   }
 
-  @Test
-  public void testDirectLargeNegatives() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testDirectLargeNegatives(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -1327,8 +1340,9 @@ public class TestNewIntegerEncoding {
     assertEquals(false, rows.nextBatch(batch));
   }
 
-  @Test
-  public void testSeek() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSeek(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
     List<Long> input = Lists.newArrayList();

--- a/java/core/src/test/org/apache/orc/TestOrcDSTNoTimezone.java
+++ b/java/core/src/test/org/apache/orc/TestOrcDSTNoTimezone.java
@@ -19,65 +19,43 @@ package org.apache.orc;
 
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 import java.util.TimeZone;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test over an orc file that does not store time zone information in the footer
  * and it was written from a time zone that observes DST for one of the timestamp
  * values stored ('2014-06-06 12:34:56.0').
  */
-@RunWith(Parameterized.class)
 public class TestOrcDSTNoTimezone {
   Configuration conf;
   FileSystem fs;
-  String readerTimeZone;
   SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.S");
   static TimeZone defaultTimeZone = TimeZone.getDefault();
 
-  public TestOrcDSTNoTimezone(String readerTZ) {
-    this.readerTimeZone = readerTZ;
-  }
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    List<Object[]> result = Arrays.asList(new Object[][]{
-        {"America/Los_Angeles"},
-        {"Europe/Berlin"},
-        {"Asia/Jerusalem"}
-    });
-    return result;
-  }
-
-  @Before
+  @BeforeEach
   public void openFileSystem() throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
   }
 
-  @After
+  @AfterEach
   public void restoreTimeZone() {
     TimeZone.setDefault(defaultTimeZone);
   }
 
-  @Test
-  public void testReadOldTimestampFormat() throws Exception {
+  @ParameterizedTest
+  @ValueSource(strings = {"America/Los_Angeles", "Europe/Berlin", "Asia/Jerusalem"})
+  public void testReadOldTimestampFormat(String readerTimeZone) throws Exception {
     TimeZone.setDefault(TimeZone.getTimeZone(readerTimeZone));
     Path oldFilePath = new Path(getClass().getClassLoader().
         getSystemResource("orc-file-dst-no-timezone.orc").getPath());

--- a/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
+++ b/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
@@ -26,16 +26,9 @@ import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
 import org.apache.orc.impl.OrcFilterContextImpl;
-import org.junit.Before;
-import org.junit.Test;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestOrcFilterContext {
   private final TypeDescription schema = TypeDescription.createStruct()
@@ -67,7 +60,7 @@ public class TestOrcFilterContext {
   private final OrcFilterContext filterContext = new OrcFilterContextImpl(schema)
     .setBatch(schema.createRowBatch());
 
-  @Before
+  @BeforeEach
   public void setup() {
     filterContext.reset();
   }
@@ -76,45 +69,45 @@ public class TestOrcFilterContext {
   public void testTopLevelElementaryType() {
     ColumnVector[] vectorBranch = filterContext.findColumnVector("f1");
     assertEquals(1, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(LongColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof LongColumnVector);
   }
 
   @Test
   public void testTopLevelCompositeType() {
     ColumnVector[] vectorBranch = filterContext.findColumnVector("f3");
     assertEquals(1, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(StructColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof StructColumnVector);
 
     vectorBranch = filterContext.findColumnVector("f4");
     assertEquals(1, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(ListColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof ListColumnVector);
 
     vectorBranch = filterContext.findColumnVector("f5");
     assertEquals(1, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(MapColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof MapColumnVector);
 
     vectorBranch = filterContext.findColumnVector("f6");
     assertEquals(1, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(UnionColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof UnionColumnVector);
   }
 
   @Test
   public void testNestedType() {
     ColumnVector[] vectorBranch = filterContext.findColumnVector("f3.a");
     assertEquals(2, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(StructColumnVector.class));
-    assertThat(vectorBranch[1], instanceOf(LongColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof StructColumnVector);
+    assertTrue(vectorBranch[1] instanceof LongColumnVector);
 
     vectorBranch = filterContext.findColumnVector("f3.c");
     assertEquals(2, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(StructColumnVector.class));
-    assertThat(vectorBranch[1], instanceOf(MapColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof StructColumnVector);
+    assertTrue(vectorBranch[1] instanceof MapColumnVector);
 
     vectorBranch = filterContext.findColumnVector("f6.1.b");
     assertEquals(3, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(UnionColumnVector.class));
-    assertThat(vectorBranch[1], instanceOf(StructColumnVector.class));
-    assertThat(vectorBranch[2], instanceOf(ListColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof UnionColumnVector);
+    assertTrue(vectorBranch[1] instanceof StructColumnVector);
+    assertTrue(vectorBranch[2] instanceof ListColumnVector);
   }
 
   @Test
@@ -181,24 +174,24 @@ public class TestOrcFilterContext {
       .setBatch(topListSchema.createRowBatch());
     ColumnVector[] vectorBranch = fc.findColumnVector("_elem");
     assertEquals(2, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(ListColumnVector.class));
-    assertThat(vectorBranch[1], instanceOf(StructColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof ListColumnVector);
+    assertTrue(vectorBranch[1] instanceof StructColumnVector);
   }
 
   @Test
   public void testUnsupportedIsNullUse() {
     ColumnVector[] vectorBranch = filterContext.findColumnVector("f4._elem.a");
     assertEquals(3, vectorBranch.length);
-    assertThat(vectorBranch[0], instanceOf(ListColumnVector.class));
-    assertThat(vectorBranch[1], instanceOf(StructColumnVector.class));
-    assertThat(vectorBranch[2], instanceOf(BytesColumnVector.class));
+    assertTrue(vectorBranch[0] instanceof ListColumnVector);
+    assertTrue(vectorBranch[1] instanceof StructColumnVector);
+    assertTrue(vectorBranch[2] instanceof BytesColumnVector);
 
     assertTrue(OrcFilterContext.noNulls(vectorBranch));
     IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
                                                       () -> OrcFilterContext.isNull(vectorBranch,
                                                                                     0));
-    assertThat(exception.getMessage(), containsString("ListColumnVector"));
-    assertThat(exception.getMessage(), containsString("List and Map vectors are not supported"));
+    assertTrue(exception.getMessage().contains("ListColumnVector"));
+    assertTrue(exception.getMessage().contains("List and Map vectors are not supported"));
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
+++ b/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
@@ -17,9 +17,12 @@
  */
 package org.apache.orc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
 import static org.apache.orc.TestVectorOrcFile.assertEmptyStats;
-import static org.junit.Assert.assertArrayEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,10 +40,6 @@ import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 
 import org.apache.orc.impl.RecordReaderImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import com.google.common.collect.Lists;
 
@@ -108,15 +107,12 @@ public class TestOrcNullOptimization {
   FileSystem fs;
   Path testFilePath;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestOrcNullOptimization." +
-        testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 

--- a/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
@@ -27,11 +27,6 @@ import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentImpl;
 import org.apache.orc.impl.RecordReaderImpl;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +34,8 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestOrcTimestampPPD {
   Path workDir =
@@ -52,18 +48,16 @@ public class TestOrcTimestampPPD {
   public TestOrcTimestampPPD() {
   }
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    testFilePath = new Path(workDir, "TestOrcTimestampPPD." + testCaseName.getMethodName() + ".orc");
+    testFilePath = new Path(workDir,
+        "TestOrcTimestampPPD." + testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
-  @After
+  @AfterEach
   public void restoreTimeZone() {
     TimeZone.setDefault(defaultTimeZone);
   }

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone3.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone3.java
@@ -17,76 +17,57 @@
  */
 package org.apache.orc;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
 
 import java.io.File;
 import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import com.google.common.collect.Lists;
 
 /**
  *
  */
-@RunWith(Parameterized.class)
 public class TestOrcTimezone3 {
   Path workDir = new Path(System.getProperty("test.tmp.dir",
       "target" + File.separator + "test" + File.separator + "tmp"));
   Configuration conf;
   FileSystem fs;
   Path testFilePath;
-  String writerTimeZone;
-  String readerTimeZone;
   static TimeZone defaultTimeZone = TimeZone.getDefault();
 
-  public TestOrcTimezone3(String writerTZ, String readerTZ) {
-    this.writerTimeZone = writerTZ;
-    this.readerTimeZone = readerTZ;
+  private static Stream<Arguments> data() {
+    return Stream.of(Arguments.of("America/Chicago", "America/Los_Angeles"));
   }
 
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    List<Object[]> result = Arrays.asList(new Object[][]{
-        {"America/Chicago", "America/Los_Angeles"},
-    });
-    return result;
-  }
-
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestOrcTimezone3." +
-        testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
-  @After
+  @AfterEach
   public void restoreTimeZone() {
     TimeZone.setDefault(defaultTimeZone);
   }
 
-  @Test
-  public void testTimestampWriter() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testTimestampWriter(String writerTimeZone, String readerTimeZone) throws Exception {
     TypeDescription schema = TypeDescription.createTimestamp();
 
     TimeZone.setDefault(TimeZone.getTimeZone(writerTimeZone));

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone4.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone4.java
@@ -23,11 +23,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import java.io.File;
 import java.sql.Timestamp;
@@ -35,7 +30,8 @@ import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.*;
 
 /**
  *
@@ -52,19 +48,16 @@ public class TestOrcTimezone4 {
   public TestOrcTimezone4() {
   }
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestOrcTimezone4." +
-        testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
-  @After
+  @AfterEach
   public void restoreTimeZone() {
     TimeZone.setDefault(defaultTimeZone);
   }

--- a/java/core/src/test/org/apache/orc/TestProlepticConversions.java
+++ b/java/core/src/test/org/apache/orc/TestProlepticConversions.java
@@ -31,12 +31,6 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.impl.DateUtils;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -48,34 +42,27 @@ import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
 import org.threeten.extra.chrono.HybridChronology;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
 
 /**
  * This class tests all of the combinations of reading and writing the hybrid
  * and proleptic calendars.
  */
-@RunWith(Parameterized.class)
 public class TestProlepticConversions {
 
-  @Parameterized.Parameter
-  public boolean writerProlepticGregorian;
-
-  @Parameterized.Parameter(1)
-  public boolean readerProlepticGregorian;
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> getParameters() {
-    List<Object[]> result = new ArrayList<>();
-    final boolean[] BOOLEANS = new boolean[]{false, true};
-    for(Boolean writer: BOOLEANS) {
-      for (Boolean reader: BOOLEANS) {
-        result.add(new Object[]{writer, reader});
-      }
-    }
-    return result;
+  private static Stream<Arguments> data() {
+    return Stream.of(
+        Arguments.of(false, false),
+        Arguments.of(false, true),
+        Arguments.of(true, false),
+        Arguments.of(true, true));
   }
 
   private Path workDir = new Path(System.getProperty("test.tmp.dir",
@@ -95,14 +82,11 @@ public class TestProlepticConversions {
   private FileSystem fs;
   private Path testFilePath;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void setupPath() throws Exception {
+  @BeforeEach
+  public void setupPath(TestInfo testInfo) throws Exception {
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestProlepticConversion." +
-       testCaseName.getMethodName().replaceFirst("\\[[0-9]+]", "") + ".orc");
+       testInfo.getTestMethod().get().getName().replaceFirst("\\[[0-9]+]", "") + ".orc");
     fs.delete(testFilePath, false);
   }
 
@@ -112,8 +96,10 @@ public class TestProlepticConversions {
     return result;
   }
 
-  @Test
-  public void testReadWrite() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testReadWrite(
+      boolean writerProlepticGregorian, boolean readerProlepticGregorian) throws Exception {
     TypeDescription schema = TypeDescription.fromString(
         "struct<d:date,t:timestamp,i:timestamp with local time zone>");
     try (Writer writer = OrcFile.createWriter(testFilePath,
@@ -197,10 +183,13 @@ public class TestProlepticConversions {
       for(int r=0; r < batch.size; ++r) {
         String expectedD = String.format("%04d-01-23", r * 2 + 1);
         String expectedT = String.format("%04d-03-21 %02d:12:34", 2 * r + 1, r % 24);
-        assertEquals("row " + r, expectedD, readerChronology.dateEpochDay(d.vector[r])
-            .format(dateFormat));
-        assertEquals("row " + r, expectedT, timeFormat.format(t.asScratchTimestamp(r)));
-        assertEquals("row " + r, expectedT, timeFormat.format(i.asScratchTimestamp(r)));
+        assertEquals(expectedD,
+            readerChronology.dateEpochDay(d.vector[r]).format(dateFormat),
+            "row " + r);
+        assertEquals(expectedT, timeFormat.format(t.asScratchTimestamp(r)),
+            "row " + r);
+        assertEquals(expectedT, timeFormat.format(i.asScratchTimestamp(r)),
+            "row " + r);
       }
     }
   }
@@ -208,8 +197,10 @@ public class TestProlepticConversions {
   /**
    * Test all of the type conversions from/to date.
    */
-  @Test
-  public void testSchemaEvolutionDate() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSchemaEvolutionDate(
+      boolean writerProlepticGregorian, boolean readerProlepticGregorian) throws Exception {
     TypeDescription schema = TypeDescription.fromString(
         "struct<d2s:date,d2t:date,s2d:string,t2d:timestamp>");
     try (Writer writer = OrcFile.createWriter(testFilePath,
@@ -271,12 +262,12 @@ public class TestProlepticConversions {
         String expectedD1 = String.format("%04d-01-23", 2 * r + 1);
         String expectedD2 = expectedD1 + " 00:00:00";
         String expectedT = String.format("%04d-03-21", 2 * r + 1);
-        assertEquals("row " + r, expectedD1, d2s.toString(r));
-        assertEquals("row " + r, expectedD2, timeFormat.format(d2t.asScratchTimestamp(r)));
-        assertEquals("row " + r, expectedD1, DateUtils.printDate((int) s2d.vector[r],
-            readerProlepticGregorian));
-        assertEquals("row " + r, expectedT, dateFormat.format(
-            new Date(TimeUnit.DAYS.toMillis(t2d.vector[r]))));
+        assertEquals(expectedD1, d2s.toString(r), "row " + r);
+        assertEquals(expectedD2, timeFormat.format(d2t.asScratchTimestamp(r)), "row " + r);
+        assertEquals(expectedD1, DateUtils.printDate((int) s2d.vector[r],
+            readerProlepticGregorian), "row " + r);
+        assertEquals(expectedT, dateFormat.format(
+            new Date(TimeUnit.DAYS.toMillis(t2d.vector[r]))), "row " + r);
       }
       assertEquals(false, rows.nextBatch(batch));
     }
@@ -286,8 +277,10 @@ public class TestProlepticConversions {
    * Test all of the type conversions from/to timestamp, except for date,
    * which was handled above.
    */
-  @Test
-  public void testSchemaEvolutionTimestamp() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testSchemaEvolutionTimestamp(
+      boolean writerProlepticGregorian, boolean readerProlepticGregorian) throws Exception {
     TypeDescription schema = TypeDescription.fromString(
         "struct<t2i:timestamp,t2d:timestamp,t2D:timestamp,t2s:timestamp,"
         + "i2t:bigint,d2t:decimal(18,2),D2t:double,s2t:string>");
@@ -365,18 +358,22 @@ public class TestProlepticConversions {
       for(int r=0; r < batch.size; ++r) {
         String time = String.format("%04d-03-21 %02d:12:34.12", 2 * r + 1, r % 24);
         long millis = DateUtils.parseTime(time, readerProlepticGregorian, true);
-        assertEquals("row " + r, time.substring(0, time.length() - 3),
-            DateUtils.printTime(i2t.time[r], readerProlepticGregorian, true));
-        assertEquals("row " + r, time,
-            DateUtils.printTime(d2t.time[r], readerProlepticGregorian, true));
-        assertEquals("row " + r, time,
-            DateUtils.printTime(D2t.time[r], readerProlepticGregorian, true));
-        assertEquals("row " + r, time,
-            DateUtils.printTime(s2t.time[r], readerProlepticGregorian, true));
-        assertEquals("row " + r, Math.floorDiv(millis, 1000), t2i.vector[r]);
-        assertEquals("row " + r, Math.floorDiv(millis, 10), t2d.vector[r]);
-        assertEquals("row " + r, millis/1000.0, t2D.vector[r], 0.1);
-        assertEquals("row " + r, time, t2s.toString(r));
+        assertEquals(time.substring(0, time.length() - 3),
+            DateUtils.printTime(i2t.time[r], readerProlepticGregorian, true),
+            "row " + r);
+        assertEquals(time,
+            DateUtils.printTime(d2t.time[r], readerProlepticGregorian, true),
+            "row " + r);
+        assertEquals(time,
+            DateUtils.printTime(D2t.time[r], readerProlepticGregorian, true),
+            "row " + r);
+        assertEquals(time,
+            DateUtils.printTime(s2t.time[r], readerProlepticGregorian, true),
+            "row " + r);
+        assertEquals(Math.floorDiv(millis, 1000), t2i.vector[r], "row " + r);
+        assertEquals(Math.floorDiv(millis, 10), t2d.vector[r], "row " + r);
+        assertEquals(millis/1000.0, t2D.vector[r], 0.1, "row " + r);
+        assertEquals(time, t2s.toString(r), "row " + r);
       }
       assertEquals(false, rows.nextBatch(batch));
     }

--- a/java/core/src/test/org/apache/orc/TestReader.java
+++ b/java/core/src/test/org/apache/orc/TestReader.java
@@ -17,7 +17,8 @@
  */
 package org.apache.orc;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 
@@ -25,10 +26,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 public class TestReader {
   Path workDir = new Path(System.getProperty("test.tmp.dir",
@@ -37,15 +34,12 @@ public class TestReader {
   FileSystem fs;
   Path testFilePath;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, TestReader.class.getSimpleName() + "." +
-        testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
@@ -59,24 +53,28 @@ public class TestReader {
     assertEquals(0, reader.getNumberOfRows());
   }
 
-  @Test(expected=FileFormatException.class)
+  @Test
   public void testReadFileLengthLessThanMagic() throws Exception {
-    FSDataOutputStream fout = fs.create(testFilePath);
-    fout.writeBoolean(true);
-    fout.close();
-    assertEquals(1, fs.getFileStatus(testFilePath).getLen());
-    OrcFile.createReader(testFilePath,
-      OrcFile.readerOptions(conf).filesystem(fs));
+    assertThrows(FileFormatException.class, () -> {
+      FSDataOutputStream fout = fs.create(testFilePath);
+      fout.writeBoolean(true);
+      fout.close();
+      assertEquals(1, fs.getFileStatus(testFilePath).getLen());
+      OrcFile.createReader(testFilePath,
+          OrcFile.readerOptions(conf).filesystem(fs));
+    });
   }
 
-  @Test(expected=FileFormatException.class)
+  @Test
   public void testReadFileInvalidHeader() throws Exception {
-    FSDataOutputStream fout = fs.create(testFilePath);
-    fout.writeLong(1);
-    fout.close();
-    assertEquals(8, fs.getFileStatus(testFilePath).getLen());
-    OrcFile.createReader(testFilePath,
-      OrcFile.readerOptions(conf).filesystem(fs));
+    assertThrows(FileFormatException.class, () -> {
+      FSDataOutputStream fout = fs.create(testFilePath);
+      fout.writeLong(1);
+      fout.close();
+      assertEquals(8, fs.getFileStatus(testFilePath).getLen());
+      OrcFile.createReader(testFilePath,
+          OrcFile.readerOptions(conf).filesystem(fs));
+    });
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypes.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypes.java
@@ -30,11 +30,9 @@ import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.RecordReaderImpl;
-import static org.junit.Assert.*;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 
@@ -48,14 +46,12 @@ public class TestRowFilteringComplexTypes {
 
     private static final int ColumnBatchRows = 1024;
 
-    @Rule
-    public TestName testCaseName = new TestName();
-
-    @Before
-    public void openFileSystem() throws Exception {
+    @BeforeEach
+    public void openFileSystem(TestInfo testInfo) throws Exception {
         conf = new Configuration();
         fs = FileSystem.getLocal(conf);
-        testFilePath = new Path(workDir, "TestRowFilteringComplexTypes." + testCaseName.getMethodName() + ".orc");
+        testFilePath = new Path(workDir,
+            "TestRowFilteringComplexTypes." + testInfo.getTestMethod().get().getName() + ".orc");
         fs.delete(testFilePath, false);
     }
 
@@ -177,14 +173,14 @@ public class TestRowFilteringComplexTypes {
                 for (int r = 0; r < batch.size; ++r) {
                     int row = batch.selected[r];
                     int originalRow = (r + previousBatchRows) * 2;
-                    assertEquals("row " + originalRow, originalRow, col1.vector[row]);
-                    assertEquals("row " + originalRow, 0, col2.tags[row]);
-                    assertEquals("row " + originalRow,
-                        originalRow * 1000, innerCol1.vector[row]);
+                    String msg = "row " + originalRow;
+                    assertEquals(originalRow, col1.vector[row], msg);
+                    assertEquals(0, col2.tags[row], msg);
+                    assertEquals(originalRow * 1000, innerCol1.vector[row], msg);
                 }
                 // check to make sure that we didn't read innerCol2
                 for(int r = 1; r < ColumnBatchRows; r += 2) {
-                    assertEquals("row " + r, 0, innerCol2.vector[r]);
+                    assertEquals(0, innerCol2.vector[r], "row " + r);
                 }
                 previousBatchRows += batch.size;
             }

--- a/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypesNulls.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypesNulls.java
@@ -31,8 +31,6 @@ import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.OrcFilterContextImpl;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,8 +42,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestRowFilteringComplexTypesNulls {
   private static final Logger LOG =
@@ -73,7 +71,7 @@ public class TestRowFilteringComplexTypesNulls {
   private static final String[] FilterColumns = new String[] {"ridx", "s2.f2", "u3.0"};
   private static final int scale = 3;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     conf = new Configuration();
     fs = FileSystem.get(conf);
@@ -193,9 +191,8 @@ public class TestRowFilteringComplexTypesNulls {
     assertEquals(0, rowCount);
     // We should read less than half the length of the file
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    assertTrue(String.format("Bytes read %.2f%% should be less than 50%%",
-                             readPercentage),
-               readPercentage < 50);
+    assertTrue(readPercentage < 50,
+        String.format("Bytes read %.2f%% should be less than 50%%", readPercentage));
   }
 
   private long validateFilteredRecordReader(RecordReader rr, VectorizedRowBatch b)
@@ -328,8 +325,8 @@ public class TestRowFilteringComplexTypesNulls {
       // stripe change
       bytesRead = readEnd().getBytesRead();
       seekToRow(rr, b, 1024);
-      assertTrue("Change of stripe should require more IO",
-                 readEnd().getBytesRead() > bytesRead);
+      assertTrue(readEnd().getBytesRead() > bytesRead,
+          "Change of stripe should require more IO");
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());

--- a/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
@@ -30,9 +30,6 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.OrcFilterContextImpl;
-import static org.junit.Assert.*;
-import org.junit.BeforeClass;
-import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +40,9 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Consumer;
+
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestRowFilteringIOSkip {
   private static final Logger LOG = LoggerFactory.getLogger(TestRowFilteringIOSkip.class);
@@ -65,7 +65,7 @@ public class TestRowFilteringIOSkip {
   private static final String[] FilterColumns = new String[] {"f1", "ridx"};
   private static final int scale = 3;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     conf = new Configuration();
     fs = FileSystem.get(conf);
@@ -139,10 +139,10 @@ public class TestRowFilteringIOSkip {
     FileSystem.Statistics stats = readEnd();
     assertEquals(RowCount, rowCount);
     // We should read less than half the length of the file
-    assertTrue(String.format("Bytes read %d is not half of file size %d",
-                                    stats.getBytesRead(),
-                                    r.getContentLength()),
-                      stats.getBytesRead() < r.getContentLength() / 2);
+    assertTrue(stats.getBytesRead() < r.getContentLength() / 2,
+        String.format("Bytes read %d is not half of file size %d",
+            stats.getBytesRead(),
+            r.getContentLength()));
   }
 
   @Test
@@ -216,9 +216,8 @@ public class TestRowFilteringIOSkip {
     assertEquals(0, rowCount);
     // We should read less than half the length of the file
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    assertTrue(String.format("Bytes read %.2f%% should be less than 50%%",
-                                    readPercentage),
-                      readPercentage < 50);
+    assertTrue(readPercentage < 50,
+        String.format("Bytes read %.2f%% should be less than 50%%", readPercentage));
   }
 
   @Test
@@ -316,8 +315,8 @@ public class TestRowFilteringIOSkip {
       // stripe change
       bytesRead = readEnd().getBytesRead();
       seekToRow(rr, b, 1024);
-      assertTrue("Change of stripe should require more IO",
-                        readEnd().getBytesRead() > bytesRead);
+      assertTrue(readEnd().getBytesRead() > bytesRead,
+          "Change of stripe should require more IO");
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());

--- a/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringNoSkip.java
@@ -24,15 +24,12 @@ import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.impl.RecordReaderImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import java.io.File;
 import java.sql.Timestamp;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Types that are not skipped at row-level include: Long, Short, Int, Date, Binary
@@ -50,14 +47,12 @@ public class TestRowFilteringNoSkip {
 
   private static final int ColumnBatchRows = 1024;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    testFilePath = new Path(workDir, "TestRowFilteringNoSkip." + testCaseName.getMethodName() + ".orc");
+    testFilePath = new Path(workDir, "TestRowFilteringNoSkip." +
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 

--- a/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringSkip.java
@@ -32,10 +32,6 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.OrcFilterContextImpl;
 import org.apache.orc.impl.RecordReaderImpl;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -44,7 +40,8 @@ import java.sql.Timestamp;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 
-import static org.junit.Assert.*;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Types that are skipped at row-level include: Decimal, Decimal64, Double, Float, Char, VarChar, String, Boolean, Timestamp
@@ -61,14 +58,12 @@ public class TestRowFilteringSkip {
 
   private static final int ColumnBatchRows = 1024;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    testFilePath = new Path(workDir, "TestRowFilteringSkip." + testCaseName.getMethodName() + ".orc");
+    testFilePath = new Path(workDir, "TestRowFilteringSkip." +
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -17,11 +17,8 @@
  */
 package org.apache.orc;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,14 +26,8 @@ import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TestTypeDescription {
-  @Rule
-  public ExpectedException thrown= ExpectedException.none();
-
   @Test
   public void testJson() {
     TypeDescription bin = TypeDescription.createBinary();
@@ -163,58 +154,66 @@ public class TestTypeDescription {
 
   @Test
   public void testMissingField() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Missing name at 'struct<^'");
-    TypeDescription.fromString("struct<");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("struct<");
+    });
+    assertTrue(e.getMessage().contains("Missing name at 'struct<^'"));
   }
 
   @Test
   public void testQuotedField1() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Unmatched quote at 'struct<^`abc'");
-    TypeDescription.fromString("struct<`abc");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("struct<`abc");
+    });
+    assertTrue(e.getMessage().contains("Unmatched quote at 'struct<^`abc'"));
   }
 
   @Test
   public void testQuotedField2() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Empty quoted field name at 'struct<``^:int>'");
-    TypeDescription.fromString("struct<``:int>");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("struct<``:int>");
+    });
+    assertTrue(e.getMessage().contains("Empty quoted field name at 'struct<``^:int>'"));
   }
 
   @Test
   public void testParserUnknownCategory() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Can't parse category at 'FOOBAR^'");
-    TypeDescription.fromString("FOOBAR");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("FOOBAR");
+    });
+    assertTrue(e.getMessage().contains("Can't parse category at 'FOOBAR^'"));
   }
 
   @Test
   public void testParserEmptyCategory() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Can't parse category at '^<int>'");
-    TypeDescription.fromString("<int>");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("<int>");
+    });
+    assertTrue(e.getMessage().contains("Can't parse category at '^<int>'"));
   }
 
   @Test
   public void testParserMissingInt() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Missing integer at 'char(^)'");
-    TypeDescription.fromString("char()");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("char()");
+    });
+    assertTrue(e.getMessage().contains("Missing integer at 'char(^)'"));
   }
 
   @Test
   public void testParserMissingSize() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Missing required char '(' at 'struct<c:char^>'");
-    TypeDescription.fromString("struct<c:char>");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("struct<c:char>");
+    });
+    assertTrue(e.getMessage().contains("Missing required char '(' at 'struct<c:char^>'"));
   }
 
   @Test
   public void testParserExtraStuff() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Extra characters at 'struct<i:int>^,'");
-    TypeDescription.fromString("struct<i:int>,");
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
+      TypeDescription.fromString("struct<i:int>,");
+    });
+    assertTrue(e.getMessage().contains("Extra characters at 'struct<i:int>^,'"));
   }
 
   @Test
@@ -462,7 +461,7 @@ public class TestTypeDescription {
     assertEquals(3, clearAttributes(schema));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testEncryptionConflict() {
     TypeDescription schema = TypeDescription.fromString(
         "struct<" +
@@ -470,10 +469,11 @@ public class TestTypeDescription {
             "address:struct<street:string,city:string,country:string,post_code:string>," +
             "credit_cards:array<struct<card_number:string,expire:date,ccv:string>>>");
     // set some encryption
-    schema.annotateEncryption("pii:address,personal:address",null);
+    assertThrows(IllegalArgumentException.class, () ->
+        schema.annotateEncryption("pii:address,personal:address",null));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testMaskConflict() {
     TypeDescription schema = TypeDescription.fromString(
         "struct<" +
@@ -481,6 +481,7 @@ public class TestTypeDescription {
             "address:struct<street:string,city:string,country:string,post_code:string>," +
             "credit_cards:array<struct<card_number:string,expire:date,ccv:string>>>");
     // set some encryption
-    schema.annotateEncryption(null,"nullify:name;sha256:name");
+    assertThrows(IllegalArgumentException.class, () ->
+        schema.annotateEncryption(null,"nullify:name;sha256:name"));
   }
 }

--- a/java/core/src/test/org/apache/orc/TestUnicode.java
+++ b/java/core/src/test/org/apache/orc/TestUnicode.java
@@ -74,7 +74,7 @@ public class TestUnicode {
   @ParameterizedTest
   @MethodSource("data")
   public void testUtf8(String type, int maxLength, boolean hasRTrim) throws Exception {
-    if (type == "varchar") {
+    if (type.equals("varchar")) {
       testVarChar(maxLength);
     } else {
       testChar(maxLength, hasRTrim);

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Lists;
 import org.apache.orc.impl.ReaderImpl;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
+import org.apache.orc.OrcFile.Version;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -62,10 +63,8 @@ import org.apache.orc.impl.RecordReaderUtils;
 import org.junit.jupiter.api.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
-
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.*;
 import org.mockito.Mockito;
 
 import javax.xml.bind.DatatypeConverter;

--- a/java/core/src/test/org/apache/orc/impl/TestBitFieldReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestBitFieldReader.java
@@ -17,13 +17,13 @@
  */
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.nio.ByteBuffer;
 
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.impl.writer.StreamOptions;
-import org.junit.Test;
 
 public class TestBitFieldReader {
 

--- a/java/core/src/test/org/apache/orc/impl/TestBitPack.java
+++ b/java/core/src/test/org/apache/orc/impl/TestBitPack.java
@@ -17,8 +17,8 @@
  */
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,10 +30,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.impl.writer.StreamOptions;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 import com.google.common.primitives.Longs;
 
@@ -48,14 +44,12 @@ public class TestBitPack {
   FileSystem fs;
   Path testFilePath;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    testFilePath = new Path(workDir, "TestOrcFile." + testCaseName.getMethodName() + ".orc");
+    testFilePath = new Path(workDir, "TestOrcFile." +
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 

--- a/java/core/src/test/org/apache/orc/impl/TestColumnStatisticsImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestColumnStatisticsImpl.java
@@ -27,14 +27,12 @@ import org.apache.orc.OrcProto;
 import org.apache.orc.Reader;
 import org.apache.orc.TimestampColumnStatistics;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.TimeZone;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestColumnStatisticsImpl {
 

--- a/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
+++ b/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
@@ -46,13 +46,9 @@ import org.apache.orc.RecordReader;
 import org.apache.orc.TestProlepticConversions;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestConvertTreeReaderFactory {
 
@@ -64,17 +60,15 @@ public class TestConvertTreeReaderFactory {
   private Path testFilePath;
   private int LARGE_BATCH_SIZE;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void setupPath() throws Exception {
+  @BeforeEach
+  public void setupPath(TestInfo testInfo) throws Exception {
     // Default CV length is 1024
     this.LARGE_BATCH_SIZE = 1030;
     this.conf = new Configuration();
     this.fs = FileSystem.getLocal(conf);
-    this.testFilePath = new Path(workDir, TestWriterImpl.class.getSimpleName() + testCaseName.getMethodName().
-        replaceFirst("\\[[0-9]+]", "") + ".orc");
+    this.testFilePath = new Path(workDir, TestWriterImpl.class.getSimpleName() +
+        testInfo.getTestMethod().get().getName().replaceFirst("\\[[0-9]+]", "") +
+        ".orc");
     fs.delete(testFilePath, false);
   }
 

--- a/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestCryptoUtils.java
@@ -25,15 +25,14 @@ import org.apache.orc.InMemoryKeystore;
 import org.apache.orc.OrcConf;
 import org.apache.orc.OrcProto;
 import org.apache.orc.impl.reader.ReaderEncryptionVariant;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.security.Key;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestCryptoUtils {
 

--- a/java/core/src/test/org/apache/orc/impl/TestDataReaderProperties.java
+++ b/java/core/src/test/org/apache/orc/impl/TestDataReaderProperties.java
@@ -20,14 +20,12 @@ package org.apache.orc.impl;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.CompressionKind;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.function.Supplier;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
 public class TestDataReaderProperties {
@@ -87,27 +85,33 @@ public class TestDataReaderProperties {
     assertFalse(properties.getZeroCopy());
   }
 
-  @Test(expected = java.lang.NullPointerException.class)
+  @Test
   public void testEmptyBuild() {
-    DataReaderProperties.builder().build();
+    assertThrows(NullPointerException.class, () -> {
+      DataReaderProperties.builder().build();
+    });
   }
 
-  @Test(expected = java.lang.NullPointerException.class)
+  @Test
   public void testMissingPath() {
-    DataReaderProperties.builder()
-      .withFileSystemSupplier(mockedSupplier)
-      .withCompression(InStream.options())
-      .withZeroCopy(mockedZeroCopy)
-      .build();
+    assertThrows(NullPointerException.class, () -> {
+      DataReaderProperties.builder()
+        .withFileSystemSupplier(mockedSupplier)
+        .withCompression(InStream.options())
+        .withZeroCopy(mockedZeroCopy)
+        .build();
+    });
   }
 
-  @Test(expected = java.lang.NullPointerException.class)
+  @Test
   public void testMissingFileSystem() {
-    DataReaderProperties.builder()
-      .withPath(mockedPath)
-      .withCompression(InStream.options())
-      .withZeroCopy(mockedZeroCopy)
-      .build();
+    assertThrows(NullPointerException.class, () -> {
+      DataReaderProperties.builder()
+        .withPath(mockedPath)
+        .withCompression(InStream.options())
+        .withZeroCopy(mockedZeroCopy)
+        .build();
+    });
   }
 
 }

--- a/java/core/src/test/org/apache/orc/impl/TestDateUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestDateUtils.java
@@ -18,9 +18,8 @@
 
 package org.apache.orc.impl;
 
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestDateUtils {
   /**
@@ -51,10 +50,10 @@ public class TestDateUtils {
 
   void checkConversion(int dayOfEpoch, String hybrid, String proleptic) {
     String result = DateUtils.printDate(dayOfEpoch, false);
-    assertEquals("day " + dayOfEpoch, hybrid, result);
+    assertEquals(hybrid, result, "day " + dayOfEpoch);
     assertEquals(dayOfEpoch, (int) DateUtils.parseDate(result, false));
     result = DateUtils.printDate(dayOfEpoch, true);
-    assertEquals("day " + dayOfEpoch, proleptic, result);
+    assertEquals(proleptic, result, "day " + dayOfEpoch);
     assertEquals(dayOfEpoch, (int) DateUtils.parseDate(result, true));
   }
 }

--- a/java/core/src/test/org/apache/orc/impl/TestDynamicArray.java
+++ b/java/core/src/test/org/apache/orc/impl/TestDynamicArray.java
@@ -21,9 +21,9 @@ import java.util.Random;
 
 import org.apache.orc.impl.DynamicByteArray;
 import org.apache.orc.impl.DynamicIntArray;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestDynamicArray {
 

--- a/java/core/src/test/org/apache/orc/impl/TestInStream.java
+++ b/java/core/src/test/org/apache/orc/impl/TestInStream.java
@@ -18,13 +18,8 @@
 
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -41,7 +36,6 @@ import org.apache.orc.EncryptionAlgorithm;
 import org.apache.orc.OrcProto;
 import org.apache.orc.PhysicalWriter;
 import org.apache.orc.impl.writer.StreamOptions;
-import org.junit.Test;
 
 public class TestInStream {
 
@@ -147,11 +141,11 @@ public class TestInStream {
         in.toString());
     for(int i=0; i < 1024; ++i) {
       int x = in.read();
-      assertEquals("value " + i, i & 0xff, x);
+      assertEquals(i & 0xff, x, "value " + i);
     }
     for(int i=1023; i >= 0; --i) {
       in.seek(positions[i]);
-      assertEquals("value " + i, i & 0xff, in.read());
+      assertEquals(i & 0xff, in.read(), "value " + i);
     }
   }
 
@@ -217,11 +211,11 @@ public class TestInStream {
                        " range: 0 offset: 0 position: 0 limit: 1965",
           in.toString());
       for (int i = 0; i < ROW_COUNT; ++i) {
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
       for (int i = ROW_COUNT - 1; i >= 0; --i) {
         in.seek(positions[i]);
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
     }
   }
@@ -265,11 +259,11 @@ public class TestInStream {
                        " range: 0 offset: 0 position: 0 limit: 1965",
           in.toString());
       for (int i = 0; i < ROW_COUNT; ++i) {
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
       for (int i = ROW_COUNT - 1; i >= 0; --i) {
         in.seek(positions[i]);
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
     }
   }
@@ -344,11 +338,11 @@ public class TestInStream {
                        (bytes.length - 15) + " to " + bytes.length,
           in.toString());
       for (int i = 0; i < ROW_COUNT; ++i) {
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
       for (int i = ROW_COUNT - 1; i >= 0; --i) {
         in.seek(positions[i]);
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
     }
   }
@@ -398,11 +392,11 @@ public class TestInStream {
                        "  range 1 = 2100 to 4044;  range 2 = 4044 to 5044",
           in.toString());
       for (int i = 0; i < ROW_COUNT; ++i) {
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
       for (int i = ROW_COUNT - 1; i >= 0; --i) {
         in.seek(positions[i]);
-        assertEquals("row " + i, i * DATA_CONST, inputStream.readLong());
+        assertEquals(i * DATA_CONST, inputStream.readLong(), "row " + i);
       }
     }
   }
@@ -845,7 +839,7 @@ public class TestInStream {
     byte[] inBuffer = new byte[4096];
     assertEquals(4096, inStream.read(inBuffer));
     for(int i=0; i < inBuffer.length; ++i) {
-      assertEquals("position " + i, (byte)i, inBuffer[i]);
+      assertEquals((byte)i, inBuffer[i], "position " + i);
     }
   }
 
@@ -891,10 +885,9 @@ public class TestInStream {
     posn = 0;
     int read = inStream.read(inBuffer);
     while (read != -1) {
-      assertEquals("Read length at " + posn,
-          Math.min(STREAM_LENGTH - posn, CHUNK_LENGTH), read);
+      assertEquals(Math.min(STREAM_LENGTH - posn, CHUNK_LENGTH), read, "Read length at " + posn);
       for(int i=0; i < read; ++i) {
-        assertEquals("posn " + posn + " + " + i, (byte)(posn + i), inBuffer[i]);
+        assertEquals((byte)(posn + i), inBuffer[i], "posn " + posn + " + " + i);
       }
       posn += read;
       read = inStream.read(inBuffer);
@@ -935,7 +928,7 @@ public class TestInStream {
     byte[] inBuffer = new byte[4096];
     assertEquals(4096, inStream.read(inBuffer));
     for(int i=0; i < inBuffer.length; ++i) {
-      assertEquals("position " + i, (byte)i, inBuffer[i]);
+      assertEquals((byte)i, inBuffer[i], "position " + i);
     }
   }
 
@@ -956,7 +949,7 @@ public class TestInStream {
     byte[] inBuffer = new byte[4096];
     assertEquals(4096, inStream.read(inBuffer));
     for(int i=0; i < inBuffer.length; ++i) {
-      assertEquals("position " + i, (byte)i, inBuffer[i]);
+      assertEquals((byte)i, inBuffer[i], "position " + i);
     }
   }
 }

--- a/java/core/src/test/org/apache/orc/impl/TestIntegerCompressionReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestIntegerCompressionReader.java
@@ -22,9 +22,9 @@ import java.util.Random;
 
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.impl.writer.StreamOptions;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestIntegerCompressionReader {
 

--- a/java/core/src/test/org/apache/orc/impl/TestMemoryManager.java
+++ b/java/core/src/test/org/apache/orc/impl/TestMemoryManager.java
@@ -20,16 +20,13 @@ package org.apache.orc.impl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.MemoryManager;
-import org.hamcrest.BaseMatcher;
-import org.hamcrest.Description;
-import org.junit.Test;
 import static org.mockito.ArgumentMatchers.eq;
 import org.mockito.Mockito;
 
 import java.lang.management.ManagementFactory;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test the ORC memory manager.
@@ -80,33 +77,8 @@ public class TestMemoryManager {
         ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
     System.err.print("Memory = " + mem);
     long pool = mgr.getTotalMemoryPool();
-    assertTrue("Pool too small: " + pool, mem * 0.899 < pool);
-    assertTrue("Pool too big: " + pool, pool < mem * 0.901);
-  }
-
-  private static class DoubleMatcher extends BaseMatcher<Double> {
-    final double expected;
-    final double error;
-    DoubleMatcher(double expected, double error) {
-      this.expected = expected;
-      this.error = error;
-    }
-
-    @Override
-    public boolean matches(Object val) {
-      double dbl = (Double) val;
-      return Math.abs(dbl - expected) <= error;
-    }
-
-    @Override
-    public void describeTo(Description description) {
-      description.appendText("not sufficiently close to ");
-      description.appendText(Double.toString(expected));
-    }
-  }
-
-  private static DoubleMatcher closeTo(double value, double error) {
-    return new DoubleMatcher(value, error);
+    assertTrue(mem * 0.899 < pool, "Pool too small: " + pool);
+    assertTrue(pool < mem * 0.901, "Pool too big: " + pool);
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
@@ -24,22 +24,12 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.TypeDescription;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestOrcFilterContextImpl {
 
@@ -49,9 +39,6 @@ public class TestOrcFilterContextImpl {
       .addField("f2a", TypeDescription.createLong())
       .addField("f2b", TypeDescription.createString()))
     .addField("f3", TypeDescription.createString());
-
-  @Rule
-  public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void testSuccessfulRetrieval() {
@@ -86,9 +73,9 @@ public class TestOrcFilterContextImpl {
     fc.setBatch(b);
 
     // Missing field at top level
-    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                      () -> fc.findColumnVector("f4"));
-    assertThat(exception.getMessage(), containsString("Field f4 not found in"));
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                                              () -> fc.findColumnVector("f4"));
+    assertTrue(e.getMessage().contains("Field f4 not found in"));
   }
 
   @Test
@@ -98,10 +85,10 @@ public class TestOrcFilterContextImpl {
     fc.setBatch(b);
 
     // Missing field at top level
-    IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                      () -> fc.findColumnVector("f2.c"));
-    assertThat(exception.getMessage(),
-               containsString("Field c not found in struct<f2a:bigint,f2b:string>"));
+    IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                                              () -> fc.findColumnVector("f2.c"));
+    assertTrue(e.getMessage().contains(
+        "Field c not found in struct<f2a:bigint,f2b:string>"));
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestOrcLargeStripe.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOrcLargeStripe.java
@@ -15,9 +15,9 @@
  */
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -47,15 +47,11 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-@RunWith(MockitoJUnitRunner.class)
+@ExtendWith(MockitoExtension.class)
 public class TestOrcLargeStripe {
 
   private Path workDir = new Path(System.getProperty("test.tmp.dir", "target" + File.separator + "test"
@@ -65,14 +61,12 @@ public class TestOrcLargeStripe {
   FileSystem fs;
   private Path testFilePath;
 
-  @Rule
-  public TestName testCaseName = new TestName();
-
-  @Before
-  public void openFileSystem() throws Exception {
+  @BeforeEach
+  public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    testFilePath = new Path(workDir, "TestOrcFile." + testCaseName.getMethodName() + ".orc");
+    testFilePath = new Path(workDir, "TestOrcFile." +
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
@@ -141,8 +135,6 @@ public class TestOrcLargeStripe {
     Configuration conf = new Configuration();
     FileSystem fs = FileSystem.getLocal(conf);
     TypeDescription schema = TypeDescription.createTimestamp();
-    testFilePath = new Path(workDir, "TestOrcLargeStripe." +
-      testCaseName.getMethodName() + ".orc");
     fs.delete(testFilePath, false);
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000).bufferSize(10000)

--- a/java/core/src/test/org/apache/orc/impl/TestOrcWideTable.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOrcWideTable.java
@@ -18,11 +18,10 @@
 
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-
-import org.junit.Test;
 
 public class TestOrcWideTable {
 

--- a/java/core/src/test/org/apache/orc/impl/TestOutStream.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOutStream.java
@@ -18,8 +18,9 @@
 
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -35,8 +36,6 @@ import org.apache.orc.InMemoryKeystore;
 import org.apache.orc.OrcProto;
 import org.apache.orc.PhysicalWriter;
 import org.apache.orc.impl.writer.StreamOptions;
-import org.junit.Assume;
-import org.junit.Test;
 import org.mockito.Mockito;
 
 public class TestOutStream {
@@ -151,7 +150,7 @@ public class TestOutStream {
       };
       assertEquals(generated.length, output.length);
       for (int i = 0; i < generated.length; ++i) {
-        assertEquals("i = " + i, (byte) (generated[i] ^ data[i]), output[i]);
+        assertEquals((byte) (generated[i] ^ data[i]), output[i], "i = " + i);
       }
 
       receiver.buffer.clear();
@@ -164,7 +163,7 @@ public class TestOutStream {
       generated = new int[]{0x16, 0x03, 0xE6, 0xC3};
       assertEquals(generated.length, output.length);
       for (int i = 0; i < generated.length; ++i) {
-        assertEquals("i = " + i, (byte) (generated[i] ^ data[i]), output[i]);
+        assertEquals((byte) (generated[i] ^ data[i]), output[i], "i = " + i);
       }
     }
   }
@@ -172,7 +171,7 @@ public class TestOutStream {
   @Test
   public void testCompression256Encryption() throws Exception {
     // disable test if AES_256 is not available
-    Assume.assumeTrue(InMemoryKeystore.SUPPORTS_AES_256);
+    assumeTrue(InMemoryKeystore.SUPPORTS_AES_256);
     TestInStream.OutputCollector receiver = new TestInStream.OutputCollector();
     EncryptionAlgorithm aes256 = EncryptionAlgorithm.AES_CTR_256;
     byte[] keyBytes = new byte[aes256.keyLength()];
@@ -212,7 +211,7 @@ public class TestOutStream {
              StandardCharsets.UTF_8))) {
       // check the contents of the decompressed stream
       for (int i = 0; i < 10000; ++i) {
-        assertEquals("i = " + i, "The Cheesy Poofs " + i, reader.readLine());
+        assertEquals("The Cheesy Poofs " + i, reader.readLine(), "i = " + i);
       }
       assertEquals(null, reader.readLine());
     }

--- a/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPhysicalFsWriter.java
@@ -31,7 +31,6 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.OrcProto;
 import org.apache.orc.PhysicalWriter;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -43,7 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestPhysicalFsWriter {
 

--- a/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
+++ b/java/core/src/test/org/apache/orc/impl/TestPredicatePushDownBounds.java
@@ -24,13 +24,13 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
 import org.apache.orc.IntegerColumnStatistics;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.util.BloomFilter;
-import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.apache.orc.impl.TestRecordReaderImpl.createPredicateLeaf;
 
 public class TestPredicatePushDownBounds {

--- a/java/core/src/test/org/apache/orc/impl/TestReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestReaderImpl.java
@@ -15,8 +15,8 @@
  */
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -49,24 +49,17 @@ import org.apache.orc.RecordReader;
 import org.apache.orc.StripeStatistics;
 import org.apache.orc.TestVectorOrcFile;
 import org.apache.orc.TypeDescription;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TestReaderImpl {
   private Path workDir = new Path(System.getProperty("example.dir",
       "../../examples/"));
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   private final Path path = new Path("test-file.orc");
   private FSDataInputStream in;
   private int psLen;
   private ByteBuffer buffer;
 
-  @Before
+  @BeforeEach
   public void setup() {
     in = null;
   }
@@ -74,15 +67,17 @@ public class TestReaderImpl {
   @Test
   public void testEnsureOrcFooterSmallTextFile() throws IOException {
     prepareTestCase("1".getBytes(StandardCharsets.UTF_8));
-    thrown.expect(FileFormatException.class);
-    ReaderImpl.ensureOrcFooter(in, path, psLen, buffer);
+    assertThrows(FileFormatException.class, () -> {
+      ReaderImpl.ensureOrcFooter(in, path, psLen, buffer);
+    });
   }
 
   @Test
   public void testEnsureOrcFooterLargeTextFile() throws IOException {
     prepareTestCase("This is Some Text File".getBytes(StandardCharsets.UTF_8));
-    thrown.expect(FileFormatException.class);
-    ReaderImpl.ensureOrcFooter(in, path, psLen, buffer);
+    assertThrows(FileFormatException.class, () -> {
+      ReaderImpl.ensureOrcFooter(in, path, psLen, buffer);
+    });
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -18,10 +18,8 @@
 
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -91,7 +89,6 @@ import org.apache.orc.OrcProto;
 
 import org.apache.orc.util.BloomFilterIO;
 import org.apache.orc.util.BloomFilterUtf8;
-import org.junit.Test;
 
 public class TestRecordReaderImpl {
 

--- a/java/core/src/test/org/apache/orc/impl/TestRunLengthByteReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRunLengthByteReader.java
@@ -21,9 +21,9 @@ import java.nio.ByteBuffer;
 
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.impl.writer.StreamOptions;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRunLengthByteReader {
 

--- a/java/core/src/test/org/apache/orc/impl/TestRunLengthIntegerReader.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRunLengthIntegerReader.java
@@ -22,9 +22,9 @@ import java.util.Random;
 
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.impl.writer.StreamOptions;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRunLengthIntegerReader {
 

--- a/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSchemaEvolution.java
@@ -17,11 +17,8 @@
  */
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -56,15 +53,8 @@ import org.apache.orc.impl.reader.StripePlanner;
 import org.apache.orc.impl.reader.tree.BatchReader;
 import org.apache.orc.impl.reader.tree.StructBatchReader;
 import org.apache.orc.impl.reader.tree.TypeReader;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TestName;
 
 public class TestSchemaEvolution {
-
-  @Rule
-  public TestName testCaseName = new TestName();
 
   Configuration conf;
   Reader.Options options;
@@ -73,13 +63,13 @@ public class TestSchemaEvolution {
   Path workDir = new Path(System.getProperty("test.tmp.dir",
       "target" + File.separator + "test" + File.separator + "tmp"));
 
-  @Before
-  public void setup() throws Exception {
+  @BeforeEach
+  public void setup(TestInfo testInfo) throws Exception {
     conf = new Configuration();
     options = new Reader.Options(conf);
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-        testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }
 
@@ -337,9 +327,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testFloatToDoubleEvolution() throws Exception {
+  public void testFloatToDoubleEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-        testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createFloat();
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -364,9 +354,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testFloatToDecimalEvolution() throws Exception {
+  public void testFloatToDecimalEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+      testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createFloat();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -391,9 +381,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testFloatToDecimal64Evolution() throws Exception {
+  public void testFloatToDecimal64Evolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createFloat();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -418,9 +408,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testDoubleToDecimalEvolution() throws Exception {
+  public void testDoubleToDecimalEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createDouble();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -445,9 +435,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testDoubleToDecimal64Evolution() throws Exception {
+  public void testDoubleToDecimal64Evolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createDouble();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -472,9 +462,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testLongToDecimalEvolution() throws Exception {
+  public void testLongToDecimalEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createLong();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -499,9 +489,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testLongToDecimal64Evolution() throws Exception {
+  public void testLongToDecimal64Evolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createLong();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -526,9 +516,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testDecimalToDecimalEvolution() throws Exception {
+  public void testDecimalToDecimalEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createDecimal().withPrecision(38).withScale(0);
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -553,9 +543,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testDecimalToDecimal64Evolution() throws Exception {
+  public void testDecimalToDecimal64Evolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createDecimal().withPrecision(38).withScale(2);
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -580,9 +570,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testBooleanToStringEvolution() throws Exception {
+  public void testBooleanToStringEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createBoolean();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -643,9 +633,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testStringToDecimalEvolution() throws Exception {
+  public void testStringToDecimalEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createString();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -671,9 +661,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testStringToDecimal64Evolution() throws Exception {
+  public void testStringToDecimal64Evolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createString();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -699,9 +689,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testTimestampToDecimalEvolution() throws Exception {
+  public void testTimestampToDecimalEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createTimestamp();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -735,9 +725,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testTimestampToDecimal64Evolution() throws Exception {
+  public void testTimestampToDecimal64Evolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-      testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.createTimestamp();
     Writer writer = OrcFile.createWriter(testFilePath,
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -762,9 +752,9 @@ public class TestSchemaEvolution {
   }
 
   @Test
-  public void testTimestampToStringEvolution() throws Exception {
+  public void testTimestampToStringEvolution(TestInfo testInfo) throws Exception {
     testFilePath = new Path(workDir, "TestSchemaEvolution." +
-                                         testCaseName.getMethodName() + ".orc");
+        testInfo.getTestMethod().get().getName() + ".orc");
     TypeDescription schema = TypeDescription.fromString("timestamp");
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
@@ -1503,13 +1493,15 @@ public class TestSchemaEvolution {
     assertSame(original, mapped);
   }
 
-  @Test(expected = SchemaEvolution.IllegalEvolutionException.class)
+  @Test
   public void testIncompatibleTypes() {
-    TypeDescription fileType = TypeDescription.fromString("struct<a:int>");
-    TypeDescription readerType = TypeDescription.fromString("struct<a:date>");
-    boolean[] included = includeAll(readerType);
-    options.tolerateMissingSchema(false);
-    new SchemaEvolution(fileType, readerType, options.include(included));
+    assertThrows(SchemaEvolution.IllegalEvolutionException.class, () -> {
+      TypeDescription fileType = TypeDescription.fromString("struct<a:int>");
+      TypeDescription readerType = TypeDescription.fromString("struct<a:date>");
+      boolean[] included = includeAll(readerType);
+      options.tolerateMissingSchema(false);
+      new SchemaEvolution(fileType, readerType, options.include(included));
+    });
   }
 
   @Test
@@ -1529,7 +1521,7 @@ public class TestSchemaEvolution {
         evo.getReaderBaseSchema().toString());
     // the first stuff should be an identity
     for(int c=0; c < 8; ++c) {
-      assertEquals("column " + c, c, evo.getFileType(c).getId());
+      assertEquals(c, evo.getFileType(c).getId(), "column " + c);
     }
     // y and z should swap places
     assertEquals(9, evo.getFileType(8).getId());
@@ -1553,7 +1545,7 @@ public class TestSchemaEvolution {
         evo.getReaderBaseSchema().toString());
     // the first stuff should be an identity
     for(int c=0; c < 9; ++c) {
-      assertEquals("column " + c, c, evo.getFileType(c).getId());
+      assertEquals(c, evo.getFileType(c).getId(), "column " + c);
     }
     // the file doesn't have z
     assertEquals(null, evo.getFileType(9));
@@ -1579,16 +1571,16 @@ public class TestSchemaEvolution {
     boolean[] fileInclude = evo.getFileIncluded();
 
     //get top level struct col
-    assertEquals("column " + 0, 0, evo.getFileType(0).getId());
-    assertTrue("column " + 0, fileInclude[0]);
+    assertEquals(0, evo.getFileType(0).getId(), "column " + 0);
+    assertTrue(fileInclude[0], "column " + 0);
     for(int c=1; c < 6; ++c) {
-      assertNull("column " + c, evo.getFileType(c));
+      assertNull(evo.getFileType(c), "column " + c);
       //skip all acid metadata columns
-      assertFalse("column " + c, fileInclude[c]);
+      assertFalse(fileInclude[c], "column " + c);
     }
     for(int c=6; c < 9; ++c) {
-      assertEquals("column " + c, c, evo.getFileType(c).getId());
-      assertTrue("column " + c, fileInclude[c]);
+      assertEquals(c, evo.getFileType(c).getId(), "column " + c);
+      assertTrue(fileInclude[c], "column " + c);
     }
     // don't read the last column
     assertFalse(fileInclude[9]);
@@ -1612,8 +1604,8 @@ public class TestSchemaEvolution {
     // the first stuff should be an identity
     boolean[] fileInclude = evo.getFileIncluded();
     for(int c=0; c < 9; ++c) {
-      assertEquals("column " + c, c, evo.getFileType(c).getId());
-      assertTrue("column " + c, fileInclude[c]);
+      assertEquals(c, evo.getFileType(c).getId(), "column " + c);
+      assertTrue(fileInclude[c], "column " + c);
     }
     // don't read the last column
     assertFalse(fileInclude[9]);
@@ -1633,7 +1625,7 @@ public class TestSchemaEvolution {
     // the first stuff should be an identity
     boolean[] fileInclude = evo.getFileIncluded();
     for(int c=0; c < 9; ++c) {
-      assertEquals("column " + c, c, evo.getFileType(c).getId());
+      assertEquals(c, evo.getFileType(c).getId(), "column " + c);
     }
     assertEquals(10, evo.getFileType(9).getId());
     assertEquals(11, evo.getFileType(10).getId());
@@ -1641,7 +1633,7 @@ public class TestSchemaEvolution {
     assertEquals(12, evo.getFileType(12).getId());
     assertEquals(13, fileInclude.length);
     for(int c=0; c < fileInclude.length; ++c) {
-      assertTrue("column " + c, fileInclude[c]);
+      assertTrue(fileInclude[c], "column " + c);
     }
   }
 
@@ -1665,7 +1657,7 @@ public class TestSchemaEvolution {
     assertEquals(5, evo.getFileType(6).getId());
     assertEquals(6, fileInclude.length);
     for(int c=0; c < fileInclude.length; ++c) {
-      assertTrue("column " + c, fileInclude[c]);
+      assertTrue(fileInclude[c], "column " + c);
     }
   }
 
@@ -1740,10 +1732,9 @@ public class TestSchemaEvolution {
     assertEquals(true, batch.cols[0].isRepeating);
     assertEquals(true, batch.cols[0].isNull[0]);
     for(int r=0; r < 10; ++r) {
-      assertEquals("col1." + r, EXPECTED.substring(r, r+1),
-          ((BytesColumnVector) batch.cols[1]).toString(r));
-      assertEquals("col2." + r, r,
-          ((LongColumnVector) batch.cols[2]).vector[r]);
+      assertEquals(EXPECTED.substring(r, r+1),
+        ((BytesColumnVector) batch.cols[1]).toString(r), "col1." + r);
+      assertEquals(r, ((LongColumnVector) batch.cols[2]).vector[r], "col2." + r);
     }
   }
 
@@ -1975,15 +1966,17 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, (timeStrings[r] + " " +
-                                          READER_ZONE.getId()).replace(".7 ", " "),
-                longTimestampToString(t1.vector[current], READER_ZONE));
-            assertEquals("row " + r, (timeStrings[r] + " " +
-                                          WRITER_ZONE.getId()).replace(".7 ", " "),
-                longTimestampToString(t2.vector[current], WRITER_ZONE));
+            assertEquals(
+                (timeStrings[r] + " " + READER_ZONE.getId()).replace(".7 ", " "),
+                longTimestampToString(t1.vector[current], READER_ZONE),
+                "row " + r);
+            assertEquals(
+                (timeStrings[r] + " " + WRITER_ZONE.getId()).replace(".7 ", " "),
+                longTimestampToString(t2.vector[current], WRITER_ZONE),
+                "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -1998,13 +1991,13 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r] + " " + READER_ZONE.getId(),
-                decimalTimestampToString(t1.vector[current], READER_ZONE));
-            assertEquals("row " + r, timeStrings[r] + " " + WRITER_ZONE.getId(),
-                decimalTimestampToString(t2.vector[current], WRITER_ZONE));
+            assertEquals( timeStrings[r] + " " + READER_ZONE.getId(),
+                decimalTimestampToString(t1.vector[current], READER_ZONE), "row " + r);
+            assertEquals(timeStrings[r] + " " + WRITER_ZONE.getId(),
+                decimalTimestampToString(t2.vector[current], WRITER_ZONE), "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2019,13 +2012,13 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r] + " " + READER_ZONE.getId(),
-                doubleTimestampToString(t1.vector[current], READER_ZONE));
-            assertEquals("row " + r, timeStrings[r] + " " + WRITER_ZONE.getId(),
-                doubleTimestampToString(t2.vector[current], WRITER_ZONE));
+            assertEquals( timeStrings[r] + " " + READER_ZONE.getId(),
+                doubleTimestampToString(t1.vector[current], READER_ZONE), "row " + r);
+            assertEquals( timeStrings[r] + " " + WRITER_ZONE.getId(),
+                doubleTimestampToString(t2.vector[current], WRITER_ZONE), "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2040,17 +2033,17 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
             String date = timeStrings[r].substring(0, 10);
-            assertEquals("row " + r, date,
+            assertEquals(date,
                 ConvertTreeReaderFactory.DATE_FORMAT.format(
-                    LocalDate.ofEpochDay(t1.vector[current])));
+                    LocalDate.ofEpochDay(t1.vector[current])), "row " + r);
             // NYC -> Sydney moves forward a day for instant
-            assertEquals("row " + r, date.replace("-27", "-28"),
+            assertEquals(date.replace("-27", "-28"),
                 ConvertTreeReaderFactory.DATE_FORMAT.format(
-                    LocalDate.ofEpochDay(t2.vector[current])));
+                    LocalDate.ofEpochDay(t2.vector[current])), "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2065,15 +2058,15 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r], bytesT1.toString(current));
+            assertEquals(timeStrings[r], bytesT1.toString(current), "row " + r);
             Instant t = Instant.from(WRITER_FORMAT.parse(timeStrings[r]));
-            assertEquals("row " + r,
+            assertEquals(
                 timestampToString(Instant.from(WRITER_FORMAT.parse(timeStrings[r])),
                     READER_ZONE),
-                bytesT2.toString(current));
+                bytesT2.toString(current), "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2088,14 +2081,16 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r] + " " + READER_ZONE.getId(),
-                timestampToString(timeT1.time[current], timeT1.nanos[current], READER_ZONE));
-            assertEquals("row " + r,
+            assertEquals(timeStrings[r] + " " + READER_ZONE.getId(),
+                timestampToString(timeT1.time[current], timeT1.nanos[current], READER_ZONE),
+                "row " + r);
+            assertEquals(
                 timestampToString(Instant.from(WRITER_FORMAT.parse(timeStrings[r])), READER_ZONE),
-                timestampToString(timeT2.time[current], timeT2.nanos[current], READER_ZONE));
+                timestampToString(timeT2.time[current], timeT2.nanos[current], READER_ZONE),
+                "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2118,15 +2113,15 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, (timeStrings[r] + " " +
-                                          UTC.getId()).replace(".7 ", " "),
-                longTimestampToString(t1.vector[current], UTC));
-            assertEquals("row " + r, (timeStrings[r] + " " +
-                                          WRITER_ZONE.getId()).replace(".7 ", " "),
-                longTimestampToString(t2.vector[current], WRITER_ZONE));
+            assertEquals(
+                (timeStrings[r] + " " + UTC.getId()).replace(".7 ", " "),
+                longTimestampToString(t1.vector[current], UTC), "row " + r);
+            assertEquals(
+                (timeStrings[r] + " " + WRITER_ZONE.getId()).replace(".7 ", " "),
+                longTimestampToString(t2.vector[current], WRITER_ZONE), "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2141,13 +2136,13 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r] + " " + UTC.getId(),
-                decimalTimestampToString(t1.vector[current], UTC));
-            assertEquals("row " + r, timeStrings[r] + " " + WRITER_ZONE.getId(),
-                decimalTimestampToString(t2.vector[current], WRITER_ZONE));
+            assertEquals(timeStrings[r] + " " + UTC.getId(),
+                decimalTimestampToString(t1.vector[current], UTC), "row " + r);
+            assertEquals(timeStrings[r] + " " + WRITER_ZONE.getId(),
+                decimalTimestampToString(t2.vector[current], WRITER_ZONE), "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2162,13 +2157,15 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r] + " " + UTC.getId(),
-                doubleTimestampToString(t1.vector[current], UTC));
-            assertEquals("row " + r, timeStrings[r] + " " + WRITER_ZONE.getId(),
-                doubleTimestampToString(t2.vector[current], WRITER_ZONE));
+            assertEquals(timeStrings[r] + " " + UTC.getId(),
+                doubleTimestampToString(t1.vector[current], UTC),
+                "row " + r);
+            assertEquals(timeStrings[r] + " " + WRITER_ZONE.getId(),
+                doubleTimestampToString(t2.vector[current], WRITER_ZONE),
+                "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2183,17 +2180,19 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
             String date = timeStrings[r].substring(0, 10);
-            assertEquals("row " + r, date,
+            assertEquals(date,
                 ConvertTreeReaderFactory.DATE_FORMAT.format(
-                    LocalDate.ofEpochDay(t1.vector[current])));
+                    LocalDate.ofEpochDay(t1.vector[current])),
+                "row " + r);
             // NYC -> UTC still moves forward a day
-            assertEquals("row " + r, date.replace("-27", "-28"),
+            assertEquals(date.replace("-27", "-28"),
                 ConvertTreeReaderFactory.DATE_FORMAT.format(
-                    LocalDate.ofEpochDay(t2.vector[current])));
+                    LocalDate.ofEpochDay(t2.vector[current])),
+                "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2208,14 +2207,15 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r], bytesT1.toString(current));
-            assertEquals("row " + r,
+            assertEquals(timeStrings[r], bytesT1.toString(current), "row " + r);
+            assertEquals(
                 timestampToString(Instant.from(WRITER_FORMAT.parse(timeStrings[r])),
                     UTC),
-                bytesT2.toString(current));
+                bytesT2.toString(current),
+                "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2230,14 +2230,16 @@ public class TestSchemaEvolution {
           int current = 0;
           for (int r = 0; r < VALUES; ++r) {
             if (current == batch.size) {
-              assertEquals("row " + r, true, rows.nextBatch(batch));
+              assertEquals(true, rows.nextBatch(batch), "row " + r);
               current = 0;
             }
-            assertEquals("row " + r, timeStrings[r] + " UTC",
-                timestampToString(timeT1.time[current], timeT1.nanos[current], UTC));
-            assertEquals("row " + r,
+            assertEquals(timeStrings[r] + " UTC",
+                timestampToString(timeT1.time[current], timeT1.nanos[current], UTC),
+                "row " + r);
+            assertEquals(
                 timestampToString(Instant.from(WRITER_FORMAT.parse(timeStrings[r])), UTC),
-                timestampToString(timeT2.time[current], timeT2.nanos[current], UTC));
+                timestampToString(timeT2.time[current], timeT2.nanos[current], UTC),
+                "row " + r);
             current += 1;
           }
           assertEquals(false, rows.nextBatch(batch));
@@ -2387,7 +2389,7 @@ public class TestSchemaEvolution {
         int current = 0;
         for (int r = 0; r < VALUES; ++r) {
           if (current == batch.size) {
-            assertEquals("row " + r, true, rows.nextBatch(batch));
+            assertEquals(true, rows.nextBatch(batch), "row " + r);
             current = 0;
           }
 
@@ -2397,41 +2399,54 @@ public class TestSchemaEvolution {
           String expectedDate1 = midnight + " " + READER_ZONE.getId();
           String expectedDate2 = midnight + " " + UTC.getId();
 
-          assertEquals("row " + r, expected1.replace(".1 ", " "),
-              timestampToString(l1.time[current], l1.nanos[current], READER_ZONE));
+          String msg = "row " + r;
+          assertEquals(expected1.replace(".1 ", " "),
+              timestampToString(l1.time[current], l1.nanos[current], READER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected2.replace(".1 ", " "),
-              timestampToString(l2.time[current], l2.nanos[current], WRITER_ZONE));
+          assertEquals(expected2.replace(".1 ", " "),
+              timestampToString(l2.time[current], l2.nanos[current], WRITER_ZONE),
+              msg);
 
-          assertEquals("row " + r, longTimestampToString(((r % 128) - offset), READER_ZONE),
-              timestampToString(t1.time[current], t1.nanos[current], READER_ZONE));
+          assertEquals(longTimestampToString(((r % 128) - offset), READER_ZONE),
+              timestampToString(t1.time[current], t1.nanos[current], READER_ZONE),
+              msg);
 
-          assertEquals("row " + r, longTimestampToString((r % 128), WRITER_ZONE),
-              timestampToString(t2.time[current], t2.nanos[current], WRITER_ZONE));
+          assertEquals(longTimestampToString((r % 128), WRITER_ZONE),
+              timestampToString(t2.time[current], t2.nanos[current], WRITER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected1,
-              timestampToString(d1.time[current], d1.nanos[current], READER_ZONE));
+          assertEquals(expected1,
+              timestampToString(d1.time[current], d1.nanos[current], READER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected2,
-              timestampToString(d2.time[current], d2.nanos[current], WRITER_ZONE));
+          assertEquals(expected2,
+              timestampToString(d2.time[current], d2.nanos[current], WRITER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected1,
-              timestampToString(dbl1.time[current], dbl1.nanos[current], READER_ZONE));
+          assertEquals(expected1,
+              timestampToString(dbl1.time[current], dbl1.nanos[current], READER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected2,
-              timestampToString(dbl2.time[current], dbl2.nanos[current], WRITER_ZONE));
+          assertEquals(expected2,
+              timestampToString(dbl2.time[current], dbl2.nanos[current], WRITER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expectedDate1,
-              timestampToString(dt1.time[current], dt1.nanos[current], READER_ZONE));
+          assertEquals(expectedDate1,
+              timestampToString(dt1.time[current], dt1.nanos[current], READER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expectedDate2,
-              timestampToString(dt2.time[current], dt2.nanos[current], UTC));
+          assertEquals(expectedDate2,
+              timestampToString(dt2.time[current], dt2.nanos[current], UTC),
+              msg);
 
-          assertEquals("row " + r, expected1,
-              timestampToString(s1.time[current], s1.nanos[current], READER_ZONE));
+          assertEquals(expected1,
+              timestampToString(s1.time[current], s1.nanos[current], READER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected2,
-              timestampToString(s2.time[current], s2.nanos[current], WRITER_ZONE));
+          assertEquals(expected2,
+              timestampToString(s2.time[current], s2.nanos[current], WRITER_ZONE),
+              msg);
           current += 1;
         }
         assertEquals(false, rows.nextBatch(batch));
@@ -2444,7 +2459,7 @@ public class TestSchemaEvolution {
         int current = 0;
         for (int r = 0; r < VALUES; ++r) {
           if (current == batch.size) {
-            assertEquals("row " + r, true, rows.nextBatch(batch));
+            assertEquals(true, rows.nextBatch(batch), "row " + r);
             current = 0;
           }
 
@@ -2452,36 +2467,46 @@ public class TestSchemaEvolution {
           String expected2 = timeStrings[r] + " " + WRITER_ZONE.getId();
           String midnight = timeStrings[r].substring(0, 10) + " 00:00:00";
           String expectedDate = midnight + " " + UTC.getId();
+          String msg = "row " + r;
+          assertEquals(expected1.replace(".1 ", " "),
+              timestampToString(l1.time[current], l1.nanos[current], UTC),
+              msg);
 
-          assertEquals("row " + r, expected1.replace(".1 ", " "),
-              timestampToString(l1.time[current], l1.nanos[current], UTC));
+          assertEquals(expected2.replace(".1 ", " "),
+              timestampToString(l2.time[current], l2.nanos[current], WRITER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected2.replace(".1 ", " "),
-              timestampToString(l2.time[current], l2.nanos[current], WRITER_ZONE));
+          assertEquals(expected1,
+              timestampToString(d1.time[current], d1.nanos[current], UTC),
+              msg);
 
-          assertEquals("row " + r, expected1,
-              timestampToString(d1.time[current], d1.nanos[current], UTC));
+          assertEquals(expected2,
+              timestampToString(d2.time[current], d2.nanos[current], WRITER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected2,
-              timestampToString(d2.time[current], d2.nanos[current], WRITER_ZONE));
+          assertEquals(expected1,
+              timestampToString(dbl1.time[current], dbl1.nanos[current], UTC),
+              msg);
 
-          assertEquals("row " + r, expected1,
-              timestampToString(dbl1.time[current], dbl1.nanos[current], UTC));
+          assertEquals(expected2,
+              timestampToString(dbl2.time[current], dbl2.nanos[current], WRITER_ZONE),
+              msg);
 
-          assertEquals("row " + r, expected2,
-              timestampToString(dbl2.time[current], dbl2.nanos[current], WRITER_ZONE));
+          assertEquals(expectedDate,
+              timestampToString(dt1.time[current], dt1.nanos[current], UTC),
+              msg);
 
-          assertEquals("row " + r, expectedDate,
-              timestampToString(dt1.time[current], dt1.nanos[current], UTC));
+          assertEquals(expectedDate,
+              timestampToString(dt2.time[current], dt2.nanos[current], UTC),
+              msg);
 
-          assertEquals("row " + r, expectedDate,
-              timestampToString(dt2.time[current], dt2.nanos[current], UTC));
+          assertEquals(expected1,
+              timestampToString(s1.time[current], s1.nanos[current], UTC),
+              msg);
 
-          assertEquals("row " + r, expected1,
-              timestampToString(s1.time[current], s1.nanos[current], UTC));
-
-          assertEquals("row " + r, expected2,
-              timestampToString(s2.time[current], s2.nanos[current], WRITER_ZONE));
+          assertEquals(expected2,
+              timestampToString(s2.time[current], s2.nanos[current], WRITER_ZONE),
+              msg);
           current += 1;
         }
         assertEquals(false, rows.nextBatch(batch));
@@ -2565,7 +2590,7 @@ public class TestSchemaEvolution {
          RecordReader rows = reader.rows(reader.options().schema(readerSchema))) {
       int value = 0;
       while (value < values.length) {
-        assertTrue("value " + value, rows.nextBatch(batchTimeStamp));
+        assertTrue(rows.nextBatch(batchTimeStamp), "value " + value);
         for(int row=0; row < batchTimeStamp.size; ++row) {
           double expected = values[value + row];
           String rowName = String.format("value %d", value + row);
@@ -2573,18 +2598,18 @@ public class TestSchemaEvolution {
           if (expected * 1000 < Long.MIN_VALUE ||
                   expected * 1000 > Long.MAX_VALUE ||
                   ((expected >= 0) != isPositive)) {
-            assertFalse(rowName, t1.noNulls);
-            assertTrue(rowName, t1.isNull[row]);
+            assertFalse(t1.noNulls, rowName);
+            assertTrue(t1.isNull[row], rowName);
           } else {
             double actual = Math.floorDiv(t1.time[row], 1000) +
                                 t1.nanos[row] / 1_000_000_000.0;
-            assertEquals(rowName, expected, actual,
-                Math.abs(expected * (isFloat ? 0.000001 : 0.0000000000000001)));
-            assertFalse(rowName, t1.isNull[row]);
-            assertTrue(String.format(
-                "%s nanos should be 0 to 1,000,000,000 instead it's: %d",
-                rowName, t1.nanos[row]),
-                t1.nanos[row] >= 0 && t1.nanos[row] < 1_000_000_000);
+            assertEquals(expected, actual,
+                Math.abs(expected * (isFloat ? 0.000001 : 0.0000000000000001)), rowName);
+            assertFalse(t1.isNull[row], rowName);
+            assertTrue(t1.nanos[row] >= 0 && t1.nanos[row] < 1_000_000_000,
+                String.format(
+                    "%s nanos should be 0 to 1,000,000,000 instead it's: %d",
+                    rowName, t1.nanos[row]));
           }
         }
         value += batchTimeStamp.size;
@@ -2607,8 +2632,8 @@ public class TestSchemaEvolution {
     SchemaEvolution evoCc = new SchemaEvolution(typeCamelCaseColumns, null, options);
     SchemaEvolution evoLc = new SchemaEvolution(typeLowerCaseColumns, null, options);
 
-    assertTrue("Schema (" + ccSchema +") was found to be non-acid ", evoCc.isAcid());
-    assertTrue("Schema (" + lcSchema +") was found to be non-acid ", evoLc.isAcid());
+    assertTrue(evoCc.isAcid(), "Schema (" + ccSchema +") was found to be non-acid ");
+    assertTrue(evoLc.isAcid(), "Schema (" + lcSchema +") was found to be non-acid ");
   }
 
   @Test
@@ -2621,13 +2646,13 @@ public class TestSchemaEvolution {
     TypeDescription readerSchema = TypeDescription.fromString(acidSchema);
     SchemaEvolution schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
 
-    assertEquals(String.format("Reader schema %s is not acid", schemaEvolution.getReaderSchema().toString()),
-        acidSchema, schemaEvolution.getReaderSchema().toString());
+    assertEquals(acidSchema, schemaEvolution.getReaderSchema().toString(),
+        String.format("Reader schema %s is not acid", schemaEvolution.getReaderSchema().toString()));
 
     String notAcidSchema ="struct<a:int,b:int>";
     readerSchema = TypeDescription.fromString(notAcidSchema);
     schemaEvolution = new SchemaEvolution(fileSchema, readerSchema, options);
-    assertEquals(String.format("Reader schema %s is not acid", schemaEvolution.getReaderSchema().toString()),
-        acidSchema, schemaEvolution.getReaderSchema().toString());
+    assertEquals(acidSchema, schemaEvolution.getReaderSchema().toString(),
+        String.format("Reader schema %s is not acid", schemaEvolution.getReaderSchema().toString()));
   }
 }

--- a/java/core/src/test/org/apache/orc/impl/TestSerializationUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSerializationUtils.java
@@ -17,17 +17,16 @@
  */
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.util.Random;
-
-import org.junit.Test;
 
 import com.google.common.math.LongMath;
 
@@ -80,10 +79,10 @@ public class TestSerializationUtils {
     for(int i=-8192; i < 8192; ++i) {
       buffer.reset();
         SerializationUtils.writeBigInteger(buffer, BigInteger.valueOf(i));
-      assertEquals("compare length for " + i,
-            i >= -64 && i < 64 ? 1 : 2, buffer.size());
-      assertEquals("compare result for " + i,
-          i, SerializationUtils.readBigInteger(fromBuffer(buffer)).intValue());
+      assertEquals(i >= -64 && i < 64 ? 1 : 2, buffer.size(),
+          "compare length for " + i);
+      assertEquals(i, SerializationUtils.readBigInteger(fromBuffer(buffer)).intValue(),
+          "compare result for " + i);
     }
     buffer.reset();
     SerializationUtils.writeBigInteger(buffer,

--- a/java/core/src/test/org/apache/orc/impl/TestStreamName.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStreamName.java
@@ -19,9 +19,9 @@
 package org.apache.orc.impl;
 
 import org.apache.orc.OrcProto;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestStreamName {
 

--- a/java/core/src/test/org/apache/orc/impl/TestStreamName.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStreamName.java
@@ -21,7 +21,7 @@ package org.apache.orc.impl;
 import org.apache.orc.OrcProto;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestStreamName {
 
@@ -38,7 +38,7 @@ public class TestStreamName {
     assertEquals(false, s1.equals(s2));
     assertEquals(false, s1.equals(s3));
     assertEquals(true, s1.equals(s1p));
-    assertEquals(false, s1.equals(null));
+    assertFalse(s1.equals(null));
     assertEquals(true, s1.compareTo(s2) < 0);
     assertEquals(true, s2.compareTo(s3) < 0);
     assertEquals(true, s3.compareTo(s4) < 0);

--- a/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringHashTableDictionary.java
@@ -24,9 +24,8 @@ import java.util.stream.Stream;
 
 import org.apache.hadoop.io.Text;
 import org.apache.orc.StringDictTestingUtils;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestStringHashTableDictionary {
 

--- a/java/core/src/test/org/apache/orc/impl/TestStringRedBlackTree.java
+++ b/java/core/src/test/org/apache/orc/impl/TestStringRedBlackTree.java
@@ -18,13 +18,13 @@
 
 package org.apache.orc.impl;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 
 import org.apache.hadoop.io.IntWritable;
 import org.apache.orc.StringDictTestingUtils;
-import org.junit.Test;
 
 /**
  * Test the red-black tree with string keys.

--- a/java/core/src/test/org/apache/orc/impl/TestWriterImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestWriterImpl.java
@@ -29,14 +29,12 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TestWriterImpl {
 
@@ -46,7 +44,7 @@ public class TestWriterImpl {
   Path testFilePath;
   TypeDescription schema;
 
-  @Before
+  @BeforeEach
   public void openFileSystem() throws Exception {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
@@ -56,16 +54,18 @@ public class TestWriterImpl {
     schema = TypeDescription.fromString("struct<x:int,y:int>");
   }
 
-  @After
+  @AfterEach
   public void deleteTestFile() throws Exception {
     fs.delete(testFilePath, false);
   }
 
-  @Test(expected = IOException.class)
+  @Test
   public void testDefaultOverwriteFlagForWriter() throws Exception {
-    // default value of the overwrite flag is false, so this should fail
-    Writer w = OrcFile.createWriter(testFilePath, OrcFile.writerOptions(conf).setSchema(schema));
-    w.close();
+    assertThrows(IOException.class, () -> {
+      // default value of the overwrite flag is false, so this should fail
+      Writer w = OrcFile.createWriter(testFilePath, OrcFile.writerOptions(conf).setSchema(schema));
+      w.close();
+    });
   }
 
   @Test

--- a/java/core/src/test/org/apache/orc/impl/TestZlib.java
+++ b/java/core/src/test/org/apache/orc/impl/TestZlib.java
@@ -19,13 +19,13 @@
 package org.apache.orc.impl;
 
 import org.apache.orc.CompressionCodec;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestZlib {
 

--- a/java/core/src/test/org/apache/orc/impl/TestZstd.java
+++ b/java/core/src/test/org/apache/orc/impl/TestZstd.java
@@ -22,11 +22,11 @@ import io.airlift.compress.zstd.ZstdCompressor;
 import io.airlift.compress.zstd.ZstdDecompressor;
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.CompressionKind;
-import org.junit.Test;
 
 import java.nio.ByteBuffer;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestZstd {
 

--- a/java/core/src/test/org/apache/orc/impl/mask/TestDataMask.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestDataMask.java
@@ -29,11 +29,11 @@ import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.DataMask;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestDataMask {
 
@@ -155,20 +155,22 @@ public class TestDataMask {
 
     // check the outputs
     for(int i=0; i < 3; ++i) {
-      assertEquals("iter " + i, (i + 1) + "." + (i + 1), a.vector[i].toString());
-      assertEquals("iter " + i, 1.25 * (i + 1), b.vector[i], 0.0001);
-      assertEquals("iter " + i, i == 0 ? 0 : c.offsets[i-1] + c.lengths[i-1], c.offsets[i]);
-      assertEquals("iter " + i, 2 * i, c.lengths[i]);
-      assertEquals("iter " + i, i == 0 ? 4 : d.offsets[i-1] - d.lengths[i], d.offsets[i]);
-      assertEquals("iter " + i, 2, d.lengths[i]);
-      assertEquals("iter " + i, i % 2, e.tags[i]);
-      assertEquals("iter " + i, Integer.toHexString(0x123 * i), f.toString(i));
+      String msg = "iter " + i;
+      assertEquals((i + 1) + "." + (i + 1), a.vector[i].toString(), msg);
+      assertEquals(1.25 * (i + 1), b.vector[i], 0.0001, msg);
+      assertEquals(i == 0 ? 0 : c.offsets[i-1] + c.lengths[i-1], c.offsets[i], msg);
+      assertEquals(2 * i, c.lengths[i], msg);
+      assertEquals(i == 0 ? 4 : d.offsets[i-1] - d.lengths[i], d.offsets[i], msg);
+      assertEquals(2, d.lengths[i], msg);
+      assertEquals(i % 2, e.tags[i], msg);
+      assertEquals(Integer.toHexString(0x123 * i), f.toString(i), msg);
     }
     // check the subvalues for the list and map
     for(int i=0; i < 6; ++i) {
-      assertEquals("iter " + i, i, ce.vector[i]);
-      assertEquals("iter " + i, i * 1111, dk.time[i]);
-      assertEquals("iter " + i, i * 11, dv.vector[i]);
+      String msg = "iter " + i;
+      assertEquals(i, ce.vector[i], msg);
+      assertEquals(i * 1111, dk.time[i], msg);
+      assertEquals(i * 11, dv.vector[i], msg);
     }
     assertEquals(0, e1.vector[0]);
     assertEquals(20, e1.vector[2]);

--- a/java/core/src/test/org/apache/orc/impl/mask/TestRedactMask.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestRedactMask.java
@@ -20,13 +20,13 @@ package org.apache.orc.impl.mask;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
-import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestRedactMask {
 
@@ -59,12 +59,12 @@ public class TestRedactMask {
         if (i == 18 && digit == 9) {
           expected = 999_999_999_999_999_999L;
         }
-        assertEquals("digit " + digit + " value " + input, expected,
-            mask.maskLong(input));
-        assertEquals("digit " + digit + " value " + (5 * input), expected,
-            mask.maskLong(5 * input));
-        assertEquals("digit " + digit + " value " + (9 * input), expected,
-            mask.maskLong(9 * input));
+        assertEquals(expected, mask.maskLong(input),
+            "digit " + digit + " value " + input);
+        assertEquals(expected, mask.maskLong(5 * input),
+            "digit " + digit + " value " + (5 * input));
+        assertEquals(expected, mask.maskLong(9 * input),
+            "digit " + digit + " value " + (9 * input));
         expected = expected * 10 + digit;
         input *= 10;
       }
@@ -235,9 +235,9 @@ public class TestRedactMask {
         " \uD863\uDCCA\uD863\uDCCA\uD863\uDCCA\uD863\uDCCA" +
         "\uD863\uDCCA\uD863\uDCCA\uD863\uDCCA\uD863\uDCCA.";
     for(int r=0; r < 1024; ++r) {
-      assertEquals("r = " + r, expected,
+      assertEquals(expected,
           new String(target.vector[r], target.start[r], target.length[r],
-              StandardCharsets.UTF_8));
+              StandardCharsets.UTF_8), "r = " + r);
     }
 
     // Make sure that the target keeps the larger output buffer.

--- a/java/core/src/test/org/apache/orc/impl/mask/TestSHA256Mask.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestSHA256Mask.java
@@ -18,7 +18,6 @@ package org.apache.orc.impl.mask;
 
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
@@ -26,8 +25,9 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestSHA256Mask {
 

--- a/java/core/src/test/org/apache/orc/impl/mask/TestUnmaskRange.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestUnmaskRange.java
@@ -19,11 +19,11 @@ package org.apache.orc.impl.mask;
 
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
-import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Unmask option

--- a/java/core/src/test/org/apache/orc/impl/reader/TestReaderEncryptionVariant.java
+++ b/java/core/src/test/org/apache/orc/impl/reader/TestReaderEncryptionVariant.java
@@ -21,13 +21,13 @@ package org.apache.orc.impl.reader;
 import org.apache.orc.EncryptionAlgorithm;
 import org.apache.orc.OrcProto;
 import org.apache.orc.StripeInformation;
-import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.ArrayList;
 
-import static org.junit.Assert.assertNull;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class TestReaderEncryptionVariant {
 

--- a/java/core/src/test/org/apache/orc/util/TestBloomFilter.java
+++ b/java/core/src/test/org/apache/orc/util/TestBloomFilter.java
@@ -22,10 +22,10 @@ import com.google.protobuf.ByteString;
 import org.apache.orc.OrcFile;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for BloomFilter

--- a/java/core/src/test/org/apache/orc/util/TestMurmur3.java
+++ b/java/core/src/test/org/apache/orc/util/TestMurmur3.java
@@ -18,7 +18,8 @@
 
 package org.apache.orc.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
@@ -27,7 +28,6 @@ import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Random;
-import org.junit.Test;
 
 /**
  * Tests for Murmur3 variants.

--- a/java/core/src/test/org/apache/orc/util/TestOrcUtils.java
+++ b/java/core/src/test/org/apache/orc/util/TestOrcUtils.java
@@ -23,8 +23,8 @@ import java.util.Arrays;
 import org.apache.orc.OrcUtils;
 import org.apache.orc.TypeDescription;
 
-import static org.junit.Assert.assertTrue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for OrcUtils.

--- a/java/core/src/test/org/apache/orc/util/TestStreamWrapperFileSystem.java
+++ b/java/core/src/test/org/apache/orc/util/TestStreamWrapperFileSystem.java
@@ -29,13 +29,13 @@ import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TestVectorOrcFile;
 import org.apache.orc.TypeDescription;
-import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for StreamWrapperFileSystem.
@@ -75,10 +75,10 @@ public class TestStreamWrapperFileSystem {
       int current = 0;
       for(int r=0; r < 7500; ++r) {
         if (current >= batch.size) {
-          assertTrue("row " + r, rows.nextBatch(batch));
+          assertTrue(rows.nextBatch(batch), "row " + r);
           current = 0;
         }
-        assertEquals("row " + r, r % 2, boolean1.vector[current++]);
+        assertEquals(r % 2, boolean1.vector[current++], "row " + r);
       }
     }
   }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -781,26 +781,20 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.7.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
         <version>5.7.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>5.7.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>3.7.0</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-junit-jupiter</artifactId>
+        <version>3.11.2</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/java/shims/pom.xml
+++ b/java/shims/pom.xml
@@ -56,7 +56,7 @@
     <!-- test inter-project -->
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes `junit-vintage-engine`.

### Why are the changes needed?

After this PR, Apache ORC JUnit5 migration is finished.

### How was this patch tested?

Pass the CIs.