### PR TITLE
ORC-1182: Use `slf4j-simple` instead of deprecated `slf4j-log4j12`

### DIFF
--- a/java/bench/core/pom.xml
+++ b/java/bench/core/pom.xml
@@ -105,7 +105,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-simple</artifactId>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -437,7 +437,7 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
+        <artifactId>slf4j-simple</artifactId>
         <version>${slf4j.version}</version>
 	<scope>runtime</scope>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `slf4j-simple` instead of the deprecated `slf4j-log4j12`.

### Why are the changes needed?

https://www.slf4j.org/manual.html

> Binding/provider for [log4j version 1.2](http://logging.apache.org/log4j/1.2/index.html), a widely used logging framework. Given that log4j 1.x has been declared EOL in 2015 and again in 2022, as of SLF4J 1.7.35, the slf4j-log4j module automatically redirects to the slf4j-reload4j module at build time. Assuming you wish to continue to use the log4j 1.x framework, we strongly encourage you to use slf4j-reload4j instead. See below.

### How was this patch tested?

Pass the CI.
