### PR TITLE
ORC-948: Add hive benchmark integration tests

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -85,6 +85,11 @@ add_test(
   COMMAND java ${ADD_OPENS} ${JAVA_NIO} -jar bench/core/orc-benchmarks-core-${ORC_VERSION}-uber.jar scan data -d sales
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
+add_test(
+  NAME java-bench-hive-test
+  COMMAND java -Dbench.root.dir=. ${ADD_OPENS} ${JAVA_NIO} -jar bench/hive/orc-benchmarks-hive-${ORC_VERSION}-uber.jar write -i 1 -I 0 -t 1 data
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 install(
   FILES ${ORC_JARS}
   DESTINATION share)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add hive benchmark integration tests. 


### Why are the changes needed?
To improve test coverage and prevent future regressions. 

### How was this patch tested?
Pass the CIs. 