### PR TITLE
ORC-941: Move `MacOS 10.15/11.5` test from Travis to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,11 +10,15 @@ on:
 
 jobs:
   build:
-    name: "Build with Java ${{ matrix.java }}"
-    runs-on: ubuntu-20.04
+    name: "Build with Java ${{ matrix.java }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-20.04
+          - macos-10.15
+          - macos-11
         java:
           - 1.8
           - 11
@@ -41,7 +45,11 @@ jobs:
         mkdir -p ~/.m2
         mkdir build
         cd build
-        cmake -DANALYZE_JAVA=ON ..
+        if [ "${{ matrix.os }}" = "ubuntu-20.04" ]; then
+          cmake -DANALYZE_JAVA=ON ..
+        else
+          cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
+        fi
         make package test-out
         cd ../java
         mvn apache-rat:check


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to migrate the following jobs from `Travis CI` to `GitHub Action`.
- Mac OS 10.15
- Mac OS 11.5

### Why are the changes needed?

This job takes 40-minutes execution time and waits in the queue over 6 hours frequently while GitHub Action jobs finish in around 20 minutes in total.

![Screen Shot 2021-08-11 at 5 02 20 PM](https://user-images.githubusercontent.com/9700541/129118727-5231e984-cb26-4942-8dbb-c7b97ab50095.png)

- https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md
    - System Version: macOS 10.15.7 (19H1323)
- https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
    - System Version: macOS 11.5 (20G71)

### How was this patch tested?

Pass the CIs.