### PR TITLE
ORC-1178: Use Hadoop 3.3.3 on Java 17+

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -471,9 +471,9 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <min.hadoop.version>3.3.2</min.hadoop.version>
-        <hadoop.version>3.3.2</hadoop.version>
-        <tools.hadoop.version>3.3.2</tools.hadoop.version>
+        <min.hadoop.version>3.3.3</min.hadoop.version>
+        <hadoop.version>3.3.3</hadoop.version>
+        <tools.hadoop.version>3.3.3</tools.hadoop.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use Hadoop 3.3.3 on Java 17 and above. 

### Why are the changes needed?
To bring the latest bug fixes. 

### How was this patch tested?
Pass the Java 17 CI. 