### PR TITLE
ORC-1179: Upgrade checkstyle to 10.2 on Java 11+

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -83,6 +83,7 @@
     <surefire.version>3.0.0-M5</surefire.version>
     <junit.version>5.8.2</junit.version>
     <mockito.version>4.5.1</mockito.version>
+    <checkstyle.version>10.2</checkstyle.version>
   </properties>
 
   <build>
@@ -280,7 +281,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>9.2.1</version>
+              <version>${checkstyle.version}</version>
             </dependency>
           </dependencies>
           <executions>
@@ -474,6 +475,15 @@
         <min.hadoop.version>3.3.2</min.hadoop.version>
         <hadoop.version>3.3.2</hadoop.version>
         <tools.hadoop.version>3.3.2</tools.hadoop.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>java8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <properties>
+        <checkstyle.version>9.3</checkstyle.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade checkstyle to 10.2 on Java 11 and above. 
However, checkstyle 10+ supports only Java 11+, so I created a Java8 profile to keep Java8 support. 

### Why are the changes needed?

- https://checkstyle.org/releasenotes.html#Release_10.2
- https://checkstyle.org/releasenotes.html#Release_10.1
- https://checkstyle.org/releasenotes.html#Release_10.0
- https://checkstyle.org/releasenotes.html#Release_9.3

### How was this patch tested?
Pass the CIs. 

Closes #1123