### PR TITLE
ORC-1004: Make orc writer support the selected vector

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/InternalColumnVector.java
+++ b/java/core/src/java/org/apache/orc/impl/InternalColumnVector.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+
+import java.util.function.Function;
+
+public abstract class InternalColumnVector {
+
+  protected final ColumnVector columnVector;
+
+  public InternalColumnVector(ColumnVector columnVector) {
+    this.columnVector = columnVector;
+  }
+
+  public ColumnVector getColumnVector() {
+    return columnVector;
+  }
+
+  public boolean isRepeating() {
+    return columnVector.isRepeating;
+  }
+
+  public boolean notRepeatNull() {
+    return columnVector.noNulls || !columnVector.isNull[0];
+  }
+
+  public boolean noNulls() {
+    return columnVector.noNulls;
+  }
+
+  public abstract void ensureSize(int size, boolean preserveData);
+
+  public abstract boolean isNull(int offset);
+
+  public abstract int getValueOffset(int offset);
+
+  public abstract Function<ColumnVector, InternalColumnVector> encapsulationFunction();
+
+}

--- a/java/core/src/java/org/apache/orc/impl/InternalVectorizedRowBatch.java
+++ b/java/core/src/java/org/apache/orc/impl/InternalVectorizedRowBatch.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+
+public abstract class InternalVectorizedRowBatch {
+
+  public static InternalVectorizedRowBatch encapsulation(VectorizedRowBatch batch) {
+    return batch.isSelectedInUse()
+        ? new SelectedVectorizedRowBatch(batch)
+        : new WholeVectorizedRowBatch(batch);
+  }
+
+  protected final VectorizedRowBatch vectorizedRowBatch;
+
+  public InternalVectorizedRowBatch(VectorizedRowBatch vectorizedRowBatch) {
+    this.vectorizedRowBatch = vectorizedRowBatch;
+  }
+
+  public VectorizedRowBatch getVectorizedRowBatch() {
+    return vectorizedRowBatch;
+  }
+
+  public int colsSize() {
+    return vectorizedRowBatch.cols.length;
+  }
+
+  public abstract void ensureSize(int rows);
+
+  public abstract InternalColumnVector cols(int col);
+
+  public abstract int size();
+
+}

