### PR TITLE
ORC-941: Move `MacOS 10.15/11.5` test from Travis to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -46,11 +46,14 @@ jobs:
         make package test-out
 
   build-mac:
-    name: "Build with Java ${{ matrix.java }}"
-    runs-on: macos-11
+    name: "Build with Java ${{ matrix.java }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - macos-10.15
+          - macos-11
         java:
           - 11
     env:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,3 +44,36 @@ jobs:
         cd build
         cmake -DANALYZE_JAVA=ON ..
         make package test-out
+
+  build-mac:
+    name: "Build with Java ${{ matrix.java }}"
+    runs-on: macos-11
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - 11
+    env:
+      MAVEN_OPTS: -Xmx2g
+      MAVEN_SKIP_RC: true
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Cache Maven local repository
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ matrix.java }}-maven-
+    - name: Install Java ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: "Test"
+      run: |
+        mkdir -p ~/.m2
+        mkdir build
+        cd build
+        cmake -DANALYZE_JAVA=ON ..
+        make package test-out

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,5 +75,5 @@ jobs:
         mkdir -p ~/.m2
         mkdir build
         cd build
-        cmake -DANALYZE_JAVA=ON ..
+        cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
         make package test-out

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: "Build with Java ${{ matrix.java }}"
+    name: "Build with Java ${{ matrix.java }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -11,10 +11,14 @@ on:
 jobs:
   build:
     name: "Build with Java ${{ matrix.java }}"
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-20.04
+          - macos-10.15
+          - macos-11
         java:
           - 1.8
           - 11
@@ -42,41 +46,9 @@ jobs:
         mkdir -p ~/.m2
         mkdir build
         cd build
-        cmake -DANALYZE_JAVA=ON ..
-        make package test-out
-
-  build-mac:
-    name: "Build with Java ${{ matrix.java }} on ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-10.15
-          - macos-11
-        java:
-          - 11
-    env:
-      MAVEN_OPTS: -Xmx2g
-      MAVEN_SKIP_RC: true
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Cache Maven local repository
-      uses: actions/cache@v2
-      with:
-        path: ~/.m2/repository
-        key: ${{ matrix.java }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ matrix.java }}-maven-
-    - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java }}
-    - name: "Test"
-      run: |
-        mkdir -p ~/.m2
-        mkdir build
-        cd build
-        cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
+        if [ "${{ matrix.os }}" = "ubuntu-20.04" ]; then
+          cmake -DANALYZE_JAVA=ON ..
+        else
+          cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
+        fi
         make package test-out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 sudo: false
 dist: focal
-addons:
-  homebrew:
-    packages:
-    - openssl
 
 matrix:
   fast_finish: true
@@ -23,17 +19,6 @@ matrix:
   - language: cpp
     compiler: clang
     os: linux
-
-  - language: cpp
-    compiler: clang
-    os: osx
-    osx_image: xcode11.3
-    script:
-    - brew link --overwrite --force openssl
-    - mkdir build
-    - cd build
-    - cmake -DBUILD_JAVA=OFF -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
-    - travis_wait 35 make package test-out
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,17 +35,6 @@ matrix:
     - cmake -DBUILD_JAVA=OFF -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
     - travis_wait 35 make package test-out
 
-  - language: cpp
-    compiler: clang
-    os: osx
-    osx_image: xcode12
-    script:
-    - brew link --overwrite --force openssl
-    - mkdir build
-    - cd build
-    - cmake -DBUILD_JAVA=OFF -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
-    - travis_wait 35 make package test-out
-
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to migrate the following jobs from `Travis CI` to `GitHub Action`.
- Mac OS 10.15
- Mac OS 11.5

### Why are the changes needed?

This job takes 40-minutes execution time and waits in the queue over 6 hours frequently while GitHub Action jobs finish in around 20 minutes in total.

![Screen Shot 2021-08-11 at 5 02 20 PM](https://user-images.githubusercontent.com/9700541/129118727-5231e984-cb26-4942-8dbb-c7b97ab50095.png)

- https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
    - System Version: macOS 10.15.7 (19H1323)
- https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md 
    - System Version: macOS 11.5 (20G71)

### How was this patch tested?

Pass the CIs.