### PR TITLE
ORC-918: Pin protobuf-java to 2.5.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,3 +39,6 @@ updates:
       # Pin maven-dependency-plugin to 3.1.2 due to MDEP-753, MDEP-757, MDEP-759
       - dependency-name: "org.apache.maven.plugins:maven-dependency-plugin"
         versions: "[3.2.0,)"
+      # Pin protobuf-java to 2.5.0
+      - dependency-name: "com.google.protobuf:protobuf-java"
+        versions: "[2.5.1,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to pin protobuf-java version to 2.5.0


### Why are the changes needed?
To avoid incompatibility risk.

### How was this patch tested?
N/A

Closes #828 .