### PR TITLE
ORC-945: Add OUTPUT_QUIET, ERROR_QUIET to suppress Java8 add-open error messages

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -67,7 +67,9 @@ add_test(
 execute_process(
   COMMAND java --add-opens java.base/java.nio=ALL-UNNAMED -version
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  RESULT_VARIABLE RET)
+  RESULT_VARIABLE RET
+  OUTPUT_QUIET
+  ERROR_QUIET)
 if(RET EQUAL 0)
   set(ADD_OPENS --add-opens)
   set(JAVA_NIO java.base/java.nio=ALL-UNNAMED)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add `OUTPUT_QUIET` and `ERROR_QUIET` to suppress Java8 `add-open` error messages

### Why are the changes needed?
Error messages could be misleading, so we had better suppress it. 
- https://github.com/apache/orc/runs/3324055264
```
Unrecognized option: --add-opens
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
```

### How was this patch tested?
Check the GHA logs on this PR. 