### PR TITLE
ORC-1205: `nextVector` should invoke `ensureSize` when reusing vectors

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -464,6 +464,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
         longColVector = (LongColumnVector) previousVector;
+      } else {
+        doubleColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, readPhase);
@@ -550,6 +552,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
         longColVector = (LongColumnVector) previousVector;
+      } else {
+        decimalColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -591,6 +595,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         longColVector = (LongColumnVector) previousVector;
+      } else {
+        bytesColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readPhase);
@@ -628,6 +634,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         longColVector = (LongColumnVector) previousVector;
+      } else {
+        timestampColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readPhase);
@@ -668,6 +676,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
         doubleColVector = (DoubleColumnVector) previousVector;
+      } else {
+        longColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readPhase);
@@ -706,6 +716,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
         doubleColVector = (DoubleColumnVector) previousVector;
+      } else {
+        decimalColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -745,6 +757,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         doubleColVector = (DoubleColumnVector) previousVector;
+      } else {
+        bytesColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readPhase);
@@ -783,6 +797,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         doubleColVector = (DoubleColumnVector) previousVector;
+      } else {
+        timestampColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readPhase);
@@ -848,6 +864,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
         decimalColVector = previousVector;
+      } else {
+        longColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readPhase);
@@ -896,6 +914,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
         decimalColVector = previousVector;
+      } else {
+        doubleColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, readPhase);
@@ -940,6 +960,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         decimalColVector = previousVector;
+      } else {
+        bytesColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readPhase);
@@ -989,6 +1011,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         decimalColVector = previousVector;
+      } else {
+        timestampColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readPhase);
@@ -1035,6 +1059,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         fileDecimalColVector = new DecimalColumnVector(batchSize, filePrecision, fileScale);
         decimalColVector = previousVector;
+      } else {
+        fileDecimalColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(fileDecimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1071,6 +1097,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
+      } else {
+        longColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readPhase);
@@ -1133,6 +1161,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
+      } else {
+        doubleColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(doubleColVector, isNull, batchSize, filterContext, readPhase);
@@ -1183,6 +1213,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
         bytesColVector = (BytesColumnVector) previousVector;
+      } else {
+        decimalColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1310,6 +1342,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         timestampColVector = new TimestampColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
+      } else {
+        timestampColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readPhase);
@@ -1349,6 +1383,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new DateColumnVector(batchSize);
         bytesColVector = (BytesColumnVector) previousVector;
+      } else {
+        longColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readPhase);
@@ -1439,6 +1475,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         inBytesColVector = new BytesColumnVector(batchSize);
         outBytesColVector = (BytesColumnVector) previousVector;
+      } else {
+        inBytesColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(inBytesColVector, isNull, batchSize, filterContext, readPhase);
@@ -1484,6 +1522,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new LongColumnVector(batchSize);
         timestampColVector = (TimestampColumnVector) previousVector;
+      } else {
+        longColVector.ensureSize(batchSize, false);
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream
@@ -1546,6 +1586,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         doubleColVector = new DoubleColumnVector(batchSize);
         timestampColVector = (TimestampColumnVector) previousVector;
+      } else {
+        doubleColVector.ensureSize(batchSize, false);
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream
@@ -1608,6 +1650,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         decimalColVector = new DecimalColumnVector(batchSize, precision, scale);
         timestampColVector = (TimestampColumnVector) previousVector;
+      } else {
+        decimalColVector.ensureSize(batchSize, false);
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream
@@ -1667,6 +1711,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         bytesColVector = new BytesColumnVector(batchSize);
         timestampColVector = (TimestampColumnVector) previousVector;
+      } else {
+        bytesColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readPhase);
@@ -1711,6 +1757,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         // Allocate column vector for file; cast column vector for reader.
         longColVector = new DateColumnVector(batchSize);
         timestampColVector = (TimestampColumnVector) previousVector;
+      } else {
+        longColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(longColVector, isNull, batchSize, filterContext, readPhase);
@@ -1764,6 +1812,9 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
                                                    " proleptic Gregorian dates.");
           }
         }
+      } else {
+        bytesColVector.ensureSize(batchSize, false);
+        dateColumnVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readPhase);
@@ -1812,6 +1863,8 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
           throw new IllegalArgumentException("Can't use LongColumnVector with" +
                                                  " proleptic Gregorian dates.");
         }
+      } else {
+        timestampColVector.ensureSize(batchSize, false);
       }
       // Read present/isNull stream
       fromReader.nextVector(timestampColVector, isNull, batchSize, filterContext, readPhase);

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1814,9 +1814,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         }
       } else {
         bytesColVector.ensureSize(batchSize, false);
-        if (dateColumnVector != null) {
-          dateColumnVector.ensureSize(batchSize, false);
-        }
       }
       // Read present/isNull stream
       fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readPhase);

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -1814,7 +1814,9 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         }
       } else {
         bytesColVector.ensureSize(batchSize, false);
-        dateColumnVector.ensureSize(batchSize, false);
+        if (dateColumnVector != null) {
+          dateColumnVector.ensureSize(batchSize, false);
+        }
       }
       // Read present/isNull stream
       fromReader.nextVector(bytesColVector, isNull, batchSize, filterContext, readPhase);


### PR DESCRIPTION
### What changes were proposed in this pull request?
The fix simply ensures the size of some batches in ConvertTreeReader instances without API change.

### Why are the changes needed?
As described on jira, if there are batches of increasing size while reading, if they are in different stripes, we can hit an edge case where nextBatch doesn't force them to ensure the size of some batches.

### How was this patch tested?
Unit tests added for all possible ConvertTreeReader, also tested in hive locally.
