### PR TITLE
ORC-965: Fix ZSTD 'Overflow detected' failure

### DIFF
--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -2281,7 +2281,7 @@ public class TestVectorOrcFile {
         OrcFile.writerOptions(conf)
             .setSchema(schema)
             .compress(CompressionKind.ZSTD)
-            .bufferSize(2000)
+            .bufferSize(1000)
             .version(fileFormat))) {
       VectorizedRowBatch batch = schema.createRowBatch();
       Random rand = new Random(3);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -568,7 +568,7 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>0.20</version>
+        <version>0.21</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Overflow detected` failures in ZSTD compression by bringing new aircompressor version.

- https://github.com/airlift/aircompressor/commit/1e364f713390008eada1daa451e7b42cd6647250 (Fix failure when data compressing incompressible data)

### Why are the changes needed?

`Overflow detected` happens not only for the small buffer, but also for the incompressible data. The following is a link to the JIRA image.

![](https://user-images.githubusercontent.com/1145830/130343897-c3f56361-a126-4817-b9d3-4f8646b5154e.png)

### How was this patch tested?

Pass the UTs.