### PR TITLE
ORC-1039: Make `FileDump.recoverFile` handle side files only if they exist

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -592,8 +592,10 @@ public final class FileDump {
 
       // Move side file to backup path
       Path sideFilePath = OrcAcidUtils.getSideFile(corruptPath);
-      Path backupSideFilePath = new Path(backupDataPath.getParent(), sideFilePath.getName());
-      moveFiles(fs, sideFilePath, backupSideFilePath);
+      if (fs.exists(sideFilePath)) {
+        Path backupSideFilePath = new Path(backupDataPath.getParent(), sideFilePath.getName());
+        moveFiles(fs, sideFilePath, backupSideFilePath);
+      }
 
       // finally move recovered file to actual file
       moveFiles(fs, recoveredPath, corruptPath);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make FileDump.recoverFile handle side files only if they exist.

### Why are the changes needed?

This is useful when the test environment does not have sideFile.
Without this, IOException occurs

### How was this patch tested?

Pass the CIs.