### PR TITLE
ORC-1170:[C++] Optimize the RowReader::seekToRow function in the case of seeking within the same stripe

### DIFF
--- a/c++/include/orc/MemoryPool.hh
+++ b/c++/include/orc/MemoryPool.hh
@@ -72,6 +72,10 @@ namespace orc {
       return currentCapacity;
     }
 
+    const T& operator[](uint64_t i) const {
+      return buf[i];
+    }
+
     T& operator[](uint64_t i) {
       return buf[i];
     }

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -424,8 +424,7 @@ namespace orc {
       if (rowIndexes.empty()) {
         loadStripeIndex();
       }
-      auto rowGroupId = static_cast<uint32_t>(rowsToSkip / rowIndexStride);
-      seekToRowGroup(rowGroupId);
+      seekToRowGroup(static_cast<uint32_t>(rowsToSkip / rowIndexStride));
       // skip leading rows in the target row group
       rowsToSkip %= rowIndexStride;
     }

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -282,7 +282,7 @@ namespace orc {
       }
     }
     firstStripe = currentStripe;
-    currentInitedStripe = lastStripe;
+    processingStripe = lastStripe;
 
     if (currentStripe == 0) {
       previousRow = (std::numeric_limits<uint64_t>::max)();
@@ -424,6 +424,7 @@ namespace orc {
       if (rowIndexes.empty()) {
         loadStripeIndex();
       }
+      // TODO: process the call of loadStripeIndex() failures
       seekToRowGroup(static_cast<uint32_t>(rowsToSkip / rowIndexStride));
       // skip leading rows in the target row group
       rowsToSkip %= rowIndexStride;
@@ -1088,7 +1089,7 @@ namespace orc {
       }
       currentStripeFooter = getStripeFooter(currentStripeInfo, *contents.get());
       rowsInCurrentStripe = currentStripeInfo.numberofrows();
-      currentInitedStripe = currentStripe;
+      processingStripe = currentStripe;
 
       if (sargsApplier) {
         bool isStripeNeeded = true;

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -424,7 +424,7 @@ namespace orc {
       if (rowIndexes.empty()) {
         loadStripeIndex();
       }
-      // TODO: process the call of loadStripeIndex() failures
+      // TODO(ORC-1175): process the failures of loadStripeIndex() call
       seekToRowGroup(static_cast<uint32_t>(rowsToSkip / rowIndexStride));
       // skip leading rows in the target row group
       rowsToSkip %= rowIndexStride;

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -188,13 +188,6 @@ namespace orc {
     friend class TestRowReader_advanceToNextRowGroup_Test;
     friend class TestRowReader_computeBatchSize_Test;
 
-    // last row number of the current stripe
-    inline uint64_t lastRowOfCurrentStripe() const {
-      return currentStripe < lastStripe ?
-        firstRowOfStripe[currentStripe] + rowsInCurrentStripe :
-        footer->numberofrows();
-    }
-
     // whether the current stripe is initialized
     inline bool isCurrentStripeInited() const {
       return currentStripe == currentInitedStripe;

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -188,12 +188,14 @@ namespace orc {
     friend class TestRowReader_advanceToNextRowGroup_Test;
     friend class TestRowReader_computeBatchSize_Test;
 
+    // last row number of the current stripe
     inline uint64_t lastRowOfCurrentStripe() const {
       return currentStripe < lastStripe ?
         firstRowOfStripe[currentStripe] + rowsInCurrentStripe :
         footer->numberofrows();
     }
 
+    // whether the current stripe is initialized
     inline bool isCurrentStripeInited() const {
       return currentStripe == currentInitedStripe;
     }

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -146,6 +146,7 @@ namespace orc {
     uint64_t firstStripe;
     uint64_t currentStripe;
     uint64_t lastStripe; // the stripe AFTER the last one
+    uint64_t currentInitedStripe;
     uint64_t currentRowInStripe;
     uint64_t rowsInCurrentStripe;
     proto::StripeInformation currentStripeInfo;
@@ -186,6 +187,16 @@ namespace orc {
 
     friend class TestRowReader_advanceToNextRowGroup_Test;
     friend class TestRowReader_computeBatchSize_Test;
+
+    inline uint64_t lastRowOfCurrentStripe() const {
+      return currentStripe < lastStripe ?
+        firstRowOfStripe[currentStripe] + rowsInCurrentStripe :
+        footer->numberofrows();
+    }
+
+    inline bool isCurrentStripeInited() const {
+      return currentStripe == currentInitedStripe;
+    }
 
     /**
      * Seek to the start of a row group in the current stripe

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -146,7 +146,7 @@ namespace orc {
     uint64_t firstStripe;
     uint64_t currentStripe;
     uint64_t lastStripe; // the stripe AFTER the last one
-    uint64_t currentInitedStripe;
+    uint64_t processingStripe;
     uint64_t currentRowInStripe;
     uint64_t rowsInCurrentStripe;
     proto::StripeInformation currentStripeInfo;
@@ -190,7 +190,7 @@ namespace orc {
 
     // whether the current stripe is initialized
     inline bool isCurrentStripeInited() const {
-      return currentStripe == currentInitedStripe;
+      return currentStripe == processingStripe;
     }
 
     /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
The patch will optimize the seekToRow function. The RowReader::seekToRow() function always call startNextStripe() to seek to the beginning of target stripe. However, when PPD is enabled many calls are still staying in the same stripe which results in many unnecessary calls. 

### Why are the changes needed?
This PR improves the seekToRow function call. I pick a 259MB file of the TPCH lineitem table which contains 7200030
records. I use a modified orc-scan tool that calls the RowReader::seekToRow function once before each call the RowReader:: next() function to test this patch.  The results are shown below:

|| original | optimized | speedup |
|:-----|:----:|:----:|:----:|
|Elapsed Time(s)|43.69|27.13|1.61|


### How was this patch tested?
The original UTs(TestPredicatePushdown, DictionaryEncoding::multipleStripesWithIndex, DictionaryEncoding::multipleStripesWithoutIndex) will cover this patch.
