### PR TITLE
ORC-1226: Add a deprecation warning for Hadoop 2.7.2 and below

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/HadoopShimsFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/HadoopShimsFactory.java
@@ -19,11 +19,15 @@
 package org.apache.orc.impl;
 
 import org.apache.hadoop.util.VersionInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The factory for getting the proper version of the Hadoop shims.
  */
 public class HadoopShimsFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(HadoopShimsFactory.class);
+
   private static final String CURRENT_SHIM_NAME =
       "org.apache.orc.impl.HadoopShimsCurrent";
   private static final String PRE_2_6_SHIM_NAME =
@@ -48,6 +52,10 @@ public class HadoopShimsFactory {
       String[] versionParts = VersionInfo.getVersion().split("[.]");
       int major = Integer.parseInt(versionParts[0]);
       int minor = Integer.parseInt(versionParts[1]);
+      if (major < 2 || (major == 2 && minor < 7)) {
+        LOG.warn("Hadoop " + VersionInfo.getVersion() + " support is deprecated. " +
+            "Please upgrade to Hadoop 2.7.3 or above.");
+      }
       if (major < 2 || (major == 2 && minor < 3)) {
         SHIMS = new HadoopShimsPre2_3();
       } else if (major == 2 && minor < 6) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add a deprecation warning for Hadoop 2.7.2 and below at Apache ORC 1.7.6.


### Why are the changes needed?
To remove old Hadoop dependency from 1.8.0.


### How was this patch tested?
Pass the CIs and test like below: 

```
$ jshell -c core/target/orc-core-1.9.0-SNAPSHOT.jar:shims/target/orc-shims-1.9.0-SNAPSHOT.jar:~/.m2/repository/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar:~/.m2/repository/org/slf4j/slf4j-simple/1.7.36/slf4j-simple-1.7.36.jar:~/.m2/repository/org/apache/hadoop/hadoop-common/2.2.0/hadoop-common-2.2.0.jar:~/.m2/repository/commons-logging/commons-logging/1.2/commons-logging-1.2.jar
|  Welcome to JShell -- Version 11.0.15
|  For an introduction type: /help intro

jshell> org.apache.orc.impl.HadoopShimsFactory.get()
[main] WARN org.apache.orc.impl.HadoopShimsFactory - Hadoop 2.2.0 support is deprecated. Please upgrade to Hadoop 2.7.3 or above.
$1 ==> org.apache.orc.impl.HadoopShimsPre2_3@646d64ab
```