### PR TITLE
ORC-1095: Deprecate `UnknownFormatException`

### DIFF
--- a/java/core/src/java/org/apache/orc/UnknownFormatException.java
+++ b/java/core/src/java/org/apache/orc/UnknownFormatException.java
@@ -23,6 +23,10 @@ import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 
+/**
+ * @deprecated This will be removed in the future releases.
+ */
+@Deprecated
 public class UnknownFormatException extends IOException {
   private final Path path;
   private final String versionString;

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -19,6 +19,7 @@
 package org.apache.orc.impl;
 
 import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.TextFormat;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -44,7 +45,6 @@ import org.apache.orc.RecordReader;
 import org.apache.orc.StripeInformation;
 import org.apache.orc.StripeStatistics;
 import org.apache.orc.TypeDescription;
-import org.apache.orc.UnknownFormatException;
 import org.apache.orc.impl.reader.ReaderEncryption;
 import org.apache.orc.impl.reader.ReaderEncryptionVariant;
 import org.slf4j.Logger;
@@ -519,8 +519,9 @@ public class ReaderImpl implements Reader {
                                         ) throws IOException {
     List<Integer> version = postscript.getVersionList();
     if (getFileVersion(version) == OrcFile.Version.FUTURE) {
-      throw new UnknownFormatException(path, versionString(version),
-          postscript);
+      throw new IOException(path + " was written by a future ORC version " +
+          versionString(version) + ". This file is not readable by this version of ORC.\n"+
+          "Postscript: " + TextFormat.shortDebugString(postscript));
     }
   }
 

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -4145,8 +4145,8 @@ public class TestVectorOrcFile {
     try {
       OrcFile.createReader(zeroFile, OrcFile.readerOptions(conf));
       fail("no exception for bad version");
-    } catch (IOException io) {
-      String m = io.getMessage();
+    } catch (IOException e) {
+      String m = e.getMessage();
       assertTrue(m.contains("version1999.orc was written by a future ORC version 19.99."));
       assertTrue(m.contains("This file is not readable by this version of ORC."));
       assertTrue(m.contains("Postscript: footerLength: 19 compression: NONE " +

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -4145,12 +4145,13 @@ public class TestVectorOrcFile {
     try {
       OrcFile.createReader(zeroFile, OrcFile.readerOptions(conf));
       fail("no exception for bad version");
-    } catch (UnknownFormatException uf) {
-      assertEquals("version1999.orc", uf.getPath().getName(), "path is correct");
-      assertEquals("19.99", uf.getVersionString());
-      OrcProto.PostScript ps = uf.getPostscript();
-      assertEquals("ORC", ps.getMagic());
-      assertEquals(OrcProto.CompressionKind.NONE, ps.getCompression());
+    } catch (IOException io) {
+      String m = io.getMessage();
+      assertTrue(m.contains("version1999.orc was written by a future ORC version 19.99."));
+      assertTrue(m.contains("This file is not readable by this version of ORC."));
+      assertTrue(m.contains("Postscript: footerLength: 19 compression: NONE " +
+          "compressionBlockSize: 65536 version: 19 version: 99 metadataLength: 0 " +
+          "writerVersion: 1"));
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to deprecate `UnknownFormatException` at Apache ORC 1.7.3.

### Why are the changes needed?

This extends `IOException` to expose more data and used once here. However, the downstream projects are not using this information because `checkOrcVersion` returns `IOException`.  The error message is enough.

https://github.com/apache/orc/blob/80b98126cf8a15d9d44c67a9aabfabfdcc7f913e/java/core/src/java/org/apache/orc/impl/ReaderImpl.java#L517-L525

This PR replaces it with `IOException` with the same message generated by `UnknownFormatException` previously.

https://github.com/apache/orc/blob/80b98126cf8a15d9d44c67a9aabfabfdcc7f913e/java/core/src/java/org/apache/orc/UnknownFormatException.java#L33-L35

### How was this patch tested?

Pass the CIs.