### PR TITLE
ORC-950: Bump aircompressor to 0.20

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -568,7 +568,7 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>0.19</version>
+        <version>0.20</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump `aircompressor` to 0.20.

### Why are the changes needed?

To bring the following patch.
- https://github.com/airlift/aircompressor/commit/5e353d056222ea633b79dbead71137d85934ca96

### How was this patch tested?

Pass the Cis.