### PR TITLE
ORC-1106: Use transitive commons-lang3 dependency in bench module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -114,12 +114,6 @@
         <version>1.9.0</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.7</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-common</artifactId>
         <version>${hadoop.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use transitive `commons-lang3` dependency in `bench` module. 


### Why are the changes needed?
Hadoop 3.3 and Spark 3.2 are using `commons-lang3` 3.12.0


### How was this patch tested?
Manually check with 
```
mvn dependency:tree
```
