### PR TITLE
ORC-1219: Remove redundant `toString`

### DIFF
--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -611,7 +611,7 @@ public interface Reader extends Closeable {
       buffer.append(length);
       if (sarg != null) {
         buffer.append(", sarg: ");
-        buffer.append(sarg.toString());
+        buffer.append(sarg);
       }
       if (schema != null) {
         buffer.append(", schema: ");

--- a/java/core/src/java/org/apache/orc/impl/OutStream.java
+++ b/java/core/src/java/org/apache/orc/impl/OutStream.java
@@ -131,11 +131,9 @@ public class OutStream extends PositionedOutputStream {
     try {
       cipher.init(Cipher.ENCRYPT_MODE, key, new IvParameterSpec(iv));
     } catch (InvalidKeyException e) {
-      throw new IllegalStateException("ORC bad encryption key for " +
-                                          toString(), e);
+      throw new IllegalStateException("ORC bad encryption key for " + this, e);
     } catch (InvalidAlgorithmParameterException e) {
-      throw new IllegalStateException("ORC bad encryption parameter for " +
-                                          toString(), e);
+      throw new IllegalStateException("ORC bad encryption parameter for " + this, e);
     }
   }
 
@@ -154,10 +152,10 @@ public class OutStream extends PositionedOutputStream {
         receiver.output(output);
         if (encrypted != len) {
           throw new IllegalArgumentException("Encryption of incomplete buffer "
-              + len + " -> " + encrypted + " in " + toString());
+              + len + " -> " + encrypted + " in " + this);
         }
       } catch (ShortBufferException e) {
-        throw new IOException("Short buffer in encryption in " + toString(), e);
+        throw new IOException("Short buffer in encryption in " + this, e);
       }
     } else {
       receiver.output(buffer);
@@ -172,8 +170,7 @@ public class OutStream extends PositionedOutputStream {
     try {
       byte[] finalBytes = cipher.doFinal();
       if (finalBytes != null && finalBytes.length != 0) {
-        throw new IllegalStateException("We shouldn't have remaining bytes " +
-            toString());
+        throw new IllegalStateException("We shouldn't have remaining bytes " + this);
       }
     } catch (IllegalBlockSizeException e) {
       throw new IllegalArgumentException("Bad block size", e);

--- a/java/core/src/java/org/apache/orc/impl/ParserUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/ParserUtils.java
@@ -387,7 +387,7 @@ public class ParserUtils {
             }
           } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Field " + first +
-                "not found in " + current.toString(), e);
+                "not found in " + current, e);
           }
           break;
         }
@@ -396,7 +396,7 @@ public class ParserUtils {
       }
       if (posn < 0) {
         throw new IllegalArgumentException("Field " + first +
-                                           " not found in " + current.toString());
+                                           " not found in " + current);
       }
       current = current.getChildren().get(posn);
       visitor.visit(current, posn);

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -304,7 +304,7 @@ public class RecordReaderUtils {
         buffer.append("{");
       }
       isFirst = false;
-      buffer.append(range.toString());
+      buffer.append(range);
       buffer.append("}");
       range = range.next;
     }

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -565,8 +565,8 @@ public class SchemaEvolution {
       throw new IllegalEvolutionException(
           String.format("ORC does not support type conversion from file" +
                         " type %s (%d) to reader type %s (%d)",
-                        fileType.toString(), fileType.getId(),
-                        readerType.toString(), readerType.getId()));
+                        fileType, fileType.getId(),
+                  readerType, readerType.getId()));
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
+++ b/java/core/src/java/org/apache/orc/impl/SchemaEvolution.java
@@ -566,7 +566,7 @@ public class SchemaEvolution {
           String.format("ORC does not support type conversion from file" +
                         " type %s (%d) to reader type %s (%d)",
                         fileType, fileType.getId(),
-                  readerType, readerType.getId()));
+                        readerType, readerType.getId()));
     }
   }
 

--- a/java/core/src/java/org/apache/orc/util/BloomFilter.java
+++ b/java/core/src/java/org/apache/orc/util/BloomFilter.java
@@ -238,7 +238,7 @@ public class BloomFilter {
       this.bitSet.putAll(that.bitSet);
     } else {
       throw new IllegalArgumentException("BloomFilters are not compatible for merging." +
-          " this - " + this.toString() + " that - " + that.toString());
+          " this - " + this + " that - " + that);
     }
   }
 

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -289,7 +289,7 @@ public final class FileDump {
           buffer.append(' ');
           buffer.append(file);
         }
