### PR TITLE
ORC-1228: Fix `setAttribute` to handle null value

### DIFF
--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -247,7 +247,11 @@ public class TypeDescription
    */
   public TypeDescription setAttribute(@NotNull String key,
                                       String value) {
-    attributes.put(key, value);
+    if (value == null) {
+      attributes.remove(key);
+    } else {
+      attributes.put(key, value);
+    }
     return this;
   }
 

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -514,5 +514,7 @@ public class TestTypeDescription {
   public void testSetAttribute() {
     TypeDescription type = TypeDescription.fromString("int");
     type.setAttribute("key1", null);
+
+    assertEquals(0, type.getAttributeNames().size());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix `setAttribute` to handle null value.


### Why are the changes needed?
In case of clearing the value with null, we should remove the corresponding key also to save memory. 


### How was this patch tested?
Pass the CIs with the new test case. 