### PR TITLE
ORC-1109: Use zstd instead of none in the default compress option

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/GenerateVariants.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/GenerateVariants.java
@@ -113,7 +113,7 @@ public class GenerateVariants implements OrcBenchmark {
   public void run(String[] args) throws Exception {
     CommandLine cli = parseCommandLine(args);
     String[] compressList =
-        cli.getOptionValue("compress", "none,snappy,zlib").split(",");
+        cli.getOptionValue("compress", "snappy,zlib,zstd").split(",");
     String[] dataList =
         cli.getOptionValue("data", "taxi,sales,github").split(",");
     String[] formatList =

--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/ScanVariants.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/ScanVariants.java
@@ -67,7 +67,7 @@ public class ScanVariants implements OrcBenchmark {
   public void run(String[] args) throws Exception {
     CommandLine cli = parseCommandLine(args);
     String[] compressList =
-        cli.getOptionValue("compress", "none,snappy,gz").split(",");
+        cli.getOptionValue("compress", "snappy,gz,zstd").split(",");
     String[] dataList =
         cli.getOptionValue("data", "taxi,sales,github").split(",");
     String[] formatList =


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use `zstd` instead of `none` in the default compress option.


### Why are the changes needed?
This will reduce the hardware requirements for running benchmark. 

```
$ du -h * | sort -nr
112G	github
 67G	sales
 21G	taxi
```
```
$ du -h */*none | sort -nr
663M	taxi/parquet.none
 28G	github/json.none
 22G	sales/json.none
 18G	github/avro.none
 14G	github/parquet.none
 12G	github/orc.none
 10G	taxi/json.none
4.9G	sales/avro.none
4.2G	sales/parquet.none
2.9G	sales/orc.none
2.0G	taxi/avro.none
1.2G	taxi/orc.none
```
### How was this patch tested?
Manually generate benchmark data. 