### PR TITLE
ORC-931: Modify RunLengthIntegerWriterV2 code to improve readability

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerWriterV2.java
@@ -533,16 +533,13 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
       if ((brBits100p - brBits95p) != 0 && Math.abs(min) < BASE_VALUE_LIMIT) {
         encoding = EncodingType.PATCHED_BASE;
         preparePatchedBlob();
-        return;
       } else {
         encoding = EncodingType.DIRECT;
-        return;
       }
     } else {
       // if difference in bits between 95th percentile and 100th percentile is
       // 0, then patch length will become 0. Hence we will fallback to direct
       encoding = EncodingType.DIRECT;
-      return;
     }
   }
 
@@ -692,16 +689,13 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
           variableRunLength = fixedRunLength;
           fixedRunLength = 0;
           determineEncoding();
-          writeValues();
-        } else if (fixedRunLength >= MIN_REPEAT
-            && fixedRunLength <= MAX_SHORT_REPEAT_LENGTH) {
+        } else if (fixedRunLength <= MAX_SHORT_REPEAT_LENGTH) {
           encoding = EncodingType.SHORT_REPEAT;
-          writeValues();
         } else {
           encoding = EncodingType.DELTA;
           isFixedDelta = true;
-          writeValues();
         }
+        writeValues();
       }
     }
     output.flush();
@@ -772,12 +766,11 @@ public class RunLengthIntegerWriterV2 implements IntegerWriter {
           if (fixedRunLength >= MIN_REPEAT) {
             if (fixedRunLength <= MAX_SHORT_REPEAT_LENGTH) {
               encoding = EncodingType.SHORT_REPEAT;
-              writeValues();
             } else {
               encoding = EncodingType.DELTA;
               isFixedDelta = true;
-              writeValues();
             }
+            writeValues();
           }
 
           // if fixed run length is <MIN_REPEAT and current value is


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
RunLengthIntegerWriterV2.java
512-546 line
```java
  if (diffBitsLH > 1) {
      for (int i = 0; i < numLiterals; i++) {
        baseRedLiterals[i] = literals[i] - min;
      }
      brBits95p = utils.percentileBits(baseRedLiterals, 0, numLiterals, 0.95);
      brBits100p = utils.percentileBits(baseRedLiterals, 0, numLiterals, 1.0);
      if ((brBits100p - brBits95p) != 0 && Math.abs(min) < BASE_VALUE_LIMIT) {
        encoding = EncodingType.PATCHED_BASE;
        preparePatchedBlob();
        return;
      } else {
        encoding = EncodingType.DIRECT;
        return;
      }
    } else {
      // if difference in bits between 95th percentile and 100th percentile is
      // 0, then patch length will become 0. Hence we will fallback to direct
      encoding = EncodingType.DIRECT;
      return;
    }
```
All three conditional branch logics have been completed and the return statement is redundant.

691-704 line
```java
      if (fixedRunLength < MIN_REPEAT) {
          variableRunLength = fixedRunLength;
          fixedRunLength = 0;
          determineEncoding();
          writeValues();
        } else if (fixedRunLength >= MIN_REPEAT
            && fixedRunLength <= MAX_SHORT_REPEAT_LENGTH) {
          encoding = EncodingType.SHORT_REPEAT;
          writeValues();
        } else {
          encoding = EncodingType.DELTA;
          isFixedDelta = true;
          writeValues();
        }
```
fixedRunLength >= MIN_REPEAT is redundant, the previous condition already ensures this.  
Extract the writeValues() method to the end. It seems better for conditional judgements to deal only with encoding and state.

772-781 line
```java
          if (fixedRunLength >= MIN_REPEAT) {
            if (fixedRunLength <= MAX_SHORT_REPEAT_LENGTH) {
              encoding = EncodingType.SHORT_REPEAT;
              writeValues();
            } else {
              encoding = EncodingType.DELTA;
              isFixedDelta = true;
              writeValues();
            }
          }
```
Ditto

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Modify code to improve readability

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass the CIs