### PR TITLE
ORC-939: Remove threetenbp dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -782,11 +782,6 @@
       </dependency>
       <dependency>
         <groupId>org.threeten</groupId>
-        <artifactId>threetenbp</artifactId>
-        <version>1.3.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.threeten</groupId>
         <artifactId>threeten-extra</artifactId>
         <version>1.7.0</version>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes `threetenbp` dependency because it's removed at Apache ORC 1.7.0 via ORC-738
- https://github.com/apache/orc/pull/631/files#diff-1108423b084c5105f5c0309e48278ea6b98c7fd3c95d37df984bd1139a2699d6L81-L84

### Why are the changes needed?

This is not used.
```
$ git grep org.threeten.bp | wc -l
       0
```

### How was this patch tested?

Manual.

This closes #827 .