### PR TITLE
ORC-927: Extracting duplicate codes for RowFilterBenchmark

### DIFF
--- a/java/bench/hive/src/findbugs/exclude.xml
+++ b/java/bench/hive/src/findbugs/exclude.xml
@@ -14,7 +14,7 @@
 -->
 <FindBugsFilter>
   <Match>
-    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2,MS_EXPOSE_REP"/>
+    <Bug pattern="EI_EXPOSE_REP,EI_EXPOSE_REP2,MS_EXPOSE_REP,DM_EXIT"/>
   </Match>
   <Match>
     <Class name="~org\.openjdk\.jmh\.infra\.generated.*"/>

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
@@ -84,7 +84,8 @@ public class BooleanRowFilterBenchmark extends org.openjdk.jmh.Main {
     while (rows.nextBatch(state.batch)) {
       blackhole.consume(state.batch);
     }
-    rows.close();  }
+    rows.close();
+  }
 
   /*
    * Run this test:

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
@@ -17,16 +17,8 @@
  */
 package org.apache.orc.bench.hive.rowfilter;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.apache.orc.OrcFile;
-import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.bench.core.Utilities;
-import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,7 +27,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
@@ -43,8 +34,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -55,10 +44,8 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class BooleanRowFilterBenchmark extends org.openjdk.jmh.Main {
 
-  private static final Path root = new Path(System.getProperty("user.dir"));
-
   @State(Scope.Thread)
-  public static class InputState {
+  public static class InputState extends RowFilterInputState {
 
     @Param({"ORIGINAL"})
     public TypeDescription.RowBatchVersion version;
@@ -72,79 +59,19 @@ public class BooleanRowFilterBenchmark extends org.openjdk.jmh.Main {
     @Param({"2"})
     public int filterColsNum;
 
-    Configuration conf = new Configuration();
-    FileSystem fs;
-    TypeDescription schema;
-    VectorizedRowBatch batch;
-    Path path;
-    boolean[] include;
-    Reader reader;
-    Reader.Options readerOptions;
-    String filter_column = "sales_id";
+    String dataRelativePath = "data/generated/sales/orc.none";
 
-    @Setup
-    public void setup() throws IOException {
-      fs = FileSystem.getLocal(conf).getRaw();
-      path = new Path(root, "data/generated/sales/orc.none");
-      schema = Utilities.loadSchema("sales.schema");
-      batch = schema.createRowBatch(version, 1024);
-      include = new boolean[schema.getMaximumId() + 1];
-      for(TypeDescription child: schema.getChildren()) {
-        if (schema.getFieldNames().get(child.getId()-1).compareTo(filter_column) == 0) {
-          System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-        } else if (child.getCategory() == benchType) {
-          System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-          if (--filterColsNum == 0) break;
-        }
-      }
-      if (filterColsNum != 0) {
-        System.err.println("Dataset does not contain type: "+ benchType);
-        System.exit(-1);
-      }
-      generateRandomSet(Double.parseDouble(filterPerc));
-      reader = OrcFile.createReader(path,
-          OrcFile.readerOptions(conf).filesystem(fs));
-      // just read the Boolean columns
-      readerOptions = reader.options().include(include);
-    }
+    String schemaName = "sales.schema";
 
-    static boolean[] filterValues = null;
-    public static boolean[] generateRandomSet(double percentage) throws IllegalArgumentException {
-      if (percentage > 1.0) {
-        throw new IllegalArgumentException("Filter percentage must be < 1.0 but was "+ percentage);
-      }
-      filterValues = new boolean[1024];
-      int count = 0;
-      while (count < (1024 * percentage)) {
-        Random randomGenerator = new Random();
-        int randVal = randomGenerator.nextInt(1024);
-        if (filterValues[randVal] == false) {
-          filterValues[randVal] = true;
-          count++;
-        }
-      }
-      return filterValues;
-    }
+    String filterColumn = "sales_id";
 
-    public static void customIntRowFilter(OrcFilterContext batch) {
-      int newSize = 0;
-      for (int row = 0; row < batch.getSelectedSize(); ++row) {
-        if (filterValues[row]) {
-          batch.getSelected()[newSize++] = row;
-        }
-      }
-      batch.setSelectedInUse(true);
-      batch.setSelectedSize(newSize);
-    }
   }
 
   @Benchmark
   public void readOrcRowFilter(Blackhole blackhole, InputState state) throws Exception {
     RecordReader rows =
         state.reader.rows(state.readerOptions
-            .setRowFilter(new String[]{state.filter_column}, InputState::customIntRowFilter));
+            .setRowFilter(new String[]{state.filterColumn}, state::customIntRowFilter));
     while (rows.nextBatch(state.batch)) {
       blackhole.consume(state.batch);
     }
@@ -157,8 +84,7 @@ public class BooleanRowFilterBenchmark extends org.openjdk.jmh.Main {
     while (rows.nextBatch(state.batch)) {
       blackhole.consume(state.batch);
     }
-    rows.close();
-  }
+    rows.close();  }
 
   /*
    * Run this test:

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
@@ -17,16 +17,8 @@
  */
 package org.apache.orc.bench.hive.rowfilter;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.apache.orc.OrcFile;
-import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.bench.core.Utilities;
-import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,7 +27,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
@@ -43,8 +34,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -55,10 +44,8 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class DecimalRowFilterBenchmark extends org.openjdk.jmh.Main {
 
-  private static final Path root = new Path(System.getProperty("user.dir"));
-
   @State(Scope.Thread)
-  public static class InputState {
+  public static class InputState extends RowFilterInputState {
 
     // try both DecimalColumnVector and Decimal64
     @Param({"ORIGINAL", "USE_DECIMAL64"})
@@ -73,79 +60,19 @@ public class DecimalRowFilterBenchmark extends org.openjdk.jmh.Main {
     @Param({"2"})
     public int filterColsNum;
 
-    Configuration conf = new Configuration();
-    FileSystem fs;
-    TypeDescription schema;
-    VectorizedRowBatch batch;
-    Path path;
-    boolean[] include;
-    Reader reader;
-    Reader.Options readerOptions;
-    String filter_column = "vendor_id";
+    String dataRelativePath = "data/generated/taxi/orc.none";
 
-    @Setup
-    public void setup() throws IOException {
-      fs = FileSystem.getLocal(conf).getRaw();
-      path = new Path(root, "data/generated/taxi/orc.none");
-      schema = Utilities.loadSchema("taxi.schema");
-      batch = schema.createRowBatch(version, 1024);
-      include = new boolean[schema.getMaximumId() + 1];
-      for(TypeDescription child: schema.getChildren()) {
-        if (schema.getFieldNames().get(child.getId()-1).compareTo(filter_column) == 0) {
-          System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-        } else if (child.getCategory() == benchType) {
-          System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-          if (--filterColsNum == 0) break;
-        }
-      }
-      if (filterColsNum != 0) {
-        System.err.println("Dataset does not contain type: "+ benchType);
-        System.exit(-1);
-      }
-      generateRandomSet(Double.parseDouble(filterPerc));
-      reader = OrcFile.createReader(path,
-          OrcFile.readerOptions(conf).filesystem(fs));
-      // just read the Decimal columns
-      readerOptions = reader.options().include(include);
-    }
+    String schemaName = "taxi.schema";
 
-    static boolean[] filterValues = null;
-    public static boolean[] generateRandomSet(double percentage) throws IllegalArgumentException {
-      if (percentage > 1.0) {
-        throw new IllegalArgumentException("Filter percentage must be < 1.0 but was "+ percentage);
-      }
-      filterValues = new boolean[1024];
-      int count = 0;
-      while (count < (1024 * percentage)) {
-        Random randomGenerator = new Random();
-        int randVal = randomGenerator.nextInt(1024);
-        if (filterValues[randVal] == false) {
-          filterValues[randVal] = true;
-          count++;
-        }
-      }
-      return filterValues;
-    }
+    String filterColumn = "vendor_id";
 
-    public static void customIntRowFilter(OrcFilterContext batch) {
-      int newSize = 0;
-      for (int row = 0; row < batch.getSelectedSize(); ++row) {
-        if (filterValues[row]) {
-          batch.getSelected()[newSize++] = row;
-        }
-      }
-      batch.setSelectedInUse(true);
-      batch.setSelectedSize(newSize);
-    }
   }
 
   @Benchmark
   public void readOrcRowFilter(Blackhole blackhole, InputState state) throws Exception {
     RecordReader rows =
         state.reader.rows(state.readerOptions
-            .setRowFilter(new String[]{state.filter_column}, InputState::customIntRowFilter));
+            .setRowFilter(new String[]{state.filterColumn}, state::customIntRowFilter));
     while (rows.nextBatch(state.batch)) {
       blackhole.consume(state.batch);
     }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
@@ -17,16 +17,8 @@
  */
 package org.apache.orc.bench.hive.rowfilter;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.apache.orc.OrcFile;
-import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.bench.core.Utilities;
-import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,7 +27,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
@@ -43,8 +34,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -54,10 +43,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class DoubleRowFilterBenchmark extends org.openjdk.jmh.Main {
-  private static final Path root = new Path(System.getProperty("user.dir"));
 
   @State(Scope.Thread)
-  public static class InputState {
+  public static class InputState extends RowFilterInputState {
 
     // try both DecimalColumnVector and Decimal64
     @Param({"ORIGINAL"})
@@ -72,79 +60,19 @@ public class DoubleRowFilterBenchmark extends org.openjdk.jmh.Main {
     @Param({"2"})
     public int filterColsNum;
 
-    Configuration conf = new Configuration();
-    FileSystem fs;
-    TypeDescription schema;
-    VectorizedRowBatch batch;
-    Path path;
-    boolean[] include;
-    Reader reader;
-    Reader.Options readerOptions;
-    String filter_column = "vendor_id";
+    String dataRelativePath = "data/generated/taxi/orc.none";
 
-    @Setup
-    public void setup() throws IOException {
-      fs = FileSystem.getLocal(conf).getRaw();
-      path = new Path(root, "data/generated/taxi/orc.none");
-      schema = Utilities.loadSchema("taxi.schema");
-      batch = schema.createRowBatch(version, 1024);
-      include = new boolean[schema.getMaximumId() + 1];
-      for(TypeDescription child: schema.getChildren()) {
-        if (schema.getFieldNames().get(child.getId()-1).compareTo(filter_column) == 0) {
-          System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-        } else if (child.getCategory() == benchType) {
-          System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-          if (--filterColsNum == 0) break;
-        }
-      }
-      if (filterColsNum != 0) {
-        System.err.println("Dataset does not contain type: "+ benchType);
-        System.exit(-1);
-      }
-      generateRandomSet(Double.parseDouble(filterPerc));
-      reader = OrcFile.createReader(path,
-          OrcFile.readerOptions(conf).filesystem(fs));
-      // just read the Double columns
-      readerOptions = reader.options().include(include);
-    }
+    String schemaName = "taxi.schema";
 
-    static boolean[] filterValues = null;
-    public static boolean[] generateRandomSet(double percentage) throws IllegalArgumentException {
-      if (percentage > 1.0) {
-        throw new IllegalArgumentException("Filter percentage must be < 1.0 but was "+ percentage);
-      }
-      filterValues = new boolean[1024];
-      int count = 0;
-      while (count < (1024 * percentage)) {
-        Random randomGenerator = new Random();
-        int randVal = randomGenerator.nextInt(1024);
-        if (filterValues[randVal] == false) {
-          filterValues[randVal] = true;
-          count++;
-        }
-      }
-      return filterValues;
-    }
+    String filterColumn = "vendor_id";
 
-    public static void customIntRowFilter(OrcFilterContext batch) {
-      int newSize = 0;
-      for (int row = 0; row < batch.getSelectedSize(); ++row) {
-        if (filterValues[row]) {
-          batch.getSelected()[newSize++] = row;
-        }
-      }
-      batch.setSelectedInUse(true);
-      batch.setSelectedSize(newSize);
-    }
   }
 
   @Benchmark
   public void readOrcRowFilter(Blackhole blackhole, InputState state) throws Exception {
     RecordReader rows =
         state.reader.rows(state.readerOptions
-            .setRowFilter(new String[]{state.filter_column}, InputState::customIntRowFilter));
+            .setRowFilter(new String[]{state.filterColumn}, state::customIntRowFilter));
     while (rows.nextBatch(state.batch)) {
       blackhole.consume(state.batch);
     }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
@@ -37,80 +37,80 @@ import java.util.Random;
 @State(Scope.Thread)
 public abstract class RowFilterInputState {
 
-    private static final Path root = new Path(System.getProperty("user.dir"));
+  private static final Path root = new Path(System.getProperty("user.dir"));
 
-    Configuration conf = new Configuration();
-    FileSystem fs;
-    TypeDescription schema;
-    VectorizedRowBatch batch;
-    Path path;
-    boolean[] include;
-    Reader reader;
-    Reader.Options readerOptions;
-    boolean[] filterValues = null;
+  Configuration conf = new Configuration();
+  FileSystem fs;
+  TypeDescription schema;
+  VectorizedRowBatch batch;
+  Path path;
+  boolean[] include;
+  Reader reader;
+  Reader.Options readerOptions;
+  boolean[] filterValues = null;
 
-    @Setup
-    public void setup() throws IOException, IllegalAccessException {
-        TypeDescription.RowBatchVersion version =
-            (TypeDescription.RowBatchVersion)FieldUtils.readField(this, "version", true);
-        TypeDescription.Category benchType = (TypeDescription.Category)FieldUtils.readField(this, "benchType", true);
-        String filterPerc = (String)FieldUtils.readField(this, "filterPerc", true);
-        int filterColsNum = (int)FieldUtils.readField(this, "filterColsNum", true);
-        String dataRelativePath = (String)FieldUtils.readField(this, "dataRelativePath", true);
-        String schemaName = (String)FieldUtils.readField(this, "schemaName", true);
-        String filterColumn = (String)FieldUtils.readField(this, "filterColumn", true);
+  @Setup
+  public void setup() throws IOException, IllegalAccessException {
+    TypeDescription.RowBatchVersion version =
+        (TypeDescription.RowBatchVersion) FieldUtils.readField(this, "version", true);
+    TypeDescription.Category benchType = (TypeDescription.Category) FieldUtils.readField(this, "benchType", true);
+    String filterPerc = (String) FieldUtils.readField(this, "filterPerc", true);
+    int filterColsNum = (int) FieldUtils.readField(this, "filterColsNum", true);
+    String dataRelativePath = (String) FieldUtils.readField(this, "dataRelativePath", true);
+    String schemaName = (String) FieldUtils.readField(this, "schemaName", true);
+    String filterColumn = (String) FieldUtils.readField(this, "filterColumn", true);
 
-        fs = FileSystem.getLocal(conf).getRaw();
-        path = new Path(root, dataRelativePath);
-        schema = Utilities.loadSchema(schemaName);
-        batch = schema.createRowBatch(version, 1024);
-        include = new boolean[schema.getMaximumId() + 1];
-        for(TypeDescription child: schema.getChildren()) {
-            if (schema.getFieldNames().get(child.getId()-1).compareTo(filterColumn) == 0) {
-                System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId()-1));
-                include[child.getId()] = true;
-            } else if (child.getCategory() == benchType) {
-                System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId()-1));
-                include[child.getId()] = true;
-                if (--filterColsNum == 0) break;
-            }
-        }
-        if (filterColsNum != 0) {
-            System.err.println("Dataset does not contain type: " + benchType);
-            System.exit(-1);
-        }
-        generateRandomSet(Double.parseDouble(filterPerc));
-        reader = OrcFile.createReader(path,
-                OrcFile.readerOptions(conf).filesystem(fs));
-        // just read the Boolean columns
-        readerOptions = reader.options().include(include);
+    fs = FileSystem.getLocal(conf).getRaw();
+    path = new Path(root, dataRelativePath);
+    schema = Utilities.loadSchema(schemaName);
+    batch = schema.createRowBatch(version, 1024);
+    include = new boolean[schema.getMaximumId() + 1];
+    for (TypeDescription child : schema.getChildren()) {
+      if (schema.getFieldNames().get(child.getId() - 1).compareTo(filterColumn) == 0) {
+        System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId() - 1));
+        include[child.getId()] = true;
+      } else if (child.getCategory() == benchType) {
+        System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId() - 1));
+        include[child.getId()] = true;
+        if (--filterColsNum == 0) break;
+      }
     }
-
-    public void generateRandomSet(double percentage) throws IllegalArgumentException {
-        if (percentage > 1.0) {
-            throw new IllegalArgumentException("Filter percentage must be < 1.0 but was "+ percentage);
-        }
-        filterValues = new boolean[1024];
-        int count = 0;
-        while (count < (1024 * percentage)) {
-            Random randomGenerator = new Random();
-            int randVal = randomGenerator.nextInt(1024);
-            if (!filterValues[randVal]) {
-                filterValues[randVal] = true;
-                count++;
-            }
-        }
+    if (filterColsNum != 0) {
+      System.err.println("Dataset does not contain type: " + benchType);
+      System.exit(-1);
     }
+    generateRandomSet(Double.parseDouble(filterPerc));
+    reader = OrcFile.createReader(path,
+        OrcFile.readerOptions(conf).filesystem(fs));
+    // just read the Boolean columns
+    readerOptions = reader.options().include(include);
+  }
 
-    public void customIntRowFilter(OrcFilterContext batch) {
-        int newSize = 0;
-        for (int row = 0; row < batch.getSelectedSize(); ++row) {
-            if (filterValues[row]) {
-                batch.getSelected()[newSize++] = row;
-            }
-        }
-        batch.setSelectedInUse(true);
-        batch.setSelectedSize(newSize);
+  public void generateRandomSet(double percentage) throws IllegalArgumentException {
+    if (percentage > 1.0) {
+      throw new IllegalArgumentException("Filter percentage must be < 1.0 but was " + percentage);
     }
+    filterValues = new boolean[1024];
+    int count = 0;
+    while (count < (1024 * percentage)) {
+      Random randomGenerator = new Random();
+      int randVal = randomGenerator.nextInt(1024);
+      if (!filterValues[randVal]) {
+        filterValues[randVal] = true;
+        count++;
+      }
+    }
+  }
+
+  public void customIntRowFilter(OrcFilterContext batch) {
+    int newSize = 0;
+    for (int row = 0; row < batch.getSelectedSize(); ++row) {
+      if (filterValues[row]) {
+        batch.getSelected()[newSize++] = row;
+      }
+    }
+    batch.setSelectedInUse(true);
+    batch.setSelectedSize(newSize);
+  }
 
 }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
@@ -1,0 +1,99 @@
+package org.apache.orc.bench.hive.rowfilter;
+
+import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.OrcFile;
+import org.apache.orc.OrcFilterContext;
+import org.apache.orc.Reader;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.bench.core.Utilities;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+import java.io.IOException;
+import java.util.Random;
+
+@State(Scope.Thread)
+public abstract class RowFilterInputState {
+
+    private static final Path root = new Path(System.getProperty("user.dir"));
+
+    Configuration conf = new Configuration();
+    FileSystem fs;
+    TypeDescription schema;
+    VectorizedRowBatch batch;
+    Path path;
+    boolean[] include;
+    Reader reader;
+    Reader.Options readerOptions;
+    boolean[] filterValues = null;
+
+    @Setup
+    public void setup() throws IOException, IllegalAccessException {
+        TypeDescription.RowBatchVersion version =
+            (TypeDescription.RowBatchVersion)FieldUtils.readField(this, "version", true);
+        TypeDescription.Category benchType = (TypeDescription.Category)FieldUtils.readField(this, "benchType", true);
+        String filterPerc = (String)FieldUtils.readField(this, "filterPerc", true);
+        int filterColsNum = (int)FieldUtils.readField(this, "filterColsNum", true);
+        String dataRelativePath = (String)FieldUtils.readField(this, "dataRelativePath", true);
+        String schemaName = (String)FieldUtils.readField(this, "schemaName", true);
+        String filterColumn = (String)FieldUtils.readField(this, "filterColumn", true);
+
+        fs = FileSystem.getLocal(conf).getRaw();
+        path = new Path(root, dataRelativePath);
+        schema = Utilities.loadSchema(schemaName);
+        batch = schema.createRowBatch(version, 1024);
+        include = new boolean[schema.getMaximumId() + 1];
+        for(TypeDescription child: schema.getChildren()) {
+            if (schema.getFieldNames().get(child.getId()-1).compareTo(filterColumn) == 0) {
+                System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId()-1));
+                include[child.getId()] = true;
+            } else if (child.getCategory() == benchType) {
+                System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId()-1));
+                include[child.getId()] = true;
+                if (--filterColsNum == 0) break;
+            }
+        }
+        if (filterColsNum != 0) {
+            System.err.println("Dataset does not contain type: " + benchType);
+            System.exit(-1);
+        }
+        generateRandomSet(Double.parseDouble(filterPerc));
+        reader = OrcFile.createReader(path,
+                OrcFile.readerOptions(conf).filesystem(fs));
+        // just read the Boolean columns
+        readerOptions = reader.options().include(include);
+    }
+
+    public void generateRandomSet(double percentage) throws IllegalArgumentException {
+        if (percentage > 1.0) {
+            throw new IllegalArgumentException("Filter percentage must be < 1.0 but was "+ percentage);
+        }
+        filterValues = new boolean[1024];
+        int count = 0;
+        while (count < (1024 * percentage)) {
+            Random randomGenerator = new Random();
+            int randVal = randomGenerator.nextInt(1024);
+            if (!filterValues[randVal]) {
+                filterValues[randVal] = true;
+                count++;
+            }
+        }
+    }
+
+    public void customIntRowFilter(OrcFilterContext batch) {
+        int newSize = 0;
+        for (int row = 0; row < batch.getSelectedSize(); ++row) {
+            if (filterValues[row]) {
+                batch.getSelected()[newSize++] = row;
+            }
+        }
+        batch.setSelectedInUse(true);
+        batch.setSelectedSize(newSize);
+    }
+
+}

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.orc.bench.hive.rowfilter;
 
 import org.apache.commons.lang.reflect.FieldUtils;

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
@@ -17,16 +17,8 @@
  */
 package org.apache.orc.bench.hive.rowfilter;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.apache.orc.OrcFile;
