### PR TITLE
[ORC-1062]Rename orc.schema.evolution.case.sensitive to orc.schema.evolution.case.aware

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -164,8 +164,8 @@ public enum OrcConf {
       "testing.  Setting this too low may negatively affect performance."),
   OVERWRITE_OUTPUT_FILE("orc.overwrite.output.file", "orc.overwrite.output.file", false,
     "A boolean flag to enable overwriting of the output file if it already exists.\n"),
-  IS_SCHEMA_EVOLUTION_CASE_SENSITIVE("orc.schema.evolution.case.sensitive",
-      "orc.schema.evolution.case.sensitive", true,
+  IS_SCHEMA_EVOLUTION_CASE_AWARE("orc.schema.evolution.case.aware",
+      "orc.schema.evolution.case.aware", true,
       "A boolean flag to determine if the comparision of field names " +
       "in schema evolution is case sensitive .\n"),
   ALLOW_SARG_TO_FILTER("orc.sarg.to.filter", "org.sarg.to.filter", false,

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -229,7 +229,7 @@ public interface Reader extends Closeable {
     private Boolean tolerateMissingSchema = null;
     private boolean forcePositionalEvolution;
     private boolean isSchemaEvolutionCaseAware =
-        (boolean) OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.getDefaultValue();
+        (boolean) OrcConf.IS_SCHEMA_EVOLUTION_CASE_AWARE.getDefaultValue();
     private boolean includeAcidColumns = true;
     private boolean allowSARGToFilter = false;
     private boolean useSelected = false;
@@ -252,7 +252,7 @@ public interface Reader extends Closeable {
       forcePositionalEvolution = OrcConf.FORCE_POSITIONAL_EVOLUTION.getBoolean(conf);
       positionalEvolutionLevel = OrcConf.FORCE_POSITIONAL_EVOLUTION_LEVEL.getInt(conf);
       isSchemaEvolutionCaseAware =
-          OrcConf.IS_SCHEMA_EVOLUTION_CASE_SENSITIVE.getBoolean(conf);
+          OrcConf.IS_SCHEMA_EVOLUTION_CASE_AWARE.getBoolean(conf);
       allowSARGToFilter = OrcConf.ALLOW_SARG_TO_FILTER.getBoolean(conf);
       useSelected = OrcConf.READER_USE_SELECTED.getBoolean(conf);
       allowPluginFilters = OrcConf.ALLOW_PLUGIN_FILTER.getBoolean(conf);

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -120,7 +120,7 @@ public class TestRecordReaderImpl {
     Configuration conf = new Configuration();
     TypeDescription file = TypeDescription.fromString("struct<A:int>");
     TypeDescription reader = TypeDescription.fromString("struct<a:int>");
-    conf.setBoolean("orc.schema.evolution.case.sensitive", false);
+    conf.setBoolean("orc.schema.evolution.case.aware", false);
     SchemaEvolution evo = new SchemaEvolution(file, reader, new Reader.Options(conf));
     assertEquals(1, RecordReaderImpl.findColumns(evo, "A"));
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently, OrcConf have a enum configuration to determine if the comparision of field names in schema evolution is case sensitive, However, the code block using this configuration thinks that this configuration should be orc.schema.evolution.case.aware

### Why are the changes needed?
code simplification

### How was this patch tested?
Pass GitHub Action and jenkins
