### PR TITLE
ORC-1261: Rename shaded pattern `com.google.protobuf25` to `org.apache.orc.protobuf`

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -471,7 +471,7 @@
                 <relocations>
                   <relocation>
                     <pattern>com.google.protobuf</pattern>
-                    <shadedPattern>com.google.protobuf25</shadedPattern>
+                    <shadedPattern>org.apache.orc.protobuf</shadedPattern>
                   </relocation>
                 </relocations>
                 <filters>
@@ -506,7 +506,7 @@
                 <relocations>
                   <relocation>
                     <pattern>com.google.protobuf</pattern>
-                    <shadedPattern>com.google.protobuf25</shadedPattern>
+                    <shadedPattern>org.apache.orc.protobuf</shadedPattern>
                   </relocation>
                   <relocation>
                     <pattern>org.apache.hadoop.hive</pattern>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -136,7 +136,7 @@
               <relocations>
                 <relocation>
                   <pattern>com.google.protobuf</pattern>
-                  <shadedPattern>com.google.protobuf25</shadedPattern>
+                  <shadedPattern>org.apache.orc.protobuf</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.hadoop.hive</pattern>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename `shadedPattern` from `com.google.protobuf25` to `org.apache.orc.protobuf`.

### Why are the changes needed?

We had better use `protobuf-java`-version-neutral name because we start to shade this.

### How was this patch tested?

Pass the CIs.