-import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.bench.core.Utilities;
-import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,7 +27,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
@@ -43,8 +34,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -55,10 +44,8 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class StringRowFilterBenchmark extends org.openjdk.jmh.Main {
 
-  private static final Path root = new Path(System.getProperty("user.dir"));
-
   @State(Scope.Thread)
-  public static class InputState {
+  public static class InputState extends RowFilterInputState {
 
     @Param({"ORIGINAL"})
     public TypeDescription.RowBatchVersion version;
@@ -72,79 +59,19 @@ public class StringRowFilterBenchmark extends org.openjdk.jmh.Main {
     @Param({"2"})
     public int filterColsNum;
 
-    Configuration conf = new Configuration();
-    FileSystem fs;
-    TypeDescription schema;
-    VectorizedRowBatch batch;
-    Path path;
-    boolean[] include;
-    Reader reader;
-    Reader.Options readerOptions;
-    String filter_column = "sales_id";
+    String dataRelativePath = "data/generated/sales/orc.none";
 
-    @Setup
-    public void setup() throws IOException {
-      fs = FileSystem.getLocal(conf).getRaw();
-      path = new Path(root, "data/generated/sales/orc.none");
-      schema = Utilities.loadSchema("sales.schema");
-      batch = schema.createRowBatch(version, 1024);
-      include = new boolean[schema.getMaximumId() + 1];
-      for(TypeDescription child: schema.getChildren()) {
-        if (schema.getFieldNames().get(child.getId()-1).compareTo(filter_column) == 0) {
-          System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-        } else if (child.getCategory() == benchType) {
-          System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-          if (--filterColsNum == 0) break;
-        }
-      }
-      if (filterColsNum != 0) {
-        System.err.println("Dataset does not contain type: "+ benchType);
-        System.exit(-1);
-      }
-      generateRandomSet(Double.parseDouble(filterPerc));
-      reader = OrcFile.createReader(path,
-          OrcFile.readerOptions(conf).filesystem(fs));
-      // just read the String columns
-      readerOptions = reader.options().include(include);
-    }
+    String schemaName = "sales.schema";
 
-    static boolean[] filterValues = null;
-    public static boolean[] generateRandomSet(double percentage) throws IllegalArgumentException {
-      if (percentage > 1.0) {
-        throw new IllegalArgumentException("Filter percentage must be < 1.0 but was "+ percentage);
-      }
-      filterValues = new boolean[1024];
-      int count = 0;
-      while (count < (1024 * percentage)) {
-        Random randomGenerator = new Random();
-        int randVal = randomGenerator.nextInt(1024);
-        if (filterValues[randVal] == false) {
-          filterValues[randVal] = true;
-          count++;
-        }
-      }
-      return filterValues;
-    }
+    String filterColumn = "sales_id";
 
-    public static void customIntRowFilter(OrcFilterContext batch) {
-      int newSize = 0;
-      for (int row = 0; row < batch.getSelectedSize(); ++row) {
-        if (filterValues[row]) {
-          batch.getSelected()[newSize++] = row;
-        }
-      }
-      batch.setSelectedInUse(true);
-      batch.setSelectedSize(newSize);
-    }
   }
 
   @Benchmark
   public void readOrcRowFilter(Blackhole blackhole, InputState state) throws Exception {
     RecordReader rows =
         state.reader.rows(state.readerOptions
-            .setRowFilter(new String[]{state.filter_column}, InputState::customIntRowFilter));
+            .setRowFilter(new String[]{state.filterColumn}, state::customIntRowFilter));
     while (rows.nextBatch(state.batch)) {
       blackhole.consume(state.batch);
     }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
@@ -17,16 +17,9 @@
  */
 package org.apache.orc.bench.hive.rowfilter;
 
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
-import org.apache.orc.OrcFile;
-import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.bench.core.Utilities;
-import org.apache.orc.OrcFilterContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -35,7 +28,6 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.infra.Blackhole;
@@ -43,8 +35,6 @@ import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
-import java.io.IOException;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 @State(Scope.Benchmark)
@@ -57,7 +47,7 @@ public class TimestampRowFilterBenchmark extends org.openjdk.jmh.Main {
   private static final Path root = new Path(System.getProperty("user.dir"));
 
   @State(Scope.Thread)
-  public static class InputState {
+  public static class InputState extends RowFilterInputState {
 
     // try both DecimalColumnVector and Decimal64
     @Param({"ORIGINAL"})
@@ -72,79 +62,19 @@ public class TimestampRowFilterBenchmark extends org.openjdk.jmh.Main {
     @Param({"2"})
     public int filterColsNum;
 
-    Configuration conf = new Configuration();
-    FileSystem fs;
-    TypeDescription schema;
-    VectorizedRowBatch batch;
-    Path path;
-    boolean[] include;
-    Reader reader;
-    Reader.Options readerOptions;
-    String filter_column = "vendor_id";
+    String dataRelativePath = "data/generated/taxi/orc.none";
 
-    @Setup
-    public void setup() throws IOException {
-      fs = FileSystem.getLocal(conf).getRaw();
-      path = new Path(root, "data/generated/taxi/orc.none");
-      schema = Utilities.loadSchema("taxi.schema");
-      batch = schema.createRowBatch(version, 1024);
-      include = new boolean[schema.getMaximumId() + 1];
-      for(TypeDescription child: schema.getChildren()) {
-        if (schema.getFieldNames().get(child.getId()-1).compareTo(filter_column) == 0) {
-          System.out.println("Apply Filter on column: " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-        } else if (child.getCategory() == benchType) {
-          System.out.println("Skip column(s): " + schema.getFieldNames().get(child.getId()-1));
-          include[child.getId()] = true;
-          if (--filterColsNum == 0) break;
-        }
-      }
-      if (filterColsNum != 0) {
-        System.err.println("Dataset does not contain type: "+ benchType);
-        System.exit(-1);
-      }
-      generateRandomSet(Double.parseDouble(filterPerc));
-      reader = OrcFile.createReader(path,
-          OrcFile.readerOptions(conf).filesystem(fs));
-      // just read the Timestamp columns
-      readerOptions = reader.options().include(include);
-    }
+    String schemaName = "taxi.schema";
 
-    static boolean[] filterValues = null;
-    public static boolean[] generateRandomSet(double percentage) throws IllegalArgumentException {
-      if (percentage > 1.0) {
-        throw new IllegalArgumentException("Filter percentage must be < 1.0 but was "+ percentage);
-      }
-     filterValues = new boolean[1024];
-      int count = 0;
-      while (count < (1024 * percentage)) {
-        Random randomGenerator = new Random();
-        int randVal = randomGenerator.nextInt(1024);
-        if (filterValues[randVal] == false) {
-          filterValues[randVal] = true;
-          count++;
-        }
-      }
-      return filterValues;
-    }
+    String filterColumn = "vendor_id";
 
-    public static void customIntRowFilter(OrcFilterContext batch) {
-      int newSize = 0;
-      for (int row = 0; row < batch.getSelectedSize(); ++row) {
-        if (filterValues[row]) {
-          batch.getSelected()[newSize++] = row;
-        }
-      }
-      batch.setSelectedInUse(true);
-      batch.setSelectedSize(newSize);
-    }
   }
 
   @Benchmark
   public void readOrcRowFilter(Blackhole blackhole, InputState state) throws Exception {
     RecordReader rows =
         state.reader.rows(state.readerOptions
-            .setRowFilter(new String[]{state.filter_column}, InputState::customIntRowFilter));
+            .setRowFilter(new String[]{state.filterColumn}, state::customIntRowFilter));
     while (rows.nextBatch(state.batch)) {
       blackhole.consume(state.batch);
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Create a new class RowFilterInputState to hold duplicate code.
`filterValues`, `generateRandomSet` and `customIntRowFilter` previously existed in different internal classes as static variables/methods and do not affect each other. After refactoring, they were changed to instance variables/methods to avoid interaction between different benchmarks.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Easier to maintain.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass the CIs.