### PR TITLE
ORC-1255: Fix ORC website navbar highlight

### DIFF
--- a/site/_includes/primary-nav-items.html
+++ b/site/_includes/primary-nav-items.html
@@ -2,7 +2,7 @@
   <li class="{% if page.overview %}current{% endif %}">
     <a href="/">Home</a>
   </li>
-  <li class="{% if page.url contains '/releases/' %}current{% endif %}">
+  <li class="{% if page.url == '/releases/' %}current{% endif %}">
     <a href="/releases/"><span class="show-on-mobiles">Rel</span>
                          <span class="hide-on-mobiles">Releases</span></a>
   </li>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix the ORC website navbar highlight issue.


### Why are the changes needed?
**BEFORE**
<img width="717" alt="Screen Shot 2022-08-19 at 5 53 16 PM" src="https://user-images.githubusercontent.com/62487364/185723100-572ed69a-3400-4d53-a5b1-894fbeb68860.png">


**AFTER**
<img width="717" alt="Screen Shot 2022-08-19 at 5 53 23 PM" src="https://user-images.githubusercontent.com/62487364/185723102-a138eb61-2e21-4792-a419-e5ffff58e1ff.png">


### How was this patch tested?
Manually build and check.