### PR TITLE
ORC-1009: [C++] Missing string include causes build failure with MSVC++

### DIFF
--- a/c++/src/sargs/ExpressionTree.hh
+++ b/c++/src/sargs/ExpressionTree.hh
@@ -23,6 +23,7 @@
 
 #include <limits>
 #include <memory>
+#include <string>
 #include <vector>
 
 static const size_t UNUSED_LEAF = std::numeric_limits<size_t>::max();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
Include string in ExpressionTree.hh.


### Why are the changes needed?
Without it the library cannot be built on Windows with newer msvc++ compiler (version 19.29).

### How was this patch tested?
Manually, successfully building the library on Windows on a local machine. 
