### PR TITLE
ORC-1266: DecimalColumnVector resets the isRepeating flag in the nextVector method

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -554,6 +554,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         longColVector = (LongColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
+        decimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -718,6 +719,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         doubleColVector = (DoubleColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
+        decimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1061,6 +1063,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         decimalColVector = previousVector;
       } else {
         fileDecimalColVector.ensureSize(batchSize, false);
+        fileDecimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(fileDecimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1215,6 +1218,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         bytesColVector = (BytesColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
+        decimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1652,6 +1656,7 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         timestampColVector = (TimestampColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
+        decimalColVector.reset();
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -554,7 +554,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         longColVector = (LongColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
-        decimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -719,7 +718,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         doubleColVector = (DoubleColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
-        decimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1063,7 +1061,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         decimalColVector = previousVector;
       } else {
         fileDecimalColVector.ensureSize(batchSize, false);
-        fileDecimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(fileDecimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1218,7 +1215,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         bytesColVector = (BytesColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
-        decimalColVector.reset();
       }
       // Read present/isNull stream
       fromReader.nextVector(decimalColVector, isNull, batchSize, filterContext, readPhase);
@@ -1656,7 +1652,6 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         timestampColVector = (TimestampColumnVector) previousVector;
       } else {
         decimalColVector.ensureSize(batchSize, false);
-        decimalColVector.reset();
       }
       timestampColVector.changeCalendar(fileUsedProlepticGregorian, false);
       // Read present/isNull stream

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -1727,8 +1727,7 @@ public class TreeReaderFactory {
     private void setIsRepeatingIfNeeded(Decimal64ColumnVector result, int index) {
       if (result.isRepeating
           && index > 0
-          && (result.vector[0] != result.vector[index] ||
-          result.isNull[0] != result.isNull[index])) {
+          && (result.vector[0] != result.vector[index] || result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
       }
     }
@@ -1736,17 +1735,8 @@ public class TreeReaderFactory {
     private void setIsRepeatingIfNeeded(DecimalColumnVector result, int index) {
       if (result.isRepeating
           && index > 0
-          && (!eq(result.vector[0], result.vector[index]) ||
-          result.isNull[0] != result.isNull[index])) {
+          && (!result.vector[0].equals(result.vector[index]) || result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
-      }
-    }
-
-    private boolean eq(HiveDecimalWritable first, HiveDecimalWritable other) {
-      if (first != null) {
-        return first.equals(other);
-      } else {
-        return other == null;
       }
     }
 
@@ -1917,17 +1907,8 @@ public class TreeReaderFactory {
     private void setIsRepeatingIfNeeded(DecimalColumnVector result, int index) {
       if (result.isRepeating
           && index > 0
-          && (!eq(result.vector[0], result.vector[index]) ||
-          result.isNull[0] != result.isNull[index])) {
+          && (!result.vector[0].equals(result.vector[index]) || result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
-      }
-    }
-
-    private boolean eq(HiveDecimalWritable first, HiveDecimalWritable other) {
-      if (first != null) {
-        return first.equals(other);
-      } else {
-        return other == null;
       }
     }
 

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -1578,12 +1578,12 @@ public class TreeReaderFactory {
               result.isNull[r] = true;
               result.noNulls = false;
             }
-            if (result.isRepeating
-                && r > 0
-                && (!eq(vector[0], vector[r]) ||
-                result.isNull[0] != result.isNull[r])) {
-              result.isRepeating = false;
-            }
+          }
+          if (result.isRepeating
+              && r > 0
+              && (!eq(vector[0], vector[r]) ||
+              result.isNull[0] != result.isNull[r])) {
+            result.isRepeating = false;
           }
         }
       }
@@ -1688,12 +1688,12 @@ public class TreeReaderFactory {
           if (!result.isNull[r]) {
             final long scaleFactor = powerOfTenTable[scale - scratchScaleVector[r]];
             result.vector[r] = SerializationUtils.readVslong(valueStream) * scaleFactor;
-            if (result.isRepeating
-                && r > 0
-                && (result.vector[0] != result.vector[r] ||
-                result.isNull[0] != result.isNull[r])) {
-              result.isRepeating = false;
-            }
+          }
+          if (result.isRepeating
+             && r > 0
+             && (result.vector[0] != result.vector[r] ||
+             result.isNull[0] != result.isNull[r])) {
+            result.isRepeating = false;
           }
         }
       }

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -1727,7 +1727,8 @@ public class TreeReaderFactory {
     private void setIsRepeatingIfNeeded(Decimal64ColumnVector result, int index) {
       if (result.isRepeating
           && index > 0
-          && (result.vector[0] != result.vector[index] || result.isNull[0] != result.isNull[index])) {
+          && (result.vector[0] != result.vector[index]
+              || result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
       }
     }
@@ -1735,7 +1736,8 @@ public class TreeReaderFactory {
     private void setIsRepeatingIfNeeded(DecimalColumnVector result, int index) {
       if (result.isRepeating
           && index > 0
-          && (!result.vector[0].equals(result.vector[index]) || result.isNull[0] != result.isNull[index])) {
+          && (!result.vector[0].equals(result.vector[index])
+              || result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
       }
     }
@@ -1907,7 +1909,8 @@ public class TreeReaderFactory {
     private void setIsRepeatingIfNeeded(DecimalColumnVector result, int index) {
       if (result.isRepeating
           && index > 0
-          && (!result.vector[0].equals(result.vector[index]) || result.isNull[0] != result.isNull[index])) {
+          && (!result.vector[0].equals(result.vector[index])
+              || result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
       }
     }

--- a/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
+++ b/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.orc.OrcConf;
 import org.apache.orc.OrcFile;
 import org.apache.orc.OrcFile.WriterOptions;
 import org.apache.orc.Reader;
@@ -52,6 +53,7 @@ import java.util.GregorianCalendar;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
@@ -638,5 +640,95 @@ public class TestConvertTreeReaderFactory {
 
   private void testConvertToBinaryIncreasingSize() throws Exception {
     readORCFileIncreasingBatchSize("binary", BytesColumnVector.class);
+  }
+
+  @Test
+  public void testDecimalConvertInNullStripe() throws Exception {
+    try {
+      Configuration decimalConf = new Configuration(conf);
+      decimalConf.set(OrcConf.STRIPE_ROW_COUNT.getAttribute(), "1024");
+      decimalConf.set(OrcConf.ROWS_BETWEEN_CHECKS.getAttribute(), "1");
+
+      String typeStr = "decimal(5,1)";
+      TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeStr + ">");
+      Writer w = OrcFile.createWriter(testFilePath, OrcFile.writerOptions(decimalConf).setSchema(schema));
+
+      VectorizedRowBatch b = schema.createRowBatch();
+      DecimalColumnVector f1 = (DecimalColumnVector) b.cols[0];
+      f1.isRepeating = true;
+      f1.set(0, (HiveDecimal) null);
+      b.size = 1024;
+      w.addRowBatch(b);
+      b.reset();
+      for (int i = 0; i < 1024; i++) {
+        f1.set(i, HiveDecimal.create(i + 1));
+      }
+      b.size = 1024;
+      w.addRowBatch(b);
+      b.reset();
+      w.close();
+
+      testDecimalConvertToLongInNullStripe();
+      testDecimalConvertToDoubleInNullStripe();
+      testDecimalConvertToStringInNullStripe();
+      testDecimalConvertToTimestampInNullStripe();
+      testDecimalConvertToDecimalInNullStripe();
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
+
+  private void readDecimalInNullStripe(String typeString, Class<?> expectedColumnType,
+      String expectedResult) throws Exception {
+    Reader.Options options = new Reader.Options();
+    TypeDescription schema = TypeDescription.fromString("struct<col1:" + typeString + ">");
+    options.schema(schema);
+    String expected = options.toString();
+
+    Configuration conf = new Configuration();
+
+    Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf));
+    RecordReader rows = reader.rows(options);
+    VectorizedRowBatch batch = schema.createRowBatch();
+
+    rows.nextBatch(batch);
+    assertEquals(1024, batch.size);
+    assertEquals(expected, options.toString());
+    assertEquals(batch.cols.length, 1);
+    assertEquals(batch.cols[0].getClass(), expectedColumnType);
+    assertTrue(batch.cols[0].isRepeating);
+    StringBuilder sb = new StringBuilder();
+    batch.cols[0].stringifyValue(sb, 1023);
+    assertEquals(sb.toString(), "null");
+
+    rows.nextBatch(batch);
+    assertEquals(1024, batch.size);
+    assertEquals(expected, options.toString());
+    assertEquals(batch.cols.length, 1);
+    assertEquals(batch.cols[0].getClass(), expectedColumnType);
+    assertFalse(batch.cols[0].isRepeating);
+    StringBuilder sb2 = new StringBuilder();
+    batch.cols[0].stringifyValue(sb2, 1023);
+    assertEquals(sb2.toString(), expectedResult);
+  }
+
+  private void testDecimalConvertToLongInNullStripe() throws Exception {
+    readDecimalInNullStripe("bigint", LongColumnVector.class, "1024");
+  }
+
+  private void testDecimalConvertToDoubleInNullStripe() throws Exception {
+    readDecimalInNullStripe("double", DoubleColumnVector.class, "1024.0");
+  }
+
+  private void testDecimalConvertToStringInNullStripe() throws Exception {
+    readDecimalInNullStripe("string", BytesColumnVector.class, "\"1024\"");
+  }
+
+  private void testDecimalConvertToTimestampInNullStripe() throws Exception {
+    readDecimalInNullStripe("timestamp", TimestampColumnVector.class, "1970-01-01 00:17:04.0");
+  }
+
+  private void testDecimalConvertToDecimalInNullStripe() throws Exception {
+    readDecimalInNullStripe("decimal(18,2)", DecimalColumnVector.class, "1024");
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
`DecimalColumnVector` resets the `isRepeating` flag in the `nextVector` method.

### Why are the changes needed?
`DecimalColumnVector` does not set `isRepeating` when reading decimal data, which leads to the use of type promotion to read decimal, and the obtained data may be wrong.


### How was this patch tested?
add UT
