### PR TITLE
ORC-969: [C++] Evaluate SearchArguments using file and stripe level stats

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1043,6 +1043,7 @@ namespace orc {
       // skip the entire file
       currentStripe = lastStripe;
       currentRowInStripe = 0;
+      rowsInCurrentStripe = 0;
       return;
     }
 
@@ -1135,7 +1136,7 @@ namespace orc {
     uint64_t rowsToRead =
       std::min(static_cast<uint64_t>(data.capacity),
                rowsInCurrentStripe - currentRowInStripe);
-    if (sargsApplier) {
+    if (sargsApplier && rowsToRead > 0) {
       rowsToRead = computeBatchSize(rowsToRead,
                                     currentRowInStripe,
                                     rowsInCurrentStripe,

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -66,6 +66,7 @@ namespace orc {
     /// Decimal64 in ORCv2 uses RLE to store values. This flag indicates whether
     /// this new encoding is used.
     bool isDecimalAsLong;
+    std::unique_ptr<proto::Metadata> metadata;
   };
 
   proto::StripeFooter getStripeFooter(const proto::StripeInformation& info,
@@ -253,9 +254,6 @@ namespace orc {
                                const proto::StripeFooter& currentStripeFooter,
                                std::vector<std::vector<proto::ColumnStatistics> >* indexStats) const;
 
-    // metadata
-    mutable std::unique_ptr<proto::Metadata> metadata;
-    mutable bool isMetadataLoaded;
    public:
     /**
      * Constructor that lets the user specify additional options.

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -153,8 +153,11 @@ namespace orc {
     std::unique_ptr<ColumnReader> reader;
 
     bool enableEncodedBlock;
-    // internal methods
-    void startNextStripe();
+    /**
+     * seek to the next stripe to read
+     * @return true if the next valid stripe exists
+     */
+    bool startNextStripe();
 
     // row index of current stripe with column id as the key
     std::unordered_map<uint64_t, proto::RowIndex> rowIndexes;

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -254,6 +254,8 @@ namespace orc {
                                const proto::StripeFooter& currentStripeFooter,
                                std::vector<std::vector<proto::ColumnStatistics> >* indexStats) const;
 
+    // metadata
+    mutable bool isMetadataLoaded;
    public:
     /**
      * Constructor that lets the user specify additional options.

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -153,11 +153,8 @@ namespace orc {
     std::unique_ptr<ColumnReader> reader;
 
     bool enableEncodedBlock;
-    /**
-     * seek to the next stripe to read
-     * @return true if the next valid stripe exists
-     */
-    bool startNextStripe();
+    // internal methods
+    void startNextStripe();
 
     // row index of current stripe with column id as the key
     std::unordered_map<uint64_t, proto::RowIndex> rowIndexes;

--- a/c++/src/sargs/SargsApplier.cc
+++ b/c++/src/sargs/SargsApplier.cc
@@ -149,20 +149,15 @@ namespace orc {
   }
 
   bool SargsApplier::evaluateStripeStatistics(
-                            uint64_t rowsInStripe,
                             const proto::StripeStatistics& stripeStats) {
     if (stripeStats.colstats_size() == 0) {
       return true;
     }
 
     bool ret = evaluateColumnStatistics(stripeStats.colstats());
-    if (!ret && mRowIndexStride > 0) {
-      // allocate evaluation result for row groups
-      uint64_t groupsInStripe =
-        (rowsInStripe + mRowIndexStride - 1) / mRowIndexStride;
-      mRowGroups.resize(groupsInStripe);
-      mTotalRowsInStripe = rowsInStripe;
-      std::fill(mRowGroups.begin(), mRowGroups.end(), false);
+    if (!ret) {
+      // reset mRowGroups when the current stripe does not satisfy the PPD
+      mRowGroups.clear();
     }
     return ret;
   }

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -38,6 +38,19 @@ namespace orc {
                  WriterVersion writerVersion);
 
     /**
+     * Evaluate search argument on file statistics
+     * @return true if file statistics satisfy the sargs
+     */
+    bool evaluateFileStatistics(const proto::Footer& footer);
+
+    /**
+     * Evaluate search argument on stripe statistics
+     * @return true if stripe statistics satisfy the sargs
+     */
+    bool evaluateStripeStatistics(uint64_t rowsInStripe,
+                                  const proto::StripeStatistics& stripeStats);
+
+    /**
      * TODO: use proto::RowIndex and proto::BloomFilter to do the evaluation
      * Pick the row groups that we need to load from the current stripe.
      * @return true if any row group is selected
@@ -81,6 +94,11 @@ namespace orc {
     }
 
   private:
+    // evaluate column statistics in the form of protobuf::RepeatedPtrField
+    typedef ::google::protobuf::RepeatedPtrField<proto::ColumnStatistics>
+      PbColumnStatistics;
+    bool evaluateColumnStatistics(const PbColumnStatistics& colStats) const;
+
     friend class TestSargsApplier_findColumnTest_Test;
     friend class TestSargsApplier_findArrayColumnTest_Test;
     friend class TestSargsApplier_findMapColumnTest_Test;
@@ -101,6 +119,9 @@ namespace orc {
     bool mHasSkipped;
     // keep stats of selected RGs and evaluated RGs
     std::pair<uint64_t, uint64_t> mStats;
+    // store result of file stats evaluation
+    bool mHasEvaluatedFileStats;
+    bool mFileStatsEvalResult;
   };
 
 }

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -47,8 +47,7 @@ namespace orc {
      * Evaluate search argument on stripe statistics
      * @return true if stripe statistics satisfy the sargs
      */
-    bool evaluateStripeStatistics(uint64_t rowsInStripe,
-                                  const proto::StripeStatistics& stripeStats);
+    bool evaluateStripeStatistics(const proto::StripeStatistics& stripeStats);
 
     /**
      * TODO: use proto::RowIndex and proto::BloomFilter to do the evaluation

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -144,7 +144,7 @@ namespace orc {
       *stripeStats.add_colstats() = createIntStats(0L, 10L);
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
-      EXPECT_FALSE(applier.evaluateStripeStatistics(3000, stripeStats));
+      EXPECT_FALSE(applier.evaluateStripeStatistics(stripeStats));
     }
     // Test stripe stats 0 <= x <= 50 and 0 <= y <= 50
     {
@@ -155,7 +155,7 @@ namespace orc {
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
-      EXPECT_TRUE(applier.evaluateStripeStatistics(3000, stripeStats));
+      EXPECT_TRUE(applier.evaluateStripeStatistics(stripeStats));
     }
     // Test file stats 0 <= x <= 10 and 0 <= y <= 50
     {

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -120,4 +120,75 @@ namespace orc {
     EXPECT_EQ(true, rowgroups[3]);
   }
 
+  TEST(TestSargsApplier, testStripeAndFileStats) {
+    auto type = std::unique_ptr<Type>(
+      Type::buildTypeFromString("struct<x:int,y:int>"));
+    auto sarg = SearchArgumentFactory::newBuilder()
+      ->startAnd()
+      .equals(
+              "x",
+              PredicateDataType::LONG,
+              Literal(static_cast<int64_t>(20)))
+      .equals(
+              "y",
+              PredicateDataType::LONG,
+              Literal(static_cast<int64_t>(40)))
+      .end()
+      .build();
+    // Test stripe stats 0 <= x <= 10 and 0 <= y <= 50
+    {
+      orc::proto::StripeStatistics stripeStats;
+      proto::ColumnStatistics structStatistics;
+      structStatistics.set_hasnull(false);
+      *stripeStats.add_colstats() = structStatistics;
+      *stripeStats.add_colstats() = createIntStats(0L, 10L);
+      *stripeStats.add_colstats() = createIntStats(0L, 50L);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
+      EXPECT_FALSE(applier.evaluateStripeStatistics(3000, stripeStats));
+    }
+    // Test stripe stats 0 <= x <= 50 and 0 <= y <= 50
+    {
+      orc::proto::StripeStatistics stripeStats;
+      proto::ColumnStatistics structStatistics;
+      structStatistics.set_hasnull(false);
+      *stripeStats.add_colstats() = structStatistics;
+      *stripeStats.add_colstats() = createIntStats(0L, 50L);
+      *stripeStats.add_colstats() = createIntStats(0L, 50L);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
+      EXPECT_TRUE(applier.evaluateStripeStatistics(3000, stripeStats));
+    }
+    // Test file stats 0 <= x <= 10 and 0 <= y <= 50
+    {
+      orc::proto::Footer footer;
+      proto::ColumnStatistics structStatistics;
+      structStatistics.set_hasnull(false);
+      *footer.add_statistics() = structStatistics;
+      *footer.add_statistics() = createIntStats(0L, 10L);
+      *footer.add_statistics() = createIntStats(0L, 50L);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
+      EXPECT_FALSE(applier.evaluateFileStatistics(footer));
+    }
+    // Test file stats 0 <= x <= 50 and 0 <= y <= 30
+    {
+      orc::proto::Footer footer;
+      proto::ColumnStatistics structStatistics;
+      structStatistics.set_hasnull(false);
+      *footer.add_statistics() = structStatistics;
+      *footer.add_statistics() = createIntStats(0L, 50L);
+      *footer.add_statistics() = createIntStats(0L, 30L);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
+      EXPECT_FALSE(applier.evaluateFileStatistics(footer));
+    }
+    // Test file stats 0 <= x <= 50 and 0 <= y <= 50
+    {
+      orc::proto::Footer footer;
+      proto::ColumnStatistics structStatistics;
+      structStatistics.set_hasnull(false);
+      *footer.add_statistics() = structStatistics;
+      *footer.add_statistics() = createIntStats(0L, 50L);
+      *footer.add_statistics() = createIntStats(0L, 50L);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
+      EXPECT_TRUE(applier.evaluateFileStatistics(footer));
+    }
+  }
 }  // namespace orc


### PR DESCRIPTION
### What changes were proposed in this pull request?
PPD use file stats and stripe stats to filter file content.


### Why are the changes needed?
To make better use of file and stripe stats.

### How was this patch tested?
use the UT testStripeAndFileStats test.
