### PR TITLE
ORC-1172: Add row count limit config in one stripe

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -29,6 +29,10 @@ public enum OrcConf {
   STRIPE_SIZE("orc.stripe.size", "hive.exec.orc.default.stripe.size",
       64L * 1024 * 1024,
       "Define the default ORC stripe size, in bytes."),
+  STRIPE_ROW_COUNT("orc.stripe.row.count","orc.stripe.row.count",
+      Integer.MAX_VALUE, "This value limit the row count in one stripe. "
+      + "The number of stripe rows can be controlled at"
+      + " (0, \"orc.stripe.row.count\" + max(batchSize, \"orc.rows.between.memory.checks\"))"),
   BLOCK_SIZE("orc.block.size", "hive.exec.orc.default.block.size",
       256L * 1024 * 1024,
       "Define the default file system block size for ORC files."),
@@ -161,7 +165,8 @@ public enum OrcConf {
   ROWS_BETWEEN_CHECKS("orc.rows.between.memory.checks", "orc.rows.between.memory.checks", 5000,
     "How often should MemoryManager check the memory sizes? Measured in rows\n" +
       "added to all of the writers.  Valid range is [1,10000] and is primarily meant for" +
-      "testing.  Setting this too low may negatively affect performance."),
+      "testing.  Setting this too low may negatively affect performance."
+        + " Use orc.stripe.row.count instead if the value larger than orc.stripe.row.count."),
   OVERWRITE_OUTPUT_FILE("orc.overwrite.output.file", "orc.overwrite.output.file", false,
     "A boolean flag to enable overwriting of the output file if it already exists.\n"),
   IS_SCHEMA_EVOLUTION_CASE_SENSITIVE("orc.schema.evolution.case.sensitive",

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -29,10 +29,10 @@ public enum OrcConf {
   STRIPE_SIZE("orc.stripe.size", "hive.exec.orc.default.stripe.size",
       64L * 1024 * 1024,
       "Define the default ORC stripe size, in bytes."),
-  STRIPE_ROW_COUNT("orc.stripe.row.count","orc.stripe.row.count",
-      Integer.MAX_VALUE, "This value limit the row count in one stripe. "
-      + "The number of stripe rows can be controlled at"
-      + " (0, \"orc.stripe.row.count\" + max(batchSize, \"orc.rows.between.memory.checks\"))"),
+  STRIPE_ROW_COUNT("orc.stripe.row.count", "orc.stripe.row.count",
+      Integer.MAX_VALUE, "This value limit the row count in one stripe. \n" +
+      "The number of stripe rows can be controlled at \n" +
+      "(0, \"orc.stripe.row.count\" + max(batchSize, \"orc.rows.between.memory.checks\"))"),
   BLOCK_SIZE("orc.block.size", "hive.exec.orc.default.block.size",
       256L * 1024 * 1024,
       "Define the default file system block size for ORC files."),

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -430,6 +430,7 @@ public class OrcFile {
     private FileSystem fileSystemValue = null;
     private TypeDescription schema = null;
     private long stripeSizeValue;
+    private long stripeRowCountValue;
     private long blockSizeValue;
     private int rowIndexStrideValue;
     private int bufferSizeValue;
@@ -463,6 +464,7 @@ public class OrcFile {
       memoryManagerValue = getStaticMemoryManager(conf);
       overwrite = OrcConf.OVERWRITE_OUTPUT_FILE.getBoolean(tableProperties, conf);
       stripeSizeValue = OrcConf.STRIPE_SIZE.getLong(tableProperties, conf);
+      stripeRowCountValue = OrcConf.STRIPE_ROW_COUNT.getLong(tableProperties, conf);
       blockSizeValue = OrcConf.BLOCK_SIZE.getLong(tableProperties, conf);
       rowIndexStrideValue =
           (int) OrcConf.ROW_INDEX_STRIDE.getLong(tableProperties, conf);
@@ -869,6 +871,10 @@ public class OrcFile {
 
     public long getStripeSize() {
       return stripeSizeValue;
+    }
+
+    public long getStripeRowCountValue() {
+      return stripeRowCountValue;
     }
 
     public CompressionKind getCompress() {


### PR DESCRIPTION

### What changes were proposed in this pull request?
add row count limit config "orc.stripe.row.count" to limit row count in one stripe.

### Why are the changes needed?
for query engine like presto，stripe is the base unit for query concurrency, one stripe can only be processed by one split.
In current implement of orc writer, the only config which can control row count in stripe is the "orc.stripe.size".
But for different kind of table, the row count is difficult to use.

for table with much columns( eg. 100 columns), 64MB may contain 5000 rows.
for table with less columns(eg. 5 columns), 64MB may contain 100000 rows.
for presto, normal olap query only read a subset of table columns, the row count is the key factor of query performance. If one stripe contain much rows, the query performance may become too low.

So, besides the config "orc.stripe.size", we need another config like "orc.stripe.row.count" to control the row count of one stripe.
The similar config has been introduced to cudf ( a GPU DataFrame library base on apache arrow): [rapidsai/cudf#9261](https://github.com/rapidsai/cudf/issues/9261)

### How was this patch tested?
testStripeRowCountLimit added.
can be test by command below: 
```
cd java
./mvnw -Dtest=TestWriterImpl test
```

implement #1117 