### PR TITLE
ORC-1041: Use `memcpy` during LZO decompression

### DIFF
--- a/c++/src/LzoDecompressor.cc
+++ b/c++/src/LzoDecompressor.cc
@@ -312,13 +312,11 @@ namespace orc {
               output += SIZE_OF_INT;
               matchAddress += increment32;
 
-              *reinterpret_cast<int32_t*>(output) =
-                *reinterpret_cast<int32_t*>(matchAddress);
+              memcpy(output, matchAddress, SIZE_OF_INT);
               output += SIZE_OF_INT;
               matchAddress -= decrement64;
             } else {
-              *reinterpret_cast<int64_t*>(output) =
-                *reinterpret_cast<int64_t*>(matchAddress);
+              memcpy(output, matchAddress, SIZE_OF_LONG);
               matchAddress += SIZE_OF_LONG;
               output += SIZE_OF_LONG;
             }
@@ -329,8 +327,7 @@ namespace orc {
               }
 
               while (output < fastOutputLimit) {
-                *reinterpret_cast<int64_t*>(output) =
-                  *reinterpret_cast<int64_t*>(matchAddress);
+                memcpy(output, matchAddress, SIZE_OF_LONG);
                 matchAddress += SIZE_OF_LONG;
                 output += SIZE_OF_LONG;
               }
@@ -340,8 +337,7 @@ namespace orc {
               }
             } else {
               while (output < matchOutputLimit) {
-                *reinterpret_cast<int64_t*>(output) =
-                  *reinterpret_cast<int64_t*>(matchAddress);
+                memcpy(output, matchAddress, SIZE_OF_LONG);
                 matchAddress += SIZE_OF_LONG;
                 output += SIZE_OF_LONG;
               }

--- a/c++/src/LzoDecompressor.cc
+++ b/c++/src/LzoDecompressor.cc
@@ -362,8 +362,7 @@ namespace orc {
           // fast copy. We may over-copy but there's enough room in input
           // and output to not overrun them
           do {
-            *reinterpret_cast<int64_t*>(output) =
-              *reinterpret_cast<const int64_t*>(input);
+            memcpy(output, input, SIZE_OF_LONG);
             input += SIZE_OF_LONG;
             output += SIZE_OF_LONG;
           } while (output < literalOutputLimit);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This pr is aimed to fix the implementation of copy data blocks during LZO decompression.

`*reinterpret_cast< int64_t*>(output) = *reinterpret_cast< int64_t*>(matchAddress);`  can lead to unexpected behavior, and in failed test cases it does not appear to be an atomic operation.

This pr uses memcpy instead of the above statement.

Here are the performance benchmarks, where `memcpy` is basically the same as `reinterpret_cast` + `assignment`.  The newer compilers outperform unfolded assignment, so here is a screenshot of the results with only some of the parameters, which you can reproduce with the following test code at https://quick-bench.com/

![WX20211104-104627](https://user-images.githubusercontent.com/4069905/140250827-6282739b-c060-43fa-b348-87ede15129fc.png)
![WX20211104-105010](https://user-images.githubusercontent.com/4069905/140250854-cf6da388-18d8-42f0-8cd6-18468633acc3.png)
![WX20211104-105348](https://user-images.githubusercontent.com/4069905/140250863-6c99cfcb-0b72-4ee0-a6b0-ac31344ac771.png)

```c++
#include <string.h>

static void use_memcpy(benchmark::State& state) {
  auto size = state.range(0);
  char buf[size];
  for (int i = 0; i < 8; ++i) {
    buf[i] = 'a';
  }
  for (auto _ : state) {
    char *output = buf + 8;
    char *matchAddress = buf;
    char *matchOutputLimit = buf + size;
    while (output < matchOutputLimit) {
      memcpy(output, matchAddress, 8);
      matchAddress += 8;
      output += 8;
    }
  }
}

static void use_expanded_assignment(benchmark::State& state) {
  auto size = state.range(0);
  char buf[size];
  for (int i = 0; i < 8; ++i) {
    buf[i] = 'a';
  }
  for (auto _ : state) {
    char *output = buf + 8;
    char *matchAddress = buf;
    char *matchOutputLimit = buf + size;
    while (output < matchOutputLimit) {
      output[0] = *matchOutputLimit;
      output[1] = *(matchOutputLimit + 1);
      output[2] = *(matchOutputLimit + 2);
      output[3] = *(matchOutputLimit + 3);
      output[4] = *(matchOutputLimit + 4);
      output[5] = *(matchOutputLimit + 5);
      output[6] = *(matchOutputLimit + 6);
      output[7] = *(matchOutputLimit + 7);
      matchAddress += 8;
      output += 8;
    }
  }
}

static void use_reinterpret_assignment(benchmark::State& state) {
  auto size = state.range(0);
  char buf[size];
  for (int i = 0; i < 8; ++i) {
    buf[i] = 'a';
  }
  for (auto _ : state) {
    char *output = buf + 8;
    char *matchAddress = buf;
    char *matchOutputLimit = buf + size;
    while (output < matchOutputLimit) {
      *reinterpret_cast<int64_t*>(output) =
                *reinterpret_cast<int64_t*>(matchAddress);
      matchAddress += 8;
      output += 8;
    }
  }
}

BENCHMARK(use_memcpy)->Arg(100000);

BENCHMARK(use_expanded_assignment)->Arg(100000);

BENCHMARK(use_reinterpret_assignment)->Arg(100000);
```

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix the bug of LZO decompression.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass the CIs.