### PR TITLE
ORC-911: Remove janino dependency in favor of Spark's transitive dependency

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -409,18 +409,6 @@
         <version>${spark.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.janino</groupId>
-        <artifactId>janino</artifactId>
-        <version>3.0.8</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.janino</groupId>
-        <artifactId>commons-compiler</artifactId>
-        <version>3.0.8</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
         <groupId>org.jodd</groupId>
         <artifactId>jodd-core</artifactId>
         <version>3.5.2</version>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -171,6 +171,22 @@
               </artifactSet>
               <shadedArtifactAttached>false</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>
+              <filters>
+                <filter>
+                  <artifact>org.codehaus.janino:janino</artifact>
+                  <excludes>
+                    <exclude>META-INF/DUMMY.SF</exclude>
+                    <exclude>META-INF/DUMMY.DSA</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.codehaus.janino:commons-compiler</artifact>
+                  <excludes>
+                    <exclude>META-INF/DUMMY.SF</exclude>
+                    <exclude>META-INF/DUMMY.DSA</exclude>
+                  </excludes>
+                </filter>
+              </filters>
               <relocations>
                 <relocation>
                   <pattern>org.apache.orc.storage</pattern>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -111,14 +111,6 @@
       <artifactId>spark-avro_2.12</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.codehaus.janino</groupId>
-      <artifactId>janino</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.janino</groupId>
-      <artifactId>commons-compiler</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.jodd</groupId>
       <artifactId>jodd-core</artifactId>
     </dependency>
@@ -179,22 +171,6 @@
               </artifactSet>
               <shadedArtifactAttached>false</shadedArtifactAttached>
               <shadedClassifierName>shaded</shadedClassifierName>
-              <filters>
-                <filter>
-                  <artifact>org.codehaus.janino:janino</artifact>
-                  <excludes>
-                    <exclude>META-INF/DUMMY.SF</exclude>
-                    <exclude>META-INF/DUMMY.DSA</exclude>
-                  </excludes>
-                </filter>
-                <filter>
-                  <artifact>org.codehaus.janino:commons-compiler</artifact>
-                  <excludes>
-                    <exclude>META-INF/DUMMY.SF</exclude>
-                    <exclude>META-INF/DUMMY.DSA</exclude>
-                  </excludes>
-                </filter>
-              </filters>
               <relocations>
                 <relocation>
                   <pattern>org.apache.orc.storage</pattern>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `janino` runtime dependency from `bench` module in favor of Spark's transitive dependency.

### Why are the changes needed?

We should not override it. Spark uses a specific version because some latest Janino has bugs.

### How was this patch tested?

Pass the CIs.

Closes #799 and #804 .