### PR TITLE
ORC-1174: Add Ubuntu 22.04 to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,6 +67,24 @@ jobs:
         fi
         make package test-out
 
+  ubuntu22:
+    name: "Build on Ubuntu 22.04"
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: "Test"
+      run: |
+        apt update
+        apt-get install --no-install-recommends -y git cmake libsasl2-dev libssl-dev make gcc g++ curl openjdk-17-jdk tzdata
+        mkdir -p ~/.m2
+        mkdir build
+        cd build
+        cmake -DANALYZE_JAVA=ON ..
+        make package test-out
+
   windows:
     name: "Build on Windows"
     runs-on: windows-2019


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Ubuntu 22.04` to GitHub Action.

### Why are the changes needed?

This will help the verification on the latest release.

Since [GitHub Action Virtual Environments](https://github.com/actions/virtual-environments) don't support `Ubuntu 22.04` officially yet, this PR uses a workaround.
```
runs-on: ubuntu-latest
container:
  image: ubuntu:22.04
```

### How was this patch tested?

Pass the GitHub Action on this PR.