### PR TITLE
ORC-1216: Pin `org.jetbrains.annotations` dependency to 17.0.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,3 +45,6 @@ updates:
       # Pin jodd-core to 3.5.2
       - dependency-name: "org.jodd:jodd-core"
         versions: "[3.5.3,)"
+      # Pin annotations to 17.0.0
+      - dependency-name: "org.jetbrains.annotations"
+        versions: "[17.0.1,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to pin `org.jetbrains.annotations` dependency to 17.0.0.


### Why are the changes needed?
ORC only uses `@NotNull`, so we do not need to upgrade the annotations dependency. 

- https://github.com/apache/orc/issues/1176


### How was this patch tested?
Pass the CIs. 

Closes #1176