### PR TITLE
ORC-1016: Use `openssl@1.1` in GitHub Action MacOS CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,7 +54,7 @@ jobs:
         if [ "${{ matrix.os }}" = "ubuntu-20.04" ]; then
           cmake -DANALYZE_JAVA=ON -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} -DSTOP_BUILD_ON_WARNING=OFF ..
         else
-          cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl` ..
+          cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl@1.1` ..
         fi
         make package test-out
         cd ../java


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport of ORC-1016 because `branch-1.6` seems to hit this issue in the following PR.
- https://github.com/apache/orc/pull/1078

This PR aims to recover GitHub Action by using `openssl@1.1` because GitHub Action `macOS` image does not ship `openssl` recently.

### Why are the changes needed?

GitHub changed its `openssl` install version.
- [[MacOS] Do not install latest OpenSSL](https://github.com/actions/virtual-environments/pull/4154)
- [Updating readme file for macOS-10.15 version 20210927.1](https://github.com/actions/virtual-environments/commit/3198af0e94db478c4529106e3835ce27b43153e4#diff-7a1606bd717fc0cf55f9419157117d9ca306f91bd2fdfc294720687d7be1b2c7R85)

### How was this patch tested?

Pass the GitHub Action.