### PR TITLE
ORC-817: Replace aircompressor ZStandard compression with zstd-jni

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>aircompressor</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.luben</groupId>
+      <artifactId>zstd-jni</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
     </dependency>

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -65,6 +65,18 @@ public enum OrcConf {
       "Define the compression strategy to use while writing data.\n" +
           "This changes the compression level of higher level compression\n" +
           "codec (like ZLIB)."),
+  COMPRESSION_ZSTD_LEVEL("orc.compression.zstd.level",
+          "hive.exec.orc.compression.zstd.level", 3,
+          "Define the compression level to use with ZStandard codec "
+              + "while writing data."),
+  COMPRESSION_ZSTD_WINDOWLOG("orc.compression.zstd.windowlog",
+          "hive.exec.orc.compression.zstd.windowlog", 0,
+          "Set the maximum allowed back-reference distance for "
+              + "ZStandard codec, expressed as power of 2."),
+  COMPRESSION_ZSTD_LONGMODE("orc.compression.zstd.longmode",
+      "hive.exec.orc.compression.zstd.longmode", false,
+      "If enabled, the Zstandard codec will employ long mode during "
+          + "compression."),
   BLOCK_PADDING_TOLERANCE("orc.block.padding.tolerance",
       "hive.exec.orc.block.padding.tolerance", 0.05,
       "Define the tolerance for block padding as a decimal fraction of\n" +

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -441,6 +441,9 @@ public class OrcFile {
     private WriterCallback callback;
     private EncodingStrategy encodingStrategy;
     private CompressionStrategy compressionStrategy;
+    private int compressionZstdLevel;
+    private int compressionZstdWindowLog;
+    private boolean compressionZstdLongMode;
     private double paddingTolerance;
     private String bloomFilterColumns;
     private double bloomFilterFpp;
@@ -484,6 +487,15 @@ public class OrcFile {
       String compString =
           OrcConf.COMPRESSION_STRATEGY.getString(tableProperties, conf);
       compressionStrategy = CompressionStrategy.valueOf(compString);
+
+      compressionZstdLevel =
+              OrcConf.COMPRESSION_ZSTD_LEVEL.getInt(tableProperties, conf);
+
+      compressionZstdWindowLog =
+              OrcConf.COMPRESSION_ZSTD_WINDOWLOG.getInt(tableProperties, conf);
+
+      compressionZstdLongMode =
+          OrcConf.COMPRESSION_ZSTD_LONGMODE.getBoolean(tableProperties, conf);
 
       paddingTolerance =
           OrcConf.BLOCK_PADDING_TOLERANCE.getDouble(tableProperties, conf);
@@ -901,6 +913,18 @@ public class OrcFile {
 
     public CompressionStrategy getCompressionStrategy() {
       return compressionStrategy;
+    }
+
+    public int getCompressionZstdLevel() {
+      return compressionZstdLevel;
+    }
+
+    public int getCompressionZstdWindowLog() {
+      return compressionZstdWindowLog;
+    }
+
+    public boolean getCompressionZstdLongMode() {
+      return compressionZstdLongMode;
     }
 
     public EncodingStrategy getEncodingStrategy() {

--- a/java/core/src/java/org/apache/orc/impl/OutStream.java
+++ b/java/core/src/java/org/apache/orc/impl/OutStream.java
@@ -280,9 +280,11 @@ public class OutStream extends PositionedOutputStream {
       outputBuffer(current);
       getNewInputBuffer();
     } else {
+      // Make sure both compressed and overflow are not null before passing to compress
       if (compressed == null) {
         compressed = getNewOutputBuffer();
-      } else if (overflow == null) {
+      }
+      if (overflow == null) {
         overflow = getNewOutputBuffer();
       }
       int sizePosn = compressed.position();

--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.orc.impl;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdCompressCtx;
+import com.github.luben.zstd.ZstdDecompressCtx;
+
+import org.apache.orc.CompressionCodec;
+import org.apache.orc.CompressionKind;
+
+public class ZstdCodec implements CompressionCodec {
+  private ZstdOptions zstdOptions = null;
+  private Boolean direct = null;
+  private ZstdCompressCtx zstdCompressCtx = null;
+  private ZstdDecompressCtx zstdDecompressCtx = null;
+
+  public ZstdCodec(int level, int windowLog, boolean longMode, boolean fixed) {
+    this.zstdOptions = new ZstdOptions(level, windowLog, longMode, fixed);
+  }
+
+  public ZstdCodec(int level, int windowLog) {
+    this(level, windowLog, false, false);
+  }
+
+  public ZstdCodec() {
+    this(3, 0);
+  }
+
+  // Thread local buffer
+  private static final ThreadLocal<byte[]> threadBuffer =
+      new ThreadLocal<byte[]>() {
+        @Override
+        protected byte[] initialValue() {
+          return null;
+        }
+      };
+
+  protected static byte[] getBuffer(int size) {
+    byte[] result = threadBuffer.get();
+    if (result == null || result.length < size || result.length > size * 2) {
+      result = new byte[size];
+      threadBuffer.set(result);
+    }
+    return result;
+  }
+
+  static class ZstdOptions implements Options {
+    private int level;
+    private int windowLog;
+    private boolean longMode;
+    private final boolean FIXED;
+
+    ZstdOptions(int level, int windowLog, boolean longMode, boolean FIXED) {
+      this.level = level;
+      this.windowLog = windowLog;
+      this.longMode = longMode;
+      this.FIXED = FIXED;
+    }
+
+    @Override
+    public ZstdOptions copy() {
+      return new ZstdOptions(level, windowLog, longMode, FIXED);
+    }
+
+    /**
+     * Sets the Zstandard long mode maximum back-reference distance, expressed
+     * as a power of 2.
+     *
+     * The value must be between ZSTD_WINDOWLOG_MIN (10) and ZSTD_WINDOWLOG_MAX
+     * (30 and 31 on 32/64-bit architectures, respectively).
+     *
+     * A value of 0 is a special value indicating to use the default
+     * ZSTD_WINDOWLOG_LIMIT_DEFAULT of 27, which corresponds to back-reference
+     * window size of 128MiB.
+     *
+     * @param newValue The desired power-of-2 value back-reference distance.
+     * @return
+     */
+    public ZstdOptions setWindowLog(int newValue) {
+      if ((newValue < Zstd.windowLogMin() || newValue > Zstd.windowLogMax())
+          && newValue != 0) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Zstd compression window size should be in the range %d to %d,"
+                    + " or set to the default value of 0.",
+                Zstd.windowLogMin(),
+                Zstd.windowLogMax()));
+      }
+      windowLog = newValue;
+      return this;
+    }
+
+    /**
+     * Sets explicitly whether long mode is used. Note that long mode will be
+     * enabled by default in the underlying library if windowLog >= 128 MB and
+     * compression level is 16+ (compression strategy >= ZSTD_btopt).
+     *
+     * @param newValue A boolean indicating whether to explicitly use long mode.
+     * @return
+     */
+    public ZstdOptions setLongMode(boolean newValue) {
+      longMode = newValue;
+      return this;
+    }
+
+    /**
+     * Sets the Zstandard compression codec compression level directly using
+     * the integer setting. This value is typically between 0 and 22, with
+     * larger numbers indicating more aggressive compression and lower speed.
+     * <p>
+     * This method provides additional granularity beyond the setSpeed method
+     * so that users can select a specific level.
+     *
+     * @param newValue The level value of compression to set.
+     * @return
+     */
+    public ZstdOptions setLevel(int newValue) {
+      if (newValue < Zstd.minCompressionLevel()
+          || newValue > Zstd.maxCompressionLevel()) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Zstd compression level should be in the range %d to %d",
+                Zstd.minCompressionLevel(),
+                Zstd.maxCompressionLevel()));
+      }
+      level = newValue;
+      return this;
+    }
+
+    /**
+     * Sets the Zstandard compression codec compression level via the Enum
+     * (FASTEST, FAST, DEFAULT). The default value of 3 is the
+     * ZSTD_CLEVEL_DEFAULT level.
+     * <p>
+     * Alternatively, the compression level can be set directly with setLevel.
+     *
+     * @param newValue An Enum specifying how aggressively to compress.
+     * @return
+     */
+    @Override
+    public ZstdOptions setSpeed(SpeedModifier newValue) {
+      if (FIXED) {
+        throw new IllegalStateException(
+            "Attempt to modify the default options");
+      }
+      switch (newValue) {
+        case FAST:
+          setLevel(2);
+          break;
+        case DEFAULT:
+          // zstd level 3 achieves good ratio/speed tradeoffs, and is the
+          // ZSTD_CLEVEL_DEFAULT level.
+          setLevel(3);
+          break;
+        case FASTEST:
+          // zstd level 1 is the fastest level.
+          setLevel(1);
+          break;
+        default:
+          break;
+      }
+      return this;
+    }
+
+    @Override
+    public ZstdOptions setData(DataKind newValue) {
+      return this; // We don't support setting DataKind in ZstdCodec.
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (other == null || getClass() != other.getClass()) {
+        return false;
+      } else if (this == other) {
+        return true;
+      } else {
+        ZstdOptions otherOpts = (ZstdOptions) other;
+        return (level == otherOpts.level) &&
+            (windowLog == otherOpts.windowLog);
+      }
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(level, windowLog, FIXED);
+    }
+  }
+
+  /**
+   *
+   */
+  private static final ZstdOptions DEFAULT_OPTIONS =
+      new ZstdOptions(3, 0, false, false);
+
+  @Override
+  public Options getDefaultOptions() {
+    return DEFAULT_OPTIONS;
+  }
+
+  /**
+   * Compresses an input ByteBuffer into an output ByteBuffer using Zstandard
+   * compression. If the maximum bound of the number of output bytes exceeds
+   * the output ByteBuffer size, the remaining bytes are written to the overflow
+   * ByteBuffer.
+   *
+   * @param in       the bytes to compress
+   * @param out      the compressed bytes
+   * @param overflow put any additional bytes here
+   * @param options  the options to control compression
+   * @return
+   */
+  @Override
+  public boolean compress(ByteBuffer in, ByteBuffer out,
+      ByteBuffer overflow,
+      Options options) throws IOException {
+    ZstdOptions zlo = (ZstdOptions) options;
+    // TODO(@dchristle): Add case for when ByteBuffers are direct.
+
+    zstdCompressCtx = new ZstdCompressCtx();
+    zstdCompressCtx.setLevel(zlo.level);
+    zstdCompressCtx.setLong(zlo.windowLog);
+    zstdCompressCtx.setChecksum(false);
+
+    int inBytes = in.remaining();
+    int srcOffset = in.arrayOffset() + in.position();
+    int dstOffset = out.arrayOffset() + out.position();
+    int compressBound = (int) Zstd.compressBound(inBytes);
+    int dstSize = out.limit() - out.position();
+    long compressOutput;
+
+    if (dstSize < compressBound) {
+      // The detected output ByteBuffer is too small, based on the maximum
+      // compression estimate. Allocate a temporary buffer of the appropriate
+      // size.
+      byte[] compressed = new byte[compressBound];
+      int remaining = out.remaining();
+
+      compressOutput =
+          zstdCompressCtx.compressByteArray(compressed, 0, compressBound,
+              in.array(), srcOffset, inBytes);
+      if (Zstd.isError(compressOutput)) {
+        throw new IOException(String.format("Error code %s!", compressOutput));
+      }
+
+      if ((int) compressOutput <= remaining) {
+        // Single copy ok, no need for overflow
+        System.arraycopy(compressed, 0, out.array(), out.arrayOffset() +
+            out.position(), (int) compressOutput);
+        out.position(out.position() + (int) compressOutput);
+      } else {
+        // Single copy not OK, need to copy to both out and overflow
+        System.arraycopy(compressed, 0, out.array(), out.arrayOffset() +
+            out.position(), remaining);
+        out.position(out.limit());
+
+        System.arraycopy(compressed, remaining, overflow.array(),
+            overflow.arrayOffset(), (int) compressOutput - remaining);
+        overflow.position((int) compressOutput - remaining);
+      }
+    } else {
+      // Copy directly to output buffer
+      compressOutput =
+          Zstd.compressByteArray(out.array(), dstOffset, dstSize, in.array(),
+              srcOffset, inBytes, zlo.level);
+      if (Zstd.isError(compressOutput)) {
+        throw new IOException(String.format("Error code %s!", compressOutput));
+      }
+      out.position(dstOffset + (int) compressOutput);
+    }
+    zstdCompressCtx.close();
+    return inBytes > (int) compressOutput;
+  }
+
+  //  TODO(dchristle): Do we need to add loops similar to ZlibCodec, e.g.
+  //  "while (!deflater.finished() && (length > outSize)) { ..."
+  @Override
+  public void decompress(ByteBuffer in, ByteBuffer out) throws IOException {
+
+    if (zstdDecompressCtx == null) {
+      zstdDecompressCtx = new ZstdDecompressCtx();
+    }
+
+    int srcOffset = in.arrayOffset() + in.position();
+    int srcSize = in.remaining();
+    int dstOffset = out.arrayOffset() + out.position();
+    int dstSize = out.remaining() - dstOffset;
+
+    long decompressOut =
+        Zstd.decompressByteArray(out.array(), dstOffset, dstSize, in.array(),
+            srcOffset, srcSize);
+    if (Zstd.isError(decompressOut)) {
+      System.out.format("Error code %s!", decompressOut);
+    }
+    in.position(in.limit());
+    out.position(dstOffset + (int) decompressOut);
+    out.flip();
+  }
+
+  @Override
+  public void reset() {
+
+  }
+
+  @Override
+  public void destroy() {
+    if (zstdCompressCtx != null) {
+      zstdCompressCtx.close();
+    }
+    if (zstdDecompressCtx != null) {
+      zstdDecompressCtx.close();
+    }
+  }
+
+  @Override
+  public CompressionKind getKind() {
+    return CompressionKind.ZSTD;
+  }
+
+  @Override
+  public void close() {
+    OrcCodecPool.returnCodec(CompressionKind.ZSTD, this);
+  }
+}

