### PR TITLE
ORC-1174: Add `Ubuntu 22.04` to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
+          - ubuntu-22.04
           - macos-11
           - macos-12
         java:
@@ -60,6 +61,10 @@ jobs:
           cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl@1.1` ..
         fi
         make package test-out
+    - name: Step on failure
+      if: ${{ failure() }}
+      run: |
+        cat /home/runner/work/orc/orc/build/java/rat.txt
 
   windows:
     name: "Build on Windows"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -263,6 +263,7 @@
               <exclude>**/*.out</exclude>
               <exclude>**/*.schema</exclude>
               <exclude>**/*.md</exclude>
+              <exclude>**/m2.conf</exclude>
               <exclude>**/target/**</exclude>
               <exclude>.idea/**</exclude>
               <exclude>**/*.iml</exclude>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Ubuntu 22.04` to GitHub Action.

### Why are the changes needed?

This will help the verification on the latest release.

Although [GitHub Action Virtual Environments](https://github.com/actions/virtual-environments) don't support `Ubuntu 22.04` officially yet, `Ubuntu 22.04` is available as `Public Beta`.

- https://github.com/actions/virtual-environments/issues/5490

### How was this patch tested?

Pass the GitHub Action on this PR.