### PR TITLE
ORC-1146: Float category missing check if the statistic sum is a finite value

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -546,7 +546,8 @@ public class RecordReaderImpl implements RecordReader {
                    " include ORC-517. Writer version: {}",
           predicate.getColumnName(), writerVersion);
       return TruthValue.YES_NO_NULL;
-    } else if (category == TypeDescription.Category.DOUBLE) {
+    } else if (category == TypeDescription.Category.DOUBLE
+        || category == TypeDescription.Category.FLOAT) {
       DoubleColumnStatistics dstas = (DoubleColumnStatistics) cs;
       if (!Double.isFinite(dstas.getSum())) {
         LOG.debug("Not using predication pushdown on {} because stats contain NaN values",


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr is aimed at checking whether the float category statistic sum has a finite value.

### Why are the changes needed?

When the orc float category is written with NaN, pushing down is not supported.

### How was this patch tested?

Added unit test.