### PR TITLE
ORC-1269: Remove FindBugs

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -289,27 +289,6 @@
           </configuration>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.5</version>
-          <configuration>
-            <effort>Max</effort>
-            <excludeFilterFile>${basedir}/src/findbugs/exclude.xml</excludeFilterFile>
-            <xmlOutput>true</xmlOutput>
-            <findbugsXmlOutputDirectory>${project.build.directory}/findbugs</findbugsXmlOutputDirectory>
-            <includeTests>true</includeTests>
-          </configuration>
-          <executions>
-            <execution>
-              <id>analyze-compile</id>
-              <phase>test</phase>
-              <goals>
-                <goal>check</goal>
-              </goals>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
           <version>4.7.1.1</version>
@@ -554,10 +533,6 @@
       <id>analyze</id>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>findbugs-maven-plugin</artifactId>
-          </plugin>
           <plugin>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-maven-plugin</artifactId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove FindBugs.


### Why are the changes needed?
FindBugs supports only up to Java 1.8.
Since we have SpotBugs, FindBugs is obsolete. 

### How was this patch tested?
Pass the CIs.
