### PR TITLE
ORC-915: Remove `io.netty:netty` from Spark benchmark

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -95,12 +95,6 @@
         <scope>runtime</scope>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>3.9.9.Final</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro</artifactId>
         <version>${avro.version}</version>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -53,10 +53,6 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `io.netty:netty` dependency from Spark benchmark.

### Why are the changes needed?

```
$ ls spark-2.4.8-bin-hadoop2.7/jars/netty-*
spark-2.4.8-bin-hadoop2.7/jars/netty-3.9.9.Final.jar      spark-2.4.8-bin-hadoop2.7/jars/netty-all-4.1.47.Final.jar

$ ls spark-3.1.2-bin-hadoop3.2/jars/netty-all-4.1.51.Final.jar
spark-3.1.2-bin-hadoop3.2/jars/netty-all-4.1.51.Final.jar
```

### How was this patch tested?

Manual.
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data -d sales -c none -f orc
$ java -jar spark/target/orc-benchmarks-spark-1.8.0-SNAPSHOT.jar spark data
```

This closes #794 