### PR TITLE
ORC-1155: Add Ubuntu 22.04 to docker tests

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 * CentOS 7
 * Debian 9 and 10
-* Ubuntu 18 and 20
+* Ubuntu 18, 20 and 22
 
 ## Test
 

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,6 +4,7 @@ debian10
 debian11
 ubuntu18
 ubuntu20
+ubuntu22
 debian10_jdk=11
 ubuntu20_jdk=11
 ubuntu20_jdk=11_cc=clang

--- a/docker/ubuntu22/Dockerfile
+++ b/docker/ubuntu22/Dockerfile
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Ubuntu 22
+#
+
+FROM ubuntu:22.04
+LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+ARG jdk=8
+ARG cc=gcc
+
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+RUN apt-get update
+RUN apt-get install -y \
+  cmake \
+  git \
+  libsasl2-dev \
+  libssl-dev \
+  make \
+  curl \
+  maven \
+  openjdk-${jdk}-jdk \
+  tzdata; \
+  if [ "${cc}" = "gcc" ] ; then \
+    apt-get install -y \
+    gcc \
+    g++ \
+  ; else \
+    apt-get install -y \
+    clang \
+    && \
+    update-alternatives --set cc  /usr/bin/clang && \
+    update-alternatives --set c++ /usr/bin/clang++ \
+  ; fi
+RUN update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
+    update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk})
+
+ENV CC=cc
+ENV CXX=c++
+
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
This PR aims to add Ubuntu 22.04 to docker tests. 


### Why are the changes needed?
Ubuntu 22.04 is the new LTS version. 
This PR is to verify ORC in the latest Ubuntu environment. 


### How was this patch tested?
Manually run the docker tests. 
