### PR TITLE
ORC-1150: [C++] Optimize RowReaderImpl::computeBatchSize() by pre-computation

### DIFF
--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -175,13 +175,13 @@ namespace orc {
                                      uint64_t currentRowInStripe,
                                      uint64_t rowsInCurrentStripe,
                                      uint64_t rowIndexStride,
-                                     const std::vector<bool>& includedRowGroups);
+                                     const std::vector<uint64_t>& nextSkippedRows);
 
     // Skip non-selected rows
     static uint64_t advanceToNextRowGroup(uint64_t currentRowInStripe,
                                           uint64_t rowsInCurrentStripe,
                                           uint64_t rowIndexStride,
-                                          const std::vector<bool>& includedRowGroups);
+                                          const std::vector<uint64_t>& nextSkippedRows);
 
     friend class TestRowReader_advanceToNextRowGroup_Test;
     friend class TestRowReader_computeBatchSize_Test;

--- a/c++/src/sargs/SargsApplier.cc
+++ b/c++/src/sargs/SargsApplier.cc
@@ -166,7 +166,7 @@ namespace orc {
 
     bool ret = evaluateColumnStatistics(stripeStats.colstats());
     if (!ret) {
-      // reset mRowGroups when the current stripe does not satisfy the PPD
+      // reset mNextSkippedRows when the current stripe does not satisfy the PPD
       mNextSkippedRows.clear();
     }
     return ret;

--- a/c++/src/sargs/SargsApplier.cc
+++ b/c++/src/sargs/SargsApplier.cc
@@ -86,7 +86,9 @@ namespace orc {
     mHasSelected = false;
     mHasSkipped = false;
     uint64_t nextSkippedRowGroup = groupsInStripe;
-    for (int rowGroup = static_cast<int>(groupsInStripe - 1); rowGroup >= 0; --rowGroup) {
+    size_t rowGroup = groupsInStripe;
+    do {
+      --rowGroup;
       for (size_t pred = 0; pred != leaves.size(); ++pred) {
         uint64_t columnIdx = mFilterColumns[pred];
         auto rowIndexIter = rowIndexes.find(columnIdx);
@@ -121,7 +123,7 @@ namespace orc {
       }
       mHasSelected |= needed;
       mHasSkipped |= !needed;
-    }
+    } while (rowGroup != 0);
 
     // update stats
     mStats.first = std::accumulate(

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -114,7 +114,7 @@ namespace orc {
 
     // Map from RowGroup index to the next skipped row of the selected range it
     // locates. If the RowGroup is not selected, set the value to 0.
-    // Calculated in pickRowGroups.
+    // Calculated in pickRowGroups().
     std::vector<uint64_t> mNextSkippedRows;
     uint64_t mTotalRowsInStripe;
     bool mHasSelected;

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -60,10 +60,11 @@ namespace orc {
                       const std::map<uint32_t, BloomFilterIndex>& bloomFilters);
 
     /**
-     * Return a vector of bool for each row group for their selection
-     * in the last evaluation
+     * Return a vector of the next skipped row for each RowGroup. Each value is the row id
+     * in stripe. 0 means the current RowGroup is entirely skipped.
+     * Only valid after invoking pickRowGroups().
      */
-    const std::vector<bool>& getRowGroups() const { return mRowGroups; }
+    const std::vector<uint64_t>& getNextSkippedRows() const { return mNextSkippedRows; }
 
     /**
      * Indicate whether any row group is selected in the last evaluation
@@ -80,8 +81,8 @@ namespace orc {
      */
     bool hasSelectedFrom(uint64_t currentRowInStripe) const {
       uint64_t rg = currentRowInStripe / mRowIndexStride;
-      for (; rg < mRowGroups.size(); ++rg) {
-        if (mRowGroups[rg]) {
+      for (; rg < mNextSkippedRows.size(); ++rg) {
+        if (mNextSkippedRows[rg]) {
           return true;
         }
       }
@@ -111,8 +112,10 @@ namespace orc {
     // column ids for each predicate leaf in the search argument
     std::vector<uint64_t> mFilterColumns;
 
-    // store results of last call of pickRowGroups
-    std::vector<bool> mRowGroups;
+    // Map from RowGroup index to the next skipped row of the selected range it
+    // locates. If the RowGroup is not selected, set the value to 0.
+    // Calculated in pickRowGroups.
+    std::vector<uint64_t> mNextSkippedRows;
     uint64_t mTotalRowsInStripe;
     bool mHasSelected;
     bool mHasSkipped;

--- a/c++/test/TestReader.cc
+++ b/c++/test/TestReader.cc
@@ -58,8 +58,6 @@ namespace orc {
   TEST(TestRowReader, computeBatchSize) {
     uint64_t rowIndexStride = 100;
     uint64_t rowsInCurrentStripe = 100 * 8 + 50;
-    std::vector<bool> includedRowGroups =
-      { false, false, true, true, false, false, true, true, false };
     std::vector<uint64_t> nextSkippedRows =
       { 0, 0, 400, 400, 0, 0, 800, 800, 0 };
 

--- a/c++/test/TestReader.cc
+++ b/c++/test/TestReader.cc
@@ -60,53 +60,55 @@ namespace orc {
     uint64_t rowsInCurrentStripe = 100 * 8 + 50;
     std::vector<bool> includedRowGroups =
       { false, false, true, true, false, false, true, true, false };
+    std::vector<uint64_t> nextSkippedRows =
+      { 0, 0, 400, 400, 0, 0, 800, 800, 0 };
 
     EXPECT_EQ(0, RowReaderImpl::computeBatchSize(
-      1024, 0, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      1024, 0, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(0, RowReaderImpl::computeBatchSize(
-      1024, 50, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      1024, 50, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(200, RowReaderImpl::computeBatchSize(
-      1024, 200, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      1024, 200, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(150, RowReaderImpl::computeBatchSize(
-      1024, 250, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      1024, 250, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(0, RowReaderImpl::computeBatchSize(
-      1024, 550, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      1024, 550, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(100, RowReaderImpl::computeBatchSize(
-      1024, 700, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      1024, 700, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(50, RowReaderImpl::computeBatchSize(
-      50, 700, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      50, 700, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(0, RowReaderImpl::computeBatchSize(
-      50, 810, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      50, 810, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(0, RowReaderImpl::computeBatchSize(
-      50, 900, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      50, 900, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
   }
 
   TEST(TestRowReader, advanceToNextRowGroup) {
     uint64_t rowIndexStride = 100;
     uint64_t rowsInCurrentStripe = 100 * 8 + 50;
-    std::vector<bool> includedRowGroups =
-      { false, false, true, true, false, false, true, true, false };
+    std::vector<uint64_t> nextSkippedRows =
+      { 0, 0, 400, 400, 0, 0, 800, 800, 0 };
 
     EXPECT_EQ(200, RowReaderImpl::advanceToNextRowGroup(
-      0, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      0, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(200, RowReaderImpl::advanceToNextRowGroup(
-      150, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      150, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(250, RowReaderImpl::advanceToNextRowGroup(
-      250, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      250, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(350, RowReaderImpl::advanceToNextRowGroup(
-      350, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      350, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(350, RowReaderImpl::advanceToNextRowGroup(
-      350, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      350, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(600, RowReaderImpl::advanceToNextRowGroup(
-      500, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      500, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(699, RowReaderImpl::advanceToNextRowGroup(
-      699, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      699, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(799, RowReaderImpl::advanceToNextRowGroup(
-      799, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      799, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(850, RowReaderImpl::advanceToNextRowGroup(
-      800, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      800, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
     EXPECT_EQ(850, RowReaderImpl::advanceToNextRowGroup(
-      900, rowsInCurrentStripe, rowIndexStride, includedRowGroups));
+      900, rowsInCurrentStripe, rowIndexStride, nextSkippedRows));
   }
 
   void CheckFileWithSargs(const char* fileName, const char* softwareVersion) {

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -112,12 +112,12 @@ namespace orc {
     // evaluate row group index
     SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135);
     EXPECT_TRUE(applier.pickRowGroups(4000, rowIndexes, {}));
-    std::vector<bool> rowgroups = applier.getRowGroups();
-    EXPECT_EQ(4, rowgroups.size());
-    EXPECT_EQ(false, rowgroups[0]);
-    EXPECT_EQ(false, rowgroups[1]);
-    EXPECT_EQ(false, rowgroups[2]);
-    EXPECT_EQ(true, rowgroups[3]);
+    const auto& nextSkippedRows = applier.getNextSkippedRows();
+    EXPECT_EQ(4, nextSkippedRows.size());
+    EXPECT_EQ(0, nextSkippedRows[0]);
+    EXPECT_EQ(0, nextSkippedRows[1]);
+    EXPECT_EQ(0, nextSkippedRows[2]);
+    EXPECT_EQ(4000, nextSkippedRows[3]);
   }
 
   TEST(TestSargsApplier, testStripeAndFileStats) {

--- a/tools/test/TestFileScan.cc
+++ b/tools/test/TestFileScan.cc
@@ -206,7 +206,7 @@ void checkForError(const std::string& filename, const std::string& error_msg) {
   std::string error;
   EXPECT_EQ(1, runProgram({pgm, filename}, output, error));
   EXPECT_EQ("", output);
-  EXPECT_NE(std::string::npos, error.find(error_msg));
+  EXPECT_NE(std::string::npos, error.find(error_msg)) << error;
 }
 
 TEST (TestFileScan, testErrorHandling) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
In case of PPD, SargsApplier mantains a bool vector representing whether a RowGroup is picked after evaluating the SearchArguments. The bool vector is then used in RowReaderImpl::computeBatchSize() to compute the next skipped row id for  the current row range. The computation is done for each batch.

In the worst case, if all RowGroups are picked, computeBatchSize() has to iterate the whole vector starts from the current RowGroup. In practise, a stripe can have thousands of RowGroups. The complexity of iterating the bool vector is comparable to materializing the batch (usually have size as 1024). The perf result in the JIRA description shows that it can take 1/4 of the scan time.

Instead of maintaining the bool vector, we can pre-compute the next skipped row id of the row range that each RowGroup locates. RowReaderImpl::computeBatchSize() can use the results directly. This PR replaces the bool vector with the vector of row ids explained above. If the current RowGroup is skipped, the value is 0. This matches the case when the original bool value is false.

The pre-computation is still done in SargsApplier::pickRowGroups(). RowReaderImpl::computeBatchSize() and RowReaderImpl::advanceToNextRowGroup() are optimized to use the pre-computed results.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This PR improves the performance in case of PPD. I pick a 252MB file of the tpcds inventory table, use a modified orc-scan with PPD that picks all RowGroups to scan it. Here are the results measure by perf-stat:

|                | original    | optimized   | speedup      |
|----------------|-------------|-------------|--------------|
| Time taken (s) | 0.722492053 | 0.527221077 | 1.3703777875 |
| instructions   | 8725349519  | 5989083282  | 1.4568756366 |
| branches       | 1143322885  | 752821194   | 1.5187177169 |


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Passed all existing tests.