### PR TITLE
ORC-1212: Upgrade `protobuf-java` to 3.17.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,9 +39,9 @@ updates:
       # Pin maven-dependency-plugin to 3.1.2 due to MDEP-753, MDEP-757, MDEP-759
       - dependency-name: "org.apache.maven.plugins:maven-dependency-plugin"
         versions: "[3.2.0,)"
-      # Pin protobuf-java to 2.5.0
+      # Pin protobuf-java to 3.17.3
       - dependency-name: "com.google.protobuf:protobuf-java"
-        versions: "[2.5.1,)"
+        versions: "[3.17.4,)"
       # Pin jodd-core to 3.5.2
       - dependency-name: "org.jodd:jodd-core"
         versions: "[3.5.3,)"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -79,7 +79,6 @@
     <maven-assembly-plugin.version>3.4.2</maven-assembly-plugin.version>
     <maven-shade-plugin.version>3.3.0</maven-shade-plugin.version>
     <slf4j.version>2.0.0</slf4j.version>
-    <protoc.artifact>com.google.protobuf:protoc:2.5.0</protoc.artifact>
     <surefire.version>3.0.0-M5</surefire.version>
     <junit.version>5.9.0</junit.version>
     <mockito.version>4.7.0</mockito.version>
@@ -438,8 +437,7 @@
                 <goal>run</goal>
               </goals>
               <configuration>
-                 <protocArtifact>${protoc.artifact}</protocArtifact>
-                 <protocVersion>2.5.0</protocVersion>
+                <protocVersion>3.17.3</protocVersion>
                 <addSources>none</addSources>
                 <includeDirectories>
                   <include>../../proto</include>
@@ -552,18 +550,6 @@
       </modules>
     </profile>
     <profile>
-      <id>aarch64</id>
-      <properties>
-        <protoc.artifact>com.google.protobuf:protoc:2.5.0:exe:osx-x86_64</protoc.artifact>
-      </properties>
-      <activation>
-        <os>
-          <family>mac</family>
-          <arch>aarch64</arch>
-        </os>
-      </activation>
-    </profile>
-    <profile>
       <id>java17</id>
       <activation>
         <jdk>[17,)</jdk>
@@ -633,7 +619,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>2.5.0</version>
+        <version>3.17.3</version>
       </dependency>
       <dependency>
         <groupId>com.opencsv</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `protobuf-java` to 3.17.3 for Apache ORC v1.8.0+.

### Why are the changes needed?

- CVE-2021-22569 is fixed at 3.16.1+
- `osx_aarch_64` artifact is supported at 3.17.3+
  - https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.17.3/ (with osx_aarch_64 artifact)

### How was this patch tested?

Pass the CIs and check the log manually to find `protoc-3.17.3-osx-aarch_64.exe`.

```
[INFO] Protoc version: 3.17.3
protoc-jar: protoc version: 3.17.3, detected platform: osx-aarch_64 (mac os x/aarch64)
protoc-jar: using default maven settings, didn't find user settings.xml
protoc-jar: cached: /var/folders/d4/dr6zxyvd4cl38877bj3fxs_m0000gn/T/protocjar.webcache/com/google/protobuf/protoc/maven-metadata.xml
protoc-jar: using default maven settings, didn't find user settings.xml
protoc-jar: cached: /var/folders/d4/dr6zxyvd4cl38877bj3fxs_m0000gn/T/protocjar.webcache/com/github/os72/protoc/maven-metadata.xml
protoc-jar: using default maven settings, didn't find user settings.xml
protoc-jar: cached: /var/folders/d4/dr6zxyvd4cl38877bj3fxs_m0000gn/T/protocjar.webcache/com/google/protobuf/protoc/maven-metadata.xml
protoc-jar: downloading: https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/3.17.3/protoc-3.17.3-osx-aarch_64.exe
protoc-jar: saved: /var/folders/d4/dr6zxyvd4cl38877bj3fxs_m0000gn/T/protocjar.webcache/com/google/protobuf/protoc/3.17.3/protoc-3.17.3-osx-aarch_64.exe
protoc-jar: executing: [/var/folders/d4/dr6zxyvd4cl38877bj3fxs_m0000gn/T/protocjar12212425749339978128/bin/protoc.exe, --version]
libprotoc 3.17.3
[INFO] Protoc command: /var/folders/d4/dr6zxyvd4cl38877bj3fxs_m0000gn/T/protocjar12212425749339978128/bin/protoc.exe
[INFO] Input directories:
[INFO]     /Users/dongjoon/APACHE/orc-merge/proto
[INFO] Include directories:
[INFO]     /Users/dongjoon/APACHE/orc-merge/proto
[INFO] Output targets:
[INFO]     java: /Users/dongjoon/APACHE/orc-merge/java/core/target/generated-sources (add: none, clean: false, plugin: null, outputOptions: null)
[INFO] /Users/dongjoon/APACHE/orc-merge/java/core/target/generated-sources does not exist. Creating...
[INFO]     Processing (java): orc_proto.proto
protoc-jar: executing: [/var/folders/d4/dr6zxyvd4cl38877bj3fxs_m0000gn/T/protocjar12212425749339978128/bin/protoc.exe, -I/Users/dongjoon/APACHE/orc-merge/proto, -I/Users/dongjoon/APACHE/orc-merge/proto, --java_out=/Users/dongjoon/APACHE/orc-merge/java/core/target/generated-sources, /Users/dongjoon/APACHE/orc-merge/proto/orc_proto.proto]
[INFO]
```