### PR TITLE
ORC-1205: Size of batches in some ConvertTreeReaders should be ensured before using

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -364,6 +364,11 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       Integer schemaLevel = numericTypes.get(readerType.getCategory());
       return (schemaLevel.intValue() < fileLevel.intValue());
     }
+
+    @Override
+    protected void ensureSize(ColumnVector vector, int batchSize) {
+      super.ensureSize(vector, batchSize);
+    }
   }
 
   private static TreeReader createFromInteger(int columnId,
@@ -461,6 +466,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(doubleColVector, longColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(doubleColVector, batchSize);
+    }
   }
 
   public static class AnyIntegerFromDecimalTreeReader extends ConvertTreeReader {
@@ -545,6 +556,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(decimalColVector, longColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(decimalColVector, batchSize);
+    }
   }
 
   public static class AnyIntegerFromStringGroupTreeReader extends ConvertTreeReader {
@@ -584,6 +601,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(bytesColVector, longColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(bytesColVector, batchSize);
+    }
   }
 
   public static class AnyIntegerFromTimestampTreeReader extends ConvertTreeReader {
@@ -618,6 +641,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       fromReader.nextVector(timestampColVector, isNull, batchSize);
 
       convertVector(timestampColVector, longColVector, batchSize);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(timestampColVector, batchSize);
     }
   }
 
@@ -657,6 +686,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(longColVector, doubleColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(longColVector, batchSize);
+    }
   }
 
   public static class DoubleFromDecimalTreeReader extends ConvertTreeReader {
@@ -691,6 +726,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       fromReader.nextVector(decimalColVector, isNull, batchSize);
 
       convertVector(decimalColVector, doubleColVector, batchSize);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(decimalColVector, batchSize);
     }
   }
 
@@ -729,6 +770,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(bytesColVector, doubleColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(bytesColVector, batchSize);
+    }
   }
 
   public static class DoubleFromTimestampTreeReader extends ConvertTreeReader {
@@ -764,6 +811,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       fromReader.nextVector(timestampColVector, isNull, batchSize);
 
       convertVector(timestampColVector, doubleColVector, batchSize);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(timestampColVector, batchSize);
     }
   }
 
@@ -824,6 +877,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(longColVector, decimalColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(longColVector, batchSize);
+    }
   }
 
   public static class DecimalFromDoubleTreeReader extends ConvertTreeReader {
@@ -868,6 +927,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(doubleColVector, decimalColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(doubleColVector, batchSize);
+    }
   }
 
   public static class DecimalFromStringGroupTreeReader extends ConvertTreeReader {
@@ -909,6 +974,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       fromReader.nextVector(bytesColVector, isNull, batchSize);
 
       convertVector(bytesColVector, decimalColVector, batchSize);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(bytesColVector, batchSize);
     }
   }
 
@@ -954,6 +1025,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(timestampColVector, decimalColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(timestampColVector, batchSize);
+    }
   }
 
   public static class DecimalFromDecimalTreeReader extends ConvertTreeReader {
@@ -995,6 +1072,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(fileDecimalColVector, decimalColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(fileDecimalColVector, batchSize);
+    }
   }
 
   public static class StringGroupFromAnyIntegerTreeReader extends ConvertTreeReader {
@@ -1028,6 +1111,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       fromReader.nextVector(longColVector, isNull, batchSize);
 
       convertVector(longColVector, bytesColVector, batchSize);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(longColVector, batchSize);
     }
   }
 
@@ -1088,6 +1177,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(doubleColVector, bytesColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(doubleColVector, batchSize);
+    }
   }
 
 
@@ -1135,6 +1230,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       fromReader.nextVector(decimalColVector, isNull, batchSize);
 
       convertVector(decimalColVector, bytesColVector, batchSize);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(decimalColVector, batchSize);
     }
   }
 
