### PR TITLE
ORC-1237: Remove a wrong image link to `article-footer.png`

### DIFF
--- a/site/css/screen.scss
+++ b/site/css/screen.scss
@@ -468,7 +468,7 @@ aside {
   text-align: center;
   padding-top: 40px;
   position: relative;
-  background: url(../img/article-footer.png) top center no-repeat;
+  background: top center no-repeat;
   margin: 40px -20px 10px;
 
   > div { width: 49.5%; }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This Pr aims to remove a wrong image link to `article-footer.png`.


### Why are the changes needed?
Currently, this missing image link shows a 404 error. 


### How was this patch tested?
Manually. 