### PR TITLE
ORC-1082: Improve `FileDump` and `JsonFileDump` to be robust on missing column statistics

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -747,10 +747,10 @@ public final class FileDump {
         buf.append("unknown\n");
         continue;
       }
-      OrcProto.ColumnStatistics colStats = entry.getStatistics();
-      if (colStats == null) {
+      if (!entry.hasStatistics()) {
         buf.append("no stats at ");
       } else {
+        OrcProto.ColumnStatistics colStats = entry.getStatistics();
         ColumnStatistics cs =
             ColumnStatisticsImpl.deserialize(colSchema, colStats,
                 reader.writerUsedProlepticGregorian(),

--- a/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
@@ -444,7 +444,7 @@ public class JsonFileDump {
       writer.beginObject();
       writer.name("entryId").value(entryIx);
       OrcProto.RowIndexEntry entry = index.getEntry(entryIx);
-      if (entry == null) {
+      if (entry == null || !entry.hasStatistics()) {
         continue;
       }
       OrcProto.ColumnStatistics colStats = entry.getStatistics();


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This pr is aims to fixing code in the FileDump and JsonFileDump commands that determines whether a column statistic exists or not.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before we can get the ColumnStatistics from RowIndex we need to determine whether it exists or not.

`entry.getStatistics()` does not return null at any time, and will return a default object when it is not set.

The current impl is wrong
```java
      OrcProto.ColumnStatistics colStats = entry.getStatistics();
      if (colStats == null) {
        buf.append("no stats at ");
      }
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

This can be tested with the following code

```java
  @Test
  public void test() {
    OrcProto.RowIndexEntry entry = OrcProto.RowIndexEntry.newBuilder().addPositions(0).build();
    assertFalse(entry.hasStatistics());
    assertNotNull(entry.getStatistics());
  }
```
But since this is just testing Protobuf generated code, I'm not sure if I should add it to the unit tests.

On the other hand, our proto is defined as follows, statistics is optional

https://github.com/apache/orc/blob/7d2838b4b38111bc1bfa00592d84a8b36286b9f2/proto/orc_proto.proto#L102-L105

Our orc writer implementation, however, will definitely write statistics, and there is no optional configuration, so it cannot be verified by the files written by orc

https://github.com/apache/orc/blob/7d2838b4b38111bc1bfa00592d84a8b36286b9f2/java/core/src/java/org/apache/orc/impl/writer/TreeWriterBase.java#L322-L330