### PR TITLE
ORC-1184: Use Hadoop 3.3.3 in benchmark module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -37,7 +37,7 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.2</parquet.version>
     <spark.version>3.2.1</spark.version>
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.3.3</hadoop.version>
     <junit.version>5.8.2</junit.version>
   </properties>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Hadoop 3.3.3 in `benchmark` module for testing.

### Why are the changes needed?

This will bring the latest bug fixes in Hadoop library.

### How was this patch tested?

Pass the CI and manual tests.