### PR TITLE
ORC-1171: Skip build and test on docker and site updates

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,9 +2,15 @@ name: Build and test
 
 on:
   push:
+    paths-ignore:
+    - 'docker'
+    - 'site/**'
     branches:
     - main
   pull_request:
+    paths-ignore:
+    - 'docker'
+    - 'site/**'
     branches:
     - main
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to skip build and test on docker and site updates.

### Why are the changes needed?
To save community resources from running tests on irrelevant changes. 

### How was this patch tested?
Manually verify after merging.