### PR TITLE
ORC-1283: ENABLE_INDEXES does not take effect

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -432,6 +432,7 @@ public class OrcFile {
     private long stripeSizeValue;
     private long stripeRowCountValue;
     private long blockSizeValue;
+    private boolean buildIndex;
     private int rowIndexStrideValue;
     private int bufferSizeValue;
     private boolean enforceBufferSize = false;
@@ -466,6 +467,7 @@ public class OrcFile {
       stripeSizeValue = OrcConf.STRIPE_SIZE.getLong(tableProperties, conf);
       stripeRowCountValue = OrcConf.STRIPE_ROW_COUNT.getLong(tableProperties, conf);
       blockSizeValue = OrcConf.BLOCK_SIZE.getLong(tableProperties, conf);
+      buildIndex = OrcConf.ENABLE_INDEXES.getBoolean(tableProperties, conf);
       rowIndexStrideValue =
           (int) OrcConf.ROW_INDEX_STRIDE.getLong(tableProperties, conf);
       bufferSizeValue = (int) OrcConf.BUFFER_SIZE.getLong(tableProperties,
@@ -849,6 +851,8 @@ public class OrcFile {
       return blockSizeValue;
     }
 
+
+
     public String getBloomFilterColumns() {
       return bloomFilterColumns;
     }
@@ -903,6 +907,10 @@ public class OrcFile {
 
     public int getRowIndexStride() {
       return rowIndexStrideValue;
+    }
+
+    public boolean isBuildIndex() {
+      return buildIndex;
     }
 
     public CompressionStrategy getCompressionStrategy() {

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -851,8 +851,6 @@ public class OrcFile {
       return blockSizeValue;
     }
 
-
-
     public String getBloomFilterColumns() {
       return bloomFilterColumns;
     }

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -184,7 +184,8 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     this.compressionStrategy = opts.getCompressionStrategy();
 
     this.rowIndexStride = opts.getRowIndexStride();
-    buildIndex = rowIndexStride > 0;
+
+    this.buildIndex = opts.isBuildIndex() && (rowIndexStride > 0);
     if (buildIndex && rowIndexStride < MIN_ROW_INDEX_STRIDE) {
       throw new IllegalArgumentException("Row stride must be at least " +
           MIN_ROW_INDEX_STRIDE);

--- a/site/_docs/hive-config.md
+++ b/site/_docs/hive-config.md
@@ -16,7 +16,7 @@ orc.compress             | ZLIB        | high level compression = {NONE, ZLIB, S
 orc.compress.size        | 262,144     | compression chunk size
 orc.stripe.size          | 67,108,864  | memory buffer in bytes for writing
 orc.row.index.stride     | 10,000      | number of rows between index entries
-orc.create.index         | true        | create indexes?
+orc.create.index         | true        | whether the ORC writer create indexes as part of the file or not
 orc.bloom.filter.columns | ""          | comma separated list of column names
 orc.bloom.filter.fpp     | 0.05        | bloom filter false positive rate
 

--- a/site/_docs/spark-config.md
+++ b/site/_docs/spark-config.md
@@ -16,7 +16,7 @@ orc.compress             | ZLIB        | high level compression = {NONE, ZLIB, S
 orc.compress.size        | 262,144     | compression chunk size
 orc.stripe.size          | 67,108,864  | memory buffer in bytes for writing
 orc.row.index.stride     | 10,000      | number of rows between index entries
-orc.create.index         | true        | create indexes?
+orc.create.index         | true        | whether the ORC writer create indexes as part of the file or not
 orc.bloom.filter.columns | ""          | comma separated list of column names
 orc.bloom.filter.fpp     | 0.05        | bloom filter false positive rate
 orc.key.provider         | "hadoop"    | key provider


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix the problem that ENABLE_INDEXES does not take effect.

### Why are the changes needed?
Now, if the orc config `ENABLE_INDEXES` is set to `false`. Orc will still write index because orc writes to index or not is only related to the configure of `ROW_INDEX_STRIDE`.


### How was this patch tested?
Added UT
