### PR TITLE
ORC-1129: [C++] Make tool-test depends on cpp tools

### DIFF
--- a/tools/src/CMakeLists.txt
+++ b/tools/src/CMakeLists.txt
@@ -94,12 +94,18 @@ target_link_libraries (csv-import
   ${CMAKE_THREAD_LIBS_INIT}
   )
 
+set(CPP_TOOL_NAMES
+  orc-contents
+  orc-metadata
+  orc-statistics
+  orc-scan
+  orc-memory
+  timezone-dump
+  csv-import
+  )
+
+add_custom_target(tool-set ALL DEPENDS ${CPP_TOOL_NAMES})
+
 install(TARGETS
-   orc-contents
-   orc-metadata
-   orc-statistics
-   orc-scan
-   orc-memory
-   timezone-dump
-   csv-import
+   ${CPP_TOOL_NAMES}
    DESTINATION bin)

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -39,6 +39,8 @@ target_link_libraries (tool-test
   orc::gmock
 )
 
+add_dependencies(tool-test tool-set)
+
 if (TEST_VALGRIND_MEMCHECK)
   add_test (tool-test valgrind --tool=memcheck --leak-check=full --error-exitcode=1 ./tool-test ${EXAMPLE_DIRECTORY} ${PROJECT_BINARY_DIR})
 else ()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Make `tool-test` depends on cpp tools so when any of the tool codes change, recompile tool-test will also recompile the tool.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This avoids mistakes when `tool-test` is using the old tool binaries that are inconsistent with the current codes.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manually tested `make -j8 tool-test` and `make -j8 DESTDIR=./tmp install`