### PR TITLE
ORC-1014. Add details when we get IOException from the file system

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -414,7 +414,15 @@ public class RecordReaderUtils {
     long offset = first.getOffset();
     int readSize = (int) (computeEnd(first, last) - offset);
     byte[] buffer = new byte[readSize];
-    file.readFully(offset, buffer, 0, buffer.length);
+    try {
+      file.readFully(offset, buffer, 0, buffer.length);
+    } catch(IOException e) {
+      throw new IOException(String.format("Failed while reading %s %d:%d",
+                                          file,
+                                          offset,
+                                          buffer.length),
+                            e);
+    }
 
     // get the data into a ByteBuffer
     ByteBuffer bytes;


### PR DESCRIPTION
### What changes were proposed in this pull request?

It catches and wraps IOException in the data reader to give information about the range of bytes that the reader was trying to read.

### Why are the changes needed?

To help debugging.

### How was this patch tested?

By reading files in S3 with a version of Hadoop that had HADOOP-16109.
