### PR TITLE
ORC-1222: Upgrade `tools.hadoop.version` to 2.10.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,7 +72,7 @@
 
     <min.hadoop.version>2.2.0</min.hadoop.version>
     <hadoop.version>2.7.3</hadoop.version>
-    <tools.hadoop.version>2.10.1</tools.hadoop.version>
+    <tools.hadoop.version>2.10.2</tools.hadoop.version>
     <storage-api.version>2.8.1</storage-api.version>
     <zookeeper.version>3.8.0</zookeeper.version>
     <maven.version>3.8.6</maven.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump `tools.hadoop.version` to 2.10.2 for Apache ORC 1.8.0.

### Why are the changes needed?

To improve tools.

### How was this patch tested?

Pass the CIs.