### PR TITLE
ORC-1241: Use `apache/orc-dev` DockerHub repository in Docker tests

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,16 @@
 * Debian 10 and 11
 * Ubuntu 18, 20 and 22
 
+## Pre-built Images
+
+Apache ORC community provides a set of pre-built docker images and uses it during testing.
+
+    docker pull apache/orc-dev:ubuntu22
+
+You can find all tags here.
+
+    https://hub.docker.com/r/apache/orc-dev/tags
+
 ## Test
 
 To test against all of the Linux OSes against Apache's main branch:

--- a/docker/reinit.sh
+++ b/docker/reinit.sh
@@ -17,7 +17,6 @@
 
 start=`date`
 for build in `cat os-list.txt`; do
-  echo "Re-initialize $build"
   OS=$(echo "$build" | cut -d '_' -f1)
   REST=$(echo "$build" | cut -d '_' -f2- -s)
   if [ -z "$REST" ]; then
@@ -25,7 +24,8 @@ for build in `cat os-list.txt`; do
   else
     ARGS=$(echo "$REST" | sed -e 's/^/--build-arg /' -e 's/_/ --build-arg /g')
   fi
-  TAG=$(echo "orc-$build" | sed -e 's/=/-/g')
+  TAG=$(echo "apache/orc-dev:$build" | sed -e 's/=/-/g')
+  echo "Re-initialize $TAG"
   ( cd $OS && docker build --no-cache -t "$TAG" $ARGS . )
 done
 echo "Start: $start"

--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -32,19 +32,6 @@ function failure {
 rm -f logs/pids.txt logs/*.log
 
 start=`date`
-for build in `cat os-list.txt`; do
-  echo "Building $build"
-  OS=$(echo "$build" | cut -d '_' -f1)
-  REST=$(echo "$build" | cut -d '_' -f2- -s)
-  if [ -z "$REST" ]; then
-    ARGS=""
-  else
-    ARGS=$(echo "$REST" | sed -e 's/^/--build-arg /' -e 's/_/ --build-arg /g')
-  fi
-  TAG=$(echo "orc-$build" | sed -e 's/=/-/g')
-  ( cd $OS && docker build -t "$TAG" $ARGS . ) > logs/$build-build.log 2>&1 || exit 1
-done
-testStart=`date`
 
 for build in `cat os-list.txt`; do
     ./run-one.sh $1 $2 $build > logs/$build-test.log 2>&1 &
@@ -58,6 +45,5 @@ for job in `cat logs/pids.txt`; do
 done
 
 echo ""
-echo "Build start: $start"
-echo "Test start: $testStart"
+echo "Test start: $start"
 echo "End:" `date`

--- a/docker/run-one.sh
+++ b/docker/run-one.sh
@@ -26,7 +26,7 @@ function failure {
 }
 
 VOLUME="--volume m2cache:/root/.m2/repository"
-TAG=$(echo "orc-$BUILD" | sed -e 's/=/-/g')
+TAG=$(echo "apache/orc-dev:$BUILD" | sed -e 's/=/-/g')
 if [ $GITHUB_USER == "local" ]; then
   BRANCH=`git status| head -1 | sed -e 's/On branch //'`
   echo "Started local run for $BRANCH on $BUILD at $(date)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use `apache/orc-dev` DockerHub repository in Docker tests.


### Why are the changes needed?
https://issues.apache.org/jira/browse/INFRA-23534 
We should utilize the prebuilt image 

### How was this patch tested?
Manually. 