### PR TITLE
MINOR: Update `README.md` to remove `Travis CI` links and add release tags and plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Releases:
 * Latest: <a href="http://orc.apache.org/releases">Apache ORC releases</a>
 * Maven Central: <a href="http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.orc%22">![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.orc/orc/badge.svg)</a>
 * Downloads: <a href="http://orc.apache.org/downloads">Apache ORC downloads</a>
+* Release tags: <a href="https://github.com/apache/orc/releases">Apache ORC release tags</a>
+* Plan: <a href="https://github.com/apache/orc/milestones">Apache ORC future release plan</a>
 
 The current build status:
 * Main branch <a href="https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain">

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@ Releases:
 
 The current build status:
 * Main branch <a href="https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain">
-![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)</a> <a href="https://travis-ci.com/apache/orc/branches">
-![main build status](https://travis-ci.com/apache/orc.svg?branch=main)</a>
+![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)</a>
 
 Bug tracking: <a href="http://orc.apache.org/bugs">Apache Jira</a>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `README.md` by
- Removing `Travis CI` link
- Adding `release tags` link and `plan` link.

### Why are the changes needed?

To make release information more visible.

### How was this patch tested?

Manually check the new README in the following link.

- https://github.com/apache/orc/blob/39680343ef9a4bb3b90268ebdda6f93016e668c8/README.md