### PR TITLE
ORC-1227: Use `Constructor.newInstance` instead of `Class.newInstance`

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/HadoopShimsFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/HadoopShimsFactory.java
@@ -20,6 +20,8 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.util.VersionInfo;
 
+import java.lang.reflect.InvocationTargetException;
+
 /**
  * The factory for getting the proper version of the Hadoop shims.
  */
@@ -37,8 +39,10 @@ public class HadoopShimsFactory {
     try {
       Class<? extends HadoopShims> cls =
           (Class<? extends HadoopShims>) Class.forName(name);
-      return cls.newInstance();
-    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      return cls.getDeclaredConstructor().newInstance();
+    } catch (ClassNotFoundException | NoSuchMethodException | SecurityException |
+             InstantiationException | IllegalAccessException | IllegalArgumentException |
+             InvocationTargetException e) {
       throw new IllegalStateException("Can't create shims for " + name, e);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use `Constructor.newInstance` instead of `Class.newInstance`.


### Why are the changes needed?
`Class.newInstance` is deprecated at Java 9.

### How was this patch tested?
Pass the CIs. 