### PR TITLE
ORC-236: Support `UNION` type in Java Convert tool

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
@@ -59,6 +59,8 @@ public class ConvertTool {
   private final String csvNullString;
   private final String timestampFormat;
   private final String bloomFilterColumns;
+  private final String unionTag;
+  private final String unionValue;
   private final Writer writer;
   private final VectorizedRowBatch batch;
 
@@ -151,7 +153,7 @@ public class ConvertTool {
         }
         case JSON: {
           FSDataInputStream underlying = filesystem.open(path);
-          return new JsonReader(getReader(underlying), underlying, size, schema, timestampFormat);
+          return new JsonReader(getReader(underlying), underlying, size, schema, timestampFormat, unionTag, unionValue);
         }
         case CSV: {
           FSDataInputStream underlying = filesystem.open(path);
@@ -196,6 +198,8 @@ public class ConvertTool {
     this.csvNullString = opts.getOptionValue('n', "");
     this.timestampFormat = opts.getOptionValue("t", DEFAULT_TIMESTAMP_FORMAT);
     this.bloomFilterColumns = opts.getOptionValue('b', null);
+    this.unionTag = opts.getOptionValue("union-tag", "tag");
+    this.unionValue = opts.getOptionValue("union-value", "value");
     String outFilename = opts.hasOption('o')
         ? opts.getOptionValue('o') : "output.orc";
     boolean overwrite = opts.hasOption('O');
@@ -274,6 +278,12 @@ public class ConvertTool {
         Option.builder("O").longOpt("overwrite").desc("Overwrite an existing file")
             .build()
     );
+    options.addOption(
+        Option.builder().longOpt("union-tag").desc("JSON key name representing UNION tag. Default to \"tag\".")
+            .hasArg().build());
+    options.addOption(
+        Option.builder().longOpt("union-value").desc("JSON key name representing UNION value. Default to \"value\".")
+            .hasArg().build());
     CommandLine cli = new DefaultParser().parse(options, args);
     if (cli.hasOption('h') || cli.getArgs().length == 0) {
       HelpFormatter formatter = new HelpFormatter();

--- a/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
@@ -153,7 +153,8 @@ public class ConvertTool {
         }
         case JSON: {
           FSDataInputStream underlying = filesystem.open(path);
-          return new JsonReader(getReader(underlying), underlying, size, schema, timestampFormat, unionTag, unionValue);
+          return new JsonReader(getReader(underlying), underlying, size, schema, timestampFormat,
+              unionTag, unionValue);
         }
         case CSV: {
           FSDataInputStream underlying = filesystem.open(path);
@@ -279,10 +280,12 @@ public class ConvertTool {
             .build()
     );
     options.addOption(
-        Option.builder().longOpt("union-tag").desc("JSON key name representing UNION tag. Default to \"tag\".")
+        Option.builder().longOpt("union-tag")
+            .desc("JSON key name representing UNION tag. Default to \"tag\".")
             .hasArg().build());
     options.addOption(
-        Option.builder().longOpt("union-value").desc("JSON key name representing UNION value. Default to \"value\".")
+        Option.builder().longOpt("union-value")
+            .desc("JSON key name representing UNION value. Default to \"value\".")
             .hasArg().build());
     CommandLine cli = new DefaultParser().parse(options, args);
     if (cli.hasOption('h') || cli.getArgs().length == 0) {

--- a/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
@@ -63,8 +63,8 @@ public class JsonReader implements RecordReader {
   private final FSDataInputStream input;
   private long rowNumber = 0;
   private final DateTimeFormatter dateTimeFormatter;
-  private final String unionTag;
-  private final String unionValue;
+  private String unionTag = "tag";
+  private String unionValue = "value";
 
   interface JsonConverter {
     void convert(JsonElement value, ColumnVector vect, int row);
@@ -367,17 +367,24 @@ public class JsonReader implements RecordReader {
                     String timestampFormat,
                     String unionTag,
                     String unionValue) throws IOException {
-    this(new JsonStreamParser(reader), underlying, size, schema, timestampFormat, unionTag,
-         unionValue);
+    this(new JsonStreamParser(reader), underlying, size, schema, timestampFormat);
+    this.unionTag = unionTag;
+    this.unionValue = unionValue;
+  }
+
+  public JsonReader(Reader reader,
+                    FSDataInputStream underlying,
+                    long size,
+                    TypeDescription schema,
+                    String timestampFormat) throws IOException {
+    this(new JsonStreamParser(reader), underlying, size, schema, timestampFormat);
   }
 
   public JsonReader(Iterator<JsonElement> parser,
                     FSDataInputStream underlying,
                     long size,
                     TypeDescription schema,
-                    String timestampFormat,
-                    String unionTag,
-                    String unionValue) throws IOException {
+                    String timestampFormat) throws IOException {
     this.schema = schema;
     if (schema.getCategory() != TypeDescription.Category.STRUCT) {
       throw new IllegalArgumentException("Root must be struct - " + schema);
@@ -391,8 +398,6 @@ public class JsonReader implements RecordReader {
     for(int c = 0; c < converters.length; ++c) {
       converters[c] = createConverter(fieldTypes.get(c));
     }
-    this.unionTag = unionTag;
-    this.unionValue = unionValue;
   }
 
   @Override

--- a/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
@@ -367,7 +367,8 @@ public class JsonReader implements RecordReader {
                     String timestampFormat,
                     String unionTag,
                     String unionValue) throws IOException {
-    this(new JsonStreamParser(reader), underlying, size, schema, timestampFormat, unionTag, unionValue);
+    this(new JsonStreamParser(reader), underlying, size, schema, timestampFormat, unionTag,
+         unionValue);
   }
 
   public JsonReader(Iterator<JsonElement> parser,

--- a/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.UnionColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
@@ -293,6 +294,32 @@ public class JsonReader implements RecordReader {
     }
   }
 
+  class UnionColumnConverter implements JsonConverter {
+    private JsonConverter[] childConverter;
+
+    UnionColumnConverter(TypeDescription schema) {
+      int size = schema.getChildren().size();
+      childConverter = new JsonConverter[size];
+      for (int i = 0; i < size; i++) {
+        childConverter[i] = createConverter(schema.getChildren().get(i));
+      }
+    }
+
+    @Override
+    public void convert(JsonElement value, ColumnVector vect, int row) {
+      if (value == null || value.isJsonNull()) {
+        vect.noNulls = false;
+        vect.isNull[row] = true;
+      } else {
+        UnionColumnVector vector = (UnionColumnVector) vect;
+        JsonObject obj = value.getAsJsonObject();
+        int tag = obj.get("tag").getAsInt();
+        vector.tags[row] = tag;
+        childConverter[tag].convert(obj.get("value"), vector.fields[tag], row);
+      }
+    }
+  }
+
   JsonConverter createConverter(TypeDescription schema) {
     switch (schema.getCategory()) {
       case BYTE:
@@ -324,6 +351,8 @@ public class JsonReader implements RecordReader {
         return new ListColumnConverter(schema);
       case MAP:
         return new MapColumnConverter(schema);
+      case UNION:
+        return new UnionColumnConverter(schema);
       default:
         throw new IllegalArgumentException("Unhandled type " + schema);
     }

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
@@ -174,5 +174,4 @@ public class TestJsonReader {
         assertEquals(0, union.tags[2]);
         assertEquals(3, longs.vector[2]);
     }
-
 }

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
@@ -50,7 +50,7 @@ public class TestJsonReader {
         StringReader input = new StringReader(s);
         TypeDescription schema = TypeDescription.fromString(
                 "struct<a:timestamp>");
-        JsonReader reader = new JsonReader(input, null, 1, schema, tsFormat, "tag", "value");
+        JsonReader reader = new JsonReader(input, null, 1, schema, tsFormat);
         VectorizedRowBatch batch = schema.createRowBatch(2);
         assertTrue(reader.nextBatch(batch));
         assertEquals(2, batch.size);
@@ -72,7 +72,7 @@ public class TestJsonReader {
         StringReader input = new StringReader(s);
         TypeDescription schema = TypeDescription.fromString(
                 "struct<a:timestamp>");
-        JsonReader reader = new JsonReader(input, null, 1, schema, tsFormat, "tag", "value");
+        JsonReader reader = new JsonReader(input, null, 1, schema, tsFormat);
         VectorizedRowBatch batch = schema.createRowBatch(6);
         assertTrue(reader.nextBatch(batch));
         assertEquals(6, batch.size);
@@ -98,7 +98,7 @@ public class TestJsonReader {
         StringReader input = new StringReader(inputString);
 
         TypeDescription schema = TypeDescription.fromString("struct<dt:date>");
-        JsonReader reader = new JsonReader(input, null, 1, schema, "", "tag", "value");
+        JsonReader reader = new JsonReader(input, null, 1, schema, "");
         VectorizedRowBatch batch = schema.createRowBatch(4);
         assertTrue(reader.nextBatch(batch));
         assertEquals(4, batch.size);
@@ -133,7 +133,7 @@ public class TestJsonReader {
         StringReader input = new StringReader(inputString);
 
         TypeDescription schema = TypeDescription.fromString("struct<dt:timestamp>");
-        JsonReader reader = new JsonReader(input, null, 1, schema, timestampFormat, "tag", "value");
+        JsonReader reader = new JsonReader(input, null, 1, schema, timestampFormat);
         VectorizedRowBatch batch = schema.createRowBatch(6);
         assertTrue(reader.nextBatch(batch));
         assertEquals(6, batch.size);


### PR DESCRIPTION
### What changes were proposed in this pull request?
This patch add support to convert json to UNION type in orc file. For
example, for schema `struct<foo:uniontype<int,string>>`, the following
json lines can be parsed into UNION type.

```
{"foo": {"tag": 0, "value": 1}}
{"foo": {"tag": 1, "value": "testing"}}
{"foo": {"tag": 0, "value": 3}}
```


### Why are the changes needed?
This add a missing support for UNION type in java convert tool.


### How was this patch tested?
Manually test against handcrafted json file.
