### PR TITLE
ORC-959: [C++] Fix crash of SargsApplier in finding nested field names

### DIFF
--- a/c++/src/sargs/SargsApplier.cc
+++ b/c++/src/sargs/SargsApplier.cc
@@ -25,7 +25,8 @@ namespace orc {
   uint64_t SargsApplier::findColumn(const Type& type,
                                     const std::string& colName) {
     for (uint64_t i = 0; i != type.getSubtypeCount(); ++i) {
-      if (type.getFieldName(i) == colName) {
+      // Only STRUCT type has field names
+      if (type.getKind() == STRUCT && type.getFieldName(i) == colName) {
         return type.getSubtype(i)->getColumnId();
       } else {
         uint64_t ret = findColumn(*type.getSubtype(i), colName);

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -82,6 +82,8 @@ namespace orc {
 
   private:
     friend class TestSargsApplier_findColumnTest_Test;
+    friend class TestSargsApplier_findArrayColumnTest_Test;
+    friend class TestSargsApplier_findMapColumnTest_Test;
     static uint64_t findColumn(const Type& type, const std::string& colName);
 
   private:

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -33,6 +33,30 @@ namespace orc {
       SargsApplier::findColumn(*type, "b"));
   }
 
+  TEST(TestSargsApplier, findArrayColumnTest) {
+    auto type = std::unique_ptr<Type>(Type::buildTypeFromString(
+      "struct<a:int,c:string,e:array<struct<f:bigint,g:double>>>"));
+    EXPECT_EQ(1, SargsApplier::findColumn(*type, "a"));
+    EXPECT_EQ(2, SargsApplier::findColumn(*type, "c"));
+    EXPECT_EQ(3, SargsApplier::findColumn(*type, "e"));
+    EXPECT_EQ(5, SargsApplier::findColumn(*type, "f"));
+    EXPECT_EQ(6, SargsApplier::findColumn(*type, "g"));
+    EXPECT_EQ(std::numeric_limits<uint64_t>::max(),
+      SargsApplier::findColumn(*type, "b"));
+  }
+
+  TEST(TestSargsApplier, findMapColumnTest) {
+    auto type = std::unique_ptr<Type>(Type::buildTypeFromString(
+      "struct<a:int,c:string,e:map<int,struct<f:bigint,g:double>>>"));
+    EXPECT_EQ(1, SargsApplier::findColumn(*type, "a"));
+    EXPECT_EQ(2, SargsApplier::findColumn(*type, "c"));
+    EXPECT_EQ(3, SargsApplier::findColumn(*type, "e"));
+    EXPECT_EQ(6, SargsApplier::findColumn(*type, "f"));
+    EXPECT_EQ(7, SargsApplier::findColumn(*type, "g"));
+    EXPECT_EQ(std::numeric_limits<uint64_t>::max(),
+      SargsApplier::findColumn(*type, "b"));
+  }
+
   static proto::ColumnStatistics createIntStats(
     int64_t min, int64_t max, bool hasNull = false) {
     proto::ColumnStatistics statistics;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This patch fixes a crash in the C++ reader when SearchArgument is created on nested columns of collection types (e.g. array/map). Only STRUCT type has field names for subtypes. So we should check the current node type before checking any field names. JIRA description contains details on how to reproduce the crash.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Same as the above.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests in c++/test/TestSargsApplier.cc to reproduce the crash and verify the fix on ARRAY and MAP types.