### PR TITLE
ORC-990: [C++] fix RowReaderImpl::seekToRowGroup

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -385,7 +385,7 @@ namespace orc {
 
   void RowReaderImpl::seekToRowGroup(uint32_t rowGroupEntryId) {
     // store positions for selected columns
-    std::vector<std::list<uint64_t>> positions;
+    std::list<std::list<uint64_t>> positions;
     // store position providers for selected colimns
     std::unordered_map<uint64_t, PositionProvider> positionProviders;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
ORC-990: [C++] fix RowReaderImpl::seekToRowGroup

### Why are the changes needed?
In environment Windows, MSVC 19.12.25835.0 
test DictionaryEncoding.multipleStripesWithIndex failed due to invalid iterators in positionProviders.

```
    for (auto rowIndex ... {
      // copy index positions for a specific column
      positions.push_back({});
      auto& position = positions.back();
      for (int pos = 0; pos != entry.positions_size(); ++pos) {
        position.push_back(entry.positions(pos));             // iterators may be invalidated here due to reallocation
      }
      positionProviders.insert(std::make_pair(colId, PositionProvider(position))); //    iterator taken here
    }
```

### How was this patch tested?
test DictionaryEncoding.multipleStripesWithIndex passed with proposed fix