### PR TITLE
ORC-1217: Downgrade `org.jetbrains.annotations` to 17.0.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -823,7 +823,7 @@
       <dependency>
         <groupId>org.jetbrains</groupId>
         <artifactId>annotations</artifactId>
-        <version>23.0.0</version>
+        <version>17.0.0</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to downgrade `org.jetbrains.annotations` to 17.0.0.


### Why are the changes needed?
ORC-916, ORC-956, and ORC-1056 bumped `annotations`, but we only use `@NotNull` so we do not need to update the `annotations` version. 


### How was this patch tested?
Pass the CIs. 