### PR TITLE
ORC-1254: Add spotbugs check

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -304,6 +304,31 @@
           </executions>
         </plugin>
         <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>4.7.1.1</version>
+          <dependencies>
+            <dependency>
+              <groupId>com.github.spotbugs</groupId>
+              <artifactId>spotbugs</artifactId>
+              <version>4.7.1</version>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <includeFilterFile>spotbugs-include.xml</includeFilterFile>
+            <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>
+          </configuration>
+          <executions>
+            <execution>
+              <id>analyze-compile</id>
+              <phase>test</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <executions>
@@ -492,6 +517,10 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-maven-plugin</artifactId>
           </plugin>
           <plugin>
             <groupId>org.apache.rat</groupId>

--- a/java/spotbugs-exclude.xml
+++ b/java/spotbugs-exclude.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+  <Match>
+    <Or>
+      <Class name="~org.apache.orc.OrcProto.*" />
+      <Class name="~org.apache.orc.bench.*" />
+    </Or>
+  </Match>
+
+  <Match>
+    <And>
+      <Bug pattern="SA_LOCAL_SELF_COMPARISON" />
+      <Class name="org.apache.orc.impl.ConvertTreeReaderFactory$ConvertTreeReader" />
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Bug pattern="CN_IDIOM_NO_SUPER_CALL" />
+      <Class name="org.apache.orc.TypeDescription" />
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Bug pattern="EQ_UNUSUAL" />
+      <Class name="org.apache.orc.TypeDescription" />
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Bug pattern="SF_SWITCH_FALLTHROUGH" />
+      <Class name="org.apache.orc.util.Murmur3" />
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Bug pattern="SF_SWITCH_NO_DEFAULT" />
+      <Class name="org.apache.orc.util.Murmur3" />
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Bug pattern="DM_EXIT" />
+      <Class name="org.apache.orc.tools.KeyTool" />
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Bug pattern="DM_EXIT" />
+      <Class name="org.apache.orc.tools.json.JsonSchemaFinder" />
+    </And>
+  </Match>
+  <Match>
+    <And>
+      <Bug pattern="REC_CATCH_EXCEPTION" />
+      <Class name="org.apache.orc.tools.ScanData" />
+    </And>
+  </Match>
+</FindBugsFilter>

--- a/java/spotbugs-include.xml
+++ b/java/spotbugs-include.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+  <Match>
+    <Bug category="SECURITY,CORRECTNESS,MT_CORRECTNESS,BAD_PRACTICE,PERFORMANCE,STYLE"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add spotbugs check. 


### Why are the changes needed?
This will improve test coverage on Java 8+. 
- https://github.com/spotbugs/spotbugs

`findbug` does not support Java 9+.


### How was this patch tested?
Pass the CIs.