### PR TITLE
ORC-914: Pin `maven-dependency-plugin` to 3.1.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
       # Pin scala-library to 2.12.10
       - dependency-name: "org.scala-lang:scala-library"
         versions: "[2.12.11,)"
+      # Pin maven-dependency-plugin to 3.1.2 due to MDEP-753, MDEP-757, MDEP-759
+      - dependency-name: "org.apache.maven.plugins:maven-dependency-plugin"
+        versions: "[3.2.0,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `maven-dependency-plugin` to 3.1.2.

### Why are the changes needed?

There are multiple bugs like MDEP-753, MDEP-757, MDEP-759.

### How was this patch tested?

N/A

Closes #820