### PR TITLE
ORC-998: Sharing compression output buffer among treeWriter: Refactoring within OutStream for portability 

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/OutStream.java
+++ b/java/core/src/java/org/apache/orc/impl/OutStream.java
@@ -275,7 +275,6 @@ public class OutStream extends PositionedOutputStream {
      */
     ByteBuffer overflow = null;
 
-    // TODO: Not sure if this logical cascading is correct or not. Also, maybe not needed if this is shared.
     public void init() {
       if (compressed == null) {
         compressed = getNewOutputBuffer();

--- a/java/core/src/java/org/apache/orc/impl/OutStream.java
+++ b/java/core/src/java/org/apache/orc/impl/OutStream.java
@@ -333,7 +333,6 @@ public class OutStream extends PositionedOutputStream {
       return totalBytes + HEADER_SIZE;
     }
 
-    // TODO: This should be test covered as well.
     public void abortCompress(int currentPosn) throws IOException {
       // we are using the original, but need to spill the current
       // compressed buffer first for ordering. So back up to where we started,

--- a/java/core/src/java/org/apache/orc/impl/OutStream.java
+++ b/java/core/src/java/org/apache/orc/impl/OutStream.java
@@ -59,7 +59,6 @@ public class OutStream extends PositionedOutputStream {
 
   /**
    * Lazily initialized: Won't allocate byte buffer until invocation of init()
-   * TODO: May need to change this setting.
    */
   public OutputCompressedBuffer compressedBuffer = new OutputCompressedBuffer();
 

--- a/java/core/src/java/org/apache/orc/impl/OutStream.java
+++ b/java/core/src/java/org/apache/orc/impl/OutStream.java
@@ -390,7 +390,8 @@ public class OutStream extends PositionedOutputStream {
       compressedBuffer.advanceTo(currentPosn + HEADER_SIZE);
 
       // Worth compression
-      if (codec.compress(current, compressedBuffer.compressed, compressedBuffer.overflow, options)) {
+      if (codec.compress(current, compressedBuffer.compressed,
+          compressedBuffer.overflow, options)) {
         // move position back to after the header
         uncompressedBytes = 0;
 

--- a/java/core/src/test/org/apache/orc/impl/TestOutStream.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOutStream.java
@@ -60,6 +60,41 @@ public class TestOutStream {
   }
 
   @Test
+  public void testCompressWithoutEncryption() throws Exception {
+    TestInStream.OutputCollector receiver = new TestInStream.OutputCollector();
+    CompressionCodec codec = new ZlibCodec();
+    StreamOptions options = new StreamOptions( 1024)
+        .withCodec(codec, codec.getDefaultOptions());
+
+    try (OutStream stream = new OutStream("test", options, receiver)) {
+      for (int i = 0; i < 20000; ++i) {
+        stream.write(("The Cheesy Poofs " + i + "\n")
+            .getBytes(StandardCharsets.UTF_8));
+      }
+      stream.flush();
+    }
+
+    byte[] compressed = receiver.buffer.get();
+
+    // use InStream to decompress it
+    BufferChunkList ranges = new BufferChunkList();
+    ranges.add(new BufferChunk(ByteBuffer.wrap(compressed), 0));
+    try (InStream decompressedStream = InStream.create("test", ranges.get(), 0,
+        compressed.length,
+        InStream.options().withCodec(new ZlibCodec()).withBufferSize(1024));
+        BufferedReader reader
+            = new BufferedReader(new InputStreamReader(decompressedStream,
+            StandardCharsets.UTF_8))) {
+      // check the contents of the decompressed stream
+      for (int i = 0; i < 20000; ++i) {
+        assertEquals("The Cheesy Poofs " + i, reader.readLine(), "i = " + i);
+      }
+      assertNull(reader.readLine());
+    }
+
+  }
+
+  @Test
   public void testAssertBufferSizeValid() {
     try {
       OutStream.assertBufferSizeValid(1 + (1<<23));

--- a/java/core/src/test/org/apache/orc/impl/TestOutStream.java
+++ b/java/core/src/test/org/apache/orc/impl/TestOutStream.java
@@ -35,6 +35,7 @@ import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -59,10 +60,25 @@ public class TestOutStream {
     }
   }
 
+  /**
+   * Creates randomness into whether a compression should be committed or aborted (so that
+   * the isOriginal bits is set to true and data being flushed as uncompressed).
+   * This class should be used for testing purpose only.
+   */
+  private static class TestZlibCodec extends ZlibCodec {
+    private Random rand = new Random();
+
+    @Override
+    public boolean compress(ByteBuffer in, ByteBuffer out, ByteBuffer overflow, Options options) {
+      super.compress(in, out, overflow, options);
+      return rand.nextBoolean();
+    }
+  }
+
   @Test
   public void testCompressWithoutEncryption() throws Exception {
     TestInStream.OutputCollector receiver = new TestInStream.OutputCollector();
-    CompressionCodec codec = new ZlibCodec();
+    CompressionCodec codec = new TestZlibCodec();
     StreamOptions options = new StreamOptions( 1024)
         .withCodec(codec, codec.getDefaultOptions());
 
@@ -81,7 +97,7 @@ public class TestOutStream {
     ranges.add(new BufferChunk(ByteBuffer.wrap(compressed), 0));
     try (InStream decompressedStream = InStream.create("test", ranges.get(), 0,
         compressed.length,
-        InStream.options().withCodec(new ZlibCodec()).withBufferSize(1024));
+        InStream.options().withCodec(new TestZlibCodec()).withBufferSize(1024));
         BufferedReader reader
             = new BufferedReader(new InputStreamReader(decompressedStream,
             StandardCharsets.UTF_8))) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->

There's individual instance of `OutStream` within each TreeWriter created by `WriterContext#createStream` method. Within `OutStream`, there are totally 3 buffers: 

- current: the regular input buffer holding uncompressed, unencrypted bytes.
- compress: the output buffer holding compressed bytes 
- overflow: same as "compress" but only used when the last compression output is larger than remaining capacity of compress buffer. 

Potentially the compress and overflow buffer don't have to be allocated individually within each `OutStream` object, but shared across all of them so to save memory allocation. 

This PR is the first step for sharing the compression output buffer, which refactors internal of `OutStream` and make the relevant object bundled together since they are logically related(and details of dealing with overflow doesn't have to be visible). This refactoring makes it easier to share the compression output buffer as a pass-in arguments in the follow-up PR. 


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For the context of ORC-997, this change makes the compression output buffer, as a single entity, easier to be shared and passed in from caller. 


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

There's no functional changes from this PR so passing all existed unit tests. Also added a new test in `TestOutStream` to make sure that, the scenario where `codec.compress()` returns false (meaning the compression output is larger than original input) is also covered in the unit test.
