### PR TITLE
ORC-1220: Set `min.hadoop.version` to 2.7.3

### DIFF
--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -76,6 +76,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>${min.hadoop.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -121,6 +127,9 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
+            <ignoredUnusedDeclaredDependency>
+              org.apache.hadoop:hadoop-hdfs
+            </ignoredUnusedDeclaredDependency>
             <ignoredUnusedDeclaredDependency>
               org.apache.hadoop:hadoop-mapreduce-client-jobclient
             </ignoredUnusedDeclaredDependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,7 +70,7 @@
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
     <example.dir>${project.basedir}/../../examples</example.dir>
 
-    <min.hadoop.version>2.2.0</min.hadoop.version>
+    <min.hadoop.version>2.7.3</min.hadoop.version>
     <hadoop.version>2.7.3</hadoop.version>
     <tools.hadoop.version>2.10.1</tools.hadoop.version>
     <storage-api.version>2.8.1</storage-api.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `min.hadoop.version` to 2.7.3 for Apache ORC 1.8.0.

### Why are the changes needed?

Apache ORC 1.8.0 will be released on September 2022 and will be supported for three years until September 2025.

Apache Hadoop 2.2 ~ 2.6 are too old to support until 2025.

- Apache Hadoop 2.2.0 was released on Oct, 2013.
- Apache Hadoop 2.3.0 was released on Feb, 2014.
- Apache Hadoop 2.4.0 was released on Mar, 2014.
- Apache Hadoop 2.5.0 was released on Aug, 2014.
- Apache Hadoop 2.6.0 was released on Nov, 2014.
- Apache Hadoop 2.7.0 was released on Apr, 2015.

### How was this patch tested?

Pass the CIs.