### PR TITLE
ORC-1223: Move `DirectDecompressWrapper` to `org.apache.orc.impl`

### DIFF
--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.util.Random;
 
 /**
@@ -38,64 +37,6 @@ import java.util.Random;
  * </ul>
  */
 public class HadoopShimsPre2_6 implements HadoopShims {
-
-  static class SnappyDirectDecompressWrapper implements DirectDecompressor {
-    private final SnappyDirectDecompressor root;
-    private boolean isFirstCall = true;
-
-    SnappyDirectDecompressWrapper(SnappyDirectDecompressor root) {
-      this.root = root;
-    }
-
-    @Override
-    public void decompress(ByteBuffer input, ByteBuffer output) throws IOException {
-      if (!isFirstCall) {
-        root.reset();
-      } else {
-        isFirstCall = false;
-      }
-      root.decompress(input, output);
-    }
-
-    @Override
-    public void reset() {
-      root.reset();
-    }
-
-    @Override
-    public void end() {
-      root.end();
-    }
-  }
-
-  static class ZlibDirectDecompressWrapper implements DirectDecompressor {
-    private final ZlibDecompressor.ZlibDirectDecompressor root;
-    private boolean isFirstCall = true;
-
-    ZlibDirectDecompressWrapper(ZlibDecompressor.ZlibDirectDecompressor root) {
-      this.root = root;
-    }
-
-    @Override
-    public void decompress(ByteBuffer input, ByteBuffer output) throws IOException {
-      if (!isFirstCall) {
-        root.reset();
-      } else {
-        isFirstCall = false;
-      }
-      root.decompress(input, output);
-    }
-
-    @Override
-    public void reset() {
-      root.reset();
-    }
-
-    @Override
-    public void end() {
-      root.end();
-    }
-  }
 
   static DirectDecompressor getDecompressor( DirectCompressionType codec) {
     switch (codec) {

--- a/java/shims/src/java/org/apache/orc/impl/SnappyDirectDecompressWrapper.java
+++ b/java/shims/src/java/org/apache/orc/impl/SnappyDirectDecompressWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.io.compress.snappy.SnappyDecompressor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+class SnappyDirectDecompressWrapper implements HadoopShims.DirectDecompressor {
+    private final SnappyDecompressor.SnappyDirectDecompressor root;
+    private boolean isFirstCall = true;
+
+    SnappyDirectDecompressWrapper(SnappyDecompressor.SnappyDirectDecompressor root) {
+        this.root = root;
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output) throws IOException {
+        if (!isFirstCall) {
+            root.reset();
+        } else {
+            isFirstCall = false;
+        }
+        root.decompress(input, output);
+    }
+
+    @Override
+    public void reset() {
+        root.reset();
+    }
+
+    @Override
+    public void end() {
+        root.end();
+    }
+}

--- a/java/shims/src/java/org/apache/orc/impl/ZlibDirectDecompressWrapper.java
+++ b/java/shims/src/java/org/apache/orc/impl/ZlibDirectDecompressWrapper.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+class ZlibDirectDecompressWrapper implements HadoopShims.DirectDecompressor {
+    private final ZlibDecompressor.ZlibDirectDecompressor root;
+    private boolean isFirstCall = true;
+
+    ZlibDirectDecompressWrapper(ZlibDecompressor.ZlibDirectDecompressor root) {
+        this.root = root;
+    }
+
+    @Override
+    public void decompress(ByteBuffer input, ByteBuffer output) throws IOException {
+        if (!isFirstCall) {
+            root.reset();
+        } else {
+            isFirstCall = false;
+        }
+        root.decompress(input, output);
+    }
+
+    @Override
+    public void reset() {
+        root.reset();
+    }
+
+    @Override
+    public void end() {
+        root.end();
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to move `DirectDecompressWrapper` to `org.apache.orc.impl`


### Why are the changes needed?
To clean up old Hadoop support


### How was this patch tested?
Pass the CIs. 