### PR TITLE
ORC-1103: Use Maven 3.8.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The subdirectories are:
 ### Building
 
 * Install java 1.8 or higher
-* Install maven 3.6.3 or higher
+* Install maven 3.8.4 or higher
 * Install cmake
 
 To build a release version with debug information:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
     <tools.hadoop.version>2.10.1</tools.hadoop.version>
     <storage-api.version>2.8.1</storage-api.version>
     <zookeeper.version>3.7.0</zookeeper.version>
-    <maven.version>3.6.3</maven.version>
+    <maven.version>3.8.4</maven.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <slf4j.version>1.7.33</slf4j.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Maven 3.8.4 for Java building and testing.

### Why are the changes needed?

- Apache Maven 3.6.3 was released on 2019-11-25.
- Apache Maven 3.8.x has the latest fixes including CVE patches.

https://maven.apache.org/docs/history.html

### How was this patch tested?

Pass the CIs.