### PR TITLE
ORC-1116: [C++] Fix csv-import tool when exporting long bytes

### DIFF
--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iostream>
+#include <list>
 #include <memory>
 #include <getopt.h>
 #include <string>
@@ -77,8 +78,8 @@ void fillStringValues(const std::vector<std::string>& data,
                       orc::ColumnVectorBatch* batch,
                       uint64_t numValues,
                       uint64_t colIndex,
-                      orc::DataBuffer<char>& buffer,
-                      uint64_t& offset) {
+                      orc::DataBuffer<char>& buffer) {
+  uint64_t offset = 0;
   orc::StringVectorBatch* stringBatch =
     dynamic_cast<orc::StringVectorBatch*>(batch);
   bool hasNull = false;
@@ -365,7 +366,8 @@ int main(int argc, char* argv[]) {
   double totalElapsedTime = 0.0;
   clock_t totalCPUTime = 0;
 
-  orc::DataBuffer<char> buffer(*orc::getDefaultPool(), 4 * 1024 * 1024);
+  typedef std::list<orc::DataBuffer<char>> DataBufferList;
+  DataBufferList bufferList;
 
   orc::WriterOptions options;
   options.setStripeSize(stripeSize);
@@ -385,7 +387,6 @@ int main(int argc, char* argv[]) {
   std::ifstream finput(input.c_str());
   while (!eof) {
     uint64_t numValues = 0;      // num of lines read in a batch
-    uint64_t bufferOffset = 0;   // current offset in the string buffer
 
     data.clear();
     memset(rowBatch->notNull.data(), 1, batchSize);
@@ -420,13 +421,13 @@ int main(int argc, char* argv[]) {
           case orc::STRING:
           case orc::CHAR:
           case orc::VARCHAR:
-          case orc::BINARY:
+          case orc::BINARY: 
+            bufferList.emplace_back(*orc::getDefaultPool(), 4 * 1024 * 1024);
             fillStringValues(data,
                              structBatch->fields[i],
                              numValues,
                              i,
-                             buffer,
-                             bufferOffset);
+                             bufferList.back());
             break;
           case orc::FLOAT:
           case orc::DOUBLE:

--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -422,7 +422,7 @@ int main(int argc, char* argv[]) {
           case orc::CHAR:
           case orc::VARCHAR:
           case orc::BINARY: 
-            bufferList.emplace_back(*orc::getDefaultPool(), 4 * 1024 * 1024);
+            bufferList.emplace_back(*orc::getDefaultPool(), 1 * 1024 * 1024);
             fillStringValues(data,
                              structBatch->fields[i],
                              numValues,


### PR DESCRIPTION
### What changes were proposed in this pull request?
Let each string type columns use its own databuffer before writing data into orc file, so that when one column is calling buffer.resize(), the invalidated buffer.data() is not affecting other columns which points to it.

### Why are the changes needed?
When using the csv-import tool to export a orc file with schema like "struct<a:string,b:binary>", if the data in column "b" has very long bytes (over 4MB), the process could segmentation fault or the exported data in column "a" could become empty string.

Following the code in CSVFileImport.cc, when writing a orc file, all string type columns is using one databuffer inside function fillStringValues(). If a data length is larger than the buffer, the buffer will be resized. The resize() operation will cause all previous result of buffer.data() become invalid. 

In this case, when field "a" finished writing data into buffer, field "b" begin writing will resize the buffer, invalidate previous buffer.data(), so field "a"'s stringBatch is not refering to a valid buffer.data() any more.

A workaround could use different databuffers for each string type column, however requires allocating 4MB memory each. Alternatively using one same databuffer, but let all previous stringBatch re-points to databuffer's new address, after a resize() operation happens.

### How was this patch tested?
Prepare a csv file with two columns, while the second column has data larger than 4MB, like:
_str1,longbinaryabcd.........._
Run following command which finished successfully:
_$ csv-import "struct<a:string,b:binary>" Testbinary.csv /tmp/test.orc_
Run the following command shows data correctly:
_$ orc-contents /tmp/test.orc --columns=0_
_{"a": "str1"}_