### PR TITLE
MINOR: Add ASF verification instruction link

### DIFF
--- a/site/_docs/releases.md
+++ b/site/_docs/releases.md
@@ -22,6 +22,7 @@ files and looking at their contents and metadata.
 
 ## Checking signatures
 
+Verify the releases by following [ASF procedures](https://www.apache.org/info/verification.html).
 All GPG signatures should be verified as matching one of the keys in ORC's
 committers' [key list]({{ site.dist }}/KEYS).
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update RELEASES page by adding the official ASF release verification link.
- https://orc.apache.org/docs/releases.html

### Why are the changes needed?

To give more background for the verification procedure.

### How was this patch tested?

Manual review because this is a webpage update.