### PR TITLE
ORC-1020: [C++] Optimize RleDecoderV2::nextDirect base on bit sizes

### DIFF
--- a/c++/src/RleDecoderV2.cc
+++ b/c++/src/RleDecoderV2.cc
@@ -166,7 +166,7 @@ void RleDecoderV2::unrolledUnpack16(int64_t* data, uint64_t offset, uint64_t len
       buffer += 2;
       data[curIdx++] = (b0 << 8) | b1;
     }
-    bufferStart = reinterpret_cast<const char *>(buffer);
+    bufferStart = reinterpret_cast<const char*>(buffer);
     if (curIdx == offset + len) return;
 
     // One of the following readByte() will update 'bufferStart' and 'bufferEnd'.
@@ -184,7 +184,7 @@ void RleDecoderV2::unrolledUnpack24(int64_t* data, uint64_t offset, uint64_t len
     bufferNum = std::min(bufferNum, static_cast<int64_t>(offset + len - curIdx));
     uint32_t b0, b1, b2;
     // Avoid updating 'bufferStart' inside the loop.
-    const auto* __restrict__ buffer = reinterpret_cast<const unsigned char*>(bufferStart);
+    const auto* buffer = reinterpret_cast<const unsigned char*>(bufferStart);
     for (int i = 0; i < bufferNum; ++i) {
       b0 = static_cast<uint32_t>(*buffer);
       b1 = static_cast<uint32_t>(*(buffer + 1));

--- a/c++/test/TestRleDecoder.cc
+++ b/c++/test/TestRleDecoder.cc
@@ -31,11 +31,13 @@ std::vector<int64_t> decodeRLEv2(const unsigned char *bytes,
                                  unsigned long l,
                                  size_t n,
                                  size_t count,
-                                 const char* notNull = nullptr) {
-  std::unique_ptr<RleDecoder> rle =
-    createRleDecoder(std::unique_ptr<SeekableInputStream>
-                     (new SeekableArrayInputStream(bytes,l)), true,
-                     RleVersion_2, *getDefaultPool());
+                                 const char* notNull = nullptr,
+                                 bool isSigned = true,
+                                 uint64_t blockSize = 0) {
+  std::unique_ptr<RleDecoder> rle = createRleDecoder(
+      std::unique_ptr<SeekableInputStream>(
+            new SeekableArrayInputStream(bytes,l, blockSize)),
+        isSigned,RleVersion_2, *getDefaultPool());
   std::vector<int64_t> results;
   for (size_t i = 0; i < count; i+=n) {
     size_t remaining = count - i;
@@ -254,65 +256,376 @@ TEST(RLEv2, 0to2Repeat1Direct) {
   }
 };
 
-TEST(RLEv2, bitSize2Direct) {
- // 0,1 repeated 10 times (signed ints)
- const size_t count = 20;
- std::vector<int64_t> values;
- for (size_t i = 0; i < count; ++i) {
-     values.push_back(i%2);
- }
+TEST(RLEv2, bitSize1Direct) {
+  // 0,1 repeated 20 times (unsigned ints)
+  size_t count = 40;
+  std::vector<int64_t> values;
+  for (size_t i = 0; i < count; ++i) {
+    values.push_back(i % 2);
+  }
+  const unsigned char bytes[] = {0x40, 0x27, 0x55, 0x55, 0x55, 0x55, 0x55};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, false, blkSize), 1);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, false, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, false, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, false, blkSize), count);
+  }
 
