### PR TITLE
ORC-1279: Update the cmake version in ubuntu18 dockerfile to latest

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
           - macos-11

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          - ubuntu-18.04
           - ubuntu-20.04
           - ubuntu-22.04
           - macos-11

--- a/docker/ubuntu18/Dockerfile
+++ b/docker/ubuntu18/Dockerfile
@@ -24,7 +24,6 @@ ARG jdk=8
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update
 RUN apt-get install -y \
-  cmake \
   gcc \
   g++ \
   git \
@@ -34,9 +33,18 @@ RUN apt-get install -y \
   curl \
   maven \
   openjdk-${jdk}-jdk \
-  tzdata
+  tzdata \
+  wget \
+  software-properties-common
+
 RUN update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
     update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk})
+
+# Install latest cmake
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+RUN apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+RUN apt update
+RUN apt install -y cmake
 
 WORKDIR /root
 VOLUME /root/.m2/repository


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update cmake of ubuntu18 to latest.

### Why are the changes needed?
[add_compile_definitions ](https://cmake.org/cmake/help/latest/command/add_compile_definitions.html)only supprt cmake 3.12+. But the default image of ubuntu18 only support cmake 3.10. We should upgrade it.


### How was this patch tested?
Existing UT
