### PR TITLE
ORC-952: Add `since` tag to `org.apache.orc.RecordReader` interface

### DIFF
--- a/java/core/src/java/org/apache/orc/RecordReader.java
+++ b/java/core/src/java/org/apache/orc/RecordReader.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 /**
  * A row-by-row iterator for ORC files.
+ * @since 1.1.0
  */
 public interface RecordReader extends Closeable {
   /**

--- a/java/core/src/java/org/apache/orc/RecordReader.java
+++ b/java/core/src/java/org/apache/orc/RecordReader.java
@@ -66,6 +66,7 @@ public interface RecordReader extends Closeable {
 
   /**
    * Seek to a particular row number.
+   * @since 1.1.0
    */
   void seekToRow(long rowCount) throws IOException;
 }

--- a/java/core/src/java/org/apache/orc/RecordReader.java
+++ b/java/core/src/java/org/apache/orc/RecordReader.java
@@ -34,6 +34,7 @@ public interface RecordReader extends Closeable {
    * @param batch a row batch object to read into
    * @return were more rows available to read?
    * @throws java.io.IOException
+   * @since 1.1.0
    */
   boolean nextBatch(VectorizedRowBatch batch) throws IOException;
 
@@ -42,6 +43,7 @@ public interface RecordReader extends Closeable {
    * call to next().
    * @return the row number from 0 to the number of rows in the file
    * @throws java.io.IOException
+   * @since 1.1.0
    */
   long getRowNumber() throws IOException;
 
@@ -49,12 +51,14 @@ public interface RecordReader extends Closeable {
    * Get the progress of the reader through the rows.
    * @return a fraction between 0.0 and 1.0 of rows read
    * @throws java.io.IOException
+   * @since 1.1.0
    */
   float getProgress() throws IOException;
 
   /**
    * Release the resources associated with the given reader.
    * @throws java.io.IOException
+   * @since 1.1.0
    */
   @Override
   void close() throws IOException;


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `since` tag to `org.apache.orc.Reader` interface.

### Why are the changes needed?

To help ORC developers to check the API availability easily by improving code and Javadoc.

### How was this patch tested?

Manual