- const unsigned char bytes[] = {0x42, 0x13, 0x22, 0x22, 0x22, 0x22, 0x22};
- unsigned long l = sizeof(bytes) / sizeof(char);
- // Read 1 at a time, then 3 at a time, etc.
- checkResults(values, decodeRLEv2(bytes, l, 1, count), 1);
- checkResults(values, decodeRLEv2(bytes, l, 3, count), 3);
- checkResults(values, decodeRLEv2(bytes, l, 7, count), 7);
- checkResults(values, decodeRLEv2(bytes, l, count, count), count);
-};
+  values.clear();
+  // 0,1,1 repeated 10 times (unsigned ints)
+  for (size_t i = 0; i < 10; ++i) {
+    values.push_back(0);
+    values.push_back(1);
+    values.push_back(1);
+  }
+  // bytes2: 0100,0000,0001,1101,0110,1101,1011,0110,1101,1011,0110,1100
+  // First byte: 01 for encoding, 00000 for bitSize index (0), 0 for first bit of len - 1.
+  // Second byte: 0001,1101 for len - 1 = 29.
+  // Following bits repeating 011 ten times. Last byte padding with 00.
+  const unsigned char bytes2[] = {0x40, 0x1D, 0x6D, 0xB6, 0xDB, 0x6C};
+  l = sizeof(bytes2) / sizeof(char);
+  count = 30;
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes2, l, 1, count, nullptr, false, blkSize), 1);
+    checkResults(values, decodeRLEv2(bytes2, l, 3, count, nullptr, false, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes2, l, 7, count, nullptr, false, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes2, l, count, count, nullptr, false, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize2Direct) {
+  // 0,1 repeated 10 times (signed ints)
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (size_t i = 0; i < count; ++i) {
+    values.push_back(i % 2);
+  }
+
+  const unsigned char bytes[] = {0x42, 0x13, 0x22, 0x22, 0x22, 0x22, 0x22};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 1);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
 
 TEST(RLEv2, bitSize4Direct) {
- // 0,2 repeated 10 times (signed ints)
- const size_t count = 20;
- std::vector<int64_t> values;
- for (size_t i = 0; i < count; ++i) {
+  // 0,2 repeated 10 times (signed ints)
+  size_t count = 20;
+  std::vector<int64_t> values;
+  for (size_t i = 0; i < count; ++i) {
      values.push_back((i%2)*2);
- }
+  }
 
- const unsigned char bytes[] = {0x46,0x13,0x04,0x04,0x04,0x04,
-                                0x04,0x04,0x04,0x04,0x04,0x04};
- unsigned long l = sizeof(bytes) / sizeof(char);
+  const unsigned char bytes[] = {0x46,0x13,0x04,0x04,0x04,0x04,
+                                 0x04,0x04,0x04,0x04,0x04,0x04};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 1);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
 
- // Read 1 at a time, then 3 at a time, etc.
- checkResults(values, decodeRLEv2(bytes, l, 1, count), 1);
- checkResults(values, decodeRLEv2(bytes, l, 3, count), 3);
- checkResults(values, decodeRLEv2(bytes, l, 7, count), 7);
- checkResults(values, decodeRLEv2(bytes, l, count, count), count);
-};
+  // -2,0,2,4 repeated 5 times (signed ints)
+  count = 20;
+  values.clear();
+  for (size_t i = 0; i < count; ++i) {
+    values.push_back((i % 4) * 2 - 2);
+  }
+
+  const unsigned char bytes2[] = {0x46,0x13,0x30,0x48,0x30,0x48,
+                                  0x30,0x48,0x30,0x48,0x30,0x48};
+  l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes2, l, 1, count, nullptr, true, blkSize), 1);
+    checkResults(values, decodeRLEv2(bytes2, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes2, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes2, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize8Direct) {
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int i = 0; i < count; ++i) {
+    values.push_back(i);
+  }
+
+  const unsigned char bytes[] = {0x4E,0x13,0x00,0x02,0x04,0x06,0x08,0x0A,0x0C,0x0E,0x10,
+                                 0x12,0x14,0x16,0x18,0x1A,0x1C,0x1E,0x20,0x22,0x24,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 1);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize16Direct) {
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int i = 0; i < count; ++i) {
+    values.push_back((i << 8) + i);
+  }
+
+  const unsigned char bytes[] = {0x5E,0x13,
+                                 0x00,0x00,0x02,0x02,0x04,0x04,0x06,0x06,
+                                 0x08,0x08,0x0A,0x0A,0x0C,0x0C,0x0E,0x0E,
+                                 0x10,0x10,0x12,0x12,0x14,0x14,0x16,0x16,
+                                 0x18,0x18,0x1A,0x1A,0x1C,0x1C,0x1E,0x1E,
+                                 0x20,0x20,0x22,0x22,0x24,0x24,0x26,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize24Direct) {
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int64_t i = 0; i < count; ++i) {
+    values.push_back((i << 16) + (i << 8) + i);
+  }
+
+  const unsigned char bytes[] = {0x6E,0x13,
+                                 0x00,0x00,0x00,0x02,0x02,0x02,0x04,0x04,0x04,
+                                 0x06,0x06,0x06,0x08,0x08,0x08,0x0A,0x0A,0x0A,
+                                 0x0C,0x0C,0x0C,0x0E,0x0E,0x0E,0x10,0x10,0x10,
+                                 0x12,0x12,0x12,0x14,0x14,0x14,0x16,0x16,0x16,
+                                 0x18,0x18,0x18,0x1A,0x1A,0x1A,0x1C,0x1C,0x1C,
+                                 0x1E,0x1E,0x1E,0x20,0x20,0x20,0x22,0x22,0x22,
+                                 0x24,0x24,0x24,0x26,0x26,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize32Direct) {
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int64_t i = 0; i < count; ++i) {
+    values.push_back((i << 24) + (i << 16) + (i << 8) + i);
+  }
+
+  const unsigned char bytes[] = {0x76,0x13,
+                                 0x00,0x00,0x00,0x00,0x02,0x02,0x02,0x02,
+                                 0x04,0x04,0x04,0x04,0x06,0x06,0x06,0x06,
+                                 0x08,0x08,0x08,0x08,0x0A,0x0A,0x0A,0x0A,
+                                 0x0C,0x0C,0x0C,0x0C,0x0E,0x0E,0x0E,0x0E,
+                                 0x10,0x10,0x10,0x10,0x12,0x12,0x12,0x12,
+                                 0x14,0x14,0x14,0x14,0x16,0x16,0x16,0x16,
+                                 0x18,0x18,0x18,0x18,0x1A,0x1A,0x1A,0x1A,
+                                 0x1C,0x1C,0x1C,0x1C,0x1E,0x1E,0x1E,0x1E,
+                                 0x20,0x20,0x20,0x20,0x22,0x22,0x22,0x22,
+                                 0x24,0x24,0x24,0x24,0x26,0x26,0x26,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize40Direct) {
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int64_t i = 0; i < count; ++i) {
+    values.push_back((i << 32) + (i << 24) + (i << 16) + (i << 8) + i);
+  }
+
+  const unsigned char bytes[] = {0x78,0x13,
+                                 0x00,0x00,0x00,0x00,0x00,
+                                 0x02,0x02,0x02,0x02,0x02,
+                                 0x04,0x04,0x04,0x04,0x04,
+                                 0x06,0x06,0x06,0x06,0x06,
+                                 0x08,0x08,0x08,0x08,0x08,
+                                 0x0A,0x0A,0x0A,0x0A,0x0A,
+                                 0x0C,0x0C,0x0C,0x0C,0x0C,
+                                 0x0E,0x0E,0x0E,0x0E,0x0E,
+                                 0x10,0x10,0x10,0x10,0x10,
+                                 0x12,0x12,0x12,0x12,0x12,
+                                 0x14,0x14,0x14,0x14,0x14,
+                                 0x16,0x16,0x16,0x16,0x16,
+                                 0x18,0x18,0x18,0x18,0x18,
+                                 0x1A,0x1A,0x1A,0x1A,0x1A,
+                                 0x1C,0x1C,0x1C,0x1C,0x1C,
+                                 0x1E,0x1E,0x1E,0x1E,0x1E,
+                                 0x20,0x20,0x20,0x20,0x20,
+                                 0x22,0x22,0x22,0x22,0x22,
+                                 0x24,0x24,0x24,0x24,0x24,
+                                 0x26,0x26,0x26,0x26,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize48Direct) {
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int64_t i = 0; i < count; ++i) {
+    values.push_back((i << 40) + (i << 32) + (i << 24) + (i << 16) + (i << 8) + i);
+  }
+
+  const unsigned char bytes[] = {0x7A,0x13,
+                                 0x00,0x00,0x00,0x00,0x00,0x00,
+                                 0x02,0x02,0x02,0x02,0x02,0x02,
+                                 0x04,0x04,0x04,0x04,0x04,0x04,
+                                 0x06,0x06,0x06,0x06,0x06,0x06,
+                                 0x08,0x08,0x08,0x08,0x08,0x08,
+                                 0x0A,0x0A,0x0A,0x0A,0x0A,0x0A,
+                                 0x0C,0x0C,0x0C,0x0C,0x0C,0x0C,
+                                 0x0E,0x0E,0x0E,0x0E,0x0E,0x0E,
+                                 0x10,0x10,0x10,0x10,0x10,0x10,
+                                 0x12,0x12,0x12,0x12,0x12,0x12,
+                                 0x14,0x14,0x14,0x14,0x14,0x14,
+                                 0x16,0x16,0x16,0x16,0x16,0x16,
+                                 0x18,0x18,0x18,0x18,0x18,0x18,
+                                 0x1A,0x1A,0x1A,0x1A,0x1A,0x1A,
+                                 0x1C,0x1C,0x1C,0x1C,0x1C,0x1C,
+                                 0x1E,0x1E,0x1E,0x1E,0x1E,0x1E,
+                                 0x20,0x20,0x20,0x20,0x20,0x20,
+                                 0x22,0x22,0x22,0x22,0x22,0x22,
+                                 0x24,0x24,0x24,0x24,0x24,0x24,
+                                 0x26,0x26,0x26,0x26,0x26,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize56Direct) {
+  // 0,2 repeated 10 times (signed ints)
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int64_t i = 0; i < count; ++i) {
+    values.push_back((i << 48) + (i << 40) + (i << 32) + (i << 24) + (i << 16) + (i << 8) + i);
+  }
+
+  const unsigned char bytes[] = {0x7C,0x13,
+                                 0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                 0x02,0x02,0x02,0x02,0x02,0x02,0x02,
+                                 0x04,0x04,0x04,0x04,0x04,0x04,0x04,
+                                 0x06,0x06,0x06,0x06,0x06,0x06,0x06,
+                                 0x08,0x08,0x08,0x08,0x08,0x08,0x08,
+                                 0x0A,0x0A,0x0A,0x0A,0x0A,0x0A,0x0A,
+                                 0x0C,0x0C,0x0C,0x0C,0x0C,0x0C,0x0C,
+                                 0x0E,0x0E,0x0E,0x0E,0x0E,0x0E,0x0E,
+                                 0x10,0x10,0x10,0x10,0x10,0x10,0x10,
+                                 0x12,0x12,0x12,0x12,0x12,0x12,0x12,
+                                 0x14,0x14,0x14,0x14,0x14,0x14,0x14,
+                                 0x16,0x16,0x16,0x16,0x16,0x16,0x16,
+                                 0x18,0x18,0x18,0x18,0x18,0x18,0x18,
+                                 0x1A,0x1A,0x1A,0x1A,0x1A,0x1A,0x1A,
+                                 0x1C,0x1C,0x1C,0x1C,0x1C,0x1C,0x1C,
+                                 0x1E,0x1E,0x1E,0x1E,0x1E,0x1E,0x1E,
+                                 0x20,0x20,0x20,0x20,0x20,0x20,0x20,
+                                 0x22,0x22,0x22,0x22,0x22,0x22,0x22,
+                                 0x24,0x24,0x24,0x24,0x24,0x24,0x24,
+                                 0x26,0x26,0x26,0x26,0x26,0x26,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
+
+TEST(RLEv2, bitSize64Direct) {
+  const size_t count = 20;
+  std::vector<int64_t> values;
+  for (int64_t i = 0; i < count; ++i) {
+    values.push_back((i << 56) + (i << 48) + (i << 40) + (i << 32) + (i << 24) + (i << 16) + (i << 8) + i);
+  }
+
+  const unsigned char bytes[] = {0x7E,0x13,
+                                 0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+                                 0x02,0x02,0x02,0x02,0x02,0x02,0x02,0x02,
+                                 0x04,0x04,0x04,0x04,0x04,0x04,0x04,0x04,
+                                 0x06,0x06,0x06,0x06,0x06,0x06,0x06,0x06,
+                                 0x08,0x08,0x08,0x08,0x08,0x08,0x08,0x08,
+                                 0x0A,0x0A,0x0A,0x0A,0x0A,0x0A,0x0A,0x0A,
+                                 0x0C,0x0C,0x0C,0x0C,0x0C,0x0C,0x0C,0x0C,
+                                 0x0E,0x0E,0x0E,0x0E,0x0E,0x0E,0x0E,0x0E,
+                                 0x10,0x10,0x10,0x10,0x10,0x10,0x10,0x10,
+                                 0x12,0x12,0x12,0x12,0x12,0x12,0x12,0x12,
+                                 0x14,0x14,0x14,0x14,0x14,0x14,0x14,0x14,
+                                 0x16,0x16,0x16,0x16,0x16,0x16,0x16,0x16,
+                                 0x18,0x18,0x18,0x18,0x18,0x18,0x18,0x18,
+                                 0x1A,0x1A,0x1A,0x1A,0x1A,0x1A,0x1A,0x1A,
+                                 0x1C,0x1C,0x1C,0x1C,0x1C,0x1C,0x1C,0x1C,
+                                 0x1E,0x1E,0x1E,0x1E,0x1E,0x1E,0x1E,0x1E,
+                                 0x20,0x20,0x20,0x20,0x20,0x20,0x20,0x20,
+                                 0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,
+                                 0x24,0x24,0x24,0x24,0x24,0x24,0x24,0x24,
+                                 0x26,0x26,0x26,0x26,0x26,0x26,0x26,0x26};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
 
 TEST(RLEv2, multipleRunsDirect) {
- std::vector<int64_t> values;
- // 0,1 repeated 10 times (signed ints)
- for (size_t i = 0; i < 20; ++i) {
+  std::vector<int64_t> values;
+  // 0,1 repeated 10 times (signed ints)
+  for (size_t i = 0; i < 20; ++i) {
      values.push_back(i%2);
- }
- // 0,2 repeated 10 times (signed ints)
- for (size_t i = 0; i < 20; ++i) {
+  }
+  // 0,2 repeated 10 times (signed ints)
+  for (size_t i = 0; i < 20; ++i) {
      values.push_back((i%2)*2);
- }
+  }
 
- const unsigned char bytes[] = {0x42,0x13,0x22,0x22,0x22,0x22,0x22,
-                                0x46,0x13,0x04,0x04,0x04,0x04,0x04,
-                                0x04,0x04,0x04,0x04,0x04};
- unsigned long l = sizeof(bytes) / sizeof(char);
+  const unsigned char bytes[] = {0x42,0x13,0x22,0x22,0x22,0x22,0x22,
+                                 0x46,0x13,0x04,0x04,0x04,0x04,0x04,
+                                 0x04,0x04,0x04,0x04,0x04};
+  unsigned long l = sizeof(bytes) / sizeof(char);
 
- // Read 1 at a time, then 3 at a time, etc.
- checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
- checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
- checkResults(values, decodeRLEv2(bytes, l, 7, values.size()), 7);
- checkResults(values, decodeRLEv2(bytes, l, values.size(), values.size()),
-              values.size());
-};
+  size_t count = values.size();
+  for (uint32_t blkSize = 1; blkSize <= l; ++blkSize) {
+    // Read 1 at a time, then 3 at a time, etc.
+    checkResults(values, decodeRLEv2(bytes, l, 1, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 3, count, nullptr, true, blkSize), 3);
+    checkResults(values, decodeRLEv2(bytes, l, 7, count, nullptr, true, blkSize), 7);
+    checkResults(values, decodeRLEv2(bytes, l, count, count, nullptr, true, blkSize), count);
+  }
+}
 
 TEST(RLEv2, largeNegativesDirect) {
   const unsigned char buffer[] =


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This PR optimizes the C++ implementation of orc::RleDecoderV2::nextDirect. It provides different methods for different bit sizes, which significantly reduces the instructions and branches. Note that only bit sizes of 4,8,16,24,32,40,48,56,64 are optimized in this PR. bitSize 1 and 2 are skipped since they usually have short runs which won't benefit from loop unrolling. Other deprecated bit sizes, e.g. 3,5,6,7 are also skipped.

When the bit size is specified, we can better exhaust the buffer before calling readByte(). This also improves performance.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Perf tests show that orc::RleDecoderV2::nextDirect() dominant the time in reading random integers. There are more details in the JIRA description.
Performance improvement for scanning 1 billion unsigned numbers in different bit sizes:

bitSize | original time(s) | optimized time(s) | speedup
-- | -- | -- | --
4 | 5.93 | 3.25 | 1.8246153846
8 | 6.24 | 2.62 | 2.3816793893
16 | 7.24 | 2.59 | 2.7953667954
24 | 8.28 | 3.04 | 2.7236842105
32 | 9.45 | 2.9 | 3.2586206897
40 | 10.62 | 3.42 | 3.1052631579
48 | 11.67 | 3.56 | 3.2780898876
56 | 12.86 | 4.21 | 3.054631829
64 | 14.05 | 7.76 | 1.8105670103

Tested on Ubuntu16.04 with a 6 cores CPU (12 virtual cores) and 32GB RAM.
CPU: Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add more tests in TestRleDecoder.cc