### PR TITLE
MINOR: Add `.java-version` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 *.iws
 .idea
 .DS_Store
+.java-version


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `.java-version` to `.gitignore`.

### Why are the changes needed?

This is convenient when we use `jenv` to test various Java versions. 

### How was this patch tested?

Manual

```
$ touch .java-version
$ git status
On branch jenv
Your branch is up to date with 'dongjoon/jenv'.

nothing to commit, working tree clean
```