### PR TITLE
ORC-1278: Update cmake docs version to 3.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The subdirectories are:
 
 * Install java 1.8 or higher
 * Install maven 3.8.6 or higher
-* Install cmake
+* Install cmake 3.12 or higher
 
 To build a release version with debug information:
 ```shell


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add a cmake build version in [README.md](https://github.com/apache/orc/blob/main/README.md)


### Why are the changes needed?
[add_compile_definitions ](https://cmake.org/cmake/help/latest/command/add_compile_definitions.html)only supprt cmake 3.12+. We can update the docs [README.md](https://github.com/apache/orc/blob/main/README.md)

In ubuntu 18.04:

> sudo apt install cmake

> make ..

we will get an error:

CMake Error at CMakeLists.txt:147 (add_compile_definitions):
  Unknown CMake command "add_compile_definitions".


### How was this patch tested?
