### PR TITLE
ORC-1133: [C++] fix csv-import tool command line options not working

### DIFF
--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -311,9 +311,8 @@ int main(int argc, char* argv[]) {
   int opt;
   char *tail;
   do {
-    opt = getopt_long(argc, argv, "i:o:d:s:c:b:t:h", longOptions, ORC_NULLPTR);
+    opt = getopt_long(argc, argv, "d:s:c:b:t:h", longOptions, ORC_NULLPTR);
     switch (opt) {
-      case '?':
       case 'h':
         helpFlag = true;
         opt = -1;

--- a/tools/src/CSVFileImport.cc
+++ b/tools/src/CSVFileImport.cc
@@ -301,7 +301,7 @@ int main(int argc, char* argv[]) {
   static struct option longOptions[] = {
     {"help", no_argument, ORC_NULLPTR, 'h'},
     {"delimiter", required_argument, ORC_NULLPTR, 'd'},
-    {"stripe", required_argument, ORC_NULLPTR, 'p'},
+    {"stripe", required_argument, ORC_NULLPTR, 's'},
     {"block", required_argument, ORC_NULLPTR, 'c'},
     {"batch", required_argument, ORC_NULLPTR, 'b'},
     {"timezone", required_argument, ORC_NULLPTR, 't'},
@@ -311,7 +311,7 @@ int main(int argc, char* argv[]) {
   int opt;
   char *tail;
   do {
-    opt = getopt_long(argc, argv, "i:o:s:b:c:p:t:h", longOptions, ORC_NULLPTR);
+    opt = getopt_long(argc, argv, "i:o:d:s:c:b:t:h", longOptions, ORC_NULLPTR);
     switch (opt) {
       case '?':
       case 'h':
@@ -321,7 +321,7 @@ int main(int argc, char* argv[]) {
       case 'd':
         gDelimiter = optarg[0];
         break;
-      case 'p':
+      case 's':
         stripeSize = strtoul(optarg, &tail, 10);
         if (*tail != '\0') {
           fprintf(stderr, "The --stripe parameter requires an integer option.\n");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix the option strings passed to getopt_long functions, should be "d:s:c:b:t:h" instead of "s:b:c:p:t:h".

### Why are the changes needed?
The original option parsing is not dealing with stripe size option '-s' and delimiter option '-d' correctly.

### How was this patch tested?
The following command runs successfully:
./csv-import -d ',' -s 1 -b 1024 -c 1024 "struct<a:string>" a a.orc