### PR TITLE
ORC-1268: Set CMP0135 policy for CMake 3.24+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,9 @@ cmake_minimum_required (VERSION 2.8.12)
 if (POLICY CMP0048)
     cmake_policy(SET CMP0048 NEW)
 endif ()
+if (POLICY CMP0135)
+    cmake_policy(SET CMP0135 NEW)
+endif ()
 
 project(ORC C CXX)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to set the CMP0135 policy for CMake 3.24+.


### Why are the changes needed?
CMake 3.24+ adds CMP0135 which starts to complain at DOWNLOAD_EXTRACT_TIMESTAMP. 
To disable the warning, we need to set the policy explicitly.

https://cmake.org/cmake/help/latest/policy/CMP0135.html

### How was this patch tested?
Manually.
