### PR TITLE
ORC-1081: Fix heap-use-after-free in SearchArgumentBuilderImpl::end()

### DIFF
--- a/c++/src/sargs/SearchArgument.cc
+++ b/c++/src/sargs/SearchArgument.cc
@@ -83,7 +83,6 @@ namespace orc {
 
   SearchArgumentBuilder& SearchArgumentBuilderImpl::end() {
     TreeNode& current = mCurrTree.front();
-    mCurrTree.pop_front();
     if (current->getChildren().empty()) {
       throw std::invalid_argument("Cannot create expression " +
         mRoot->toString() + " with no children.");
@@ -93,6 +92,7 @@ namespace orc {
       throw std::invalid_argument("Can't create NOT expression " +
         current->toString() + " with more than 1 child.");
     }
+    mCurrTree.pop_front();
     return *this;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes the heap-use-after-free issue in `SearchArgumentBuilderImpl::end()`. `std::deque::pop_front` will delete the element. We should call it after using the element.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This crashes the test when building ORC with AddressSanitizer. The ASAN report is attached in the JIRA.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
After this fix, I'm able to run all existing tests with AddressSanitizer enabled.