### PR TITLE
ORC-1108: Use `RawLocalFileSystem` to skip checksum files during benchmark data generation

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/GenerateVariants.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/GenerateVariants.java
@@ -120,6 +120,8 @@ public class GenerateVariants implements OrcBenchmark {
         cli.getOptionValue("format", "avro,json,orc,parquet").split(",");
     long records = Long.parseLong(cli.getOptionValue("sales", "25000000"));
     Configuration conf = new Configuration();
+    // Disable Hadoop checksums
+    conf.set("fs.file.impl", "org.apache.hadoop.fs.RawLocalFileSystem");
     Path root = new Path(cli.getArgs()[0]);
 
     for (final String data: dataList) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use `RawLocalFileSystem` to skip checksum files during benchmark data generation. 

### Why are the changes needed?
There is no need to check for checksums. 


### How was this patch tested?
Manually. 