### PR TITLE
ORC-1035: Fix the way to get the backupDataPath in recoverFile

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -567,16 +567,25 @@ public final class FileDump {
     // validate the recovered file once again and start moving corrupt files to backup folder
     if (isReadable(recoveredPath, conf, Long.MAX_VALUE)) {
       Path backupDataPath;
+      Path backupDirPath;
+      Path relativeCorruptPath;
       String scheme = corruptPath.toUri().getScheme();
       String authority = corruptPath.toUri().getAuthority();
-      String filePath = corruptPath.toUri().getPath();
 
       // use the same filesystem as corrupt file if backup-path is not explicitly specified
       if (backup.equals(DEFAULT_BACKUP_PATH)) {
-        backupDataPath = new Path(scheme, authority, DEFAULT_BACKUP_PATH + filePath);
+        backupDirPath = new Path(scheme, authority, DEFAULT_BACKUP_PATH);
       } else {
-        backupDataPath = Path.mergePaths(new Path(backup), corruptPath);
+        backupDirPath = new Path(backup);
       }
+
+      if (corruptPath.isUriPathAbsolute()) {
+        relativeCorruptPath = corruptPath;
+      } else {
+        relativeCorruptPath = Path.mergePaths(new Path(Path.SEPARATOR), corruptPath);
+      }
+
+      backupDataPath = Path.mergePaths(backupDirPath, relativeCorruptPath);
 
       // Move data file to backup path
       moveFiles(fs, corruptPath, backupDataPath);


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This pr aims to fix the way to get the backupDataPath.
```java
      public static final String DEFAULT_BACKUP_PATH = System.getProperty("java.io.tmpdir");
      ......
      String scheme = corruptPath.toUri().getScheme();
      String authority = corruptPath.toUri().getAuthority();
      String filePath = corruptPath.toUri().getPath();
      if (backup.equals(DEFAULT_BACKUP_PATH)) {
        backupDataPath = new Path(scheme, authority, DEFAULT_BACKUP_PATH + filePath);
      } else {
        backupDataPath = Path.mergePaths(new Path(backup), corruptPath);
      }
```

1.  System.getProperty("java.io.tmpdir") gets a path that may or may not end in Path.SEPARATOR, as seen in the [Travis ci ](https://app.travis-ci.com/github/apache/orc/jobs/544381649#L1580) example, the path generated directly by DEFAULT_BACKUP_PATH + filePath may not be correct.

2. corruptPath is the path entered by the user, which may be absolute or relative. The second argument of Path.mergePaths is expected to be a path starting with Path.SEPARATOR, so when the user enters a relative path, Path.mergePaths(new Path(backup), corruptPath) the result is also incorrect.

example  `Path.mergePaths(new Path("/a/b/c/"), new Path("d")).toUri().getPath()`
result:  `/a/b/cd`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix bug, otherwise backup files will fail.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass the CIs.