### PR TITLE
ORC-1244: Upgrade `byte-buddy` to 1.12.13 in branch-1.7

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -924,7 +924,7 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.11.12</version>
+        <version>1.12.13</version>
         <scope>test</scope>
       </dependency>
     </dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade a test dependency, `byte-buddy`, in branch-1.7 to 1.12.13.

### Why are the changes needed?

To sync with branch-1.8 and main.

### How was this patch tested?

Pass the CIs.