### PR TITLE
ORC-1145: Add Java 18 to GitHub Action CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,6 +29,9 @@ jobs:
           - os: ubuntu-20.04
             java: 1.8
             cxx: g++
+          - os: ubuntu-20.04
+            java: 18
+            cxx: g++
     env:
       MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add Java 18 to GitHub Action CI. 


### Why are the changes needed?
To have a test coverage for Java 18 although it is not a LTS version. 

- [JEP 400:](https://openjdk.java.net/jeps/400) UTF-8 by Default—Sets UTF-8 as the default charset of the standard Java APIs. With this change, APIs that depend on the default charset will behave consistently across all implementations, operating systems, locales, and configurations.


### How was this patch tested?
Pass the CIs on this PR. 