### PR TITLE
ORC-1040: Add Debian 11 docker test

### DIFF
--- a/docker/debian11/Dockerfile
+++ b/docker/debian11/Dockerfile
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Debian 11
+#
+
+FROM debian:bullseye
+LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+ARG jdk=8
+
+RUN apt-get update
+RUN apt-get install -y \
+  cmake \
+  gcc \
+  g++ \
+  git \
+  libsasl2-dev \
+  libssl-dev \
+  make \
+  curl \
+  maven; \
+  if [ "${jdk}" = "8" ] ; then \
+    apt-get install -y \
+      gnupg2 \
+      software-properties-common \
+      wget; \
+    wget -qO - https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public | apt-key add -; \
+    add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ && \
+    apt-get update && \
+    apt-get install -y adoptopenjdk-8-hotspot && \
+    update-alternatives --set java /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/java && \
+    update-alternatives --set javac /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javac; \
+  else \
+    apt-get install -y openjdk-11-jdk; \
+  fi
+
+WORKDIR /root
+
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -2,6 +2,7 @@ centos7
 centos8
 debian9
 debian10
+debian11
 ubuntu18
 ubuntu20
 centos8_jdk=11


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to add Debian 11 docker test.

### Why are the changes needed?
To improve test coverage.


### How was this patch tested?
Manual, pass the docker tests.

Currently, there is only one C++ test case failure, which is ORC-1041.
```
[  PASSED  ] 402 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] TestDecompression.testLzoLong
```

