### PR TITLE
ORC-1051: Update benchmark dependencies

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -90,12 +90,12 @@
       <dependency>
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
-        <version>0.16</version>
+        <version>0.21</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.67.Final</version>
+        <version>4.1.68.Final</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -433,7 +433,7 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>2.12.10</version>
+        <version>2.12.15</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -36,7 +36,7 @@
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
 
     <!-- Spark Jackson version may not be same as ORC -->
-    <spark.jackson.version>2.10.0</spark.jackson.version>
+    <spark.jackson.version>2.12.3</spark.jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update the transitive dependencies of Spark 3.2.0.
- aircompressor: 0.16 -> 0.21
- Netty-all: 4.1.67.Final -> 4.1.68.Final
- scala-librari: 2.12.10 -> 2.12.15
- spark.jackson.version: 2.10.0 -> 2.12.3

### Why are the changes needed?

When ORC-1037 updates to Spark 3.2.0, these dependencies are missed.

### How was this patch tested?

Pass the CIs.