### PR TITLE
ORC-1224: Move `getDecompressor` to `HadoopShimsCurrent`

### DIFF
--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
@@ -21,6 +21,8 @@ package org.apache.orc.impl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.hdfs.client.HdfsDataOutputStream;
+import org.apache.hadoop.io.compress.snappy.SnappyDecompressor;
+import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,9 +39,26 @@ import java.util.Random;
  */
 public class HadoopShimsCurrent implements HadoopShims {
 
+  static DirectDecompressor getDecompressor( DirectCompressionType codec) {
+    switch (codec) {
+      case ZLIB:
+        return new ZlibDirectDecompressWrapper
+            (new ZlibDecompressor.ZlibDirectDecompressor());
+      case ZLIB_NOHEADER:
+        return new ZlibDirectDecompressWrapper
+            (new ZlibDecompressor.ZlibDirectDecompressor
+                (ZlibDecompressor.CompressionHeader.NO_HEADER, 0));
+      case SNAPPY:
+        return new SnappyDirectDecompressWrapper
+            (new SnappyDecompressor.SnappyDirectDecompressor());
+      default:
+        return null;
+    }
+  }
+
   @Override
   public DirectDecompressor getDirectDecompressor(DirectCompressionType codec) {
-    return HadoopShimsPre2_6.getDecompressor(codec);
+    return getDecompressor(codec);
   }
 
   @Override

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_6.java
@@ -20,8 +20,6 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.io.compress.snappy.SnappyDecompressor.SnappyDirectDecompressor;
-import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -38,26 +36,9 @@ import java.util.Random;
  */
 public class HadoopShimsPre2_6 implements HadoopShims {
 
-  static DirectDecompressor getDecompressor( DirectCompressionType codec) {
-    switch (codec) {
-      case ZLIB:
-        return new ZlibDirectDecompressWrapper
-            (new ZlibDecompressor.ZlibDirectDecompressor());
-      case ZLIB_NOHEADER:
-        return new ZlibDirectDecompressWrapper
-            (new ZlibDecompressor.ZlibDirectDecompressor
-                (ZlibDecompressor.CompressionHeader.NO_HEADER, 0));
-      case SNAPPY:
-        return new SnappyDirectDecompressWrapper
-            (new SnappyDirectDecompressor());
-      default:
-        return null;
-    }
-  }
-
   @Override
   public DirectDecompressor getDirectDecompressor(DirectCompressionType codec) {
-    return getDecompressor(codec);
+    return HadoopShimsCurrent.getDecompressor(codec);
  }
 
   @Override

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsPre2_7.java
@@ -51,7 +51,7 @@ public class HadoopShimsPre2_7 implements HadoopShims {
 
   @Override
   public DirectDecompressor getDirectDecompressor(DirectCompressionType codec) {
-    return HadoopShimsPre2_6.getDecompressor(codec);
+    return HadoopShimsCurrent.getDecompressor(codec);
  }
 
   @Override


### PR DESCRIPTION

### What changes were proposed in this pull request?
This PR aims to move `getDecompressor` to `HadoopShimsCurrent`


### Why are the changes needed?
To clean up old Hadoop support.


### How was this patch tested?
Pass the CIs.