### PR TITLE
ORC-954: Fix Javadoc generation failure

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/DictionaryUtils.java
@@ -55,7 +55,7 @@ public class DictionaryUtils {
    * @param keyOffsets starting offset of the key (in byte) in the byte array
    * @param byteArray storing raw bytes of all keys seen in dictionary
    * @return the number of bytes written to the output stream
-   * @throw IOException if an I/O error occurs
+   * @throws IOException if an I/O error occurs
    */
   public static int writeToTextInternal(OutputStream out, int position,
       DynamicIntArray keyOffsets, DynamicByteArray byteArray)

--- a/java/core/src/java/org/apache/orc/util/CuckooSetBytes.java
+++ b/java/core/src/java/org/apache/orc/util/CuckooSetBytes.java
@@ -26,7 +26,7 @@ import java.util.Random;
  * A high-performance set implementation used to support fast set membership testing,
  * using Cuckoo hashing. This is used to support fast tests of the form
  *
- *       column IN ( <list-of-values )
+ *       column IN ( list-of-values )
  *
  * For details on the algorithm, see R. Pagh and F. F. Rodler, "Cuckoo Hashing,"
  * Elsevier Science preprint, Dec. 2003. http://www.itu.dk/people/pagh/papers/cuckoo-jour.pdf.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover `Javadoc` generation failure.

### Why are the changes needed?

This is a blocker for new release.

### How was this patch tested?

Manually.
```
$ cd java
$ mvn install -DskipTests
$ mvn javadoc:javadoc
```