### PR TITLE
ORC-929: Fix NaN error at orc-tools meta command

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -437,8 +437,7 @@ public final class FileDump {
     FileSystem fs = file.getFileSystem(conf);
     long fileLen = fs.getFileStatus(file).getLen();
     long paddedBytes = getTotalPaddingSize(reader);
-    // empty ORC file is ~45 bytes. Assumption here is file length always >0
-    double percentPadding = ((double) paddedBytes / (double) fileLen) * 100;
+    double percentPadding = (fileLen == 0) ? 0.0d : 100.0d * paddedBytes / fileLen;
     DecimalFormat format = new DecimalFormat("##.##");
     System.out.println("\nFile length: " + fileLen + " bytes");
     System.out.println("Padding length: " + paddedBytes + " bytes");


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix NaN error at orc-tools `meta` command. 


### Why are the changes needed?
To fix invalid output
```
$ orc-tools meta zero.orc 2> /dev/null | grep Padding
Padding length: 0 bytes
Padding ratio: �%
```


### How was this patch tested?
Manual. 

```
$ java -jar tools/target/orc-tools-1.8.0-SNAPSHOT-uber.jar meta ../examples/zero.orc
```

