### PR TITLE
ORC-1215: Remove a wrong `NotNull` annotation on `value` of `setAttribute`

### DIFF
--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -246,7 +246,7 @@ public class TypeDescription
    * @return this for method chaining
    */
   public TypeDescription setAttribute(@NotNull String key,
-                                      @NotNull String value) {
+                                      String value) {
     attributes.put(key, value);
     return this;
   }

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -509,4 +509,10 @@ public class TestTypeDescription {
           schema.findSubtype(column, true).getFullFieldName());
     }
   }
+
+  @Test
+  public void testSetAttribute() {
+    TypeDescription type = TypeDescription.fromString("int");
+    type.setAttribute("key1", null);
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove a wrong `NotNull` annotation on `value`. 


### Why are the changes needed?
According to ORC-529, attribute value can be null to clear the existing value.

https://github.com/apache/orc/blob/8eef0c495ffe334825655ec22c1516b24ecd9f48/java/core/src/java/org/apache/orc/TypeDescription.java#L245-L249

### How was this patch tested?
Pass the CIs with the newly added test case. 