### PR TITLE
ORC-1162: Fix Apache Project Website Checks Warning

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -73,7 +73,9 @@ overview: true
                <a href="https://www.apache.org/foundation/how-it-works.html">
 	        open governance</a> and
                <a href="https://privacy.apache.org/policies/privacy-policy-public.html">
-	        privacy policy</a>. If you discover any
+	        privacy policy</a>. See upcoming
+               <a class="dropdown-item" href="https://www.apache.org/events/current-event">Apache Events</a>.
+               If you discover any
 	       <a href="security/">security</a> vulnerabilities, please
 	       report them privately. Finally,
                <a href="https://www.apache.org/foundation/thanks.html">thanks


### PR DESCRIPTION
### What changes were proposed in this pull request?

This will add Apache Event page to the Apache ORC website.

### Why are the changes needed?

Currently, Apache Project Website Checks show warnings on the Apache ORC website.
https://whimsy.apache.org/site/project/orc
 
<img width="1366" alt="Screen Shot 2022-04-28 at 9 20 56 AM" src="https://user-images.githubusercontent.com/9700541/165798852-dcdd9193-d9d2-4a28-8e74-76af4c676e3b.png">

### How was this patch tested?

Manually check the generated website.

This closes #1103