### PR TITLE
ORC-1282: Add `slf4j-simple` to avoid warning messages in Java tools

### DIFF
--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -98,6 +98,12 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -187,6 +193,7 @@
         <configuration>
           <ignoredUnusedDeclaredDependencies>
             <ignoredUnusedDeclaredDependency>com.google.guava:guava</ignoredUnusedDeclaredDependency>
+            <ignoredUnusedDeclaredDependency>org.slf4j:slf4j-simple</ignoredUnusedDeclaredDependency>
           </ignoredUnusedDeclaredDependencies>
           <ignoredDependencies>
             <ignoredDependency>org.apache.hadoop:hadoop-client-api</ignoredDependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add slf4j-impl to avoid warning message in Java tools.

### Why are the changes needed?
When we use Orc tools, the following error will show in output:
```
java  -jar ./java/tools/orc-tools-1.9.0-SNAPSHOT-uber.jar meta
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/home/deshanxiao/orc-code/build/java/tools/orc-tools-1.9.0-SNAPSHOT-uber.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
Error : ORC files are not specified 
```
This is caused by slf4j not specifying a specific implementation.
We introduce `slf4j-simple` to solve the problem because #1132 has replaced all slf4j-impl to slf4j-simple for the deprecation of log4j1.

### How was this patch tested?
UT
