### PR TITLE
ORC-1125: [C++] Support reading decimal64 in ORCv2

### DIFF
--- a/c++/src/ColumnReader.hh
+++ b/c++/src/ColumnReader.hh
@@ -91,6 +91,12 @@ namespace orc {
      * @return the number of scale digits
      */
     virtual int32_t getForcedScaleOnHive11Decimal() const = 0;
+
+    /**
+     * Whether decimals that have precision <=18 are encoded as fixed scale and values
+     * encoded in RLE.
+     */
+    virtual bool isDecimalAsLong() const = 0;
   };
 
   /**

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -63,6 +63,9 @@ namespace orc {
     CompressionKind compression;
     MemoryPool *pool;
     std::ostream *errorStream;
+    /// Decimal64 in ORCv2 uses RLE to store values. This flag indicates whether
+    /// this new encoding is used.
+    bool isDecimalAsLong;
   };
 
   proto::StripeFooter getStripeFooter(const proto::StripeInformation& info,
@@ -224,6 +227,7 @@ namespace orc {
 
     const FileContents& getFileContents() const;
     bool getThrowOnHive11DecimalOverflow() const;
+    bool getIsDecimalAsLong() const;
     int32_t getForcedScaleOnHive11Decimal() const;
   };
 

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -127,6 +127,10 @@ namespace orc {
     return reader.getThrowOnHive11DecimalOverflow();
   }
 
+  bool StripeStreamsImpl::isDecimalAsLong() const {
+    return reader.getIsDecimalAsLong();
+  }
+
   int32_t StripeStreamsImpl::getForcedScaleOnHive11Decimal() const {
     return reader.getForcedScaleOnHive11Decimal();
   }

--- a/c++/src/StripeStream.hh
+++ b/c++/src/StripeStream.hh
@@ -76,6 +76,8 @@ namespace orc {
 
     bool getThrowOnHive11DecimalOverflow() const override;
 
+    bool isDecimalAsLong() const override;
+
     int32_t getForcedScaleOnHive11Decimal() const override;
   };
 

--- a/c++/test/TestColumnReader.cc
+++ b/c++/test/TestColumnReader.cc
@@ -65,6 +65,7 @@ namespace orc {
     bool());
     MOCK_CONST_METHOD0(getForcedScaleOnHive11Decimal, int32_t()
     );
+    MOCK_CONST_METHOD0(isDecimalAsLong, bool());
 
     MemoryPool &getMemoryPool() const {
       return *getDefaultPool();
@@ -3296,6 +3297,156 @@ TEST(DecimalColumnReader, testDecimal128Skip) {
             values[3].toDecimalString(decimals->scale));
   EXPECT_EQ("-9.9999999999999999999999999999999999999",
             values[4].toDecimalString(decimals->scale));
+}
+
+TEST(DecimalColumnReader, testDecimal64V2) {
+  MockStripeStreams streams;
+
+  // set getSelectedColumns() for struct<decimal(12,2)>
+  std::vector<bool> selectedColumns(2, true);
+  EXPECT_CALL(streams, getSelectedColumns())
+      .WillRepeatedly(testing::Return(selectedColumns));
+
+  // Use the decimal encoding in ORCv2
+  EXPECT_CALL(streams, isDecimalAsLong())
+      .WillRepeatedly(testing::Return(true));
+
+  // set encoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams, getEncoding(testing::_))
+      .WillRepeatedly(testing::Return(directEncoding));
+
+  // set getStream
+  // PRESENT stream of the struct column is nullptr.
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, true))
+      .WillRepeatedly(testing::Return(nullptr));
+
+  // PRESENT stream of the decimal column is in Boolean Run Length Encoding.
+  // {0x05, 0xff} -> 8 bytes of 0xff -> 64 true values.
+  // {0x04, 0x00} -> 7 bytes of 0x00 -> 56 false values.
+  // {0xff, 0x01} -> 1 byte of 0x01 -> 7 false values followed with 1 true.
+  const unsigned char buffer1[] = { 0x05, 0xff, 0x04, 0x00, 0xff, 0x01 };
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, true))
+      .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                      (buffer1, ARRAY_SIZE(buffer1))));
+
+  // DATA stream of the decimal column is in RLEv2.
+  // Original values: [-32, -31, -30, ..., -1, 0, 1, 2, ..., 32]. See RLEv2.basicDelta5.
+  const unsigned char buffer2[] = { 0xc0, 0x40, 0x3f, 0x02 };
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                      (buffer2, ARRAY_SIZE(buffer2), 3)));
+
+  // create the row type
+  std::unique_ptr<Type> rowType = createStructType();
+  rowType->addStructField("col0", createDecimalType(12, 2));
+
+  std::unique_ptr<ColumnReader> reader = buildReader(*rowType, streams);
+
+  StructVectorBatch batch(64, *getDefaultPool());
+  Decimal64VectorBatch *decimals = new Decimal64VectorBatch(64, *getDefaultPool());
+  batch.fields.push_back(decimals);
+  reader->next(batch, 64, 0);
+  EXPECT_FALSE(batch.hasNulls);
+  EXPECT_EQ(64, batch.numElements);
+  EXPECT_FALSE(decimals->hasNulls);
+  EXPECT_EQ(64, decimals->numElements);
+  EXPECT_EQ(2, decimals->scale);
+  int64_t *values = decimals->values.data();
+  for (int64_t i = 0; i < 64; ++i) {
+    EXPECT_EQ(i - 32, values[i]);
+  }
+  reader->next(batch, 64, 0);
+  EXPECT_FALSE(batch.hasNulls);
+  EXPECT_EQ(64, batch.numElements);
+  EXPECT_TRUE(decimals->hasNulls);
+  EXPECT_EQ(64, decimals->numElements);
+  for (size_t i=0; i < 63; ++i) {
+    EXPECT_EQ(0, decimals->notNull[i]);
+  }
+  EXPECT_EQ(1, decimals->notNull[63]);
+  EXPECT_EQ(32, decimals->values.data()[63]);
+}
+
+TEST(DecimalColumnReader, testDecimal64V2Skip) {
+  MockStripeStreams streams;
+
+  // set getSelectedColumns() for struct<decimal(12,2)>
+  std::vector<bool> selectedColumns(2, true);
+  EXPECT_CALL(streams, getSelectedColumns())
+      .WillRepeatedly(testing::Return(selectedColumns));
+
+  // Use the decimal encoding in ORCv2
+  EXPECT_CALL(streams, isDecimalAsLong())
+      .WillRepeatedly(testing::Return(true));
+
+  // set encoding
+  proto::ColumnEncoding directEncoding;
+  directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+  EXPECT_CALL(streams, getEncoding(testing::_))
+      .WillRepeatedly(testing::Return(directEncoding));
+
+  // set getStream
+  // PRESENT stream of the struct column is nullptr.
+  EXPECT_CALL(streams, getStreamProxy(0, proto::Stream_Kind_PRESENT, true))
+      .WillRepeatedly(testing::Return(nullptr));
+
+  // PRESENT stream of the decimal column is in Boolean Run Length Encoding.
+  // {0x05, 0xff} -> 8 bytes of 0xff -> 64 true values.
+  // {0x04, 0x00} -> 7 bytes of 0x00 -> 56 false values.
+  // {0xff, 0x01} -> 1 byte of 0x01 -> 7 false values followed with 1 true.
+  const unsigned char buffer1[] = { 0x05, 0xff, 0x04, 0x00, 0xff, 0x01 };
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_PRESENT, true))
+      .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                      (buffer1, ARRAY_SIZE(buffer1))));
+
+  // DATA stream of the decimal column is in RLEv2.
+  // Original values: [-32, -31, -30, ..., -1, 0, 1, 2, ..., 32]. See RLEv2.basicDelta5.
+  const unsigned char buffer2[] = { 0xc0, 0x40, 0x3f, 0x02 };
+  EXPECT_CALL(streams, getStreamProxy(1, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(testing::Return(new SeekableArrayInputStream
+                                      (buffer2, ARRAY_SIZE(buffer2), 3)));
+
+  // create the row type
+  std::unique_ptr<Type> rowType = createStructType();
+  rowType->addStructField("col0", createDecimalType(12, 2));
+
+  std::unique_ptr<ColumnReader> reader = buildReader(*rowType, streams);
+  StructVectorBatch batch(64, *getDefaultPool());
+  Decimal64VectorBatch *decimals = new Decimal64VectorBatch(64, *getDefaultPool());
+  batch.fields.push_back(decimals);
+  // Read 10 values
+  reader->next(batch, 10, 0);
+  EXPECT_FALSE(batch.hasNulls);
+  EXPECT_EQ(10, batch.numElements);
+  EXPECT_FALSE(decimals->hasNulls);
+  EXPECT_EQ(10, decimals->numElements);
+  EXPECT_EQ(2, decimals->scale);
+  int64_t *values = decimals->values.data();
+  for (int64_t i = 0; i < 10; ++i) {
+    EXPECT_EQ(i - 32, values[i]);
+  }
+  // Skip 50 values and read 10 values again
+  reader->skip(50);
+  reader->next(batch, 10, 0);
+  EXPECT_FALSE(batch.hasNulls);
+  EXPECT_EQ(10, batch.numElements);
+  EXPECT_TRUE(decimals->hasNulls);
+  values = decimals->values.data();
+  for (int64_t i = 0; i < 4; ++i) {
+    EXPECT_EQ(60 + i - 32, values[i]);
+  }
+  for (size_t i = 4; i < 10; ++i) {
+    EXPECT_EQ(0, decimals->notNull[i]);
+  }
+  // Skip 57 values and read the last value
+  reader->skip(57);
+  reader->next(batch, 1, 0);
+  EXPECT_FALSE(batch.hasNulls);
+  EXPECT_EQ(1, batch.numElements);
+  EXPECT_FALSE(decimals->hasNulls);
+  EXPECT_EQ(32, decimals->values.data()[0]);
 }
 
 TEST(DecimalColumnReader, testDecimalHive11) {

--- a/c++/test/TestRleDecoder.cc
+++ b/c++/test/TestRleDecoder.cc
@@ -151,6 +151,28 @@ TEST(RLEv2, basicDelta4) {
                values.size());
 };
 
+TEST(RLEv2, basicDelta5) {
+  std::vector<int64_t> values(65);
+  for (size_t i = 0; i < 65; ++i) {
+    values[i] = static_cast<int64_t>(i - 32);
+  }
+
+  // Original values: [-32, -31, -30, ..., -1, 0, 1, 2, ..., 32]
+  // 2 bytes header: 0xc0, 0x40
+  //    2 bits for encoding type(3). 5 bits for bitSize which is 0 for fixed delta.
+  //    9 bits for length of 65(64).
+  // Base value: -32 which is 65(0x3f) after zigzag
+  // Delta base: 1 which is 2(0x02) after zigzag
+  const unsigned char bytes[] = {0xc0, 0x40, 0x3f, 0x02};
+  unsigned long l = sizeof(bytes) / sizeof(char);
+  // Read 1 at a time, then 3 at a time, etc.
+  checkResults(values, decodeRLEv2(bytes, l, 1, values.size()), 1);
+  checkResults(values, decodeRLEv2(bytes, l, 3, values.size()), 3);
+  checkResults(values, decodeRLEv2(bytes, l, 7, values.size()), 7);
+  checkResults(values, decodeRLEv2(bytes, l, values.size(), values.size()),
+               values.size());
+}
+
 TEST(RLEv2, delta0Width) {
   const unsigned char buffer[] = {0x4e, 0x2, 0x0, 0x1, 0x2, 0xc0, 0x2, 0x42,
 				  0x0};

--- a/tools/test/TestFileContents.cc
+++ b/tools/test/TestFileContents.cc
@@ -157,13 +157,13 @@ TEST (TestFileContents, testDecimal64V2) {
       "{\"a\": 17292380422, \"b\": 12, \"c\": 14836.80, \"d\": 0.09, \"e\": 0.06}\n"
       "{\"a\": 17292380422, \"b\": 41, \"c\": 82152.52, \"d\": 0.07, \"e\": 0.02}\n"
       "{\"a\": 17292380422, \"b\": 38, \"c\": 47240.84, \"d\": 0.10, \"e\": 0.00}\n";
-  const std::string error_msg =
-      "decimal64_v2.orc was written in an unknown format version UNSTABLE-PRE-2.0";
+  const std::string error_msg = "Warning: ORC file " + file +
+      " was written in an unknown format version UNSTABLE-PRE-2.0\n";
 
   std::string output;
   std::string error;
 
-  EXPECT_EQ(0, runProgram({pgm, file}, output, error));
+  EXPECT_EQ(0, runProgram({pgm, file}, output, error)) << error;
   EXPECT_EQ(expected, output);
-  EXPECT_NE(std::string::npos, error.find(error_msg)) << error;
+  EXPECT_EQ(error_msg, error);
 }

--- a/tools/test/TestFileContents.cc
+++ b/tools/test/TestFileContents.cc
@@ -142,3 +142,28 @@ TEST (TestFileContents, testInvalidName) {
   EXPECT_EQ("", output);
   EXPECT_NE(std::string::npos, error.find(error_msg));
 }
+
+TEST (TestFileContents, testDecimal64V2) {
+  const std::string pgm = findProgram("tools/src/orc-contents");
+  const std::string file = findExample("decimal64_v2.orc");
+  const std::string expected =
+      "{\"a\": 17292380420, \"b\": 24, \"c\": 36164.16, \"d\": 0.03, \"e\": 0.01}\n"
+      "{\"a\": 17292380421, \"b\": 38, \"c\": 63351.70, \"d\": 0.08, \"e\": 0.01}\n"
+      "{\"a\": 17292380421, \"b\": 28, \"c\": 42673.96, \"d\": 0.09, \"e\": 0.06}\n"
+      "{\"a\": 17292380421, \"b\": 40, \"c\": 76677.60, \"d\": 0.05, \"e\": 0.04}\n"
+      "{\"a\": 17292380421, \"b\": 2, \"c\": 2096.48, \"d\": 0.07, \"e\": 0.07}\n"
+      "{\"a\": 17292380421, \"b\": 42, \"c\": 45284.82, \"d\": 0.07, \"e\": 0.05}\n"
+      "{\"a\": 17292380421, \"b\": 10, \"c\": 18572.90, \"d\": 0.01, \"e\": 0.08}\n"
+      "{\"a\": 17292380422, \"b\": 12, \"c\": 14836.80, \"d\": 0.09, \"e\": 0.06}\n"
+      "{\"a\": 17292380422, \"b\": 41, \"c\": 82152.52, \"d\": 0.07, \"e\": 0.02}\n"
+      "{\"a\": 17292380422, \"b\": 38, \"c\": 47240.84, \"d\": 0.10, \"e\": 0.00}\n";
+  const std::string error_msg =
+      "decimal64_v2.orc was written in an unknown format version UNSTABLE-PRE-2.0";
+
+  std::string output;
+  std::string error;
+
+  EXPECT_EQ(0, runProgram({pgm, file}, output, error));
+  EXPECT_EQ(expected, output);
+  EXPECT_NE(std::string::npos, error.find(error_msg)) << error;
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This PR adds a reader for decimal64 in ORCv2 (added in ORC-49). Also extends `FileVersion` to recognize the version of "UNSTABLE-PRE-2.0". Decimal columns written in such version will be read using the new reader.

The original reader codes come from #147 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before this PR, the cpp reader is unable to read decimal columns in ORCv2.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Adds unit tests in TestColumnReader.cc
Adds an end to end test in TestFileContents.cc. 
Unfortunately, I can't find a clean way to generate such ORC files. So this PR introduces a new test file (decimal_v2.orc) generated by Hive.