### PR TITLE
ORC-1070: Upgrade site docker image to use Ubuntu 20.04

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -17,7 +17,7 @@
 # ORC site builder
 #
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
 
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade the `site` docker image to use Ubuntu 20.04


### Why are the changes needed?
To migrate to the latest OS. 


### How was this patch tested?
Manually.