### PR TITLE
ORC-1002: Add `java17` profile to support Java 17 unit testing

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -153,6 +153,8 @@
           </ignoredUnusedDeclaredDependencies>
           <ignoredDependencies>
             <ignoredDependency>org.apache.hive:hive-storage-api</ignoredDependency>
+            <ignoredDependency>org.apache.hadoop:hadoop-client-api</ignoredDependency>
+            <ignoredDependency>org.apache.hadoop:hadoop-client-runtime</ignoredDependency>
           </ignoredDependencies>
         </configuration>
       </plugin>
@@ -165,6 +167,23 @@
       <build>
         <directory>${build.dir}/core</directory>
       </build>
+    </profile>
+    <profile>
+      <id>java17</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-api</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-runtime</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>

--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -110,7 +110,11 @@
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>com.google.guava:guava</ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>org.apache.hadoop:hadoop-hdfs</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.apache.hadoop:hadoop-common</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+          <ignoredDependencies>
+            <ignoredDependency>org.apache.hadoop:hadoop-client-api</ignoredDependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
     </plugins>

--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -129,6 +129,10 @@
               org.apache.hadoop:hadoop-mapreduce-client-jobclient
             </ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+          <ignoredDependencies>
+            <ignoredDependency>org.apache.hadoop:hadoop-client-api</ignoredDependency>
+            <ignoredDependency>org.apache.hadoop:hadoop-client-runtime</ignoredDependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
     </plugins>
@@ -140,6 +144,23 @@
       <build>
         <directory>${build.dir}/mapreduce</directory>
       </build>
+    </profile>
+    <profile>
+      <id>java17</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-api</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-runtime</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -462,6 +462,14 @@
         </os>
       </activation>
     </profile>
+    <profile>
+      <id>java17</id>
+      <properties>
+        <min.hadoop.version>3.3.1</min.hadoop.version>
+        <hadoop.version>3.3.1</hadoop.version>
+        <tools.hadoop.version>3.3.1</tools.hadoop.version>
+      </properties>
+    </profile>
   </profiles>
 
   <dependencyManagement>

--- a/java/shims/pom.xml
+++ b/java/shims/pom.xml
@@ -95,5 +95,15 @@
         <directory>${build.dir}/shims</directory>
       </build>
     </profile>
+    <profile>
+      <id>java17</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-api</artifactId>
+          <version>${hadoop.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 </project>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -147,6 +147,10 @@
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>com.google.guava:guava</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
+          <ignoredDependencies>
+            <ignoredDependency>org.apache.hadoop:hadoop-client-api</ignoredDependency>
+            <ignoredDependency>org.apache.hadoop:hadoop-client-runtime</ignoredDependency>
+          </ignoredDependencies>
         </configuration>
       </plugin>
     </plugins>
@@ -158,6 +162,23 @@
       <build>
         <directory>${build.dir}/tools</directory>
       </build>
+    </profile>
+    <profile>
+      <id>java17</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-api</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-client-runtime</artifactId>
+          <version>${hadoop.version}</version>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
     </profile>
   </profiles>
 </project>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `java17` profile for Java 17 Unit testing.

### Why are the changes needed?

This is required because Java 17 is supported by Hadoop 3.3.

### How was this patch tested?

Manual. This PR didn't add `activation` intentionally.
```
$ java -version
openjdk version "17" 2021-09-14 LTS
OpenJDK Runtime Environment Zulu17.28+13-CA (build 17+35-LTS)
OpenJDK 64-Bit Server VM Zulu17.28+13-CA (build 17+35-LTS, mixed mode, sharing)

$ mvn package -Pjava17
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:53 min
[INFO] Finished at: 2021-09-16T02:33:07-07:00
[INFO] ------------------------------------------------------------------------
```
