### PR TITLE
ORC-1190: Fix `ORCWriterBenchMark` `dumpDir` initialization

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -88,7 +88,7 @@ add_test(
 
 add_test(
   NAME java-bench-hive-test
-  COMMAND java -Dbench.root.dir=. ${ADD_OPENS} ${JAVA_NIO} -jar bench/hive/orc-benchmarks-hive-${ORC_VERSION}-uber.jar write -i 1 -I 0 -t 1 data
+  COMMAND java ${ADD_OPENS} ${JAVA_NIO} -jar bench/hive/orc-benchmarks-hive-${ORC_VERSION}-uber.jar write -i 1 -I 0 -t 1 data
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 install(

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/ORCWriterBenchMark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/ORCWriterBenchMark.java
@@ -59,8 +59,11 @@ import java.util.concurrent.TimeUnit;
 @AutoService(OrcBenchmark.class)
 public class ORCWriterBenchMark implements OrcBenchmark {
   private static final Path root = Utilities.getBenchmarkRoot();
-  private Path dumpDir = new Path(root, "dumpDir");
   private List<VectorizedRowBatch> batches = new ArrayList<>();
+
+  private Path dumpDir() {
+    return new Path(root, "dumpDir");
+  }
 
   @Override
   public String getName() {
@@ -112,7 +115,7 @@ public class ORCWriterBenchMark implements OrcBenchmark {
     Configuration conf = new Configuration();
     TrackingLocalFileSystem fs = new TrackingLocalFileSystem();
     fs.initialize(new URI("file:///"), conf);
-    fs.delete(dumpDir, true);
+    fs.delete(dumpDir(), true);
   }
 
   @Override
@@ -136,7 +139,7 @@ public class ORCWriterBenchMark implements OrcBenchmark {
     fs.initialize(new URI("file:///"), conf);
     FileSystem.Statistics statistics = fs.getLocalStatistics();
     statistics.reset();
-    Path testFilePath = new Path(dumpDir, "dictBench");
+    Path testFilePath = new Path(dumpDir(), "dictBench");
 
     TypeDescription schema = TypeDescription.fromString("struct<str:string>");
     // Note that the total data volume will be around 100 * 1024 * 1024


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix writer benchmark initialization


### How was this patch tested?
This does not affect main ORC or tests, only the benchmark suite.

```$ java -jar hive/target/orc-benchmarks-hive-*-uber.jar write data
$ java -jar hive/target/orc-benchmarks-hive-*-uber.jar write data
# JMH version: 1.20
# VM version: JDK 17.0.3, VM 17.0.3+7-LTS
# VM invoker: /Users/dongjoon/A/jdk-release/applejdk-17.0.3.7.3.jdk/Contents/Home/bin/java
# VM options: -server -Xms256m -Xmx2g -Dbench.root.dir=/Users/dongjoon/APACHE/orc-merge/java/bench/data
# Warmup: 2 iterations, 10 s each
# Measurement: 5 iterations, 10 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: org.apache.orc.bench.hive.ORCWriterBenchMark.dictBench
# Parameters: (dictImpl = RBTREE, distinctCount = 10000)

# Run progress: 0.00% complete, ETA 00:10:30
# Fork: 1 of 1
# Warmup Iteration   1: [WARN ] Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
...
```