### PR TITLE
ORC-1104: Use Spark 3.2.1 in benchmark

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -36,7 +36,7 @@
     <jmh.version>1.20</jmh.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.2</parquet.version>
-    <spark.version>3.2.0</spark.version>
+    <spark.version>3.2.1</spark.version>
     <hadoop.version>3.3.1</hadoop.version>
     <junit.version>5.8.2</junit.version>
   </properties>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use Spark 3.2.1 in benchmark. 


### Why are the changes needed?
To make benchmark up-to-date. 


### How was this patch tested?
N/A.
