### PR TITLE
ORC-1122: [C++] Add buffer to decode the whole run in RleDecoderV2

### DIFF
--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -160,7 +160,7 @@ private:
   int64_t readVslong();
   uint64_t readVulong();
   void readLongs(int64_t *data, uint64_t offset, uint64_t len, uint64_t fbs);
-  void readLongsSlow(int64_t *data, uint64_t offset, uint64_t len, uint64_t fbs);
+  void plainUnpackLongs(int64_t *data, uint64_t offset, uint64_t len, uint64_t fbs);
 
   void unrolledUnpack4(int64_t *data, uint64_t offset, uint64_t len);
   void unrolledUnpack8(int64_t *data, uint64_t offset, uint64_t len);

--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -194,7 +194,6 @@ private:
   const char *bufferEnd;
   uint32_t bitsLeft; // Used by readLongs when bitSize < 8
   uint32_t curByte; // Used by anything that uses readLongs
-  DataBuffer<int64_t> unpacked; // Used by PATCHED_BASE
   DataBuffer<int64_t> unpackedPatch; // Used by PATCHED_BASE
   DataBuffer<int64_t> literals; // Values of the current run
 };

--- a/c++/src/RleDecoderV2.cc
+++ b/c++/src/RleDecoderV2.cc
@@ -95,7 +95,7 @@ void RleDecoderV2::readLongs(int64_t *data, uint64_t offset, uint64_t len, uint6
       return;
     default:
       // Fallback to the default implementation for deprecated bit size.
-      readLongsSlow(data, offset, len, fbs);
+      plainUnpackLongs(data, offset, len, fbs);
       return;
   }
 }
@@ -367,8 +367,8 @@ void RleDecoderV2::unrolledUnpack64(int64_t *data, uint64_t offset, uint64_t len
   }
 }
 
