### PR TITLE
ORC-1029: ServiceLoader is not thread-safe, avoid concurrent calls

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestEncryption.java
+++ b/java/core/src/test/org/apache/orc/impl/TestEncryption.java
@@ -40,13 +40,8 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestEncryption {
 
@@ -143,45 +138,6 @@ public class TestEncryption {
   public void testPushDownReadEncryption() throws IOException {
     write();
     read(true);
-  }
-
-  @Test
-  @SuppressWarnings("unchecked")
-  public void testConcurrentCreation() throws InterruptedException {
-    ExecutorService executorService = Executors.newFixedThreadPool(10);
-    Future<Writer>[] futures = new Future[10];
-    for (int i = 0; i < 10; i++) {
-      Path path = new Path("testWriterImpl" + i + ".orc");
-      futures[i] = executorService.submit(() -> {
-        try {
-          return OrcFile.createWriter(new Path("testWriterImpl" + path + ".orc"),
-              OrcFile.writerOptions(conf)
-                  .setSchema(schema)
-                  .overwrite(true)
-                  .setKeyProvider(keyProvider)
-                  .encrypt(encryption)
-                  .masks(mask));
-        } catch (Exception e) {
-          throw new RuntimeException("create writer fail", e);
-        } finally {
-          try {
-            if (fs.exists(path)) {
-              fs.delete(path, false);
-            }
-          } catch (IOException e) {
-            e.printStackTrace();
-          }
-        }
-      });
-    }
-    for (Future<Writer> future : futures) {
-      try {
-        future.get();
-      } catch (ExecutionException e) {
-        e.printStackTrace();
-        fail();
-      }
-    }
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
The previous code reuses LOADER to build DataMask, but the ServiceLoader class is not thread-safe and will cause an exception if called concurrently.
Checking the source code, I found that ServiceLoader.load is a lazy method, which is relatively lightweight and only records the relevant information until the iterator starts reading before loading the class, so I think it is acceptable not to reuse it.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Avoid concurrent calls leading to exceptions.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add UT.