### PR TITLE
ORC-940: Use Hadoop 3.3.1 in bench module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -38,6 +38,7 @@
     <parquet.version>1.12.0</parquet.version>
     <spark.version>3.1.2</spark.version>
     <jackson.version>2.12.4</jackson.version>
+    <hadoop.version>3.3.1</hadoop.version>
   </properties>
 
   <modules>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Hadoop 3.3.1 instead of 2.7.3 in benchmark module.

### Why are the changes needed?

Both Apache Hive 3.1.2 and Apache Spark 3.1.2 depends on Apache Hadoop 3.

### How was this patch tested?

Pass the CIs.