### PR TITLE
ORC-920: Use junit.version and mockito.version property and bump junit to 5.7.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -80,6 +80,8 @@
     <slf4j.version>1.7.32</slf4j.version>
     <protoc.artifact>com.google.protobuf:protoc:2.5.0</protoc.artifact>
     <surefire.version>3.0.0-M5</surefire.version>
+    <junit.version>5.7.2</junit.version>
+    <mockito.version>3.11.2</mockito.version>
   </properties>
 
   <build>
@@ -796,25 +798,25 @@
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-api</artifactId>
-        <version>5.7.0</version>
+        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
         <artifactId>junit-jupiter-params</artifactId>
-        <version>5.7.0</version>
+        <version>${junit.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.11.2</version>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-junit-jupiter</artifactId>
-        <version>3.11.2</version>
+        <version>${mockito.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to define `junit.version` and `mockito.version` properties and use it.
In addition, `junit.version` is updated to 5.7.2.

### Why are the changes needed?

Currently, `Dependabot` makes separate PRs per dependencies.
This will advise it to make one PR in the future.

### How was this patch tested?

Pass the CIs.

Closes #831