### PR TITLE
ORC-1183: Upgrade Gson to 2.9.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -531,7 +531,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.2.4</version>
+        <version>2.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Gson` to `2.9.0`.

### Why are the changes needed?

This will bring the latest bug fixes.
- https://github.com/google/gson/releases/tag/gson-parent-2.9.0

### How was this patch tested?

I manually test this by running `benchmark` module.

Closes #1131 .