@@ -1257,6 +1358,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(timestampColVector, bytesColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(timestampColVector, batchSize);
+    }
   }
 
   public static class StringGroupFromDateTreeReader extends ConvertTreeReader {
@@ -1293,6 +1400,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       fromReader.nextVector(longColVector, isNull, batchSize);
 
       convertVector(longColVector, bytesColVector, batchSize);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(longColVector, batchSize);
     }
   }
 
@@ -1380,6 +1493,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(inBytesColVector, outBytesColVector, batchSize);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(inBytesColVector, batchSize);
+    }
   }
 
   public static class TimestampFromAnyIntegerTreeReader extends ConvertTreeReader {
@@ -1424,6 +1543,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(longColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, true);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(longColVector, batchSize);
     }
   }
 
@@ -1485,6 +1610,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       convertVector(doubleColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, true);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(doubleColVector, batchSize);
+    }
   }
 
   public static class TimestampFromDecimalTreeReader extends ConvertTreeReader {
@@ -1543,6 +1674,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       convertVector(decimalColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, true);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(decimalColVector, batchSize);
+    }
   }
 
   public static class TimestampFromStringGroupTreeReader extends ConvertTreeReader {
@@ -1599,6 +1736,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       convertVector(bytesColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, false);
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(bytesColVector, batchSize);
+    }
   }
 
   public static class TimestampFromDateTreeReader extends ConvertTreeReader {
@@ -1640,6 +1783,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
 
       convertVector(longColVector, timestampColVector, batchSize);
       timestampColVector.changeCalendar(useProlepticGregorian, false);
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(longColVector, batchSize);
     }
   }
 
@@ -1694,6 +1843,13 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         dateColumnVector.changeCalendar(useProlepticGregorian, false);
       }
     }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(bytesColVector, batchSize);
+      super.ensureSize(dateColumnVector, batchSize);
+    }
   }
 
   public static class DateFromTimestampTreeReader extends ConvertTreeReader {
@@ -1740,6 +1896,12 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         ((DateColumnVector) longColVector)
             .changeCalendar(useProlepticGregorian, false);
       }
+    }
+
+    @Override
+    protected void ensureSize(ColumnVector previous, int batchSize) {
+      super.ensureSize(previous, batchSize);
+      super.ensureSize(timestampColVector, batchSize);
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -308,6 +308,19 @@ public class TreeReaderFactory {
       }
     }
 
+    /**
+     * Ensures the size of a vector, and gives the power to TreeReader subclasses to
+     * ensure the size of any other inner/intermediate vectors which are in use (e.g. in ConvertTreeReaders).
+     *
+     * @param vector The ColumnVector object
+     * @param batchSize Size of the column vector
+     */
+    protected void ensureSize(ColumnVector vector, int batchSize) {
+      if (vector != null) {
+        vector.ensureSize(batchSize, false);
+      }
+    }
+
     public BitFieldReader getPresent() {
       return present;
     }
@@ -2043,7 +2056,7 @@ public class TreeReaderFactory {
         ColumnVector colVector = batch.cols[i];
         if (colVector != null) {
           colVector.reset();
-          colVector.ensureSize((int) batchSize, false);
+          fields[i].ensureSize(colVector, (int) batchSize);
           fields[i].nextVector(colVector, null, batchSize);
         }
       }

--- a/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
+++ b/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
+import org.apache.orc.OrcFile.WriterOptions;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
 import org.apache.orc.TestProlepticConversions;
