### PR TITLE
ORC-1221: Move `NullKeyProvider` to `org.apache.orc.impl`

### DIFF
--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_3.java
@@ -23,9 +23,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.security.Key;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Random;
 
 /**
@@ -60,31 +57,4 @@ public class HadoopShimsPre2_3 implements HadoopShims {
     return new NullKeyProvider();
   }
 
-  static class NullKeyProvider implements KeyProvider {
-
-    @Override
-    public List<String> getKeyNames() {
-      return new ArrayList<>();
-    }
-
-    @Override
-    public KeyMetadata getCurrentKeyVersion(String keyName) {
-      throw new IllegalArgumentException("Unknown key " + keyName);
-    }
-
-    @Override
-    public LocalKey createLocalKey(KeyMetadata key) {
-      throw new IllegalArgumentException("Unknown key " + key);
-    }
-
-    @Override
-    public Key decryptLocalKey(KeyMetadata key, byte[] encryptedKey) {
-      return null;
-    }
-
-    @Override
-    public KeyProviderKind getKind() {
-      return null;
-    }
-  }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
@@ -133,6 +133,6 @@ public class HadoopShimsPre2_6 implements HadoopShims {
 
   @Override
   public KeyProvider getHadoopKeyProvider(Configuration conf, Random random) {
-    return new HadoopShimsPre2_3.NullKeyProvider();
+    return new NullKeyProvider();
   }
 }

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -222,7 +222,7 @@ public class HadoopShimsPre2_7 implements HadoopShims {
     if (result.size() == 0) {
       LOG.info("Can't get KeyProvider for ORC encryption from" +
           " hadoop.security.key.provider.path.");
-      return new HadoopShimsPre2_3.NullKeyProvider();
+      return new NullKeyProvider();
     } else {
       return new KeyProviderImpl(result.get(0), random);
     }

--- a/java/shims/src/java/org/apache/orc/impl/NullKeyProvider.java
+++ b/java/shims/src/java/org/apache/orc/impl/NullKeyProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import java.security.Key;
+import java.util.ArrayList;
+import java.util.List;
+
+class NullKeyProvider implements KeyProvider {
+
+    @Override
+    public List<String> getKeyNames() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public HadoopShims.KeyMetadata getCurrentKeyVersion(String keyName) {
+        throw new IllegalArgumentException("Unknown key " + keyName);
+    }
+
+    @Override
+    public LocalKey createLocalKey(HadoopShims.KeyMetadata key) {
+        throw new IllegalArgumentException("Unknown key " + key);
+    }
+
+    @Override
+    public Key decryptLocalKey(HadoopShims.KeyMetadata key, byte[] encryptedKey) {
+        return null;
+    }
+
+    @Override
+    public HadoopShims.KeyProviderKind getKind() {
+        return null;
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to move `NullKeyProvider` to `org.apache.orc.impl`


### Why are the changes needed?
To prepare for #1186 

### How was this patch tested?
Pass the CIs.