### PR TITLE
ORC-1159: [C++] Fix crash when the last stripe is skipped

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1137,7 +1137,7 @@ namespace orc {
     if (currentRowInStripe == 0) {
       startNextStripe();
     }
-    uint64_t rowsToRead =
+    uint64_t rowsToRead = currentStripe >= lastStripe ? 0 :
       std::min(static_cast<uint64_t>(data.capacity),
                rowsInCurrentStripe - currentRowInStripe);
     if (sargsApplier && rowsToRead > 0) {

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1035,6 +1035,20 @@ namespace orc {
     return memory + decompressorMemory ;
   }
 
+  // Update fields to indicate we've reached the end of file
+  void RowReaderImpl::markEndOfFile() {
+    currentStripe = lastStripe;
+    currentRowInStripe = 0;
+    rowsInCurrentStripe = 0;
+    if (lastStripe == 0) {
+      // Empty file
+      previousRow = 0;
+    } else {
+      previousRow = firstRowOfStripe[lastStripe - 1] +
+          footer->stripes(static_cast<int>(lastStripe - 1)).numberofrows();
+    }
+  }
+
   void RowReaderImpl::startNextStripe() {
     reader.reset(); // ColumnReaders use lots of memory; free old memory first
     rowIndexes.clear();
@@ -1043,9 +1057,7 @@ namespace orc {
     // evaluate file statistics if it exists
     if (sargsApplier && !sargsApplier->evaluateFileStatistics(*footer)) {
       // skip the entire file
-      currentStripe = lastStripe;
-      currentRowInStripe = 0;
-      rowsInCurrentStripe = 0;
+      markEndOfFile();
       return;
     }
 
@@ -1120,24 +1132,22 @@ namespace orc {
           seekToRowGroup(static_cast<uint32_t>(currentRowInStripe / footer->rowindexstride()));
         }
       }
+    } else {
+      // All remaining stripes are skipped.
+      markEndOfFile();
     }
   }
 
   bool RowReaderImpl::next(ColumnVectorBatch& data) {
     if (currentStripe >= lastStripe) {
       data.numElements = 0;
-      if (lastStripe > 0) {
-        previousRow = firstRowOfStripe[lastStripe - 1] +
-          footer->stripes(static_cast<int>(lastStripe - 1)).numberofrows();
-      } else {
-        previousRow = 0;
-      }
+      markEndOfFile();
       return false;
     }
     if (currentRowInStripe == 0) {
       startNextStripe();
     }
-    uint64_t rowsToRead = currentStripe >= lastStripe ? 0 :
+    uint64_t rowsToRead =
       std::min(static_cast<uint64_t>(data.capacity),
                rowsInCurrentStripe - currentRowInStripe);
     if (sargsApplier && rowsToRead > 0) {
@@ -1149,9 +1159,7 @@ namespace orc {
     }
     data.numElements = rowsToRead;
     if (rowsToRead == 0) {
-      previousRow = lastStripe <= 0 ? footer->numberofrows() :
-                    firstRowOfStripe[lastStripe - 1] +
-                    footer->stripes(static_cast<int>(lastStripe - 1)).numberofrows();
+      markEndOfFile();
       return false;
     }
     if (enableEncodedBlock) {

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -155,6 +155,7 @@ namespace orc {
     bool enableEncodedBlock;
     // internal methods
     void startNextStripe();
+    inline void markEndOfFile();
 
     // row index of current stripe with column id as the key
     std::unordered_map<uint64_t, proto::RowIndex> rowIndexes;

--- a/c++/test/TestPredicatePushdown.cc
+++ b/c++/test/TestPredicatePushdown.cc
@@ -386,7 +386,9 @@ namespace orc {
     TestMultipleSeeksWithoutRowIndexes(reader.get(), false);
   }
 
-  void TestNoRowsSelectedWithFileStats(Reader* reader) {
+  // Test Sarg skips the whole file based on file stats.
+  // Seeking to 'seekRowNumber' (if it's non-negative) before reads.
+  void TestNoRowsSelectedWithFileStats(Reader* reader, int seekRowNumber) {
     std::unique_ptr<SearchArgument> sarg =
       SearchArgumentFactory::newBuilder()
         ->startAnd()
@@ -400,49 +402,85 @@ namespace orc {
     auto rowReader = reader->createRowReader(rowReaderOpts);
 
     auto readBatch = rowReader->createRowBatch(2000);
+    if (seekRowNumber >= 0) {
+      rowReader->seekToRow(static_cast<uint64_t>(seekRowNumber));
+    }
     EXPECT_EQ(false, rowReader->next(*readBatch));
+    EXPECT_EQ(7000, rowReader->getRowNumber());
   }
 
-  void TestSelectedWithStripeStats(Reader* reader) {
+  void TestLastStripeSelectedWithStripeStats(Reader* reader, int seekRowNumber) {
+    // Sargs: col1 between 3500 and 7000. First stripe (3500 rows) will be skipped.
     std::unique_ptr<SearchArgument> sarg =
       SearchArgumentFactory::newBuilder()
-          ->startAnd()
-          .between("col1",
-                   PredicateDataType::LONG,
-                   Literal(static_cast<int64_t>(3500)),
-                   Literal(static_cast<int64_t>(7000)))
-          .end()
+          ->between("col1",
+                    PredicateDataType::LONG,
+                    Literal(static_cast<int64_t>(3500)),
+                    Literal(static_cast<int64_t>(7000)))
           .build();
 
     RowReaderOptions rowReaderOpts;
     rowReaderOpts.searchArgument(std::move(sarg));
     auto rowReader = reader->createRowReader(rowReaderOpts);
 
-    auto readBatch = rowReader->createRowBatch(2000);
-    // 1st batch of 2000 rows
-    EXPECT_EQ(true, rowReader->next(*readBatch));
-    // test previous row number
-    EXPECT_EQ(3500, rowReader->getRowNumber());
-    EXPECT_EQ(2000, readBatch->numElements);
-    auto& batch0 = dynamic_cast<StructVectorBatch&>(*readBatch);
-    auto& batch1 = dynamic_cast<LongVectorBatch&>(*batch0.fields[0]);
-    for (uint64_t i = 0; i < 2000; ++i) {
-      EXPECT_EQ(i + 3500 , batch1.data[i]);
+    if (seekRowNumber >= 0) {
+      rowReader->seekToRow(static_cast<uint64_t>(seekRowNumber));
     }
-    // 2nd batch of 1500 rows
-    EXPECT_EQ(true, rowReader->next(*readBatch));
-    // test previous row number
-    EXPECT_EQ(5500, rowReader->getRowNumber());
-    EXPECT_EQ(1500, readBatch->numElements);
-    for (uint64_t i = 0; i < 1500; ++i) {
-      EXPECT_EQ(i + 5500 , batch1.data[i]) << i;
+    // Seek within the first stripe which is skipped due to PPD. Any seeks within it
+    // will go to the end of the first stripe.
+    if (seekRowNumber < 3500) {
+      auto readBatch = rowReader->createRowBatch(2000);
+      // 1st batch of 2000 rows
+      EXPECT_EQ(true, rowReader->next(*readBatch));
+      // test previous row number
+      EXPECT_EQ(3500, rowReader->getRowNumber());
+      EXPECT_EQ(2000, readBatch->numElements);
+      auto& batch0 = dynamic_cast<StructVectorBatch&>(*readBatch);
+      auto& batch1 = dynamic_cast<LongVectorBatch&>(*batch0.fields[0]);
+      for (uint64_t i = 0; i < 2000; ++i) {
+        EXPECT_EQ(i + 3500 , batch1.data[i]);
+      }
+
+      // 2nd batch of the remaining 1500 rows
+      EXPECT_EQ(true, rowReader->next(*readBatch));
+      // test previous row number
+      EXPECT_EQ(5500, rowReader->getRowNumber());
+      EXPECT_EQ(1500, readBatch->numElements);
+      for (uint64_t i = 0; i < 1500; ++i) {
+        EXPECT_EQ(i + 5500 , batch1.data[i]);
+      }
+      // no more batches
+      EXPECT_EQ(false, rowReader->next(*readBatch));
+      return;
     }
-    // no more batches
-    EXPECT_EQ(false, rowReader->next(*readBatch));
+
+    // Seek to the end of file
+    if (seekRowNumber >= 7000) {
+      auto readBatch = rowReader->createRowBatch(2000);
+      EXPECT_EQ(false, rowReader->next(*readBatch));
+      EXPECT_EQ(7000, rowReader->getRowNumber());
+      return;
+    }
+
+    {
+      // Seek within the second stripe. Use 3500 as the batch size so we can read all rows
+      // at once.
+      auto readBatch = rowReader->createRowBatch(3500);
+      EXPECT_EQ(true, rowReader->next(*readBatch));
+      EXPECT_EQ(seekRowNumber, rowReader->getRowNumber());
+      EXPECT_EQ(7000 - seekRowNumber, readBatch->numElements);
+      auto& batch0 = dynamic_cast<StructVectorBatch&>(*readBatch);
+      auto& batch1 = dynamic_cast<LongVectorBatch&>(*batch0.fields[0]);
+      for (uint64_t i = 0; i < readBatch->numElements; ++i) {
+        EXPECT_EQ(i + static_cast<unsigned long>(seekRowNumber), batch1.data[i]);
+      }
+      // no more batches
+      EXPECT_EQ(false, rowReader->next(*readBatch));
+    }
   }
 
-  void TestSelectedWithStripeStats2(Reader* reader) {
-    // Sargs: col1 < 3500
+  void TestFirstStripeSelectedWithStripeStats(Reader* reader, int seekRowNumber) {
+    // Sargs: col1 < 3500. Last stripe (3500 rows) will be skipped.
     std::unique_ptr<SearchArgument> sarg = SearchArgumentFactory::newBuilder()
         ->lessThan("col1",
                    PredicateDataType::LONG,
@@ -452,27 +490,26 @@ namespace orc {
     rowReaderOpts.searchArgument(std::move(sarg));
     auto rowReader = reader->createRowReader(rowReaderOpts);
 
-    auto readBatch = rowReader->createRowBatch(2000);
-    // 1st batch of 2000 rows
-    EXPECT_EQ(true, rowReader->next(*readBatch));
-    // test previous row number
-    EXPECT_EQ(0, rowReader->getRowNumber());
-    EXPECT_EQ(2000, readBatch->numElements);
+    auto readBatch = rowReader->createRowBatch(3500);
     auto& batch0 = dynamic_cast<StructVectorBatch&>(*readBatch);
     auto& batch1 = dynamic_cast<LongVectorBatch&>(*batch0.fields[0]);
-    for (uint64_t i = 0; i < 2000; ++i) {
-      EXPECT_EQ(i, batch1.data[i]);
+
+    uint64_t firstRowNumber = 0;
+    if (seekRowNumber >= 0) {
+      rowReader->seekToRow(static_cast<uint64_t>(seekRowNumber));
+      firstRowNumber = static_cast<uint64_t>(seekRowNumber);
     }
-    // 2nd batch of the remaining 1500 rows
-    EXPECT_EQ(true, rowReader->next(*readBatch));
-    // test previous row number
-    EXPECT_EQ(2000, rowReader->getRowNumber());
-    EXPECT_EQ(1500, readBatch->numElements);
-    for (uint64_t i = 0; i < 1500; ++i) {
-      EXPECT_EQ(i + 2000, batch1.data[i]);
+    if (seekRowNumber < 3500) {
+      EXPECT_EQ(true, rowReader->next(*readBatch));
+      EXPECT_EQ(firstRowNumber, rowReader->getRowNumber());
+      EXPECT_EQ(3500 - firstRowNumber, readBatch->numElements);
+      for (uint64_t i = 0; i < readBatch->numElements; ++i) {
+        EXPECT_EQ(i + firstRowNumber, batch1.data[i]);
+      }
     }
     // no more batches
     EXPECT_EQ(false, rowReader->next(*readBatch));
+    EXPECT_EQ(7000, rowReader->getRowNumber());
   }
 
   TEST(TestPredicatePushdown, testStripeAndFileStats) {
@@ -512,8 +549,12 @@ namespace orc {
     EXPECT_EQ(7000, reader->getNumberOfRows());
     EXPECT_EQ(stripeCount, reader->getNumberOfStripes());
 
-    TestNoRowsSelectedWithFileStats(reader.get());
-    TestSelectedWithStripeStats(reader.get());
-    TestSelectedWithStripeStats2(reader.get());
+    // Seek to different positions before each test. -1 means no seek.
+    int seekRowNumber[] = {-1, 0, 1000, 4000, 8000};
+    for (int pos : seekRowNumber) {
+      TestNoRowsSelectedWithFileStats(reader.get(), pos);
+      TestLastStripeSelectedWithStripeStats(reader.get(), pos);
+      TestFirstStripeSelectedWithStripeStats(reader.get(), pos);
+    }
   }
 }  // namespace orc


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes a bug introduced by a recent improvement (#1073). When the last stripe is skipped by StartNextStripe(), we should return in RowReaderImpl::next().

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This fixes a crash of the C++ client when sargs exist and the last stripe is skipped.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
We are lack of test coverage for the above case. Add more tests in TestPredicatePushdown.