### PR TITLE
ORC-1118: Support Java 17 and ARM64 docker tests

### DIFF
--- a/docker/debian10/Dockerfile
+++ b/docker/debian10/Dockerfile
@@ -41,10 +41,10 @@ RUN apt-get install -y \
     add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ && \
     apt-get update && \
     apt-get install -y adoptopenjdk-8-hotspot && \
-    update-alternatives --set java /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/java && \
-    update-alternatives --set javac /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javac; \
+    update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
+    update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk}); \
   else \
-    apt-get install -y openjdk-11-jdk; \
+    apt-get install -y openjdk-${jdk}-jdk; \
   fi
 
 WORKDIR /root

--- a/docker/debian11/Dockerfile
+++ b/docker/debian11/Dockerfile
@@ -41,10 +41,10 @@ RUN apt-get install -y \
     add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/ && \
     apt-get update && \
     apt-get install -y adoptopenjdk-8-hotspot && \
-    update-alternatives --set java /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/java && \
-    update-alternatives --set javac /usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/bin/javac; \
+    update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
+    update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk}); \
   else \
-    apt-get install -y openjdk-11-jdk; \
+    apt-get install -y openjdk-${jdk}-jdk; \
   fi
 
 WORKDIR /root

--- a/docker/ubuntu18/Dockerfile
+++ b/docker/ubuntu18/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get install -y \
   maven \
   openjdk-${jdk}-jdk \
   tzdata
-RUN update-java-alternatives --set java-1.${jdk}.0-openjdk-amd64
+RUN update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
+    update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk})
 
 WORKDIR /root
 VOLUME /root/.m2/repository

--- a/docker/ubuntu20/Dockerfile
+++ b/docker/ubuntu20/Dockerfile
@@ -45,7 +45,8 @@ RUN apt-get install -y \
     update-alternatives --set cc  /usr/bin/clang && \
     update-alternatives --set c++ /usr/bin/clang++ \
   ; fi
-RUN update-java-alternatives --set java-1.${jdk}.0-openjdk-amd64
+RUN update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
+    update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk})
 
 ENV CC=cc
 ENV CXX=c++


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims two goals:
- Support Java 17 docker test
- Support ARM64 docker test

### Why are the changes needed?

The current test Dockerfile contains a hardcoded architecture postfix `-amd64` which was broken on ARM64.
Although we only support Apple Silicon so far, this test suite should support ARM64 first.

### How was this patch tested?

Manually tested with the build argument in the OS directories on ARM64 machine.
```
docker build -t test --build-arg jdk=17 .
```

Note that `protoc 2.5.0` supports only Intel Architecture and `Apple Silicon` so far. We cannot make the all Docker tests pass on ARM64.