### PR TITLE
ORC-1245: Use Hadoop 3.3.4 on Java 17+ and benchmark

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -37,7 +37,7 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.3</parquet.version>
     <spark.version>3.3.0</spark.version>
-    <hadoop.version>3.3.3</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <junit.version>5.9.0</junit.version>
   </properties>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -533,9 +533,9 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <min.hadoop.version>3.3.3</min.hadoop.version>
-        <hadoop.version>3.3.3</hadoop.version>
-        <tools.hadoop.version>3.3.3</tools.hadoop.version>
+        <min.hadoop.version>3.3.4</min.hadoop.version>
+        <hadoop.version>3.3.4</hadoop.version>
+        <tools.hadoop.version>3.3.4</tools.hadoop.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use use Hadoop 3.3.4 on Java 17+ and benchmark.

### Why are the changes needed?
This will bring the following bug fixes. 
- https://hadoop.apache.org/docs/r3.3.4/hadoop-project-dist/hadoop-common/release/3.3.4/CHANGELOG.3.3.4.html

### How was this patch tested?
Pass the CIs. 