### PR TITLE
ORC-1260: Publish `shaded-protobuf` classifier artifacts

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -455,6 +455,41 @@
           <version>${maven-shade-plugin.version}</version>
           <executions>
             <execution>
+              <id>shaded-protobuf</id>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <artifactSet>
+                  <includes>
+                    <include>com.google.protobuf:protobuf-java</include>
+                  </includes>
+                </artifactSet>
+                <shadedArtifactAttached>true</shadedArtifactAttached>
+                <shadedClassifierName>shaded-protobuf</shadedClassifierName>
+                <relocations>
+                  <relocation>
+                    <pattern>com.google.protobuf</pattern>
+                    <shadedPattern>com.google.protobuf25</shadedPattern>
+                  </relocation>
+                </relocations>
+                <filters>
+                  <filter>
+                    <artifact>*:*</artifact>
+                    <excludes>
+                      <exclude>module-info.class</exclude>
+                      <exclude>META-INF/MANIFEST.MF</exclude>
+                      <exclude>META-INF/DEPENDENCIES</exclude>
+                      <exclude>META-INF/LICENSE</exclude>
+                      <exclude>META-INF/NOTICE</exclude>
+                    </excludes>
+                  </filter>
+                </filters>
+              </configuration>
+            </execution>
+            <execution>
+              <id>nohive</id>
               <phase>package</phase>
               <goals>
                 <goal>shade</goal>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Apache ORC has `nohive` classifier artifacts. This PR aims to add `shaded-protobuf` classifier artifacts additionally.

```
$ ls -al ~/.m2/repository/org/apache/orc/orc-core/1.9.0-SNAPSHOT
total 16472
drwxr-xr-x  11 dongjoon  staff      352 Aug 24 00:03 .
drwxr-xr-x   4 dongjoon  staff      128 Aug 24 00:03 ..
-rw-r--r--   1 dongjoon  staff      400 Aug 24 00:03 _remote.repositories
-rw-r--r--   1 dongjoon  staff     1743 Aug 24 00:03 maven-metadata-local.xml
-rw-r--r--   1 dongjoon  staff  3106139 Aug 24 00:03 orc-core-1.9.0-SNAPSHOT-nohive.jar
-rw-r--r--   1 dongjoon  staff  2854127 Aug 24 00:03 orc-core-1.9.0-SNAPSHOT-shaded-protobuf.jar
-rw-r--r--   1 dongjoon  staff   514669 Aug 24 00:03 orc-core-1.9.0-SNAPSHOT-sources.jar
-rw-r--r--   1 dongjoon  staff   267487 Aug 24 00:03 orc-core-1.9.0-SNAPSHOT-test-sources.jar
-rw-r--r--   1 dongjoon  staff   489298 Aug 24 00:03 orc-core-1.9.0-SNAPSHOT-tests.jar
-rw-r--r--   1 dongjoon  staff  1166451 Aug 24 00:03 orc-core-1.9.0-SNAPSHOT.jar
-rw-r--r--   1 dongjoon  staff    13628 Aug 24 00:03 orc-core-1.9.0-SNAPSHOT.pom
```

### Why are the changes needed?

To help the downstream projects choose the latest `protobuf-java`.

### How was this patch tested?

Pass the CIs.