### PR TITLE
ORC-1093: Remove `debian8` specific code in `run-one.sh`

### DIFF
--- a/docker/run-one.sh
+++ b/docker/run-one.sh
@@ -37,15 +37,6 @@ else
 
   echo "Started $GITHUB_USER/$BRANCH on $BUILD at $(date)"
 
-  case $BUILD in
-  debian8*)
-     OPTS="-DSNAPPY_HOME=/usr/local"
-     ;;
-  *)
-     OPTS=""
-     ;;
-  esac
-
   docker run $VOLUME "$TAG" /bin/bash -c \
      "$CLONE && $MAKEDIR && cmake $OPTS .. && make package test-out" \
        || failure


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove `debian8` specific code in `run-one.sh`

### Why are the changes needed?
ORC removed `debian8` support already. 

### How was this patch tested?
Manually review. 