### PR TITLE
ORC-1117: Add `Dask` page at `Using in Python` section

### DIFF
--- a/site/_data/docs.yml
+++ b/site/_data/docs.yml
@@ -11,14 +11,15 @@
   - building
   - releases
 
-- title: Using in Python
-  docs:
-  - pyarrow
-
 - title: Using in Spark
   docs:
   - spark-ddl
   - spark-config
+
+- title: Using in Python
+  docs:
+  - pyarrow
+  - dask
 
 - title: Using in Hive
   docs:

--- a/site/_docs/dask.md
+++ b/site/_docs/dask.md
@@ -1,0 +1,34 @@
+---
+layout: docs
+title: Dask
+permalink: /docs/dask.html
+---
+
+## How to install
+
+[Dask](https://dask.org) also supports Apache ORC.
+
+```
+pip3 install "dask[dataframe]==2022.2.0"
+pip3 install pandas
+```
+
+## How to write and read an ORC file
+
+```
+In [1]: import pandas as pd
+
+In [2]: import dask.dataframe as dd
+
+In [3]: pf = pd.DataFrame(data={"col1": [1, 2, 3]})
+
+In [4]: dd.to_orc(dd.from_pandas(pf, npartitions=2), path="/tmp/orc")
+Out[4]: (None,)
+
+In [5]: dd.read_orc(path="/tmp/orc").compute()
+Out[5]:
+   col1
+0     1
+1     2
+2     3
+```

--- a/site/index.html
+++ b/site/index.html
@@ -44,8 +44,8 @@ overview: true
     <div class="unit golden-large code">
       <p class="title">Quickstart Documentation</p>
       <ul class="shell">
-        <li><a href="docs/pyarrow.html">Using with Python</a></li>
         <li><a href="docs/spark-ddl.html">Using with Spark</a></li>
+        <li><a href="docs/pyarrow.html">Using with Python</a></li>
         <li><a href="docs/hive-ddl.html">Using with Hive</a></li>
         <li><a href="docs/mapred.html">Using with Hadoop MapRed</a></li>
         <li><a href="docs/mapreduce.html">Using with Hadoop MapReduce</a></li>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Dask` page under `Using in Python` section.

### Why are the changes needed?

This helps more users.

### How was this patch tested?

Manually generate the page and check.

<img width="915" alt="Screen Shot 2022-02-15 at 9 42 07 PM" src="https://user-images.githubusercontent.com/9700541/154203515-644338ff-cc75-4b13-a48d-d01c5fab270a.png">

