### PR TITLE
ORC-1169: Use Hadoop to 3.3.2 on Java 17+

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -470,9 +470,9 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <min.hadoop.version>3.3.1</min.hadoop.version>
-        <hadoop.version>3.3.1</hadoop.version>
-        <tools.hadoop.version>3.3.1</tools.hadoop.version>
+        <min.hadoop.version>3.3.2</min.hadoop.version>
+        <hadoop.version>3.3.2</hadoop.version>
+        <tools.hadoop.version>3.3.2</tools.hadoop.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Hadoop to 3.3.2 on `java17` profile in Apache ORC 1.8.0.

### Why are the changes needed?

[Apache Hadoop 3.3.2 is the latest version](https://hadoop.apache.org/docs/r3.3.2/index.html) with the following.

  - This is the first release to support ARM architectures.
  - Upgrade protobuf from 2.5.0 to something newer
  - Java 11 runtime support is completed.
  - Shaded Guava from thirdparty

### How was this patch tested?

Pass the Java 17+ CIs.