### PR TITLE
ORC-879: Fix testDateTimeTypeSupport unit test

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
@@ -117,10 +117,13 @@ public class TestJsonReader {
         ZonedDateTime datetime5 = ZonedDateTime.of(datetime1, ZoneId.of("UTC"));
         ZonedDateTime datetime6 = ZonedDateTime.of(datetime2, ZoneId.of("America/New_York"));
 
+        String datetime4Str = datetime4.toString();
+        datetime4Str = datetime4Str.substring(0, datetime4Str.length() - 5) + "0700";
+
         String inputString = "{\"dt\": \"" + datetime1.toString() + "\"}\n" +
                              "{\"dt\": \"" + datetime2.toString() + "\"}\n" +
                              "{\"dt\": \"" + datetime3.toString() + "\"}\n" +
-                             "{\"dt\": \"" + datetime4.toString().replace("07:00", "0700") + "\"}\n" +
+                             "{\"dt\": \"" + datetime4Str + "\"}\n" +
                              "{\"dt\": \"" + datetime5.toLocalDateTime().toString() + "[" + datetime5.getZone() + "]\"}\n" +
                              "{\"dt\": \"" + datetime6.toLocalDateTime().toString() + "[" + datetime6.getZone() + "]\"}\n";
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
```java
OffsetDateTime datetime4 = OffsetDateTime.of(datetime2, ZoneOffset.ofHours(-7));
datetime4.toString().replace("07:00", "0700")
```
The intention here is to replace the format of the time zone, but it is possible to replace HH:mm.

https://github.com/apache/orc/pull/941#issuecomment-946774472
```
java.time.format.DateTimeParseException: Text '2021-10-19T0700:01.683210-0700' could not be parsed at index 13
	at java.base/java.time.format.DateTimeFormatter.parseResolved0(DateTimeFormatter.java:2046)
	at java.base/java.time.format.DateTimeFormatter.parseBest(DateTimeFormatter.java:1994)
	at org.apache.orc.tools.convert.JsonReader$TimestampColumnConverter.convert(JsonReader.java:169)
	at org.apache.orc.tools.convert.JsonReader.nextBatch(JsonReader.java:375)
	at org.apache.orc.tools.convert.TestJsonReader.testDateTimeTypeSupport(TestJsonReader.java:132)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
	at 
```

This pr is aimed at fixing this bug.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Ensure that UT behave consistently at all times.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Using the current UT.