### PR TITLE
ORC-1053: Fix time zone offset precision when convert tool converts `LocalDateTime` to `Timestamp` is not consistent with the internal default precision of ORC

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -31,7 +31,7 @@
   </description>
 
   <properties>
-    <avro.version>1.10.2</avro.version>
+    <avro.version>1.11.0</avro.version>
     <hive.version>3.1.2</hive.version>
     <jmh.version>1.20</jmh.version>
     <orc.version>${project.version}</orc.version>

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -43,7 +43,6 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAccessor;

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -303,8 +303,7 @@ public class CsvReader implements RecordReader {
           Timestamp timestamp = Timestamp.from(offsetDateTime.toInstant());
           vector.set(row, timestamp);
         } else if (temporalAccessor instanceof LocalDateTime) {
-          ZonedDateTime tz = ((LocalDateTime) temporalAccessor).atZone(ZoneId.systemDefault());
-          Timestamp timestamp = Timestamp.from(tz.toInstant());
+          Timestamp timestamp = Timestamp.valueOf((LocalDateTime) temporalAccessor);
           vector.set(row, timestamp);
         } else {
           column.noNulls = false;
@@ -371,5 +370,16 @@ public class CsvReader implements RecordReader {
       default:
         throw new IllegalArgumentException("Unhandled type " + schema);
     }
+  }
+
+  public static void main(String[] args) {
+    DateTimeFormatter timestampFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS zZ");
+    TemporalAccessor temporalAccessor =
+        timestampFormat.parseBest("0001-01-01 00:00:00.000 GMT+0000",
+            ZonedDateTime::from, OffsetDateTime::from, LocalDateTime::from);
+    System.out.println(temporalAccessor.getClass().getSimpleName());
+    ZonedDateTime zonedDateTime = (ZonedDateTime) temporalAccessor;
+    Timestamp timestamp = Timestamp.from(zonedDateTime.toInstant());
+    System.out.println(timestamp);
   }
 }

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
@@ -89,7 +89,6 @@ public class TestConvert {
     VectorizedRowBatch batch = readSchema.createRowBatch();
     RecordReader rowIterator = reader.rows(reader.options().schema(readSchema));
     TimestampColumnVector tcv = (TimestampColumnVector) batch.cols[0];
-    rowIterator.nextBatch(batch);
 
     while (rowIterator.nextBatch(batch)) {
       for (int row = 0; row < batch.size; ++row) {

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
@@ -29,16 +29,21 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.sql.Timestamp;
+import java.util.TimeZone;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class TestConvert {
+
+  public static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getDefault();
 
   Path workDir = new Path(System.getProperty("test.tmp.dir"));
   Configuration conf;
@@ -52,6 +57,16 @@ public class TestConvert {
     fs.setWorkingDirectory(workDir);
     testFilePath = new Path("TestConvert.testConvert.orc");
     fs.delete(testFilePath, false);
+  }
+
+  @BeforeAll
+  public static void changeDefaultTimeZone() {
+    TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"));
+  }
+
+  @AfterAll
+  public static void resetDefaultTimeZone() {
+    TimeZone.setDefault(DEFAULT_TIME_ZONE);
   }
 
   @Test

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.tools.convert;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.RecordReader;
+import org.apache.orc.TypeDescription;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TestConvert {
+
+  Path workDir = new Path(System.getProperty("test.tmp.dir"));
+  Configuration conf;
+  FileSystem fs;
+  Path testFilePath;
+
+  @BeforeEach
+  public void openFileSystem () throws Exception {
+    conf = new Configuration();
+    fs = FileSystem.getLocal(conf);
+    fs.setWorkingDirectory(workDir);
+    testFilePath = new Path("TestConvert.testConvert.orc");
+    fs.delete(testFilePath, false);
+  }
+
+  @Test
+  public void testConvertCustomTimestampFromCsv() throws IOException, ParseException {
+    Path csvFile = new Path("test.csv");
+    FSDataOutputStream stream = fs.create(csvFile, true);
+    String[] timeValues = new String[] {"0001-01-01 00:00:00.000", "2021-12-01 18:36:00.800"};
+    stream.writeBytes(String.join("\n", timeValues));
+    stream.close();
+    String schema = "struct<d:timestamp>";
+    String timestampFormat = "yyyy-MM-dd HH:mm:ss.SSS";
+    TypeDescription readSchema = TypeDescription.fromString(schema);
+
+    ConvertTool.main(conf, new String[]{"--schema", schema, "-o", testFilePath.toString(),
+        "-t", timestampFormat, csvFile.toString()});
+
+    assertTrue(fs.exists(testFilePath));
+
+    Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf));
+    VectorizedRowBatch batch = readSchema.createRowBatch();
+    RecordReader rowIterator = reader.rows(reader.options().schema(readSchema));
+    TimestampColumnVector tcv = (TimestampColumnVector) batch.cols[0];
+    rowIterator.nextBatch(batch);
+
+    while (rowIterator.nextBatch(batch)) {
+      for (int row = 0; row < batch.size; ++row) {
+        Timestamp timestamp = Timestamp.valueOf(timeValues[row]);
+        assertEquals(timestamp.getTime(), tcv.time[row]);
+        assertEquals(timestamp.getNanos(), tcv.nanos[row]);
+      }
+    }
+    rowIterator.close();
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

```java
// use tool compute offset : 17762
int toolOffset = ((LocalDateTime) temporalAccessor).atZone(TimeZone.getTimeZone("America/New_York").toZoneId()).getOffset().getTotalSeconds();

// in orc internal compute offset: 18000
int orcInternalOffset = TimeZone.getTimeZone("America/New_York").getRawOffset() / 1000
```

This pr is designed to modify the implementation of the LocalDateTime to Timestamp conversion so that the time zone accuracy is consistent with the ORC internal accuracy during the conversion

### Why are the changes needed?
Avoid inconsistencies between converted data and expected data from convert tools.


### How was this patch tested?
Add issue-specific unit test