### PR TITLE
ORC-1119: Remove timestamp from ORC API docs

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -133,6 +133,7 @@
             </offlineLink>
           </offlineLinks>
           <reportOutputDirectory>${project.basedir}/../../site/api</reportOutputDirectory>
+          <notimestamp>true</notimestamp>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR removes timestamps from ORC API docs.

### Why are the changes needed?

This will reduce the diff.
```
 <head>
-<!-- Generated by javadoc (1.8.0_312) on Mon Dec 20 12:48:20 PST 2021 -->
+<!-- Generated by javadoc -->
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>Class Hierarchy (ORC Tools 1.7.2 API)</title>
-<meta name="date" content="2021-12-20">
```

### How was this patch tested?

Manually check the generated API doc.
```
$ mvn javadoc:javadoc
```