### PR TITLE
ORC-1068: [C++] Stabilize HAS_POST_2038 test

### DIFF
--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -157,7 +157,7 @@ CHECK_CXX_SOURCE_RUNS("
       struct tm time2038;
       strptime(\"2037-05-05 12:34:56\", \"%Y-%m-%d %H:%M:%S\", &time2037);
       strptime(\"2038-05-05 12:34:56\", \"%Y-%m-%d %H:%M:%S\", &time2038);
-      return mktime(&time2038) - mktime(&time2037) != 31536000;
+      return mktime(&time2038) - mktime(&time2037) > 31500000;
     }"
   HAS_POST_2038
 )

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -157,7 +157,7 @@ CHECK_CXX_SOURCE_RUNS("
       struct tm time2038;
       strptime(\"2037-05-05 12:34:56\", \"%Y-%m-%d %H:%M:%S\", &time2037);
       strptime(\"2038-05-05 12:34:56\", \"%Y-%m-%d %H:%M:%S\", &time2038);
-      return mktime(&time2038) - mktime(&time2037) > 31500000;
+      return (mktime(&time2038) - mktime(&time2037)) <= 31500000;
     }"
   HAS_POST_2038
 )


### PR DESCRIPTION
On my machine (Ubuntu Focal 20.04.3, libc6=2.31-0ubuntu9.2, tzdata=2021e-0ubuntu0.20.04) the following results are returned by strptime:

```
time2037.tm_hour = 13; // weird
time2038.tm_hour = 12; // correct
```

This results in time difference 31532400 (which is 3600 less than expected). Some other configurations give the expected result, thus making the build variable to flap during sequential builds on different systems.

Since this is just a basic test, I suggest relaxing it a bit in order to make it stable.