### PR TITLE
MINOR: Update scala-library pinning version to `[2.12.16, )`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,9 +33,9 @@ updates:
         versions: "[2.2.1,)"
       - dependency-name: "org.apache.hadoop:hadoop-mapreduce-client-core"
         versions: "[2.2.1,)"
-      # Pin scala-library to 2.12.10
+      # Pin scala-library to 2.12.15
       - dependency-name: "org.scala-lang:scala-library"
-        versions: "[2.12.11,)"
+        versions: "[2.12.16,)"
       # Pin maven-dependency-plugin to 3.1.2 due to MDEP-753, MDEP-757, MDEP-759
       - dependency-name: "org.apache.maven.plugins:maven-dependency-plugin"
         versions: "[3.2.0,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update the pinning version of Scala library to `[2.12.16, )`.

### Why are the changes needed?

Apache Spark 3.2+ is using Scala 2.12.15.

### How was this patch tested?

N/A