--- a/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypesNulls.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypesNulls.java
@@ -332,7 +332,7 @@ public class TestRowFilteringComplexTypesNulls {
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    assertTrue(readPercentage > 130);
+    assertTrue(readPercentage > 120);
   }
 
   private void seekToRow(RecordReader rr, VectorizedRowBatch b, long row) throws IOException {

--- a/java/core/src/test/org/apache/orc/impl/TestZstd.java
+++ b/java/core/src/test/org/apache/orc/impl/TestZstd.java
@@ -18,28 +18,130 @@
 
 package org.apache.orc.impl;
 
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdException;
 import io.airlift.compress.zstd.ZstdCompressor;
 import io.airlift.compress.zstd.ZstdDecompressor;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Random;
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.CompressionKind;
 import org.junit.jupiter.api.Test;
 
-import java.nio.ByteBuffer;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TestZstd {
 
+  /**
+   * Test that Zstandard compression does not overflow nor throw an
+   * exception when the allocated output array matches
+   * the estimated upper bound ZSTD_compressBound. Random byte inputs are
+   * used, which are a worst-case for output
+   * compression sizes.
+   */
   @Test
-  public void testNoOverflow() throws Exception {
-    ByteBuffer in = ByteBuffer.allocate(10);
-    ByteBuffer out = ByteBuffer.allocate(10);
-    in.put(new byte[]{1,2,3,4,5,6,7,10});
-    in.flip();
-    CompressionCodec codec = new AircompressorCodec(
-        CompressionKind.ZSTD, new ZstdCompressor(), new ZstdDecompressor());
-    assertFalse(codec.compress(in, out, null,
-        codec.getDefaultOptions()));
+  public void testZstdCodecNoOverflow() {
+    Random rd = new Random();
+    ArrayList<Integer> testInputDataSizes =
+        new ArrayList<>(Arrays.asList(8, 27, 182, 818, 28459));
+
+    testInputDataSizes.forEach(inputSize -> {
+          ByteBuffer in = ByteBuffer.allocate(inputSize);
+          ByteBuffer out =
+              ByteBuffer.allocate((int) Zstd.compressBound((long) inputSize));
+
+          byte[] arr = new byte[inputSize];
+          rd.nextBytes(arr);
+
+          in.put(arr);
+          in.flip();
+          CompressionCodec codec = new ZstdCodec();
+          boolean overflow;
+          try {
+            overflow = codec.compress(in, out, null, codec.getDefaultOptions());
+          } catch (IOException e) {
+            overflow = true;
+          }
+          assertFalse(overflow);
+        }
+    );
   }
 
+  @Test
+  public void testCorrupt() throws Exception {
+    ByteBuffer buf = ByteBuffer.allocate(1000);
+    buf.put(new byte[] {127, 125, 1, 99, 98, 1});
+    buf.flip();
+    CompressionCodec codec = new ZstdCodec();
+    ByteBuffer out = ByteBuffer.allocate(1000);
+    try {
+      codec.decompress(buf, out);
+      fail();
+    } catch (ZstdException ioe) {
+      // EXPECTED
+    }
+  }
+
+  /**
+   * Test compatibility of zstd-jni and aircompressor Zstd implementations
+   * by checking that bytes compressed with one can be decompressed by the
+   * other when using the default options.
+   */
+  @Test
+  public void testZstdAircompressorJniCompressDecompress() throws Exception {
+    int inputSize = 27182;
+    Random rd = new Random();
+
+    CompressionCodec zstdAircompressorCodec = new AircompressorCodec(
+        CompressionKind.ZSTD, new ZstdCompressor(), new ZstdDecompressor());
+    CompressionCodec zstdJniCodec = new ZstdCodec();
+
+    ByteBuffer sourceCompressorIn = ByteBuffer.allocate(inputSize);
+    ByteBuffer sourceCompressorOut =
+        ByteBuffer.allocate((int) Zstd.compressBound(inputSize));
+    ByteBuffer destCompressorOut = ByteBuffer.allocate(inputSize);
+
+    // Use an array half filled with a constant value & half filled with
+    // random values.
+    byte[] constantBytes = new byte[inputSize / 2];
+    java.util.Arrays.fill(constantBytes, 0, inputSize / 2, (byte) 2);
+    sourceCompressorIn.put(constantBytes);
+    byte[] randomBytes = new byte[inputSize - inputSize / 2];
+    rd.nextBytes(randomBytes);
+    sourceCompressorIn.put(randomBytes);
+    sourceCompressorIn.flip();
+
+    // Verify that input -> aircompressor compresson -> zstd-jni
+    // decompression returns the input.
+    // Note: This function returns false if the bytes get larger. But why is
+    // that a problem? sourceCompressorOut has the
+    // capacity.
+    zstdAircompressorCodec.compress(sourceCompressorIn, sourceCompressorOut,
+        null, zstdAircompressorCodec.getDefaultOptions());
+    sourceCompressorOut.flip();
+
+    zstdJniCodec.decompress(sourceCompressorOut, destCompressorOut);
+    assertEquals(sourceCompressorIn, destCompressorOut,
+        "aircompressor compression with zstd-jni decompression did not return"
+            + " the input!");
+
+    sourceCompressorIn.rewind();
+    sourceCompressorOut.clear();
+    destCompressorOut.clear();
+
+    // Verify that input -> zstd-jni compresson -> aircompressor
+    // decompression returns the input.
+    zstdJniCodec.compress(sourceCompressorIn, sourceCompressorOut, null,
+        zstdJniCodec.getDefaultOptions());
+    sourceCompressorOut.flip();
+    zstdAircompressorCodec.decompress(sourceCompressorOut, destCompressorOut);
+    assertEquals(sourceCompressorIn, destCompressorOut,
+        "zstd-jni compression with aircompressor decompression did not return"
+            + " the input!");
+  }
 }

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -27,12 +27,12 @@
   <name>Apache ORC</name>
   <url>https://orc.apache.org</url>
   <description>
-     ORC is a self-describing type-aware columnar file format designed
-     for Hadoop workloads. It is optimized for large streaming reads,
-     but with integrated support for finding required rows
-     quickly. Storing data in a columnar format lets the reader read,
-     decompress, and process only the values that are required for the
-     current query.
+    ORC is a self-describing type-aware columnar file format designed
+    for Hadoop workloads. It is optimized for large streaming reads,
+    but with integrated support for finding required rows
+    quickly. Storing data in a columnar format lets the reader read,
+    decompress, and process only the values that are required for the
+    current query.
   </description>
   <inceptionYear>2013</inceptionYear>
 
@@ -343,8 +343,8 @@
                 <goal>run</goal>
               </goals>
               <configuration>
-                 <protocArtifact>${protoc.artifact}</protocArtifact>
-                 <protocVersion>2.5.0</protocVersion>
+                <protocArtifact>${protoc.artifact}</protocArtifact>
+                <protocVersion>2.5.0</protocVersion>
                 <addSources>none</addSources>
                 <includeDirectories>
                   <include>../../proto</include>
@@ -478,7 +478,7 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- intra-project depedencies -->
+      <!-- intra-project dependencies -->
       <dependency>
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-shims</artifactId>
@@ -510,7 +510,7 @@
         <version>1.8.0-SNAPSHOT</version>
       </dependency>
 
-      <!-- inter-project depedencies -->
+      <!-- inter-project dependencies -->
       <dependency>
         <groupId>com.esotericsoftware</groupId>
         <artifactId>kryo-shaded</artifactId>
@@ -556,6 +556,11 @@
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
         <version>0.21</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.luben</groupId>
+        <artifactId>zstd-jni</artifactId>
+        <version>1.5.1-1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR proposes to replace the [`aircompressor`](https://github.com/airlift/aircompressor) library for ORC's ZStandard compression with [`zstd-jni`](https://github.com/luben/zstd-jni), which is a set of JNI bindings around the [official `zstd` library](https://github.com/facebook/zstd). In addition to switching the underlying library, this PR also exposes the compression level and "long mode" settings to ORC users. These settings allow user choice around different speed/compression tradeoffs, rather than the current approach that primarily uses a default setting.

### Why are the changes needed?
These change makes sense for a few reasons:

* ORC users will gain all the improvements from the main `zstd` library. It is under active development and receives regular speed and compression improvements. In contrast, `aircompressor`'s zstd implementation is older and stale.
* ORC users will be able to use the entire speed/compression tradeoff space. Today, `aircompressor`'s implementation has only one of eight compression strategies ([link](https://github.com/airlift/aircompressor/blob/c5e6972bd37e1d3834514957447028060a268eea/src/main/java/io/airlift/compress/zstd/CompressionParameters.java#L143)). This means only a small range of faster but less compressive strategies can be exposed to ORC users. ORC storage with high compression (e.g. for large-but-infrequently-used data) is a clear use case that this PR would unlock.
* It will harmonize the Java ORC implementation with other projects in the Hadoop ecosystem. Parquet, Spark, and even the C++ ORC reader/writers all rely on the official `zstd` implementation either via `zstd-jni` or directly. In this way, the Java reader/writer code is an outlier.
* Detection and fixing any bugs or regressions will generally happen much faster, given the larger number of users and active developer community of `zstd` and `zstd-jni`.

The largest tradeoff is that `zstd-jni` wraps compiled code. That said, many microprocessor architectures are already targeted & bundled into `zstd-jni`, so this should be a rare hurdle.

### Open issues:

* What is the best way to expose codec-specific options to users? In this PR, we add the compression level, window log size, and a boolean for enabling long mode, as new conf settings. But the `CompressionCodec` interface seems limited to exposing an enum with 3 options for speed, e.g. `FAST` or `DEFAULT`, and other codec-specific configs don't have a clear way to make it down into the codec implementation itself. I think we want to allow users to set the actual level as an integer, and to specify the window log size & long mode boolean as they wish. It wasn't clear how I could communicate these confs down to the lower level `ZstdCodec` within the bounds of the existing `CompressionCodec` interface. Right now, I used a hack to get the codec to read the conf options.
* I still need to implement the `DirectByteBuffer` handling case. Right now, each call is treated the same way and will incur unnecessary copying if the input `ByteBuffer` is direct.
* The existing code has a loop structure to repeatedly decompress. I wasn't sure why this exists, but we should mimic it in this PR, and I haven't done that yet.
* Benchmarks should be added to this PR description. Although `zstd-jni` should have superior performance across the board, it's important to actually measure that with the benchmark suite.

**List of changes:**

* Add zstd-jni dependency, and add a new CompressionCodec ZstdCodec that uses it. Add ORC conf to set compression level.

* Add ORC conf to use long mode, and add configuration setters for windowLog and longModeEnable.

* Add tests that verify the correctness of writing and reading across compression levels, window sizes, and long mode use.

* Add test for compatibility between Zstd aircompressor and zstd-jni implementations.

* Fix filterWithSeek test with a smaller percentage.

* Minor formatting and spelling fixes.

### How was this patch tested?
* Unit tests for reading and writing ORC files using a variety of compression levels, window logs, and long mode booleans, all pass.
* Unit test to compress and decompress between `aircompressor` and `zstd-jni` passes. Note that the current `aircompressor` implementation uses a small subset of levels, so the test only compares data using the default compression settings.

@dongjoon-hyun @wgtmac 




