### PR TITLE
ORC-1186: Limit `family` in `aarch64` profile

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -462,6 +462,7 @@
       </properties>
       <activation>
         <os>
+          <family>mac</family>
           <arch>aarch64</arch>
         </os>
       </activation>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to limit OS family to `mac` in the AS-IS `aarch64` profile

### Why are the changes needed?

ORC-814 added `applesilicon` profile and ORC-816 renamed it to `aarch64`.
However, the current Apache ORC doesn't support Linux `aarch64` yet.
We had better be clear what is working in that profile.

### How was this patch tested?

This profile should be tested on Apple Silicon manually. I tested it.