### PR TITLE
ORC-1101: [C++] Improve malformed STRUCT handling

### DIFF
--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -24,9 +24,9 @@
 #include <sstream>
 
 namespace orc {
-  
-   Type::~Type() {
-   // PASS
+
+  Type::~Type() {
+    // PASS
   }
 
   TypeImpl::TypeImpl(TypeKind _kind) {
@@ -454,7 +454,6 @@ namespace orc {
         throw ParseError("Illegal MAP type that doesn't contain two subtypes");
       if (type.kind() == proto::Type_Kind_UNION && type.subtypes_size() == 0)
         throw ParseError("Illegal UNION type that doesn't contain any subtypes");
-      
       for(int i=0; i < type.subtypes_size(); ++i) {
         result->addUnionChild(convertType(footer.types(static_cast<int>
                                                        (type.subtypes(i))),
@@ -466,7 +465,7 @@ namespace orc {
     case proto::Type_Kind_STRUCT: {
       TypeImpl* result = new TypeImpl(STRUCT);
       ret = std::unique_ptr<Type>(result);
-     if (type.subtypes_size() > type.fieldnames_size())
+      if (type.subtypes_size() > type.fieldnames_size())
         throw ParseError("Illegal STRUCT type that contains less fieldnames than subtypes");
       for(int i=0; i < type.subtypes_size(); ++i) {
         result->addStructField(type.fieldnames(i),

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -24,9 +24,9 @@
 #include <sstream>
 
 namespace orc {
-  void checkProtoTypes(const proto::Footer &footer);
-  Type::~Type() {
-    // PASS
+  
+   Type::~Type() {
+   // PASS
   }
 
   TypeImpl::TypeImpl(TypeKind _kind) {
@@ -413,8 +413,6 @@ namespace orc {
   std::unique_ptr<Type> convertType(const proto::Type& type,
                                     const proto::Footer& footer) {
     std::unique_ptr<Type> ret;
-    //check for corrupt footers before conversion
-    checkProtoTypes(footer);
     switch (static_cast<int64_t>(type.kind())) {
 
     case proto::Type_Kind_BOOLEAN:
@@ -456,6 +454,7 @@ namespace orc {
         throw ParseError("Illegal MAP type that doesn't contain two subtypes");
       if (type.kind() == proto::Type_Kind_UNION && type.subtypes_size() == 0)
         throw ParseError("Illegal UNION type that doesn't contain any subtypes");
+      
       for(int i=0; i < type.subtypes_size(); ++i) {
         result->addUnionChild(convertType(footer.types(static_cast<int>
                                                        (type.subtypes(i))),
@@ -467,6 +466,8 @@ namespace orc {
     case proto::Type_Kind_STRUCT: {
       TypeImpl* result = new TypeImpl(STRUCT);
       ret = std::unique_ptr<Type>(result);
+     if (type.subtypes_size() > type.fieldnames_size())
+        throw ParseError("Illegal STRUCT type that contains less fieldnames than subtypes");
       for(int i=0; i < type.subtypes_size(); ++i) {
         result->addStructField(type.fieldnames(i),
                                convertType(footer.types(static_cast<int>

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -24,7 +24,7 @@
 #include <sstream>
 
 namespace orc {
-
+  void checkProtoTypes(const proto::Footer &footer);
   Type::~Type() {
     // PASS
   }
@@ -413,6 +413,8 @@ namespace orc {
   std::unique_ptr<Type> convertType(const proto::Type& type,
                                     const proto::Footer& footer) {
     std::unique_ptr<Type> ret;
+    //check for corrupt footers before conversion
+    checkProtoTypes(footer);
     switch (static_cast<int64_t>(type.kind())) {
 
     case proto::Type_Kind_BOOLEAN:

--- a/c++/test/TestType.cc
+++ b/c++/test/TestType.cc
@@ -418,7 +418,6 @@ namespace orc {
     *(footer.add_types()) = structType;
     testCorruptHelper(illStructType, footer,
         "Illegal STRUCT type that contains less fieldnames than subtypes");
-  
   }
 
   void expectParseError(const proto::Footer &footer, const char* errMsg) {

--- a/c++/test/TestType.cc
+++ b/c++/test/TestType.cc
@@ -404,6 +404,21 @@ namespace orc {
     illUnionType.set_kind(proto::Type_Kind_UNION);
     testCorruptHelper(illUnionType, footer,
         "Illegal UNION type that doesn't contain any subtypes");
+
+    proto::Type illStructType;
+    proto::Type structType;
+    illStructType.set_kind(proto::Type_Kind_STRUCT);
+    structType.set_kind(proto::Type_Kind_STRUCT);
+    structType.add_subtypes(0);  // construct a loop back to root
+    structType.add_fieldnames("root");
+    illStructType.add_subtypes(1);
+    illStructType.add_fieldnames("f1");
+    illStructType.add_subtypes(2);
+    *(footer.add_types()) = illStructType;
+    *(footer.add_types()) = structType;
+    testCorruptHelper(illStructType, footer,
+        "Illegal STRUCT type that contains less fieldnames than subtypes");
+  
   }
 
   void expectParseError(const proto::Footer &footer, const char* errMsg) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

The changes are made to validate the indices in the Protobuf message type tree especially for the Type_Kind_STRUCT when fieldnames are less than the subtypes_size() , so it won't crash when we convert the proto::Types to TypeImpls.

### Why are the changes needed?

To handle the malformed STRUCT type more gracefully.

### How was this patch tested?

Pass the CIs with the newly added test coverage.

Closes #1021 and #1023 