### PR TITLE
ORC-1210: Upgrade maven to 3.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The subdirectories are:
 ### Building
 
 * Install java 1.8 or higher
-* Install maven 3.8.4 or higher
+* Install maven 3.8.6 or higher
 * Install cmake
 
 To build a release version with debug information:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,7 +75,7 @@
     <tools.hadoop.version>2.10.1</tools.hadoop.version>
     <storage-api.version>2.8.1</storage-api.version>
     <zookeeper.version>3.8.0</zookeeper.version>
-    <maven.version>3.8.4</maven.version>
+    <maven.version>3.8.6</maven.version>
     <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
     <maven-shade-plugin.version>3.2.4</maven-shade-plugin.version>
     <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade maven to version 3.8.6.

### Why are the changes needed?
This will bring the latest changes and bug fixes. 

- https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316922&version=12351105
- https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12316922&version=12351556


### How was this patch tested?
Pass the CIs.