--- a/java/core/src/java/org/apache/orc/impl/SelectedColumnVector.java
+++ b/java/core/src/java/org/apache/orc/impl/SelectedColumnVector.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+
+import java.util.function.Function;
+
+public class SelectedColumnVector extends InternalColumnVector {
+
+  private final int[] selected;
+
+  public SelectedColumnVector(ColumnVector columnVector, int[] selected) {
+    super(columnVector);
+    this.selected = selected;
+  }
+
+  @Override
+  public void ensureSize(int size, boolean preserveData) {
+    throw new UnsupportedOperationException(
+        "The ensureSize operation is not supported for SelectedColumnVector");
+  }
+
+  @Override
+  public boolean isNull(int offset) {
+    return columnVector.isNull[getValueOffset(offset)];
+  }
+
+  @Override
+  public int getValueOffset(int offset) {
+    return selected[offset];
+  }
+
+  @Override
+  public Function<ColumnVector, InternalColumnVector> encapsulationFunction() {
+    return vector -> new SelectedColumnVector(vector, selected);
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/impl/SelectedVectorizedRowBatch.java
+++ b/java/core/src/java/org/apache/orc/impl/SelectedVectorizedRowBatch.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+
+public class SelectedVectorizedRowBatch extends InternalVectorizedRowBatch {
+
+  public SelectedVectorizedRowBatch(VectorizedRowBatch vectorizedRowBatch) {
+    super(vectorizedRowBatch);
+  }
+
+  @Override
+  public void ensureSize(int rows) {
+    throw new UnsupportedOperationException(
+        "The ensureSize operation is not supported for SelectedVectorizedRowBatch");
+  }
+
+  @Override
+  public InternalColumnVector cols(int col) {
+    return new SelectedColumnVector(vectorizedRowBatch.cols[col], vectorizedRowBatch.getSelected());
+  }
+
+  @Override
+  public int size() {
+    return vectorizedRowBatch.getSelectedSize();
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/impl/WholeColumnVector.java
+++ b/java/core/src/java/org/apache/orc/impl/WholeColumnVector.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+
+import java.util.function.Function;
+
+public class WholeColumnVector extends InternalColumnVector {
+
+  private final boolean preserved;
+
+  public WholeColumnVector(ColumnVector columnVector) {
+    this(columnVector, true);
+  }
+
+  public WholeColumnVector(ColumnVector columnVector, boolean preserved) {
+    super(columnVector);
+    this.preserved = preserved;
+  }
+
+  @Override
+  public void ensureSize(int size, boolean preserveData) {
+    if (!preserved) {
+      columnVector.ensureSize(size, preserveData);
+    } else {
+      throw new UnsupportedOperationException(
+          "The ensureSize operation is not supported after the data is preserved");
+    }
+  }
+
+  @Override
+  public boolean isNull(int offset) {
+    return columnVector.isNull[offset];
+  }
+
+  @Override
+  public int getValueOffset(int offset) {
+    return offset;
+  }
+
+  @Override
+  public Function<ColumnVector, InternalColumnVector> encapsulationFunction() {
+    return WholeColumnVector::new;
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/impl/WholeVectorizedRowBatch.java
+++ b/java/core/src/java/org/apache/orc/impl/WholeVectorizedRowBatch.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+
+public class WholeVectorizedRowBatch extends InternalVectorizedRowBatch {
+
+  private boolean preserved;
+
+  public WholeVectorizedRowBatch(VectorizedRowBatch vectorizedRowBatch) {
+    this(vectorizedRowBatch, true);
+  }
+
+  public WholeVectorizedRowBatch(VectorizedRowBatch vectorizedRowBatch, boolean preserved) {
+    super(vectorizedRowBatch);
+    this.preserved = preserved;
+  }
+
+  @Override
+  public void ensureSize(int rows) {
+    if (!preserved) {
+      vectorizedRowBatch.ensureSize(rows);
+    } else {
+      throw new UnsupportedOperationException(
+          "The ensureSize operation is not supported after the data is preserved");
+    }
+  }
+
+  public void setPreserved(boolean preserved) {
+    this.preserved = preserved;
+  }
+
+  @Override
+  public InternalColumnVector cols(int col) {
+    return new WholeColumnVector(vectorizedRowBatch.cols[col], preserved);
+  }
+
+  @Override
+  public int size() {
+    return vectorizedRowBatch.size;
+  }
+
+}

--- a/java/core/src/java/org/apache/orc/impl/writer/CharTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/CharTreeWriter.java
@@ -19,8 +19,8 @@
 package org.apache.orc.impl.writer;
 
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.InternalColumnVector;
 import org.apache.orc.impl.Utf8Utils;
 
 import java.io.IOException;
@@ -44,20 +44,20 @@ public class CharTreeWriter extends StringBaseTreeWriter {
   }
 
   @Override
-  public void writeBatch(ColumnVector vector, int offset,
+  public void writeBatch(InternalColumnVector vector, int offset,
                          int length) throws IOException {
     super.writeBatch(vector, offset, length);
-    BytesColumnVector vec = (BytesColumnVector) vector;
-    if (vector.isRepeating) {
-      if (vector.noNulls || !vector.isNull[0]) {
+    BytesColumnVector vec = (BytesColumnVector) vector.getColumnVector();
+    if (vector.isRepeating()) {
+      if (vector.notRepeatNull()) {
         // 0, length times
         writePadded(vec, 0, length);
       }
     } else {
       for(int i=0; i < length; ++i) {
-        if (vec.noNulls || !vec.isNull[i + offset]) {
+        if (vector.noNulls() || !vector.isNull(i + offset)) {
           // offset + i, once per loop
-          writePadded(vec, i + offset, 1);
+          writePadded(vec, vector.getValueOffset(i + offset), 1);
         }
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/writer/FloatTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/FloatTreeWriter.java
@@ -18,12 +18,12 @@
 
 package org.apache.orc.impl.writer;
 
-import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
 import org.apache.hadoop.hive.ql.util.JavaDataModel;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.CryptoUtils;
+import org.apache.orc.impl.InternalColumnVector;
 import org.apache.orc.impl.PositionRecorder;
 import org.apache.orc.impl.PositionedOutputStream;
 import org.apache.orc.impl.SerializationUtils;
@@ -48,12 +48,12 @@ public class FloatTreeWriter extends TreeWriterBase {
   }
 
   @Override
-  public void writeBatch(ColumnVector vector, int offset,
+  public void writeBatch(InternalColumnVector vector, int offset,
                          int length) throws IOException {
     super.writeBatch(vector, offset, length);
-    DoubleColumnVector vec = (DoubleColumnVector) vector;
-    if (vector.isRepeating) {
-      if (vector.noNulls || !vector.isNull[0]) {
+    DoubleColumnVector vec = (DoubleColumnVector) vector.getColumnVector();
+    if (vector.isRepeating()) {
+      if (vector.notRepeatNull()) {
         float value = (float) vec.vector[0];
         indexStatistics.updateDouble(value);
         if (createBloomFilter) {
@@ -68,8 +68,8 @@ public class FloatTreeWriter extends TreeWriterBase {
       }
     } else {
       for (int i = 0; i < length; ++i) {
-        if (vec.noNulls || !vec.isNull[i + offset]) {
-          float value = (float) vec.vector[i + offset];
+        if (vector.noNulls() || !vector.isNull(i + offset)) {
+          float value = (float) vec.vector[vector.getValueOffset(i + offset)];
           utils.writeFloat(stream, value);
           indexStatistics.updateDouble(value);
           if (createBloomFilter) {
@@ -82,7 +82,6 @@ public class FloatTreeWriter extends TreeWriterBase {
       }
     }
   }
-
 
   @Override
   public void writeStripe(int requiredIndexEntries) throws IOException {

--- a/java/core/src/java/org/apache/orc/impl/writer/MapTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/MapTreeWriter.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc.impl.writer;
 
-import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
 import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcProto;
@@ -32,7 +31,6 @@ import org.apache.orc.impl.WholeColumnVector;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.function.Function;
 
 public class MapTreeWriter extends TreeWriterBase {
   private final IntegerWriter lengths;

--- a/java/core/src/java/org/apache/orc/impl/writer/TreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/TreeWriter.java
@@ -18,12 +18,12 @@
 
 package org.apache.orc.impl.writer;
 
-import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.ColumnStatistics;
 import org.apache.orc.OrcFile;
 import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.InternalColumnVector;
+import org.apache.orc.impl.InternalVectorizedRowBatch;
 
 import java.io.IOException;
 
@@ -59,7 +59,7 @@ public interface TreeWriter {
    * @param offset the first row from the batch to write
    * @param length the number of rows to write
    */
-  void writeRootBatch(VectorizedRowBatch batch, int offset,
+  void writeRootBatch(InternalVectorizedRowBatch batch, int offset,
                       int length) throws IOException;
 
   /**
@@ -69,7 +69,7 @@ public interface TreeWriter {
    * @param offset the first value offset to write.
    * @param length the number of values to write
    */
-  void writeBatch(ColumnVector vector, int offset,
+  void writeBatch(InternalColumnVector vector, int offset,
                   int length) throws IOException;
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/writer/VarcharTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/VarcharTreeWriter.java
@@ -19,8 +19,8 @@
 package org.apache.orc.impl.writer;
 
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.InternalColumnVector;
 import org.apache.orc.impl.Utf8Utils;
 
 import java.io.IOException;
@@ -40,20 +40,20 @@ public class VarcharTreeWriter extends StringBaseTreeWriter {
   }
 
   @Override
-  public void writeBatch(ColumnVector vector, int offset,
+  public void writeBatch(InternalColumnVector vector, int offset,
                          int length) throws IOException {
     super.writeBatch(vector, offset, length);
-    BytesColumnVector vec = (BytesColumnVector) vector;
-    if (vector.isRepeating) {
-      if (vector.noNulls || !vector.isNull[0]) {
+    BytesColumnVector vec = (BytesColumnVector) vector.getColumnVector();
+    if (vector.isRepeating()) {
+      if (vector.notRepeatNull()) {
         // 0, length times
         writeTruncated(vec, 0, length);
       }
     } else {
       for(int i=0; i < length; ++i) {
-        if (vec.noNulls || !vec.isNull[i + offset]) {
+        if (vector.noNulls() || !vector.isNull(i + offset)) {
           // offset + i, once per loop
-          writeTruncated(vec, i + offset, 1);
+          writeTruncated(vec, vector.getValueOffset(i + offset), 1);
         }
       }
     }

--- a/java/core/src/test/org/apache/orc/TestSelectedVector.java
+++ b/java/core/src/test/org/apache/orc/TestSelectedVector.java
@@ -1,0 +1,513 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DateColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.orc.impl.KeyProvider;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestSelectedVector {
+
+  Path workDir = new Path(System.getProperty("test.tmp.dir"));
+  Configuration conf;
+  FileSystem fs;
+  Path testFilePath;
+  Random random = new Random();
+
+  @BeforeEach
+  public void openFileSystem() throws Exception {
+    conf = new Configuration();
+    conf.setInt(OrcConf.ROW_INDEX_STRIDE.getAttribute(), VectorizedRowBatch.DEFAULT_SIZE);
+    fs = FileSystem.getLocal(conf);
+    fs.setWorkingDirectory(workDir);
+    testFilePath = new Path("testWriterImpl.orc");
+  }
+
+  @AfterEach
+  public void deleteTestFile() throws Exception {
+    fs.delete(testFilePath, false);
+  }
+
+  @Test
+  public void testWriteBaseTypeUseSelectedVector() throws IOException {
+    TypeDescription schema =
+        TypeDescription.fromString("struct<a:boolean,b:tinyint,c:smallint,d:int,e:bigint," +
+            "f:float,g:double,h:string,i:date,j:timestamp,k:binary,l:decimal(20,5),m:varchar(5)," +
+            "n:char(5)>");
+
+    Writer writer = OrcFile.createWriter(testFilePath, OrcFile.writerOptions(conf)
+        .setSchema(schema).overwrite(true));
+    VectorizedRowBatch batch = schema.createRowBatch();
+    LongColumnVector a = (LongColumnVector) batch.cols[0];
+    LongColumnVector b = (LongColumnVector) batch.cols[1];
+    LongColumnVector c = (LongColumnVector) batch.cols[2];
+    LongColumnVector d = (LongColumnVector) batch.cols[3];
+    LongColumnVector e = (LongColumnVector) batch.cols[4];
+    DoubleColumnVector f = (DoubleColumnVector) batch.cols[5];
+    DoubleColumnVector g = (DoubleColumnVector) batch.cols[6];
+    BytesColumnVector h = (BytesColumnVector) batch.cols[7];
+    DateColumnVector i = (DateColumnVector) batch.cols[8];
+    TimestampColumnVector j = (TimestampColumnVector) batch.cols[9];
+    BytesColumnVector k = (BytesColumnVector) batch.cols[10];
+    DecimalColumnVector l = (DecimalColumnVector) batch.cols[11];
+    BytesColumnVector m = (BytesColumnVector) batch.cols[12];
+    BytesColumnVector n = (BytesColumnVector) batch.cols[13];
+
+    int[] selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+    int selectedSize = 0;
+    int writeRowNum = 0;
+    for (int o = 0; o < VectorizedRowBatch.DEFAULT_SIZE * 2; o++) {
+      int row = batch.size++;
+      if (row % 5 == 0) {
+        a.noNulls = false;
+        a.isNull[row] = true;
+        b.noNulls = false;
+        b.isNull[row] = true;
+        c.noNulls = false;
+        c.isNull[row] = true;
+        d.noNulls = false;
+        d.isNull[row] = true;
+        e.noNulls = false;
+        e.isNull[row] = true;
+        f.noNulls = false;
+        f.isNull[row] = true;
+        g.noNulls = false;
+        g.isNull[row] = true;
+        h.noNulls = false;
+        h.isNull[row] = true;
+        i.noNulls = false;
+        i.isNull[row] = true;
+        j.noNulls = false;
+        j.isNull[row] = true;
+        k.noNulls = false;
+        k.isNull[row] = true;
+        l.noNulls = false;
+        l.isNull[row] = true;
+        m.noNulls = false;
+        m.isNull[row] = true;
+        n.noNulls = false;
+        n.isNull[row] = true;
+      } else {
+        a.vector[row] = row % 2;
+        b.vector[row] = row % 128;
+        c.vector[row] = row;
+        d.vector[row] = row;
+        e.vector[row] = row * 10000000L;
+        f.vector[row] = row * 1.0f;
+        g.vector[row] = row * 1.0d;
+        byte[] bytes = String.valueOf(row).getBytes(StandardCharsets.UTF_8);
+        h.setRef(row, bytes, 0, bytes.length);
+        i.vector[row] = row;
+        j.time[row] = row * 1000L;
+        j.nanos[row] = row;
+        k.setRef(row, bytes, 0, bytes.length);
+        l.vector[row] = new HiveDecimalWritable(row);
+        m.setRef(row, bytes, 0, bytes.length);
+        bytes = String.valueOf(10000 - row).getBytes(StandardCharsets.UTF_8);
+        n.setRef(row, bytes, 0, bytes.length);
+      }
+      if (random.nextInt() % 2 == 0) {
+        selected[selectedSize ++] = row;
+        writeRowNum ++;
+      }
+      if (batch.size == batch.getMaxSize()) {
+        batch.setFilterContext(true, selected, selectedSize);
+        writer.addRowBatch(batch);
+        selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+        selectedSize = 0;
+        batch.reset();
+      }
+    }
+    writer.close();
+
+    Reader reader = OrcFile.createReader(testFilePath,
+        OrcFile.readerOptions(conf));
+    batch = schema.createRowBatch();
+    Reader.Options options = reader.options().schema(schema);
+    RecordReader rowIterator = reader.rows(options);
+    int readRowNum = 0;
+
+    a = (LongColumnVector) batch.cols[0];
+    b = (LongColumnVector) batch.cols[1];
+    c = (LongColumnVector) batch.cols[2];
+    d = (LongColumnVector) batch.cols[3];
+    e = (LongColumnVector) batch.cols[4];
+    f = (DoubleColumnVector) batch.cols[5];
+    g = (DoubleColumnVector) batch.cols[6];
+    h = (BytesColumnVector) batch.cols[7];
+    i = (DateColumnVector) batch.cols[8];
+    j = (TimestampColumnVector) batch.cols[9];
+    k = (BytesColumnVector) batch.cols[10];
+    l = (DecimalColumnVector) batch.cols[11];
+    m = (BytesColumnVector) batch.cols[12];
+    n = (BytesColumnVector) batch.cols[13];
+    while (rowIterator.nextBatch(batch)) {
+      for (int row = 0; row < batch.size; ++row) {
+        readRowNum ++;
+        if (c.isNull[row]) {
+          assertTrue(a.isNull[row]);
+          assertTrue(b.isNull[row]);
+          assertTrue(d.isNull[row]);
+          assertTrue(e.isNull[row]);
+          assertTrue(f.isNull[row]);
+          assertTrue(g.isNull[row]);
+          assertTrue(h.isNull[row]);
+          assertTrue(i.isNull[row]);
+          assertTrue(j.isNull[row]);
+          assertTrue(k.isNull[row]);
+          assertTrue(l.isNull[row]);
+          assertTrue(m.isNull[row]);
+          assertTrue(n.isNull[row]);
+        }
+        else {
+          int rowNum = (int)c.vector[row];
+          assertTrue(rowNum % 5 != 0);
+          assertEquals(rowNum % 2, a.vector[row]);
+          assertEquals(rowNum % 128, b.vector[row]);
+          assertEquals(rowNum, d.vector[row]);
+          assertEquals(rowNum * 10000000L, e.vector[row]);
+          assertEquals(rowNum * 1.0f, f.vector[row]);
+          assertEquals(rowNum * 1.0d, g.vector[row]);
+          assertEquals(String.valueOf(rowNum), h.toString(row));
+          assertEquals(rowNum, i.vector[row]);
+          assertEquals(rowNum * 1000L, j.time[row]);
+          assertEquals(rowNum, j.nanos[row]);
+          assertEquals(String.valueOf(rowNum), k.toString(row));
+          assertEquals(new HiveDecimalWritable(rowNum), l.vector[row]);
+          assertEquals(String.valueOf(rowNum), m.toString(row));
+          assertEquals(String.valueOf(10000 - rowNum), n.toString(row));
+        }
+      }
+    }
+    rowIterator.close();
+    assertEquals(writeRowNum, readRowNum);
+  }
+
+  @Test
+  public void testWriteComplexTypeUseSelectedVector() throws IOException {
+    TypeDescription schema =
+        TypeDescription.fromString("struct<a:map<int,uniontype<int,string>>," +
+            "b:array<struct<c:int>>>");
+
+    Writer writer = OrcFile.createWriter(testFilePath, OrcFile.writerOptions(conf)
+        .setSchema(schema).overwrite(true));
+    VectorizedRowBatch batch = schema.createRowBatch();
+    MapColumnVector a = (MapColumnVector) batch.cols[0];
+    LongColumnVector keys = (LongColumnVector) a.keys;
+    UnionColumnVector values = (UnionColumnVector) a.values;
+    LongColumnVector value1 = (LongColumnVector) values.fields[0];
+    BytesColumnVector value2 = (BytesColumnVector) values.fields[1];
+    ListColumnVector b = (ListColumnVector) batch.cols[1];
+    StructColumnVector child = (StructColumnVector) b.child;
+    LongColumnVector c = (LongColumnVector) child.fields[0];
+    int mapOffset = 0;
+    int arrayOffset = 0;
+    int[] selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+    int selectedSize = 0;
+    int writeRowNum = 0;
+
+    for (int i = 0; i < VectorizedRowBatch.DEFAULT_SIZE * 2; i++) {
+      int row = batch.size++;
+      a.offsets[row] = mapOffset;
+      b.offsets[row] = arrayOffset;
+      int tag = row % 2;
+      if (row % 5 == 0) {
+        a.lengths[row] = 1;
+        values.tags[mapOffset] = tag;
+        keys.noNulls = false;
+        keys.isNull[mapOffset] = true;
+        if (tag == 0) {
+          value1.noNulls = false;
+          value1.isNull[mapOffset] = true;
+        } else {
+          value2.noNulls = false;
+          value2.isNull[mapOffset] = true;
+        }
+        b.lengths[row] = 1;
+        c.noNulls = false;
+        c.isNull[arrayOffset] = true;
+      } else {
+        a.lengths[row] = 2;
+        values.tags[mapOffset] = tag;
+        values.tags[mapOffset + 1] = tag;
+        keys.vector[mapOffset] = row;
+        keys.vector[mapOffset + 1] = row + 1;
+        if (tag == 0) {
+          value1.vector[mapOffset] = row * 3L;
+          value1.vector[mapOffset + 1] = (row + 1) * 3L;
+        } else {
+          byte[] bytes = String.valueOf(row).getBytes(StandardCharsets.UTF_8);
+          value2.setRef(mapOffset, bytes, 0, bytes.length);
+          bytes = String.valueOf(row + 1).getBytes(StandardCharsets.UTF_8);
+          value2.setRef(mapOffset + 1, bytes, 0, bytes.length);
+        }
+        b.lengths[row] = 3;
+        c.vector[arrayOffset] = row;
+        c.vector[arrayOffset + 1] = row + 1;
+        c.vector[arrayOffset + 2] = row + 2;
+      }
+      mapOffset += a.lengths[row];
+      arrayOffset += b.lengths[row];
+
+      if (random.nextInt() % 2 == 0) {
+        selected[selectedSize ++] = row;
+        writeRowNum ++;
+      }
+      if (arrayOffset + 3 >= batch.getMaxSize()) {
+        batch.setFilterContext(true, selected, selectedSize);
+        writer.addRowBatch(batch);
+        selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+        selectedSize = 0;
+        mapOffset = 0;
+        arrayOffset = 0;
+        batch.reset();
+      }
+    }
+    if (batch.size != 0) {
+      batch.setFilterContext(true, selected, selectedSize);
+      writer.addRowBatch(batch);
+      batch.reset();
+    }
+    writer.close();
+
+    Reader reader = OrcFile.createReader(testFilePath,
+        OrcFile.readerOptions(conf));
+    batch = schema.createRowBatch();
+    Reader.Options options = reader.options().schema(schema);
+    RecordReader rowIterator = reader.rows(options);
+    int readRowNum = 0;
+
+    a = (MapColumnVector) batch.cols[0];
+    keys = (LongColumnVector) a.keys;
+    values = (UnionColumnVector) a.values;
+    value1 = (LongColumnVector) values.fields[0];
+    value2 = (BytesColumnVector) values.fields[1];
+    b = (ListColumnVector) batch.cols[1];
+    child = (StructColumnVector) b.child;
+    c = (LongColumnVector) child.fields[0];
+    while (rowIterator.nextBatch(batch)) {
+      for (int row = 0; row < batch.size; ++row) {
+        readRowNum ++;
+        mapOffset = (int)a.offsets[row];
+        int mapLen = (int)a.lengths[row];
+        arrayOffset = (int)b.offsets[row];
+        int arrayLen = (int)b.lengths[row];
+        if (mapLen == 1) {
+          assertEquals(1, arrayLen);
+          assertTrue(keys.isNull[mapOffset]);
+          if (values.tags[mapOffset] == 0) {
+            assertTrue(value1.isNull[mapOffset]);
+          } else {
+            assertTrue(value2.isNull[mapOffset]);
+          }
+          assertTrue(c.isNull[arrayOffset]);
+        }
+        else {
+          assertEquals(2, mapLen);
+          assertEquals(3, arrayLen);
+          long rowNum = keys.vector[mapOffset];
+          assertEquals(rowNum + 1, keys.vector[mapOffset + 1]);
+          if (values.tags[mapOffset] == 0) {
+            assertEquals(rowNum * 3, value1.vector[mapOffset]);
+          } else {
+            assertEquals(String.valueOf(rowNum), value2.toString(mapOffset));
+          }
+          if (values.tags[mapOffset + 1] == 0) {
+            assertEquals((rowNum + 1) * 3, value1.vector[mapOffset + 1]);
+          } else {
+            assertEquals(String.valueOf(rowNum + 1), value2.toString(mapOffset + 1));
+          }
+        }
+
+      }
+    }
+    rowIterator.close();
+    assertEquals(writeRowNum, readRowNum);
+  }
+
+  @Test
+  public void testWriteRepeatedUseSelectedVector() throws IOException {
+    TypeDescription schema =
+        TypeDescription.fromString("struct<a:int,b:string,c:decimal(20,5)>");
+
+    Writer writer = OrcFile.createWriter(testFilePath, OrcFile.writerOptions(conf)
+        .setSchema(schema).overwrite(true));
+    VectorizedRowBatch batch = schema.createRowBatch();
+    LongColumnVector a = (LongColumnVector) batch.cols[0];
+    BytesColumnVector b = (BytesColumnVector) batch.cols[1];
+    DecimalColumnVector c = (DecimalColumnVector) batch.cols[2];
+    b.fillWithNulls();
+    c.fill(new HiveDecimalWritable(42).getHiveDecimal());
+    Random random = new Random();
+    int[] selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+
+    int selectedSize = 0;
+    int writeRowNum = 0;
+
+    for (int i = 0; i < VectorizedRowBatch.DEFAULT_SIZE; i++) {
+      a.vector[i] = i;
+      if (random.nextInt() % 2 == 0) {
+        selected[selectedSize ++] = i;
+        writeRowNum ++;
+      }
+    }
+    batch.setFilterContext(true, selected, selectedSize);
+    writer.addRowBatch(batch);
+    batch.reset();
+    selectedSize = 0;
+
+    b.fill(String.valueOf(42).getBytes(StandardCharsets.UTF_8));
+    c.noNulls = false;
+    c.isRepeating = true;
+    c.vector[0].setFromLong(0);
+    c.isNull[0] = true;
+    selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+
+    for (int i = 0; i < VectorizedRowBatch.DEFAULT_SIZE; i++) {
+      a.vector[i] = i + 1024;
+      if (random.nextInt() % 2 == 0) {
+        selected[selectedSize ++] = i;
+        writeRowNum ++;
+      }
+    }
+    batch.setFilterContext(true, selected, selectedSize);
+    writer.addRowBatch(batch);
+    batch.reset();
+    writer.close();
+
+    Reader reader = OrcFile.createReader(testFilePath,
+        OrcFile.readerOptions(conf));
+    batch = schema.createRowBatch();
+    Reader.Options options = reader.options().schema(schema);
+    RecordReader rowIterator = reader.rows(options);
+    int readRowNum = 0;
+
+    a = (LongColumnVector) batch.cols[0];
+    b = (BytesColumnVector) batch.cols[1];
+    c = (DecimalColumnVector) batch.cols[2];
+
+    while (rowIterator.nextBatch(batch)) {
+      for (int row = 0; row < batch.size; ++row) {
+        readRowNum ++;
+        long rowNum = a.vector[row];
+        if (rowNum < 1024) {
+          assertNull(b.toString(row));
+          assertEquals(new HiveDecimalWritable(42), c.vector[row]);
+        } else {
+          assertEquals("42", b.toString(row));
+          assertTrue(c.isNull[row]);
+        }
+      }
+    }
+    rowIterator.close();
+    assertEquals(writeRowNum, readRowNum);
+  }
+
+  @Test
+  public void testWriteEncryptionUseSelectedVector() throws IOException {
+    TypeDescription schema =
+        TypeDescription.fromString("struct<id:int,name:string>");
+
+    byte[] kmsKey = "secret123".getBytes(StandardCharsets.UTF_8);
+    KeyProvider keyProvider = new InMemoryKeystore()
+        .addKey("pii", EncryptionAlgorithm.AES_CTR_128, kmsKey);
+    String encryption = "pii:id,name";
+    String mask = "sha256:id,name";
+
+    Writer writer = OrcFile.createWriter(testFilePath,
+        OrcFile.writerOptions(conf)
+            .setSchema(schema)
+            .overwrite(true)
+            .setKeyProvider(keyProvider)
+            .encrypt(encryption)
+            .masks(mask));
+    VectorizedRowBatch batch = schema.createRowBatch();
+    LongColumnVector id = (LongColumnVector) batch.cols[0];
+    BytesColumnVector name = (BytesColumnVector) batch.cols[1];
+
+    Random random = new Random();
+    int[] selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+
+    int selectedSize = 0;
+    int writeRowNum = 0;
+
+    for (int r = 0; r < VectorizedRowBatch.DEFAULT_SIZE * 2; ++r) {
+      int row = batch.size++;
+      id.vector[row] = r;
+      byte[] buffer = ("name-" + r).getBytes(StandardCharsets.UTF_8);
+      name.setRef(row, buffer, 0, buffer.length);
+      if (random.nextInt() % 2 == 0) {
+        selected[selectedSize ++] = r % VectorizedRowBatch.DEFAULT_SIZE;
+        writeRowNum ++;
+      }
+      if (batch.size == batch.getMaxSize()) {
+        batch.setFilterContext(true, selected, selectedSize);
+        writer.addRowBatch(batch);
+        selected = new int[VectorizedRowBatch.DEFAULT_SIZE];
+        selectedSize = 0;
+        batch.reset();
+      }
+    }
+    writer.close();
+
+    Reader reader = OrcFile.createReader(testFilePath,
+        OrcFile.readerOptions(conf).setKeyProvider(keyProvider));
+
+    batch = schema.createRowBatch();
+    Reader.Options options = reader.options().schema(schema);
+    RecordReader rowIterator = reader.rows(options);
+    int readRowNum = 0;
+    id = (LongColumnVector) batch.cols[0];
+    name = (BytesColumnVector) batch.cols[1];
+    while (rowIterator.nextBatch(batch)) {
+      for (int row = 0; row < batch.size; ++row) {
+        readRowNum ++;
+        long value = id.vector[row];
+        assertEquals("name-" + (value), name.toString(row));
+      }
+    }
+    rowIterator.close();
+    assertEquals(writeRowNum, readRowNum);
+  }
+
+}

--- a/java/core/src/test/org/apache/orc/TestStringDictionary.java
+++ b/java/core/src/test/org/apache/orc/TestStringDictionary.java
@@ -29,6 +29,7 @@ import org.apache.orc.impl.OutStream;
 import org.apache.orc.impl.RecordReaderImpl;
 import org.apache.orc.impl.StreamName;
 import org.apache.orc.impl.TestInStream;
+import org.apache.orc.impl.WholeColumnVector;
 import org.apache.orc.impl.writer.StreamOptions;
 import org.apache.orc.impl.writer.StringTreeWriter;
 import org.apache.orc.impl.writer.TreeWriter;
@@ -304,7 +305,7 @@ public class TestStringDictionary {
     batch.size = 1024;
     col.isRepeating = true;
     col.setVal(0, "foobar".getBytes(StandardCharsets.UTF_8));
-    writer.writeBatch(col, 0, batch.size);
+    writer.writeBatch(new WholeColumnVector(col), 0, batch.size);
     TestInStream.OutputCollector output = writerContext.streams.get(
         new StreamName(0, OrcProto.Stream.Kind.DATA));
     // Check to make sure that the strings are being written to the stream,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This pr is aimed at making ORC Writer support write thed selected vector.

Added InternalVectorizedRowBatch and InternalColumnVector classes to encapsulate and replace VectorizedRowBatc and ColumnVector.
WholeVectorizedRowBatch/WholeColumnVector represents a batch/vector that does not use selected.
SelectedVectorizedRowBatch/SelectedColumnVector represents a batch/vector that does use selected.

During the write process we can use the same interface (`public int getValueOffset(int offset) `) to get the offsets, making the changes minimal and not doing anything redundant.

![SelectedColumnVector](https://user-images.githubusercontent.com/4069905/139616377-51eb8e21-fd21-4c59-b324-e1aefd3d83a1.png)

When writing to the encrypted column, a copy of the Selected Vector is made without modifying the maskData interface, resulting in an unused Selected Vector. Afterwards, the processing is the same as before.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently the ORC writer doesn't support the selected vector. This could cause clients that expect it to be supported to get trash rows in the output.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add UT TestSelectedVector.java