### PR TITLE
ORC-980: Filter processing respects the case-sensitivity flag

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterBench.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/filter/FilterBench.java
@@ -168,6 +168,7 @@ public class FilterBench implements OrcBenchmark {
           .useSelected(true);
         return FilterFactory.createBatchFilter(options,
                                                FilterBenchUtil.schema,
+                                               false,
                                                OrcFile.Version.CURRENT,
                                                normalize);
       default:
@@ -198,7 +199,7 @@ public class FilterBench implements OrcBenchmark {
       Random rnd = new Random(1024);
       VectorizedRowBatch b = FilterBenchUtil.createBatch(rnd);
       Configuration conf = new Configuration();
-      fc = new OrcFilterContextImpl(FilterBenchUtil.schema).setBatch(b);
+      fc = new OrcFilterContextImpl(FilterBenchUtil.schema, false).setBatch(b);
       Map.Entry<SearchArgument, int[]> r = FilterBenchUtil.createSArg(rnd, b, fInSize);
       SearchArgument sArg = r.getKey();
       expSel = r.getValue();
@@ -247,7 +248,7 @@ public class FilterBench implements OrcBenchmark {
     public void setup() throws FilterFactory.UnSupportedSArgException {
       VectorizedRowBatch b = FilterBenchUtil.createBatch(new Random(1024));
 
-      fc = new OrcFilterContextImpl(FilterBenchUtil.schema).setBatch(b);
+      fc = new OrcFilterContextImpl(FilterBenchUtil.schema, false).setBatch(b);
       Map.Entry<SearchArgument, int[]> r = FilterBenchUtil.createComplexSArg(new Random(1024),
                                                                              b,
                                                                              inSize,

--- a/java/bench/core/src/java/org/apache/orc/impl/filter/RowFilterFactory.java
+++ b/java/bench/core/src/java/org/apache/orc/impl/filter/RowFilterFactory.java
@@ -90,6 +90,7 @@ public class RowFilterFactory {
     LeafFilter f = (LeafFilter) LeafFilterFactory.createLeafVectorFilter(leaf,
                                                                          colIds,
                                                                          readSchema,
+                                                                         false,
                                                                          version,
                                                                          negated);
     return new RowFilter.LeafFilter(f);

--- a/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestFilter.java
+++ b/java/bench/core/src/test/org/apache/orc/bench/core/filter/TestFilter.java
@@ -48,7 +48,7 @@ public class TestFilter {
   protected final Random rnd = new Random(seed);
   protected final VectorizedRowBatch b = FilterBenchUtil.createBatch(rnd);
   protected final OrcFilterContextImpl fc = (OrcFilterContextImpl)
-    new OrcFilterContextImpl(FilterBenchUtil.schema).setBatch(b);
+    new OrcFilterContextImpl(FilterBenchUtil.schema, false).setBatch(b);
 
   public static Stream<Arguments> filters() {
     return Stream.of(
@@ -108,6 +108,7 @@ public class TestFilter {
             .allowSARGToFilter(true);
           filter = FilterFactory.createBatchFilter(options,
                                                    FilterBenchUtil.schema,
+                                                   false,
                                                    OrcFile.Version.CURRENT,
                                                    normalize);
           break;

--- a/java/bench/core/src/test/org/apache/orc/impl/filter/ATestFilter.java
+++ b/java/bench/core/src/test/org/apache/orc/impl/filter/ATestFilter.java
@@ -39,7 +39,7 @@ public class ATestFilter {
     .addField("f2", TypeDescription.createString())
     .addField("f3p", TypeDescription.createDate())
     .addField("f3h", TypeDescription.createDate());
-  protected final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+  protected final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
 
   protected final VectorizedRowBatch batch = schema.createRowBatch();
 

--- a/java/bench/core/src/test/org/apache/orc/impl/filter/TestRowFilter.java
+++ b/java/bench/core/src/test/org/apache/orc/impl/filter/TestRowFilter.java
@@ -40,7 +40,7 @@ public class TestRowFilter extends ATestFilter {
   private final TypeDescription schema = TypeDescription.createStruct()
     .addField("f1", TypeDescription.createLong())
     .addField("f2", TypeDescription.createString());
-  final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+  final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
 
   private final VectorizedRowBatch batch = schema.createRowBatch();
 

--- a/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcFilterContextImpl.java
@@ -39,9 +39,11 @@ public class OrcFilterContextImpl implements OrcFilterContext {
   // Cache of field to ColumnVector, this is reset everytime the batch reference changes
   private final Map<String, ColumnVector[]> vectors;
   private final TypeDescription readSchema;
+  private final boolean isSchemaCaseAware;
 
-  public OrcFilterContextImpl(TypeDescription readSchema) {
+  public OrcFilterContextImpl(TypeDescription readSchema, boolean isSchemaCaseAware) {
     this.readSchema = readSchema;
+    this.isSchemaCaseAware = isSchemaCaseAware;
     this.vectors = new HashMap<>();
   }
 
@@ -120,6 +122,7 @@ public class OrcFilterContextImpl implements OrcFilterContext {
   public ColumnVector[] findColumnVector(String name) {
     return vectors.computeIfAbsent(name,
         key -> ParserUtils.findColumnVectors(readSchema,
-            new ParserUtils.StringPosition(key), true, batch));
+                                             new ParserUtils.StringPosition(key),
+                                             isSchemaCaseAware, batch));
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -283,6 +283,7 @@ public class RecordReaderImpl implements RecordReader {
     Consumer<OrcFilterContext> filterCallBack = null;
     BatchFilter filter = FilterFactory.createBatchFilter(options,
                                                          evolution.getReaderBaseSchema(),
+                                                         evolution.isSchemaEvolutionCaseAware,
                                                          fileReader.getFileVersion(),
                                                          false);
     if (filter != null) {

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -283,7 +283,7 @@ public class RecordReaderImpl implements RecordReader {
     Consumer<OrcFilterContext> filterCallBack = null;
     BatchFilter filter = FilterFactory.createBatchFilter(options,
                                                          evolution.getReaderBaseSchema(),
-                                                         evolution.isSchemaEvolutionCaseAware,
+                                                         evolution.isSchemaEvolutionCaseAware(),
                                                          fileReader.getFileVersion(),
                                                          false);
     if (filter != null) {

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -157,6 +157,10 @@ public class SchemaEvolution {
     return false;
   }
 
+  public boolean isSchemaEvolutionCaseAware() {
+    return isSchemaEvolutionCaseAware;
+  }
+
   public TypeDescription getReaderSchema() {
     return readerSchema;
   }

--- a/java/core/src/java/org/apache/orc/impl/filter/leaf/LeafFilterFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/leaf/LeafFilterFactory.java
@@ -223,11 +223,12 @@ public class LeafFilterFactory {
   public static VectorFilter createLeafVectorFilter(PredicateLeaf leaf,
                                                     Set<String> colIds,
                                                     TypeDescription readSchema,
+                                                    boolean isSchemaCaseAware,
                                                     OrcFile.Version version,
                                                     boolean negated)
       throws FilterFactory.UnSupportedSArgException {
     colIds.add(leaf.getColumnName());
-    TypeDescription colType = readSchema.findSubtype(leaf.getColumnName());
+    TypeDescription colType = readSchema.findSubtype(leaf.getColumnName(), isSchemaCaseAware);
 
     switch (leaf.getOperator()) {
       case IN:

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
@@ -41,7 +41,9 @@ public class StructBatchReader extends BatchReader {
   public StructBatchReader(TypeReader rowReader, TreeReaderFactory.Context context) {
     super(rowReader);
     this.context = context;
-    this.filterContext = new OrcFilterContextImpl(context.getSchemaEvolution().getReaderSchema());
+    this.filterContext = new OrcFilterContextImpl(context.getSchemaEvolution().getReaderSchema(),
+                                                  context.getSchemaEvolution()
+                                                    .isSchemaEvolutionCaseAware());
     structReader = (TreeReaderFactory.StructTreeReader) rowReader;
   }
 

--- a/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
+++ b/java/core/src/test/org/apache/orc/TestOrcFilterContext.java
@@ -61,7 +61,7 @@ public class TestOrcFilterContext {
                                            TypeDescription.createList(TypeDescription.createChar()))
                 )
     );
-  private final OrcFilterContext filterContext = new OrcFilterContextImpl(schema)
+  private final OrcFilterContext filterContext = new OrcFilterContextImpl(schema, false)
     .setBatch(schema.createRowBatch());
 
   @BeforeEach
@@ -72,6 +72,13 @@ public class TestOrcFilterContext {
   @Test
   public void testTopLevelElementaryType() {
     ColumnVector[] vectorBranch = filterContext.findColumnVector("f1");
+    assertEquals(1, vectorBranch.length);
+    assertTrue(vectorBranch[0] instanceof LongColumnVector);
+  }
+
+  @Test
+  public void testTopLevelElementaryTypeCaseInsensitive() {
+    ColumnVector[] vectorBranch = filterContext.findColumnVector("F1");
     assertEquals(1, vectorBranch.length);
     assertTrue(vectorBranch[0] instanceof LongColumnVector);
   }
@@ -174,7 +181,7 @@ public class TestOrcFilterContext {
         .addField("a", TypeDescription.createChar())
         .addField("b", TypeDescription
           .createBoolean()));
-    OrcFilterContext fc = new OrcFilterContextImpl(topListSchema)
+    OrcFilterContext fc = new OrcFilterContextImpl(topListSchema, false)
       .setBatch(topListSchema.createRowBatch());
     ColumnVector[] vectorBranch = fc.findColumnVector("_elem");
     assertEquals(2, vectorBranch.length);

--- a/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOrcFilterContextImpl.java
@@ -49,7 +49,7 @@ public class TestOrcFilterContextImpl {
   @Test
   public void testSuccessfulRetrieval() {
     VectorizedRowBatch b = createBatch();
-    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
     fc.setBatch(b);
 
     validateF1Vector(fc.findColumnVector("f1"), 1);
@@ -64,7 +64,7 @@ public class TestOrcFilterContextImpl {
     VectorizedRowBatch b1 = createBatch();
     VectorizedRowBatch b2 = createBatch();
     ((LongColumnVector) b2.cols[0]).vector[0] = 100;
-    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
     fc.setBatch(b1);
     validateF1Vector(fc.findColumnVector("f1"), 1);
     // Change the batch
@@ -75,7 +75,7 @@ public class TestOrcFilterContextImpl {
   @Test
   public void testMissingFieldTopLevel() {
     VectorizedRowBatch b = createBatch();
-    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
     fc.setBatch(b);
 
     // Missing field at top level
@@ -87,7 +87,7 @@ public class TestOrcFilterContextImpl {
   @Test
   public void testMissingFieldNestedLevel() {
     VectorizedRowBatch b = createBatch();
-    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
     fc.setBatch(b);
 
     // Missing field at top level
@@ -99,7 +99,7 @@ public class TestOrcFilterContextImpl {
 
   @Test
   public void testPropagations() {
-    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+    OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
     assertNull(fc.getBatch());
     fc.setBatch(schema.createRowBatch());
     assertNotNull(fc.getBatch());

--- a/java/core/src/test/org/apache/orc/impl/filter/ATestFilter.java
+++ b/java/core/src/test/org/apache/orc/impl/filter/ATestFilter.java
@@ -45,7 +45,7 @@ public class ATestFilter {
     .addField("f3", TypeDescription.createDecimal().withPrecision(38).withScale(2))
     .addField("f4", TypeDescription.createDouble())
     .addField("f5", TypeDescription.createTimestamp());
-  protected final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+  protected final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
 
   protected final VectorizedRowBatch batch = schema.createRowBatch();
 

--- a/java/core/src/test/org/apache/orc/impl/filter/TestAndFilter.java
+++ b/java/core/src/test/org/apache/orc/impl/filter/TestAndFilter.java
@@ -70,6 +70,7 @@ public class TestAndFilter extends ATestFilter {
                                                     colIds,
                                                     sarg.getLeaves(),
                                                     schema,
+                                                    false,
                                                     OrcFile.Version.CURRENT);
     assertNotNull(f);
     assertTrue(f instanceof AndFilter);

--- a/java/core/src/test/org/apache/orc/impl/filter/TestConvFilter.java
+++ b/java/core/src/test/org/apache/orc/impl/filter/TestConvFilter.java
@@ -41,7 +41,7 @@ public class TestConvFilter {
     .addField("f2", TypeDescription.createDate())
     .addField("f3", TypeDescription.createDecimal().withPrecision(18).withScale(scale));
 
-  private final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema);
+  private final OrcFilterContextImpl fc = new OrcFilterContextImpl(schema, false);
   private final VectorizedRowBatch batch = schema.createRowBatchV2();
 
   @BeforeEach

--- a/java/core/src/test/org/apache/orc/impl/filter/TestOrFilter.java
+++ b/java/core/src/test/org/apache/orc/impl/filter/TestOrFilter.java
@@ -46,6 +46,7 @@ public class TestOrFilter extends ATestFilter {
                                                     colIds,
                                                     sarg.getLeaves(),
                                                     schema,
+                                                    false,
                                                     OrcFile.Version.CURRENT);
     assertNotNull(f);
     assertTrue(f instanceof OrFilter);

--- a/java/core/src/test/org/apache/orc/impl/filter/leaf/TestFilters.java
+++ b/java/core/src/test/org/apache/orc/impl/filter/leaf/TestFilters.java
@@ -60,7 +60,7 @@ public class TestFilters extends ATestFilter {
                                               boolean normalize) {
     Reader.Options options = new Reader.Options().allowSARGToFilter(true);
     options.searchArgument(sArg, new String[0]);
-    return FilterFactory.createBatchFilter(options, readSchema, version, normalize);
+    return FilterFactory.createBatchFilter(options, readSchema, false, version, normalize);
   }
 
   @Test


### PR DESCRIPTION


### What changes were proposed in this pull request?
The filter processing incorrectly ignores the case-sensitivity flag for schema supplied by the reader. This fixes this bug and uses the flag in determining field and vector information.


### Why are the changes needed?
In the absence of this the read incorrectly fails by performing a case-sensitive match even when case-insensitive match was requested by the reader.


### How was this patch tested?
Unit Tests were added to verify the failure and subsequently the fix.
