### PR TITLE
ORC-1234: Upgrade `objenesis` to 3.2 in Spark benchmark

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>2.6</version>
+      <version>3.2</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This Pr aims to upgrade `objenesis` to 3.2 in Spark benchmark


### Why are the changes needed?
To match Spark 3.3.0's `objenesis` version. 


### How was this patch tested?
Pass the Cis. 

Closes #1204