### PR TITLE
ORC-1043: Fix C++ compilation error in CentOS 7

### DIFF
--- a/c++/test/TestMurmur3.cc
+++ b/c++/test/TestMurmur3.cc
@@ -33,7 +33,7 @@ namespace orc {
                        " we had everything before us, we had nothing before us,"
                        " we were all going direct to Heaven,"
                        " we were all going direct the other way.";
-    uint32_t len = sizeof(origin) / sizeof(uint8_t) - 1;
+    uint32_t len = static_cast<uint32_t>(sizeof(origin) / sizeof(uint8_t) - 1);
     uint64_t hash = Murmur3::hash64(origin, len);
     EXPECT_EQ(305830725663368540L, hash);
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to fix a C++ compilation error in CentOS 7.

### Why are the changes needed?
To recover compilation. 


### How was this patch tested?
Manually test on CentOS 7.
