### PR TITLE
ORC-963: Build benchmark module always for integration testing

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -35,7 +35,7 @@ set(ORC_JARS
 if (ANALYZE_JAVA)
   set(JAVA_PROFILE "-Pcmake,analyze,benchmark")
 else()
-  set(JAVA_PROFILE "-Pcmake")
+  set(JAVA_PROFILE "-Pcmake,benchmark")
 endif()
 
 add_custom_command(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to build the `benchmark` module always for integration testing. 

### Why are the changes needed?

Since we always run the integration tests, we need to build the `benchmark` module. Otherwise, those tests will fail when we run manually without any configurations.

### How was this patch tested?
Manually.