### PR TITLE
ORC-1076: Remove Travis PR Builder Link from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ The current build status:
 * Main branch <a href="https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain">
 ![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)</a> <a href="https://travis-ci.com/apache/orc/branches">
 ![main build status](https://travis-ci.com/apache/orc.svg?branch=main)</a>
-* <a href="https://travis-ci.com/github/apache/orc/pull_requests">Pull Requests</a>
-
 
 Bug tracking: <a href="http://orc.apache.org/bugs">Apache Jira</a>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Travis PR Builder Link` from `README.md` because it's misleading. Our main PR builder is GitHub Action which runs majority of tests. In addition, https://github.com/apache/orc/pulls is the correct link to show both PR builders' status.

### Why are the changes needed?

To make `README.md` up-to-date.

### How was this patch tested?

Since this is a doc change, manual review.