### PR TITLE
ORC-1161: Add MacOS 12 and remove MacOS 10

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-10.15
           - macos-11
+          - macos-12
         java:
           - 1.8
           - 11


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add MacOS 12 and remove MacOS 10.

### Why are the changes needed?
The latest version is MacOS 12.

https://github.com/actions/virtual-environments

- System Version: macOS 12.3.1 (21E258)
- Kernel Version: Darwin 21.4.0
- Image Version: 20220425.3
- Cmake 3.23.1
- Clang/LLVM 13.1.6
- gcc-11 (Homebrew GCC 11.2.0_3) 11.2.0
- Java 8/11/17 (Eclipse Temurin)

### How was this patch tested?
Pass the CIs.
