### PR TITLE
ORC-1137: [C++] Unroll loops and copy data directly in DoubleColumnReader::next()

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -416,7 +416,7 @@ namespace orc {
   class DoubleColumnReader: public ColumnReader {
   public:
     DoubleColumnReader(const Type& type, StripeStreams& stripe);
-    ~DoubleColumnReader() override {};
+    ~DoubleColumnReader() override {}
 
     uint64_t skip(uint64_t numValues) override;
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This PR unrolls the loops inside DoubleColumnReader::readDouble() and readFloat(). Also refactor DoubleColumnReader to be a template class to save some runtime checks.
When running on a little-endian machine, the layout of the DATA stream matches the memory layout of the output double array. We use std::memcpy to copy data as more as we can in reading double columns.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR improves the performance in DoubleColumnReader::next(). The screenshot in the JIRA description shows it as a hot path.

Ran a performance test on reading 4 double columns on a file of tpch lineitem table using orc-scan. The file is 264MB with 7,296,488 rows.
I can see #instructions reduce 20% and time elapsed reduce 13%. More details here (collected by perf-stat):

|                   | original   | optimized   | reduce rate |
|-------------------|------------|-------------|-------------|
| task-clock (msec) | 786.314603 | 686.153474  | 12.74%      |
| context-switches  | 0          | 0           |             |
| cpu-migrations    | 0          | 0           |             |
| page-faults       | 6116       | 6113        | 0.05%       |
| cycles            | 3269319861 | 2865623800  | 12.35%      |
| instructions      | 8419802727 | 6739792930  | 19.95%      |
| branches          | 1185171422 | 925421384   | 21.92%      |
| branch-misses     | 989081     | 941046      | 4.86%       |
| time elapsed (s)  | 0.78855796 | 0.687502573 | 12.82%      |

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Ran existing tests.