### PR TITLE
ORC-919: Spark bench objenesis should be the same as Spark

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -137,6 +137,13 @@
       <artifactId>jackson-annotations</artifactId>
       <version>${spark.jackson.version}</version>
     </dependency>
+    <!-- This should be the same with Spark's dependency. -->
+    <dependency>
+      <groupId>org.objenesis</groupId>
+      <artifactId>objenesis</artifactId>
+      <version>2.6</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use the same objenesis version as Spark in Spark benchmark. 


### Why are the changes needed?
To fix the class not defined error seen below

```
java.lang.NoClassDefFoundError: org/objenesis/strategy/InstantiatorStrategy
	at org.apache.orc.mapred.OrcInputFormat.setSearchArgument(OrcInputFormat.java:97)
	at org.apache.orc.mapreduce.OrcInputFormat.setSearchArgument(OrcInputFormat.java:57)
	at org.apache.spark.sql.execution.datasources.orc.OrcFileFormat.$anonfun$buildReaderWithPartitionValues$5(OrcFileFormat.scala:190)
```

### How was this patch tested?
Manual. 

```
java -jar spark/target/orc-benchmarks-spark-1.8.0-SNAPSHOT.jar spark data -d sales -c snappy -f orc
```