### PR TITLE
ORC-1067: Upgrade ZSTD to 1.5.1

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -15,7 +15,7 @@ set(SNAPPY_VERSION "1.1.7")
 set(ZLIB_VERSION "1.2.11")
 set(GTEST_VERSION "1.8.0")
 set(PROTOBUF_VERSION "3.5.1")
-set(ZSTD_VERSION "1.5.0")
+set(ZSTD_VERSION "1.5.1")
 
 option(ORC_PREFER_STATIC_PROTOBUF "Prefer static protobuf library, if available" ON)
 option(ORC_PREFER_STATIC_SNAPPY   "Prefer static snappy library, if available"   ON)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade zstd in the C++ library to version 1.5.1.


### Why are the changes needed?
This version is primarily a maintenance release that contains a variety of small bug fixes and improvements to the testing process. It also includes small performance improvements (~3-5%) at the fast compression levels. The release notes are here:

https://github.com/facebook/zstd/releases/tag/v1.5.1

### How was this patch tested?
Builds and passes CIs.
