### PR TITLE
ORC-1063: Avoid ORC Reader Max Length Confusion

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -124,7 +124,7 @@ public enum OrcConf {
   IGNORE_NON_UTF8_BLOOM_FILTERS("orc.bloom.filter.ignore.non-utf8",
       "orc.bloom.filter.ignore.non-utf8", false,
       "Should the reader ignore the obsolete non-UTF8 bloom filters."),
-  MAX_FILE_LENGTH("orc.max.file.length", "orc.max.file.length", Long.MAX_VALUE,
+  MAX_FILE_LENGTH("orc.max.file.length", "orc.max.file.length", -1L,
       "The maximum size of the file to read for finding the file tail. This\n" +
           "is primarily used for streaming ingest to read intermediate\n" +
           "footers while the file is still open"),

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 
 /**
@@ -278,7 +279,7 @@ public class OrcFile {
   public static class ReaderOptions {
     private final Configuration conf;
     private FileSystem filesystem;
-    private long maxLength = Long.MAX_VALUE;
+    private Optional<Long> maxLength = Optional.empty();
     private OrcTail orcTail;
     private KeyProvider keyProvider;
     // TODO: We can generalize FileMetada interface. Make OrcTail implement FileMetadata interface
@@ -298,8 +299,22 @@ public class OrcFile {
       return this;
     }
 
+    /**
+     * The maximum size of the file to read for finding the file tail.
+     * A value less than zero or a value equal to Long.MAX_VALUE denotes
+     * that there should be no maximum length applied.
+     *
+     * @param val the maximum length to search
+     * @return {@code this} ReaderOptions
+     */
     public ReaderOptions maxLength(long val) {
-      maxLength = val;
+      if (val < 0L) {
+        this.maxLength = Optional.empty();
+      } else if (val == Long.MAX_VALUE) {
+        this.maxLength = Optional.empty();
+      } else {
+        this.maxLength = Optional.of(val);
+      }
       return this;
     }
 
@@ -338,8 +353,16 @@ public class OrcFile {
       return filesystem;
     }
 
+    /**
+     * @deprecated Use {@link #getMaxReadLength()}
+     */
+    @Deprecated
     public long getMaxLength() {
-      return maxLength;
+      return maxLength.orElse(Long.MAX_VALUE);
+    }
+
+    public Optional<Long> getMaxReadLength() {
+        return maxLength;
     }
 
     public OrcTail getOrcTail() {

--- a/java/core/src/test/org/apache/orc/impl/TestReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestReaderImpl.java
@@ -49,6 +49,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -358,7 +359,7 @@ public class TestReaderImpl {
     FileSystem fs = path.getFileSystem(conf);
     try (ReaderImpl reader = (ReaderImpl) OrcFile.createReader(path,
         OrcFile.readerOptions(conf).filesystem(fs))) {
-      OrcTail tail = reader.extractFileTail(fs, path, Long.MAX_VALUE);
+      OrcTail tail = reader.extractFileTail(fs, path, Optional.empty());
       List<StripeStatistics> stats = tail.getStripeStatistics();
       assertEquals(1, stats.size());
       OrcProto.TimestampStatistics tsStats =


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Fix confusing logging regarding ORC Reader and max-length-size.

### Why are the changes needed?
Avoid operator confusion as it pertains to logging and troubleshooting.

### How was this patch tested?
No functional changes, uses existing unit tests.