### PR TITLE
ORC-942: Remove javax.xml.bind:jaxb-api dependency

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -52,10 +52,6 @@
       <artifactId>aircompressor</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>

--- a/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/mask/SHA256MaskFactory.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.orc.DataMask;
 import org.apache.orc.TypeDescription;
 
-import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -73,6 +72,20 @@ public class SHA256MaskFactory extends MaskFactory {
     }
   }
 
+  private static final char[] DIGITS = {
+      '0', '1', '2', '3', '4', '5', '6', '7',
+      '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'
+  };
+
+  public static String printHexBinary(byte[] data) {
+    final char[] out = new char[data.length << 1];
+    for (int i = 0, j = 0; i < data.length; i++) {
+      out[j++] = DIGITS[(0xF0 & data[i]) >>> 4];
+      out[j++] = DIGITS[0x0F & data[i]];
+    }
+    return new String(out);
+  }
+
   /**
    * Mask a string by finding the character category of each character
    * and replacing it with the matching literal.
@@ -87,8 +100,7 @@ public class SHA256MaskFactory extends MaskFactory {
 
     // take SHA-256 Hash and convert to HEX
     md.update(source.vector[row], source.start[row], source.length[row]);
-    byte[] hash = DatatypeConverter.printHexBinary(md.digest())
-                      .getBytes(StandardCharsets.UTF_8);
+    byte[] hash = printHexBinary(md.digest()).getBytes(StandardCharsets.UTF_8);
     int targetLength = hash.length;
 
     switch (schema.getCategory()) {

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -31,6 +31,7 @@ import org.apache.orc.OrcFile.WriterOptions;
 import com.google.common.collect.Lists;
 
 import org.apache.orc.impl.ReaderImpl;
+import static org.apache.orc.impl.mask.SHA256MaskFactory.printHexBinary;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.StripePlanner;
 import org.apache.orc.OrcFile.Version;
@@ -67,7 +68,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 import org.mockito.Mockito;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigInteger;
@@ -3877,7 +3877,7 @@ public class TestVectorOrcFile {
     try {
       MessageDigest md = MessageDigest.getInstance("SHA-256");
       byte[] digest = md.digest(value.getBytes(StandardCharsets.UTF_8));
-      return DatatypeConverter.printHexBinary(digest);
+      return printHexBinary(digest);
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }

--- a/java/core/src/test/org/apache/orc/impl/mask/TestSHA256Mask.java
+++ b/java/core/src/test/org/apache/orc/impl/mask/TestSHA256Mask.java
@@ -19,7 +19,6 @@ package org.apache.orc.impl.mask;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.TypeDescription;
 
-import javax.xml.bind.DatatypeConverter;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -65,9 +64,9 @@ public class TestSHA256Mask {
       expectedHashShort = md.digest(inputShort);
       expectedHashLong = md.digest(inputLong);
 
-      expectedHash32_hex = DatatypeConverter.printHexBinary(expectedHash32).getBytes(StandardCharsets.UTF_8);
-      expectedHashShort_hex = DatatypeConverter.printHexBinary(expectedHashShort).getBytes(StandardCharsets.UTF_8);
-      expectedHashLong_hex = DatatypeConverter.printHexBinary(expectedHashLong).getBytes(StandardCharsets.UTF_8);
+      expectedHash32_hex = SHA256MaskFactory.printHexBinary(expectedHash32).getBytes(StandardCharsets.UTF_8);
+      expectedHashShort_hex = SHA256MaskFactory.printHexBinary(expectedHashShort).getBytes(StandardCharsets.UTF_8);
+      expectedHashLong_hex = SHA256MaskFactory.printHexBinary(expectedHashLong).getBytes(StandardCharsets.UTF_8);
 
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -560,11 +560,6 @@
         <version>0.19</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>2.2.11</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
         <version>1.9.0</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `javax.xml.bind:jaxb-api` dependency.

### Why are the changes needed?

This was added via ORC-411 to support Java 10+ at Apache ORC 1.4.5.

Since we only use `DatatypeConverter.printHexBinary` API, we can use the similar logic of `commons-codec` `Hex.encodeHexString`.

### How was this patch tested?

Pass the CIs with Java8/11/16/17-ea.

Closes #846 