### PR TITLE
ORC-875: Add GitHub Action job for Windows Server 2019

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,6 +52,22 @@ jobs:
         fi
         make package test-out
 
+  windows:
+    name: "Build on Windows"
+    runs-on: windows-2019
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Add msbuild to PATH
+      uses: microsoft/setup-msbuild@v1.1
+    - name: "Test"
+      run: |
+        mkdir build
+        cd build
+        cmake .. -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=Debug -DBUILD_LIBHDFSPP=OFF -DBUILD_TOOLS=OFF -DBUILD_JAVA=OFF
+        cmake --build . --config Debug
+        ctest -C Debug
+
   doc:
     name: "Javadoc generation"
     runs-on: ubuntu-20.04


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a test coverage for Windows on GitHub Action additionally.

### Why are the changes needed?

This PR aims to replace `AppVeyor` with GitHub Action eventually.

**AS IS(AppVeyor)**

https://github.com/apache/orc/blob/ae660f3006cae145d0db7a897fd81fe94029c0b2/appveyor.yml#L18-L41

**THIS PR(GitHub Action)**

https://github.com/apache/orc/runs/4662857757?check_suite_focus=true

```
-- Check for working CXX compiler: C:/Program Files (x86)/Microsoft Visual Studio 14.0/VC/bin/x86_amd64/cl.exe - skipped
-- compiler MSVC version 19.0.24245.0
...
Test project D:/a/orc/orc/build
    Start 1: orc-test
1/1 Test #1: orc-test .........................   Passed   61.99 sec
```

### How was this patch tested?

Pass the GitHub Action with newly add Windows job.