### PR TITLE
ORC-955: Add Javadoc generation GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,3 +52,20 @@ jobs:
           cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
         fi
         make package test-out
+
+  doc:
+    name: "Javadoc generation"
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Install Java 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: "javadoc"
+      run: |
+        mkdir -p ~/.m2
+        cd java
+        mvn install -DskipTests
+        mvn javadoc:javadoc


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a `javadoc` generation test coverage to prevent a future regression.

### Why are the changes needed?

Although Javadoc generation is a non-functional step, we had better remove the possibility of VOTE failure completely.

### How was this patch tested?

Pass the GitHub Action with the new job.