### PR TITLE
ORC-1274: Add a checkstyle rule to ban starting LAND and LOR

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -50,5 +50,10 @@
     </module>
     <module name="UpperEll"/>
     <module name="ArrayTypeStyle"/>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="^\s+(&amp;&amp;|[|][|])"/>
+      <property name="ignoreComments" value="true"/>
+      <property name="message" value="No starting LAND and LOR allowed."/>
+    </module>
   </module>
 </module>

--- a/java/core/src/java/org/apache/orc/impl/BitFieldReader.java
+++ b/java/core/src/java/org/apache/orc/impl/BitFieldReader.java
@@ -100,9 +100,7 @@ public final class BitFieldReader {
       // The default value for nulls in Vectorization for int types is 1
       // and given that non null value can also be 1, we need to check for isNull also
       // when determining the isRepeating flag.
-      if (previous.isRepeating
-          && i > 0
-          && ((previous.vector[0] != previous.vector[i]) ||
+      if (previous.isRepeating && i > 0 && ((previous.vector[0] != previous.vector[i]) ||
           (previous.isNull[0] != previous.isNull[i]))) {
         previous.isRepeating = false;
       }

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -129,10 +129,10 @@ public class ReaderImpl implements Reader {
         return false;
       }
       StripeInformationImpl that = (StripeInformationImpl) o;
-      return stripeId == that.stripeId
-             && originalStripeId == that.originalStripeId
-             && Arrays.deepEquals(encryptedKeys, that.encryptedKeys)
-             && stripe.equals(that.stripe);
+      return stripeId == that.stripeId &&
+             originalStripeId == that.originalStripeId &&
+             Arrays.deepEquals(encryptedKeys, that.encryptedKeys) &&
+             stripe.equals(that.stripe);
     }
 
     @Override

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -695,8 +695,8 @@ public class RecordReaderImpl implements RecordReader {
                    " include ORC-517. Writer version: {}",
           predicate.getColumnName(), writerVersion);
       return TruthValue.YES_NO_NULL;
-    } else if (category == TypeDescription.Category.DOUBLE
-        || category == TypeDescription.Category.FLOAT) {
+    } else if (category == TypeDescription.Category.DOUBLE ||
+        category == TypeDescription.Category.FLOAT) {
       DoubleColumnStatistics dstas = (DoubleColumnStatistics) cs;
       if (Double.isNaN(dstas.getSum())) {
         LOG.debug("Not using predication pushdown on {} because stats contain NaN values",
@@ -783,11 +783,11 @@ public class RecordReaderImpl implements RecordReader {
     // 1) Bloom filter is available
     // 2) Min/Max evaluation yield YES or MAYBE
     // 3) Predicate is EQUALS or IN list
-    return bloomFilter != null
-           && result != TruthValue.NO_NULL && result != TruthValue.NO
-           && (predicate.getOperator().equals(PredicateLeaf.Operator.EQUALS)
-               || predicate.getOperator().equals(PredicateLeaf.Operator.NULL_SAFE_EQUALS)
-               || predicate.getOperator().equals(PredicateLeaf.Operator.IN));
+    return bloomFilter != null &&
+           result != TruthValue.NO_NULL && result != TruthValue.NO &&
+           (predicate.getOperator().equals(PredicateLeaf.Operator.EQUALS) ||
+               predicate.getOperator().equals(PredicateLeaf.Operator.NULL_SAFE_EQUALS) ||
+               predicate.getOperator().equals(PredicateLeaf.Operator.IN));
   }
 
   private static TruthValue evaluatePredicateMinMax(PredicateLeaf predicate,
@@ -1214,8 +1214,8 @@ public class RecordReaderImpl implements RecordReader {
                   LOG.warn(reason, e);
                 }
                 boolean hasNoNull = stats.hasHasNull() && !stats.getHasNull();
-                if (predicate.getOperator().equals(PredicateLeaf.Operator.NULL_SAFE_EQUALS)
-                    || hasNoNull) {
+                if (predicate.getOperator().equals(PredicateLeaf.Operator.NULL_SAFE_EQUALS) ||
+                    hasNoNull) {
                   exceptionAnswer[pred] = TruthValue.YES_NO;
                 } else {
                   exceptionAnswer[pred] = TruthValue.YES_NO_NULL;
@@ -1528,9 +1528,9 @@ public class RecordReaderImpl implements RecordReader {
     // within strip). Batch size computed out of marker position makes sure that batch size is
     // aware of row group boundary and will not cause overflow when reading rows
     // illustration of this case is here https://issues.apache.org/jira/browse/HIVE-6287
-    if (rowIndexStride != 0
-        && (includedRowGroups != null || startReadPhase != TypeReader.ReadPhase.ALL)
-        && rowInStripe < rowCountInStripe) {
+    if (rowIndexStride != 0 &&
+        (includedRowGroups != null || startReadPhase != TypeReader.ReadPhase.ALL) &&
+        rowInStripe < rowCountInStripe) {
       int startRowGroup = (int) (rowInStripe / rowIndexStride);
       if (includedRowGroups != null && !includedRowGroups[startRowGroup]) {
         while (startRowGroup < includedRowGroups.length && !includedRowGroups[startRowGroup]) {
@@ -1542,8 +1542,7 @@ public class RecordReaderImpl implements RecordReader {
       // We force row group boundaries when dealing with filters. We adjust the end row group to
       // be the next row group even if more than one are possible selections.
       if (includedRowGroups != null && startReadPhase == TypeReader.ReadPhase.ALL) {
-        while (endRowGroup < includedRowGroups.length
-               && includedRowGroups[endRowGroup]) {
+        while (endRowGroup < includedRowGroups.length && includedRowGroups[endRowGroup]) {
           endRowGroup += 1;
         }
       } else {
@@ -1603,8 +1602,8 @@ public class RecordReaderImpl implements RecordReader {
                                boolean[] included,
                                boolean[] readCols) throws IOException {
     // Use the cached objects if the read request matches the cached request
-    if (stripeIndex == currentStripe
-            && (readCols == null || Arrays.equals(readCols, rowIndexColsToRead))) {
+    if (stripeIndex == currentStripe &&
+        (readCols == null || Arrays.equals(readCols, rowIndexColsToRead))) {
       if (rowIndexColsToRead != null) {
         return indexes;
       } else {

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -545,8 +545,8 @@ public class RecordReaderUtils {
 
   static HadoopShims.ZeroCopyReaderShim createZeroCopyShim(FSDataInputStream file,
       CompressionCodec codec, ByteBufferAllocatorPool pool) throws IOException {
-    if ((codec == null || ((codec instanceof DirectDecompressionCodec)
-            && ((DirectDecompressionCodec) codec).isAvailable()))) {
+    if ((codec == null || ((codec instanceof DirectDecompressionCodec) &&
+        ((DirectDecompressionCodec) codec).isAvailable()))) {
       /* codec is null or is available */
       return SHIMS.getZeroCopyReader(file, pool);
     }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
@@ -114,10 +114,8 @@ public class RunLengthByteReader {
       // The default value for nulls in Vectorization for int types is 1
       // and given that non null value can also be 1, we need to check for isNull also
       // when determining the isRepeating flag.
-      if (previous.isRepeating
-          && i > 0
-          && ((data[0] != data[i]) ||
-              (previous.isNull[0] != previous.isNull[i]))) {
+      if (previous.isRepeating && i > 0 &&
+          ((data[0] != data[i]) || (previous.isNull[0] != previous.isNull[i]))) {
         previous.isRepeating = false;
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReader.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReader.java
@@ -113,9 +113,8 @@ public class RunLengthIntegerReader implements IntegerReader {
       // The default value for nulls in Vectorization for int types is 1
       // and given that non null value can also be 1, we need to check for isNull also
       // when determining the isRepeating flag.
-      if (previous.isRepeating
-          && i > 0
-          && (data[0] != data[i] || previous.isNull[0] != previous.isNull[i])) {
+      if (previous.isRepeating && i > 0 &&
+          (data[0] != data[i] || previous.isNull[0] != previous.isNull[i])) {
         previous.isRepeating = false;
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthIntegerReaderV2.java
@@ -386,10 +386,8 @@ public class RunLengthIntegerReaderV2 implements IntegerReader {
       // The default value for nulls in Vectorization for int types is 1
       // and given that non null value can also be 1, we need to check for isNull also
       // when determining the isRepeating flag.
-      if (previous.isRepeating
-          && i > 0
-          && (data[0] != data[i] ||
-          previous.isNull[0] != previous.isNull[i])) {
+      if (previous.isRepeating && i > 0 &&
+          (data[0] != data[i] || previous.isNull[0] != previous.isNull[i])) {
         previous.isRepeating = false;
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
@@ -459,8 +459,8 @@ public final class SerializationUtils {
    * @return decoded fixed bit width
    */
   public static int decodeBitWidth(int n) {
-    if (n >= FixedBitSizes.ONE.ordinal()
-        && n <= FixedBitSizes.TWENTYFOUR.ordinal()) {
+    if (n >= FixedBitSizes.ONE.ordinal() &&
+        n <= FixedBitSizes.TWENTYFOUR.ordinal()) {
       return n + 1;
     } else if (n == FixedBitSizes.TWENTYSIX.ordinal()) {
       return 26;
@@ -492,8 +492,7 @@ public final class SerializationUtils {
    */
   public void writeInts(long[] input, int offset, int len, int bitSize,
                         OutputStream output) throws IOException {
-    if (input == null || input.length < 1 || offset < 0 || len < 1
-        || bitSize < 1) {
+    if (input == null || input.length < 1 || offset < 0 || len < 1 || bitSize < 1) {
       return;
     }
 

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -805,8 +805,8 @@ public class TreeReaderFactory {
             // some nulls
             result.isRepeating = false;
             // conditions to ensure bounds checks skips
-            for (int i = 0; batchSize <= result.isNull.length
-                && batchSize <= result.vector.length && i < batchSize; i++) {
+            for (int i = 0; batchSize <= result.isNull.length &&
+                batchSize <= result.vector.length && i < batchSize; i++) {
               if (!result.isNull[i]) {
                 result.vector[i] = utils.readFloat(stream);
               } else {
@@ -1021,8 +1021,8 @@ public class TreeReaderFactory {
             // some nulls
             result.isRepeating = false;
             // conditions to ensure bounds checks skips
-            for (int i = 0; batchSize <= result.isNull.length
-                && batchSize <= result.vector.length && i < batchSize; i++) {
+            for (int i = 0; batchSize <= result.isNull.length &&
+                batchSize <= result.vector.length && i < batchSize; i++) {
               if (!result.isNull[i]) {
                 result.vector[i] = utils.readDouble(stream);
               } else {
@@ -1725,19 +1725,15 @@ public class TreeReaderFactory {
     }
 
     private void setIsRepeatingIfNeeded(Decimal64ColumnVector result, int index) {
-      if (result.isRepeating
-          && index > 0
-          && (result.vector[0] != result.vector[index]
-              || result.isNull[0] != result.isNull[index])) {
+      if (result.isRepeating && index > 0 && (result.vector[0] != result.vector[index] ||
+          result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
       }
     }
 
     private void setIsRepeatingIfNeeded(DecimalColumnVector result, int index) {
-      if (result.isRepeating
-          && index > 0
-          && (!result.vector[0].equals(result.vector[index])
-              || result.isNull[0] != result.isNull[index])) {
+      if (result.isRepeating && index > 0 && (!result.vector[0].equals(result.vector[index]) ||
+          result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
       }
     }
@@ -1907,10 +1903,8 @@ public class TreeReaderFactory {
     }
 
     private void setIsRepeatingIfNeeded(DecimalColumnVector result, int index) {
-      if (result.isRepeating
-          && index > 0
-          && (!result.vector[0].equals(result.vector[index])
-              || result.isNull[0] != result.isNull[index])) {
+      if (result.isRepeating && index > 0 && (!result.vector[0].equals(result.vector[index]) ||
+          result.isNull[0] != result.isNull[index])) {
         result.isRepeating = false;
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/filter/leaf/DecimalFilters.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/leaf/DecimalFilters.java
@@ -43,8 +43,8 @@ class DecimalFilters {
 
     @Override
     protected boolean allow(ColumnVector v, int rowIdx) {
-      return ((DecimalColumnVector) v).vector[rowIdx].compareTo(low) >= 0
-             && ((DecimalColumnVector) v).vector[rowIdx].compareTo(high) <= 0;
+      return ((DecimalColumnVector) v).vector[rowIdx].compareTo(low) >= 0 &&
+             ((DecimalColumnVector) v).vector[rowIdx].compareTo(high) <= 0;
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/filter/leaf/FloatFilters.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/leaf/FloatFilters.java
@@ -41,8 +41,8 @@ class FloatFilters {
 
    @Override
    protected boolean allow(ColumnVector v, int rowIdx) {
-     return ((DoubleColumnVector) v).vector[rowIdx] >= low
-            && ((DoubleColumnVector) v).vector[rowIdx] <= high;
+     return ((DoubleColumnVector) v).vector[rowIdx] >= low &&
+            ((DoubleColumnVector) v).vector[rowIdx] <= high;
    }
  }
 

--- a/java/core/src/java/org/apache/orc/impl/filter/leaf/LongFilters.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/leaf/LongFilters.java
@@ -41,8 +41,8 @@ class LongFilters {
 
     @Override
     protected boolean allow(ColumnVector v, int rowIdx) {
-      return ((LongColumnVector) v).vector[rowIdx] >= low
-             && ((LongColumnVector) v).vector[rowIdx] <= high;
+      return ((LongColumnVector) v).vector[rowIdx] >= low &&
+             ((LongColumnVector) v).vector[rowIdx] <= high;
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/filter/leaf/StringFilters.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/leaf/StringFilters.java
@@ -45,9 +45,9 @@ class StringFilters {
     protected boolean allow(ColumnVector v, int rowIdx) {
       BytesColumnVector bv = (BytesColumnVector) v;
       return StringExpr.compare(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx],
-                                low, 0, low.length) >= 0
-             && StringExpr.compare(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx],
-                                   high, 0, high.length) <= 0;
+                                low, 0, low.length) >= 0 &&
+             StringExpr.compare(bv.vector[rowIdx], bv.start[rowIdx], bv.length[rowIdx],
+                                high, 0, high.length) <= 0;
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/filter/leaf/TimestampFilters.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/leaf/TimestampFilters.java
@@ -44,8 +44,8 @@ class TimestampFilters {
 
     @Override
     protected boolean allow(ColumnVector v, int rowIdx) {
-      return ((TimestampColumnVector) v).compareTo(rowIdx, low) >= 0
-             && ((TimestampColumnVector) v).compareTo(rowIdx, high) <= 0;
+      return ((TimestampColumnVector) v).compareTo(rowIdx, low) >= 0 &&
+             ((TimestampColumnVector) v).compareTo(rowIdx, high) <= 0;
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -470,11 +470,9 @@ public class StripePlanner {
   private BufferChunkList planDataReading(TypeReader.ReadPhase readPhase) {
     BufferChunkList result = new BufferChunkList();
     for(StreamInformation stream: dataStreams) {
-      if (readPhase == TypeReader.ReadPhase.ALL
-          ||(readPhase == TypeReader.ReadPhase.LEADERS
-             && filterColIds.contains(stream.column))
-          || (readPhase == TypeReader.ReadPhase.FOLLOWERS
-              && !filterColIds.contains(stream.column))) {
+      if (readPhase == TypeReader.ReadPhase.ALL ||
+          (readPhase == TypeReader.ReadPhase.LEADERS && filterColIds.contains(stream.column)) ||
+          (readPhase == TypeReader.ReadPhase.FOLLOWERS && !filterColIds.contains(stream.column))) {
         addChunk(result, stream, stream.offset, stream.length);
       } else {
         // In case a filter is present, then don't plan the lazy columns, they will be planned only
@@ -545,9 +543,9 @@ public class StripePlanner {
       int bufferSize = compression.getBufferSize();
       OrcProto.RowIndex[] rowIndex = index.getRowGroupIndex();
       for (StreamInformation stream : dataStreams) {
-        if (readPhase == TypeReader.ReadPhase.ALL
-            || (readPhase == TypeReader.ReadPhase.LEADERS && filterColIds.contains(stream.column))
-            || (readPhase == TypeReader.ReadPhase.FOLLOWERS &&
+        if (readPhase == TypeReader.ReadPhase.ALL ||
+            (readPhase == TypeReader.ReadPhase.LEADERS && filterColIds.contains(stream.column)) ||
+            (readPhase == TypeReader.ReadPhase.FOLLOWERS &&
                 !filterColIds.contains(stream.column))) {
           processStream(stream, result, rowIndex, startGroup,
                         includedRowGroups, isCompressed, bufferSize);

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/StructBatchReader.java
@@ -94,8 +94,8 @@ public class StructBatchReader extends BatchReader {
       VectorizedRowBatch batch, int batchSize, TypeReader.ReadPhase readPhase)
       throws IOException {
     TypeReader[] children = structReader.fields;
-    for (int i = 0; i < children.length
-                    && (vectorColumnCount == -1 || i < vectorColumnCount); ++i) {
+    for (int i = 0; i < children.length && (vectorColumnCount == -1 || i < vectorColumnCount);
+        ++i) {
       if (TypeReader.shouldProcessChild(children[i], readPhase)) {
         readBatchColumn(batch, children[i], batchSize, i, readPhase);
       }

--- a/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/tree/TypeReader.java
@@ -57,8 +57,8 @@ public interface TypeReader {
    * @return true if allowed by read level or if it is a FILTER_PARENT otherwise false
    */
   static boolean shouldProcessChild(TypeReader child, ReadPhase readPhase) {
-    return readPhase.contains(child.getReaderCategory())
-           || child.getReaderCategory() == ReaderCategory.FILTER_PARENT;
+    return readPhase.contains(child.getReaderCategory()) ||
+           child.getReaderCategory() == ReaderCategory.FILTER_PARENT;
   }
 
   enum ReaderCategory {

--- a/java/core/src/java/org/apache/orc/util/CuckooSetBytes.java
+++ b/java/core/src/java/org/apache/orc/util/CuckooSetBytes.java
@@ -85,8 +85,8 @@ public class CuckooSetBytes {
    */
   public boolean lookup(byte[] b, int start, int len) {
 
-    return entryEqual(t1, h1(b, start, len), b, start, len)
-        || entryEqual(t2, h2(b, start, len), b, start, len);
+    return entryEqual(t1, h1(b, start, len), b, start, len) ||
+           entryEqual(t2, h2(b, start, len), b, start, len);
   }
 
   private static boolean entryEqual(byte[][] t, int hash, byte[] b, int start, int len) {

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -176,9 +176,9 @@ public class CsvReader implements RecordReader {
         column.noNulls = false;
         column.isNull[row] = true;
       } else {
-        if (values[offset].equalsIgnoreCase("true")
-            || values[offset].equalsIgnoreCase("t")
-            || values[offset].equals("1")) {
+        if (values[offset].equalsIgnoreCase("true") ||
+            values[offset].equalsIgnoreCase("t") ||
+            values[offset].equals("1")) {
           ((LongColumnVector) column).vector[row] = 1;
         } else {
           ((LongColumnVector) column).vector[row] = 0;

--- a/java/tools/src/java/org/apache/orc/tools/json/MapType.java
+++ b/java/tools/src/java/org/apache/orc/tools/json/MapType.java
@@ -42,8 +42,8 @@ public class MapType extends HiveType {
 
   @Override
   public boolean equals(Object o) {
-    return super.equals(o) && keyType.equals(((MapType)o).keyType)
-        && valueType.equals(((MapType)o).valueType);
+    return super.equals(o) && keyType.equals(((MapType)o).keyType) &&
+        valueType.equals(((MapType)o).valueType);
   }
 
   @Override
@@ -53,10 +53,10 @@ public class MapType extends HiveType {
 
   @Override
   public boolean subsumes(HiveType other) {
-    return (other.kind == Kind.MAP
-        && keyType.subsumes(((MapType)other).keyType)
-        && valueType.subsumes(((MapType)other).valueType))
-        || other.kind == Kind.NULL;
+    return (other.kind == Kind.MAP &&
+        keyType.subsumes(((MapType)other).keyType) &&
+        valueType.subsumes(((MapType)other).valueType)) ||
+        other.kind == Kind.NULL;
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new check style rule to ban staring LAND and LOR to improve Java coding style.

### Why are the changes needed?

Currently, Apache ORC has a mixed style and this PR proposes to change like the following to be consistent. Note that this is focusing on the position of the logical AND and OR operators instead of changing the indentation.
```java
-    if (n >= FixedBitSizes.ONE.ordinal()
-        && n <= FixedBitSizes.TWENTYFOUR.ordinal()) {
+    if (n >= FixedBitSizes.ONE.ordinal() &&
+        n <= FixedBitSizes.TWENTYFOUR.ordinal()) {
```

```java
-        if (values[offset].equalsIgnoreCase("true")
-            || values[offset].equalsIgnoreCase("t")
-            || values[offset].equals("1")) {
+        if (values[offset].equalsIgnoreCase("true") ||
+            values[offset].equalsIgnoreCase("t") ||
+            values[offset].equals("1")) {
```

```java
-    return readPhase.contains(child.getReaderCategory())
-           || child.getReaderCategory() == ReaderCategory.FILTER_PARENT;
+    return readPhase.contains(child.getReaderCategory()) ||
+           child.getReaderCategory() == ReaderCategory.FILTER_PARENT;
```
### How was this patch tested?

Pass the CIs with the newly added checkstyle rule.