-void RleDecoderV2::readLongsSlow(int64_t *data, uint64_t offset, uint64_t len,
-                                 uint64_t fbs) {
+void RleDecoderV2::plainUnpackLongs(int64_t *data, uint64_t offset, uint64_t len,
+                                    uint64_t fbs) {
   for (uint64_t i = offset; i < (offset + len); i++) {
     uint64_t result = 0;
     uint64_t bitsLeftToRead = fbs;
@@ -681,6 +681,11 @@ uint64_t RleDecoderV2::nextDelta(int64_t* const data,
     runLength |= readByte();
     ++runLength; // account for first value
     runRead = 0;
+    if (runLength < 2) {
+      std::stringstream ss;
+      ss << "Illegal run length for delta encoding: " << runLength;
+      throw ParseError(ss.str());
+    }
 
     int64_t prevValue;
     // read the first value stored as vint
@@ -737,4 +742,5 @@ uint64_t RleDecoderV2::copyDataFromBuffer(int64_t* data, uint64_t offset,
   }
   return nRead;
 }
+
 }  // namespace orc

--- a/c++/src/RleDecoderV2.cc
+++ b/c++/src/RleDecoderV2.cc
@@ -699,7 +699,7 @@ uint64_t RleDecoderV2::nextDelta(int64_t* const data,
     if (bitSize == 0) {
       // add fixed deltas to adjacent values
       for (uint64_t i = 1; i < runLength; ++i) {
-        prevValue = literals[i] = prevValue + deltaBase;
+        literals[i] = literals[i - 1] + deltaBase;
       }
     } else {
       prevValue = literals[1] = prevValue + deltaBase;
@@ -710,7 +710,8 @@ uint64_t RleDecoderV2::nextDelta(int64_t* const data,
       }
       // write the unpacked values, add it to previous value and store final
       // value to result buffer. if the delta base value is negative then it
-      // is a decreasing sequence else an increasing sequence
+      // is a decreasing sequence else an increasing sequence.
+      // read deltas using the literals buffer.
       readLongs(literals.data(), 2, runLength - 2, bitSize);
       if (deltaBase < 0) {
         for (uint64_t i = 2; i < runLength; ++i) {

--- a/c++/src/RleDecoderV2.cc
+++ b/c++/src/RleDecoderV2.cc
@@ -681,11 +681,6 @@ uint64_t RleDecoderV2::nextDelta(int64_t* const data,
     runLength |= readByte();
     ++runLength; // account for first value
     runRead = 0;
-    if (runLength < 2) {
-      std::stringstream ss;
-      ss << "Illegal run length for delta encoding: " << runLength;
-      throw ParseError(ss.str());
-    }
 
     int64_t prevValue;
     // read the first value stored as vint
@@ -708,6 +703,11 @@ uint64_t RleDecoderV2::nextDelta(int64_t* const data,
       }
     } else {
       prevValue = literals[1] = prevValue + deltaBase;
+      if (runLength < 2) {
+        std::stringstream ss;
+        ss << "Illegal run length for delta encoding: " << runLength;
+        throw ParseError(ss.str());
+      }
       // write the unpacked values, add it to previous value and store final
       // value to result buffer. if the delta base value is negative then it
       // is a decreasing sequence else an increasing sequence

--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -21,7 +21,6 @@
 #include "RLEv2.hh"
 #include "RLEV2Util.hh"
 
-#define MAX_LITERAL_SIZE 512
 #define MAX_SHORT_REPEAT_LENGTH 10
 
 namespace orc {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a buffer to decode the whole run at once in RleDecoderV2, which leverages the improvement of ORC-1020 (#944) to deal with null values. It also benifits other encodings like PATCHED_BASE and DELTA, and helps to remove the state variables in RleDecoderV2 to improve the code redability.

### Why are the changes needed?

This is a follow up task of ORC-1020 which didn't optimize the code path when the column has nulls.

Tested with random unsigned numbers fitting into bitSize n with a given ratio of nulls. Reading 1B rows for each test.

| bitSize | % nulls | baseline avg(s) | optimized avg(s) | Speedup      |
|---------|---------|-----------------|------------------|--------------|
| 4       | 0%      | 3.52            | 2.745            | 1.2823315118 |
| 4       | 5%      | 7.925           | 7.185            | 1.1029923452 |
| 4       | 10%     | 8.48            | 6.805            | 1.2461425422 |
| 4       | 25%     | 11.15           | 6.475            | 1.722007722  |
| 4       | 50%     | 11.135          | 6.47             | 1.7210200927 |
| 8       | 0%      | 3.51            | 2.73             | 1.2857142857 |
| 8       | 5%      | 7.89            | 7.13             | 1.1065918654 |
| 8       | 10%     | 8.47            | 6.795            | 1.2465047829 |
| 8       | 25%     | 9.93            | 6.44             | 1.5419254658 |
| 8       | 50%     | 11.145          | 6.465            | 1.7238979118 |
| 16      | 0%      | 3.53            | 2.745            | 1.2859744991 |
| 16      | 5%      | 7.925           | 7.155            | 1.107617051  |
| 16      | 10%     | 8.46            | 6.8              | 1.2441176471 |
| 16      | 25%     | 9.92            | 6.41             | 1.5475819033 |
| 16      | 50%     | 11.2            | 6.47             | 1.7310664606 |
| 32      | 0%      | 3.515           | 2.745            | 1.2805100182 |
| 32      | 5%      | 7.915           | 7.15             | 1.106993007  |
| 32      | 10%     | 8.475           | 6.815            | 1.2435803375 |
| 32      | 25%     | 9.935           | 6.48             | 1.5331790123 |
| 32      | 50%     | 11.175          | 6.485            | 1.7232074017 |
| 32      | 100%    | 2.19            | 2.145            | 1.020979021  |

We can see speedup in all cases.

Tested on Ubuntu16.04 with a 6 cores CPU (12 virtual cores) and 32GB RAM.
CPU: Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz

### How was this patch tested?

Passed all existing tests.