### PR TITLE
ORC-1270: Move opencsv dependency to the tools module

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -657,17 +657,6 @@
         <version>3.17.3</version>
       </dependency>
       <dependency>
-        <groupId>com.opencsv</groupId>
-        <artifactId>opencsv</artifactId>
-        <version>5.6</version>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>1.5.0</version>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -49,6 +49,13 @@
     <dependency>
       <groupId>com.opencsv</groupId>
       <artifactId>opencsv</artifactId>
+      <version>5.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-beanutils</groupId>
+          <artifactId>commons-beanutils</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to move the `opencsv` dependency to the tools module. 


### Why are the changes needed?
`opencsv` is used by only the tools module.


### How was this patch tested?
Pass the CIs.