### PR TITLE
ORC-1079: Add `Linux Clang 11` GitHub Action test coverage

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: "Build with Java ${{ matrix.java }} on ${{ matrix.os }}"
+    name: "Java ${{ matrix.java }} and ${{ matrix.cxx }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -23,6 +23,12 @@ jobs:
           - 1.8
           - 11
           - 15
+        cxx:
+          - clang++
+        include:
+          - os: ubuntu-20.04
+            java: 1.8
+            cxx: g++
     env:
       MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true
@@ -46,7 +52,7 @@ jobs:
         mkdir build
         cd build
         if [ "${{ matrix.os }}" = "ubuntu-20.04" ]; then
-          cmake -DANALYZE_JAVA=ON ..
+          cmake -DANALYZE_JAVA=ON -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DSTOP_BUILD_ON_WARNING=OFF ..
         else
           cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
         fi


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache ORC uses `Docker`-based tests to provide `GNU C++` test coverage on `CentOS 7/8`, `Debian 9/10/11`, `Ubuntu 18/20`.

- https://github.com/apache/orc/tree/main/docker

This PR aims to add a new GitHub Action job for `Linux Clang 11.0.0`(Ubuntu) test coverage. Previously, `Clang 7.0.0` test coverage was provided by Travis CI.

**BEFORE (GitHub Action)**
| OS | CXX |
|----|------|
| Ubuntu 20.04 | GNU 9.3.0 |
| MacOS 10.15 | AppleClang 12.0.0 |
| MacOS 11.6 | AppleClang 13.0.0 |
| Windows Server 2019 | MSVC 19.0.24245.0 |

**AFTER (GitHub Action)**
| OS | CXX |
|----|------|
| Ubuntu 20.04 | GNU 9.3.0 |
| **Ubuntu 20.04** | **Clang 11.0.0** |
| MacOS 10.15 | AppleClang 12.0.0 |
| MacOS 11.6 | AppleClang 13.0.0 |
| Windows Server 2019 | MSVC 19.0.24245.0 |

### Why are the changes needed?

After adding this, we can remove the slow `Travis CI` which sometime takes several hours to finish due to the lack of resources.

<img src="https://user-images.githubusercontent.com/9700541/148463375-beef2e9b-61c0-4fb1-bc8f-10b53b854b30.png" width="600">

### How was this patch tested?

Pass the CIs with new `clang++ on Ubuntu` combination.

![Screen Shot 2022-01-06 at 4 25 26 PM](https://user-images.githubusercontent.com/9700541/148471275-2a58ed8e-f322-4808-b6a1-d5d169ed07c0.png)