@@ -63,6 +64,9 @@ public class TestConvertTreeReaderFactory {
   private FileSystem fs;
   private Path testFilePath;
   private int LARGE_BATCH_SIZE;
+
+  private static final int INCREASING_BATCH_SIZE_FIRST = 30;
+  private static final int INCREASING_BATCH_SIZE_SECOND = 50;
 
   @Rule
   public TestName testCaseName = new TestName();
@@ -95,22 +99,7 @@ public class TestConvertTreeReaderFactory {
     TExpectedColumnVector dcv = (TExpectedColumnVector) (listCol).child;
     batch.size = 1;
     for (int row = 0; row < LARGE_BATCH_SIZE; ++row) {
-      if (dcv instanceof DecimalColumnVector) {
-        ((DecimalColumnVector) dcv).set(row, HiveDecimal.create(row * 2 + 1));
-      } else if (dcv instanceof DoubleColumnVector) {
-        ((DoubleColumnVector) dcv).vector[row] = row * 2 + 1;
-      } else if (dcv instanceof BytesColumnVector) {
-        ((BytesColumnVector) dcv).setVal(row, ((row * 2 + 1) + "").getBytes(StandardCharsets.UTF_8));
-      } else if (dcv instanceof LongColumnVector) {
-        ((LongColumnVector) dcv).vector[row] = row * 2 + 1;
-      } else if (dcv instanceof TimestampColumnVector) {
-        ((TimestampColumnVector) dcv).set(row, Timestamp.valueOf((1900 + row) + "-04-01 12:34:56.9"));
-      } else if (dcv instanceof DateColumnVector) {
-        String date = String.format("%04d-01-23", row * 2 + 1);
-        ((DateColumnVector) dcv).vector[row] = TimeUnit.MILLISECONDS.toDays(dateFormat.parse(date).getTime());
-      } else {
-        throw new IllegalStateException("Writing File with a large array of "+ expectedColumnType + " is not supported!");
-      }
+      setElementInVector(expectedColumnType, dateFormat, dcv, row);
     }
 
     listCol.childCount = 1;
@@ -121,6 +110,65 @@ public class TestConvertTreeReaderFactory {
     w.close();
     assertEquals(((ListColumnVector) batch.cols[0]).child.getClass(), expectedColumnType);
     return (TExpectedColumnVector) ((ListColumnVector) batch.cols[0]).child;
+  }
+
+  public <TExpectedColumnVector extends ColumnVector> TExpectedColumnVector createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(
+      TypeDescription schema, Class<TExpectedColumnVector> typeClass, boolean useDecimal64)
+      throws IOException, ParseException {
+    conf = new Configuration();
+    fs = FileSystem.getLocal(conf);
+    fs.setWorkingDirectory(workDir);
+    WriterOptions options = OrcFile.writerOptions(conf);
+    Writer w = OrcFile.createWriter(testFilePath, options.setSchema(schema));
+
+    SimpleDateFormat dateFormat = TestProlepticConversions.createParser("yyyy-MM-dd", new GregorianCalendar());
+    VectorizedRowBatch batch = schema.createRowBatch(
+        useDecimal64 ? TypeDescription.RowBatchVersion.USE_DECIMAL64 : TypeDescription.RowBatchVersion.ORIGINAL,
+        INCREASING_BATCH_SIZE_FIRST);
+
+    TExpectedColumnVector columnVector = (TExpectedColumnVector) batch.cols[0];
+    batch.size = INCREASING_BATCH_SIZE_FIRST;
+    for (int row = 0; row < INCREASING_BATCH_SIZE_FIRST; ++row) {
+      setElementInVector(typeClass, dateFormat, columnVector, row);
+    }
+
+    w.addRowBatch(batch);
+    w.writeIntermediateFooter(); //forcing a new stripe
+
+    batch = schema.createRowBatch(
+        useDecimal64 ? TypeDescription.RowBatchVersion.USE_DECIMAL64 : TypeDescription.RowBatchVersion.ORIGINAL,
+        INCREASING_BATCH_SIZE_SECOND);
+
+    columnVector = (TExpectedColumnVector) batch.cols[0];
+    batch.size = INCREASING_BATCH_SIZE_SECOND;
+    for (int row = 0; row < INCREASING_BATCH_SIZE_SECOND; ++row) {
+      setElementInVector(typeClass, dateFormat, columnVector, row);
+    }
+
+    w.addRowBatch(batch);
+    w.close();
+    return (TExpectedColumnVector) batch.cols[0];
+  }
+
+  private void setElementInVector(
+      Class<?> expectedColumnType, SimpleDateFormat dateFormat, ColumnVector dcv, int row)
+      throws ParseException {
+    if (dcv instanceof DecimalColumnVector) {
+      ((DecimalColumnVector) dcv).set(row, HiveDecimal.create(row * 2 + 1));
+    } else if (dcv instanceof DoubleColumnVector) {
+      ((DoubleColumnVector) dcv).vector[row] = row * 2 + 1;
+    } else if (dcv instanceof BytesColumnVector) {
+      ((BytesColumnVector) dcv).setVal(row, ((row * 2 + 1) + "").getBytes(StandardCharsets.UTF_8));
+    } else if (dcv instanceof LongColumnVector) {
+      ((LongColumnVector) dcv).vector[row] = row * 2 + 1;
+    } else if (dcv instanceof TimestampColumnVector) {
+      ((TimestampColumnVector) dcv).set(row, Timestamp.valueOf((1900 + row) + "-04-01 12:34:56.9"));
+    } else if (dcv instanceof DateColumnVector) {
+      String date = String.format("%04d-01-23", row * 2 + 1);
+      ((DateColumnVector) dcv).vector[row] = TimeUnit.MILLISECONDS.toDays(dateFormat.parse(date).getTime());
+    } else {
+      throw new IllegalStateException("Writing File with a large array of "+ expectedColumnType + " is not supported!");
+    }
   }
 
   public <TExpectedColumnVector extends ColumnVector> TExpectedColumnVector readORCFileWithLargeArray(
@@ -144,6 +192,31 @@ public class TestConvertTreeReaderFactory {
     assertTrue(batch.cols[0] instanceof ListColumnVector);
     assertEquals(((ListColumnVector) batch.cols[0]).child.getClass(), expectedColumnType);
     return (TExpectedColumnVector) ((ListColumnVector) batch.cols[0]).child;
+  }
+
+  public void readORCFileIncreasingBatchSize(String typeString, Class<?> expectedColumnType) throws Exception {
+    Reader.Options options = new Reader.Options();
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeString + ">");
+    options.schema(schema);
+    String expected = options.toString();
+
+    Configuration conf = new Configuration();
+
+    Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf));
+    RecordReader rows = reader.rows(options);
+    VectorizedRowBatch batch = schema.createRowBatchV2();
+
+    rows.nextBatch(batch);
+    assertEquals(INCREASING_BATCH_SIZE_FIRST , batch.size);
+    assertEquals(expected, options.toString());
+    assertEquals(batch.cols.length, 1);
+    assertEquals(batch.cols[0].getClass(), expectedColumnType);
+
+    rows.nextBatch(batch);
+    assertEquals(INCREASING_BATCH_SIZE_SECOND , batch.size);
+    assertEquals(expected, options.toString());
+    assertEquals(batch.cols.length, 1);
+    assertEquals(batch.cols[0].getClass(), expectedColumnType);
   }
 
   public void testConvertToDecimal() throws Exception {
@@ -343,13 +416,192 @@ public class TestConvertTreeReaderFactory {
     TypeDescription schema = TypeDescription.fromString("struct<col1:array<" + typeStr + ">>");
     createORCFileWithLargeArray(schema, typeClass, typeClass.equals(Decimal64ColumnVector.class));
     try {
-      // Test all possible conversions
-      // check ConvertTreeReaderFactory.createDateConvertTreeReader
       testConvertToVarchar();
       testConvertToTimestamp();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  @Test
+  public void testDecimalVectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "decimal(6,1)";
+    Class typeClass = DecimalColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass, typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToIntegerIncreasingSize();
+      testConvertToDoubleIncreasingSize();
+      testConvertToVarcharIncreasingSize();
+      testConvertToTimestampIncreasingSize();
+      testConvertToDecimalIncreasingSize();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  @Test
+  public void testDecimal64VectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "decimal(6,1)";
+    Class typeClass = Decimal64ColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass,
+        typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToIntegerIncreasingSize();
+      testConvertToDoubleIncreasingSize();
+      testConvertToVarcharIncreasingSize();
+      testConvertToTimestampIncreasingSize();
+      testConvertToDecimalIncreasingSize();
     } finally {
       // Make sure we delete file across tests
       fs.delete(testFilePath, false);
     }
+  }
+
+  @Test
+  public void testStringVectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "varchar(10)";
+    Class typeClass = BytesColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass,
+        typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToIntegerIncreasingSize();
+      testConvertToDoubleIncreasingSize();
+      testConvertToDecimalIncreasingSize();
+      testConvertToVarcharIncreasingSize();
+      testConvertToBinaryIncreasingSize();
+      testConvertToTimestampIncreasingSize();
+      testConvertToDateIncreasingSize();
+    } finally {
+      // Make sure we delete file across tests
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  @Test
+  public void testBinaryVectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "binary";
+    Class typeClass = BytesColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass,
+        typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToVarcharIncreasingSize();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  @Test
+  public void testDoubleVectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "double";
+    Class typeClass = DoubleColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass,
+        typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToDoubleIncreasingSize();
+      testConvertToIntegerIncreasingSize();
+      testConvertToFloatIncreasingSize();
+      testConvertToDecimalIncreasingSize();
+      testConvertToVarcharIncreasingSize();
+      testConvertToTimestampIncreasingSize();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  @Test
+  public void testIntVectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "int";
+    Class typeClass = LongColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass,
+        typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToIntegerIncreasingSize();
+      testConvertToDoubleIncreasingSize();
+      testConvertToDecimalIncreasingSize();
+      testConvertToVarcharIncreasingSize();
+      testConvertToTimestampIncreasingSize();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  @Test
+  public void testTimestampVectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "timestamp";
+    Class typeClass = TimestampColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass,
+        typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToIntegerIncreasingSize();
+      testConvertToDoubleIncreasingSize();
+      testConvertToDecimalIncreasingSize();
+      testConvertToVarcharIncreasingSize();
+      testConvertToTimestampIncreasingSize();
+      testConvertToDateIncreasingSize();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  @Test
+  public void testDateVectorIncreasingSizeInDifferentStripes() throws Exception {
+    String typeStr = "date";
+    Class typeClass = DateColumnVector.class;
+
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+    createORCFileWithBatchesOfIncreasingSizeInDifferentStripes(schema, typeClass,
+        typeClass.equals(Decimal64ColumnVector.class));
+    try {
+      testConvertToVarcharIncreasingSize();
+      testConvertToTimestampIncreasingSize();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  private void testConvertToDoubleIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("double", DoubleColumnVector.class);
+  }
+
+  private void testConvertToIntegerIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("int", LongColumnVector.class);
+  }
+
+  private void testConvertToFloatIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("float", DoubleColumnVector.class);
+  }
+
+  public void testConvertToDecimalIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("decimal(6,1)", Decimal64ColumnVector.class);
+  }
+
+  private void testConvertToVarcharIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("varchar(10)", BytesColumnVector.class);
+  }
+
+  private void testConvertToTimestampIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("timestamp", TimestampColumnVector.class);
+  }
+
+  private void testConvertToDateIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("date", DateColumnVector.class);
+  }
+
+  private void testConvertToBinaryIncreasingSize() throws Exception {
+    readORCFileIncreasingBatchSize("binary", BytesColumnVector.class);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This fix introduces a new API for TreeReaders: ensureSize, which is supposed to be called by TreeReader clients before making a call for reading a new batch.

### Why are the changes needed?
As described on jira, if there are batches of increasing size while reading, if they are in different stripes, we can hit an edge case where nextBatch doesn't force them to ensure the size of some batches.

### How was this patch tested?
Unit tests added for all possible ConvertTreeReader, also tested in hive locally.
