### PR TITLE
MINOR: Add more exclusion patterns at Spark bench uber jar building

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -181,9 +181,17 @@
                     <exclude>META-INF/MANIFEST.MF</exclude>
                     <exclude>META-INF/DEPENDENCIES</exclude>
                     <exclude>META-INF/LICENSE</exclude>
+                    <exclude>META-INF/LICENSE.md</exclude>
                     <exclude>META-INF/NOTICE</exclude>
+                    <exclude>META-INF/NOTICE-binary</exclude>
+                    <exclude>META-INF/NOTICE.md</exclude>
+                    <exclude>META-INF/NOTICE.txt</exclude>
                     <exclude>META-INF/DUMMY.SF</exclude>
                     <exclude>META-INF/DUMMY.DSA</exclude>
+                    <exclude>LICENSE</exclude>
+                    <exclude>NOTICE</exclude>
+                    <exclude>THIRD-PARTY</exclude>
+                    <exclude>about.html</exclude>
                   </excludes>
                 </filter>
               </filters>


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to add more exclusion patterns at Spark bench uber jar building. 


### Why are the changes needed?
Since ORC-940, it seems that we have more warnings.
This will suppress more new warnings.

### How was this patch tested?
Check GHA build logs. 