### PR TITLE
ORC-923: Bump apache from 23 to 24

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>24</version>
   </parent>
   <groupId>org.apache.orc</groupId>
   <artifactId>orc</artifactId>
@@ -63,6 +63,7 @@
 
   <properties>
     <!-- Build Properties -->
+    <project.build.outputTimestamp>2021-08-08T00:00:00Z</project.build.outputTimestamp>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump Apache parent pom to 24 and add `project.build.outputTimestamp` property to comply with the new enforcement. However, Apache ORC project is using `reproducible-build-maven-plugin` already since ORC-504.

### Why are the changes needed?

To use the latest Apache pom file.

### How was this patch tested?

Pass the CIs.

Closes #834.