### PR TITLE
ORC-1004: Java ORC writer supports the selection vector

### DIFF
--- a/java/core/src/test/org/apache/orc/TestSelectedVector.java
+++ b/java/core/src/test/org/apache/orc/TestSelectedVector.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.orc.impl.KeyProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -74,7 +73,6 @@ public class TestSelectedVector {
   }
 
   @Test
-  @Disabled("Disable until the impl of ORC-1004 is merged")
   public void testWriteBaseTypeUseSelectedVector() throws IOException {
     TypeDescription schema =
         TypeDescription.fromString("struct<a:boolean,b:tinyint,c:smallint,d:int,e:bigint," +
@@ -234,7 +232,6 @@ public class TestSelectedVector {
   }
 
   @Test
-  @Disabled("Disable until the impl of ORC-1004 is merged")
   public void testWriteComplexTypeUseSelectedVector() throws IOException {
     TypeDescription schema =
         TypeDescription.fromString("struct<a:map<int,uniontype<int,string>>," +
@@ -381,7 +378,6 @@ public class TestSelectedVector {
   }
 
   @Test
-  @Disabled("Disable until the impl of ORC-1004 is merged")
   public void testWriteRepeatedUseSelectedVector() throws IOException {
     TypeDescription schema =
         TypeDescription.fromString("struct<a:int,b:string,c:decimal(20,5)>");
@@ -465,7 +461,6 @@ public class TestSelectedVector {
   }
 
   @Test
-  @Disabled("Disable until the impl of ORC-1004 is merged")
   public void testWriteEncryptionUseSelectedVector() throws IOException {
     TypeDescription schema =
         TypeDescription.fromString("struct<id:int,name:string>");


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is to enable the Java ORC writer to respect the selection vector from VectorizedRowBatch. The implementation tries to find each longest batch that is continuously selected to get the best performance.

### Why are the changes needed?
Currently the ORC writer doesn't support the selected vector. This could cause clients that expect it to be supported to get trash rows in the output.

### How was this patch tested?
Enabled UT TestSelectedVector.java
