### PR TITLE
ORC-1213: [C++] Use `https` in `ThirdpartyToolchain.cmake`

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -133,7 +133,7 @@ else ()
   endif ()
 
   ExternalProject_Add (zlib_ep
-    URL "http://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
+    URL "https://zlib.net/fossils/zlib-${ZLIB_VERSION}.tar.gz"
     CMAKE_ARGS ${ZLIB_CMAKE_ARGS}
     ${THIRDPARTY_LOG_OPTIONS}
     BUILD_BYPRODUCTS "${ZLIB_STATIC_LIB}")
@@ -276,7 +276,7 @@ endif ()
 if (WIN32)
   SET(CURRENT_TZDATA_FILE "")
   SET(CURRENT_TZDATA_SHA512 "")
-  File(DOWNLOAD "http://ftp.osuosl.org/pub/cygwin/noarch/release/tzdata/sha512.sum" ${CMAKE_CURRENT_BINARY_DIR}/sha512.sum)
+  File(DOWNLOAD "https://ftp.osuosl.org/pub/cygwin/noarch/release/tzdata/sha512.sum" ${CMAKE_CURRENT_BINARY_DIR}/sha512.sum)
   File(READ ${CMAKE_CURRENT_BINARY_DIR}/sha512.sum TZDATA_SHA512_CONTENT)
   string(REPLACE "\n" ";" TZDATA_SHA512_LINE ${TZDATA_SHA512_CONTENT})
   foreach (LINE IN LISTS TZDATA_SHA512_LINE)
@@ -293,7 +293,7 @@ if (WIN32)
 
   if (NOT "${CURRENT_TZDATA_FILE}" STREQUAL "")
     ExternalProject_Add(tzdata_ep
-      URL "ftp://cygwin.osuosl.org/pub/cygwin/noarch/release/tzdata/${CURRENT_TZDATA_FILE}"
+      URL "https://cygwin.osuosl.org/noarch/release/tzdata/${CURRENT_TZDATA_FILE}"
       URL_HASH SHA512=${CURRENT_TZDATA_SHA512}
       CONFIGURE_COMMAND ""
       BUILD_COMMAND ""


### PR DESCRIPTION
Update some download links from using http & ftp to https