### PR TITLE
ORC-1123: Add `estimationMemory` method for writer

### DIFF
--- a/java/core/src/java/org/apache/orc/Writer.java
+++ b/java/core/src/java/org/apache/orc/Writer.java
@@ -165,4 +165,11 @@ public interface Writer extends Closeable {
    * @since 1.6.8
    */
   List<StripeInformation> getStripes() throws IOException;
+
+  /**
+   * Estimate the memory currently used by the writer to buffer the stripe.
+   * `This method help write engine to control the refresh policy of the ORC.`
+   * @return the number of bytes
+   */
+  long estimateMemory();
 }

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -1008,4 +1008,9 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     }
     return result;
   }
+
+  @Override
+  public long estimateMemory() {
+    return this.treeWriter.estimateMemory();
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Add `estimationMemory` method for writer. It exposes the internal treeWriter to estimate the memory used for the buffer.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This method help the write engine to better control the refresh policy of the ORC.

The source of this issue comes from Iceberg's discussion.
https://lists.apache.org/thread/g6yo7m46mr86ov1vkm9wnmshgw7hcl6b

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass the CIs