### PR TITLE
ORC-1001: Bump maven-enforcer-plugin to 3.0.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -90,7 +90,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>enforce-maven</id>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -90,6 +90,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -212,7 +213,7 @@
           <artifactId>maven-jar-plugin</artifactId>
           <version>3.2.0</version>
           <configuration>
-            <archive>                   
+            <archive>
               <manifest>
                 <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                 <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>


### PR DESCRIPTION
### What changes were proposed in this pull request?

While working on another PR, I found the head of main failed in GA with the failure like below. 

```Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce (enforce-java-version) on project orc: Execution enforce-java-version of goal org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-enforcer-plugin:1.4.1:enforce: java.lang.ExceptionInInitializerError: null
Error:  -----------------------------------------------------
Error:  realm =    plugin>org.apache.maven.plugins:maven-enforcer-plugin:1.4.1
Error:  strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
Error:  urls[0] = file:/Users/runner/.m2/repository/org/apache/maven/plugins/maven-enforcer-plugin/1.4.1/maven-enforcer-plugin-1.4.1.jar
...
Error:  Number of foreign imports: 1
Error:  import: Entry[import  from realm ClassRealm[maven.api, parent: null]]
Error:  
Error:  -----------------------------------------------------: begin 0, end 3, length 2
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginContainerException
make[2]: *** [java/shims/orc-shims-1.8.0-SNAPSHOT.jar] Error 1
make[1]: *** [java/CMakeFiles/java_build.dir/all] Error 2
make: *** [all] Error 2
Error: Process completed with exit code 2.
```

Google a bit and found a similar issue: https://github.com/apache/accumulo-proxy/pull/19 
This PR is a draft to see if the same change could work here ( since I don't have specific env like failed CI)

### Why are the changes needed?

Recover `compile` and `package` without tests.

### How was this patch tested?

Manual.
```
mvn compile
mvn package -DskipTests
```
