### PR TITLE
ORC-1094: Enable GitHub issues tab

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,8 @@
 github:
   description: "Apache ORC - the smallest, fastest columnar storage for Hadoop workloads"
   homepage: https://orc.apache.org/
+  features:
+    issues: true
   enabled_merge_buttons:
     merge: false
     squash: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to enable the GitHub issues tab for ORC. 

### Why are the changes needed?
To remove the hurdle of creating a Jira ID to report an issue. 

### How was this patch tested?
N/A.