### PR TITLE
ORC-1019: Remove redundant jackson dependencies

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -37,7 +37,6 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.0</parquet.version>
     <spark.version>3.1.2</spark.version>
-    <jackson.version>2.12.5</jackson.version>
     <hadoop.version>3.3.1</hadoop.version>
     <junit.version>5.8.0</junit.version>
   </properties>
@@ -67,21 +66,6 @@
         <artifactId>junit-jupiter-params</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.service</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove redundant jackson dependencies.
Unfortunately, ORC-946 forgot to remove the bench dependency on jackson. In fact, the bench module does not directly depend on jackson, only spark indirectly depends on the specified version of jackson. 

### Why are the changes needed?

Minimising dependencies.

### How was this patch tested?

Pass the CIs.

Closes #928