### PR TITLE
Added Quanlong as a committer to site

### DIFF
--- a/site/_posts/2022-03-05-add-quanlong.md
+++ b/site/_posts/2022-03-05-add-quanlong.md
@@ -1,0 +1,12 @@
+---
+layout: news_item
+title: "Quanlong Huang added as committer"
+date: "2022-03-05 12:00:00 -0700"
+author: gangwu
+categories: [team]
+---
+
+The ORC PMC is happy to add Quanlong Huang as an ORC committer
+for the work on ORC C++ library and Apache Impala integration.
+
+Thank you for your work on ORC, Quanlong!


### PR DESCRIPTION
Add a new page in the news to reflect the latest change of committer activity.