### PR TITLE
ORC-1284: Add permissions to GitHub Action labeler

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,6 +24,9 @@ jobs:
   label:
     name: Label pull requests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: actions/labeler@2.2.0
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover GitHub Action `labeler` job.

### Why are the changes needed?

As we can see in this PR, the labeler is broken. We need permissions.

### How was this patch tested?

Unfortunately, this should be tested after merging.