### PR TITLE
ORC-1128: [C++] Replace protobuf::MessageLite::ByteSize() with ByteSi…

### DIFF
--- a/c++/test/CreateTestFiles.cc
+++ b/c++/test/CreateTestFiles.cc
@@ -45,20 +45,20 @@ void writeCustomOrcFile(const std::string& filename,
     exit(1);
   }
   orc::proto::PostScript ps;
-  ps.set_footerlength(static_cast<uint64_t>(footer.ByteSize()));
+  ps.set_footerlength(static_cast<uint64_t>(footer.ByteSizeLong()));
   ps.set_compression(orc::proto::NONE);
   ps.set_compressionblocksize(64*1024);
   for(size_t i=0; i < version.size(); ++i) {
     ps.add_version(version[i]);
   }
-  ps.set_metadatalength(static_cast<uint64_t>(metadata.ByteSize()));
+  ps.set_metadatalength(static_cast<uint64_t>(metadata.ByteSizeLong()));
   ps.set_writerversion(writerVersion);
   ps.set_magic("ORC");
   if (!ps.SerializeToOstream(&output)) {
     std::cerr << "Failed to write postscript for " << filename << "\n";
     exit(1);
   }
-  output.put(static_cast<char>(ps.ByteSize()));
+  output.put(static_cast<char>(ps.ByteSizeLong()));
 }
 
 /**

--- a/c++/test/TestBufferedOutputStream.cc
+++ b/c++/test/TestBufferedOutputStream.cc
@@ -110,7 +110,7 @@ namespace orc {
 
     EXPECT_TRUE(ps.SerializeToZeroCopyStream(&bufStream));
     bufStream.flush();
-    EXPECT_EQ(ps.ByteSize(), memStream.getLength());
+    EXPECT_EQ(ps.ByteSizeLong(), memStream.getLength());
 
     proto::PostScript ps2;
     ps2.ParseFromArray(


### PR DESCRIPTION
…zeLong()

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?

Replace protobuf::MessageLite::ByteSize() with protobuf::MessageLite::ByteSizeLong() in c++ test code.

### Why are the changes needed?

protobuf::MessageLite::ByteSize() was deprecated in protobuf library. It should be replaced with protobuf::MessageLite::ByteSizeLong() since it could cause build failure when building orc with new version of protobuf library.

### How was this patch tested?

Passed orc-test and tool-test.
