### PR TITLE
ORC-1107: Fix NPE at benchmark data schema loading

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
@@ -18,6 +18,7 @@
 
 package org.apache.orc.bench.core;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.cli.CommandLine;
 import org.apache.hadoop.fs.Path;
 import org.apache.orc.TypeDescription;
@@ -33,6 +34,7 @@ public class Utilities {
 
   public static TypeDescription loadSchema(String name) throws IOException {
     InputStream in = Utilities.class.getClassLoader().getResourceAsStream(name);
+    Preconditions.checkArgument(in != null, "Schema not found: " + name);
     byte[] buffer= new byte[1 * 1024];
     int len = in.read(buffer);
     StringBuilder string = new StringBuilder();


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix a NPE at benchmark data schema loading.


### Why are the changes needed?
**BEFORE**
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar scan data -d taxy -c zstd
Exception in thread "main" java.lang.NullPointerException
	at org.apache.orc.bench.core.Utilities.loadSchema(Utilities.java:37)
	at org.apache.orc.bench.core.convert.ScanVariants.run(ScanVariants.java:78)
	at org.apache.orc.bench.core.Driver.main(Driver.java:64)
```

**AFTER**
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar scan data -d taxy -c zstd
Exception in thread "main" java.lang.IllegalArgumentException: Schema Not Found: taxy.schema
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:145)
	at org.apache.orc.bench.core.Utilities.loadSchema(Utilities.java:37)
	at org.apache.orc.bench.core.convert.ScanVariants.run(ScanVariants.java:78)
	at org.apache.orc.bench.core.Driver.main(Driver.java:64)
```


### How was this patch tested?
Manually.