### PR TITLE
ORC-1189: Update `README.md` and `help` command message in `benchmark` module and `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target
 .idea
 .DS_Store
 .java-version
+java/bench/data

--- a/java/bench/README.md
+++ b/java/bench/README.md
@@ -16,7 +16,7 @@ There are three sub-modules to try to mitigate dependency hell:
 To build this library, run the following in the parent directory:
 
 ```
-% ./mvnw clean package -Pbenchmark
+% ./mvnw clean package -Pbenchmark -DskipTests
 % cd bench
 ```
 

--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/GenerateVariants.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/GenerateVariants.java
@@ -242,7 +242,7 @@ public class GenerateVariants implements OrcBenchmark {
         .addOption("s", "sales", true, "Number of records for sales");
     CommandLine result = new DefaultParser().parse(options, args);
     if (result.hasOption("help") || result.getArgs().length == 0) {
-      new HelpFormatter().printHelp("convert <root>", options);
+      new HelpFormatter().printHelp("generate <root>", options);
       System.exit(1);
     }
     return result;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make docs and gitignore a bit more helpful for benchmark suite

### Why are the changes needed?
* Benchmark `generate` command should not refer to itself as `convert`:
```$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data --help
usage: convert <root>
 -c,--compress <arg>   List of compression
 -d,--data <arg>       List of data sets
 -f,--format <arg>     List of formats
 -h,--help             Provide help
 -s,--sales <arg>      Number of records for sales
```
 * README command for packaging the benchmark suite currently runs all tests; usually this is not necessary
 * benchmark generated data should be in .gitignore so that they are not accidentally added to git history

### How was this patch tested?
No functionality or tests were modified