-        System.err.println(buffer.toString());
+        System.err.println(buffer);
         System.out.println(SEPARATOR);
       }
     }
@@ -386,9 +386,9 @@ public final class FileDump {
         if (tz == null || tz.isEmpty()) {
           tz = UNKNOWN;
         }
-        System.out.println("  Stripe: " + stripe.toString() + " timezone: " + tz);
+        System.out.println("  Stripe: " + stripe + " timezone: " + tz);
       } else {
-        System.out.println("  Stripe: " + stripe.toString());
+        System.out.println("  Stripe: " + stripe);
       }
       long sectionStart = stripeStart;
       for (OrcProto.Stream section : footer.getStreamsList()) {
@@ -755,7 +755,7 @@ public final class FileDump {
             ColumnStatisticsImpl.deserialize(colSchema, colStats,
                 reader.writerUsedProlepticGregorian(),
                 reader.getConvertToProlepticGregorian());
-        buf.append(cs.toString());
+        buf.append(cs);
       }
       buf.append(" positions: ");
       for (int posIx = 0; posIx < entry.getPositionsCount(); ++posIx) {

--- a/java/tools/src/java/org/apache/orc/tools/PrintData.java
+++ b/java/tools/src/java/org/apache/orc/tools/PrintData.java
@@ -172,8 +172,7 @@ public class PrintData {
           printUnion(writer, (UnionColumnVector) vector, schema, row);
           break;
         default:
-          throw new IllegalArgumentException("Unknown type " +
-              schema.toString());
+          throw new IllegalArgumentException("Unknown type " + schema);
       }
     } else {
       writer.nullValue();

--- a/java/tools/src/java/org/apache/orc/tools/json/HiveType.java
+++ b/java/tools/src/java/org/apache/orc/tools/json/HiveType.java
@@ -89,7 +89,7 @@ abstract class HiveType {
    * @param prefix the prefix to add to each field name
    */
   public void printFlat(PrintStream out, String prefix) {
-    out.println(prefix + ": " + toString());
+    out.println(prefix + ": " + this);
   }
 
   public abstract TypeDescription getSchema();

--- a/java/tools/src/java/org/apache/orc/tools/json/JsonSchemaFinder.java
+++ b/java/tools/src/java/org/apache/orc/tools/json/JsonSchemaFinder.java
@@ -174,7 +174,7 @@ public class JsonSchemaFinder {
     if (type == null) {
       out.print("void");
     } else if (type.kind.isPrimitive) {
-      out.print(type.toString());
+      out.print(type);
     } else {
       switch (type.kind) {
         case STRUCT:

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestJsonReader.java
@@ -89,9 +89,9 @@ public class TestJsonReader {
     public void testDateTypeSupport() throws IOException {
         LocalDate date1 = LocalDate.of(2021, 1, 18);
         LocalDate date2 = LocalDate.now();
-        String inputString = "{\"dt\": \"" + date1.toString() + "\"}\n" +
-                             "{\"dt\": \"" + date2.toString() + "\"}\n" +
-                             "{\"dt\": \"" + date2.toString() + "\"}\n" +
+        String inputString = "{\"dt\": \"" + date1 + "\"}\n" +
+                             "{\"dt\": \"" + date2 + "\"}\n" +
+                             "{\"dt\": \"" + date2 + "\"}\n" +
                              "{\"dt\": null}";
 
 
@@ -123,9 +123,9 @@ public class TestJsonReader {
         String datetime4Str = datetime4.toString();
         datetime4Str = datetime4Str.substring(0, datetime4Str.length() - 5) + "0700";
 
-        String inputString = "{\"dt\": \"" + datetime1.toString() + "\"}\n" +
-                             "{\"dt\": \"" + datetime2.toString() + "\"}\n" +
-                             "{\"dt\": \"" + datetime3.toString() + "\"}\n" +
+        String inputString = "{\"dt\": \"" + datetime1 + "\"}\n" +
+                             "{\"dt\": \"" + datetime2 + "\"}\n" +
+                             "{\"dt\": \"" + datetime3 + "\"}\n" +
                              "{\"dt\": \"" + datetime4Str + "\"}\n" +
                              "{\"dt\": \"" + datetime5.toLocalDateTime().toString() + "[" + datetime5.getZone() + "]\"}\n" +
                              "{\"dt\": \"" + datetime6.toLocalDateTime().toString() + "[" + datetime6.getZone() + "]\"}\n";


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to clean up redundant `toString` invocation style.

ORC-1219 will be assigned to @deadwind4 .

### Why are the changes needed?

Simple clean ups.

### How was this patch tested?

Pass the CIs.

Closes #1181