### PR TITLE
ORC-1105: fetch-data.sh should use zsh instead of bash

### DIFF
--- a/java/bench/fetch-data.sh
+++ b/java/bench/fetch-data.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env zsh
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use zsh in `fetch-data.sh` instead of bash. 


### Why are the changes needed?

`bash` has a different behavior in `MacOS` environment. `zsh` works like Linux bash.
```
$ bash -c "echo {01..15}"
1 2 3 4 5 6 7 8 9 10 11 12 13 14 15

$ zsh -c "echo {01..15}"
01 02 03 04 05 06 07 08 09 10 11 12 13 14 15

$ docker run -it --rm ubuntu bash -c 'echo {01..15}'
01 02 03 04 05 06 07 08 09 10 11 12 13 14 15
```


### How was this patch tested?
Manually test by running `fetch-data.sh` on MacOS.
