### PR TITLE
ORC-971: [C++] Fix LESS_THAN_EQUALS doesn't handle the case when minValue equals to maxValue

### DIFF
--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -293,7 +293,8 @@ namespace orc {
         }
       case PredicateLeaf::Operator::LESS_THAN_EQUALS:
         loc = compareToRange(values.at(0), minValue, maxValue);
-        if (loc == Location::AFTER || loc == Location::MAX) {
+        if (loc == Location::AFTER || loc == Location::MAX ||
+            (loc == Location::MIN && minValue == maxValue)) {
           return hasNull ? TruthValue::YES_NULL : TruthValue::YES;
         } else if (loc == Location::BEFORE) {
           return hasNull ? TruthValue::NO_NULL : TruthValue::NO;

--- a/c++/test/TestPredicateLeaf.cc
+++ b/c++/test/TestPredicateLeaf.cc
@@ -366,6 +366,13 @@ namespace orc {
               evaluate(pred, createIntStats(10L, 15L, true)));
     EXPECT_EQ(TruthValue::YES_NULL,
               evaluate(pred, createIntStats(0L, 10L, true)));
+    // Edge cases where minValue == maxValue
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(10L, 10L, true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createIntStats(15L, 15L, true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createIntStats(20L, 20L, true)));
     // Edge case where stats contain NaN or Inf numbers
     PredicateLeaf pred4(
             PredicateLeaf::Operator::LESS_THAN,
@@ -518,8 +525,13 @@ namespace orc {
               evaluate(pred, createStringStats("c", "d", true)));
     EXPECT_EQ(TruthValue::YES_NO_NULL,
               evaluate(pred, createStringStats("b", "d", true)));
-    EXPECT_EQ(TruthValue::YES_NO_NULL,
+    // Edge cases where minValue == maxValue
+    EXPECT_EQ(TruthValue::YES_NULL,
+              evaluate(pred, createStringStats("a", "a", true)));
+    EXPECT_EQ(TruthValue::YES_NULL,
               evaluate(pred, createStringStats("c", "c", true)));
+    EXPECT_EQ(TruthValue::NO_NULL,
+              evaluate(pred, createStringStats("d", "d", true)));
   }
 
   TEST(TestPredicateLeaf, testInWithNullInStats) {
@@ -874,8 +886,12 @@ namespace orc {
                         PredicateDataType::TIMESTAMP,
                         "x",
                         Literal(static_cast<int64_t>(0), 500000));
-    EXPECT_EQ(TruthValue::YES_NO, evaluate(
+    EXPECT_EQ(TruthValue::YES, evaluate(
+      pred2, createTimestampStats(0, 499999, 0, 499999)));
+    EXPECT_EQ(TruthValue::YES, evaluate(
       pred2, createTimestampStats(0, 500000, 0, 500000)));
+    EXPECT_EQ(TruthValue::NO, evaluate(
+      pred2, createTimestampStats(0, 500001, 0, 500001)));
 
     PredicateLeaf pred3(PredicateLeaf::Operator::LESS_THAN,
                         PredicateDataType::TIMESTAMP,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
When evaluating the LESS_THAN_EQUALS predicates, the case that has identical minValue and maxValue is not handled correctly. E.g. predicate "x <= 15" on a range [15, 15] should get YES or YES_NULL results. But what we currently get is YES_NO or YES_NO_NULL. This patch fixes evaluatePredicateRange() to handle this case.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Described above.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added unit tests in c++/test/TestPredicateLeaf.cc