### PR TITLE
ORC-1286: [C++] replace DataBuffer with BlockBuffer in class BufferedOutputStream

### DIFF
--- a/c++/src/BlockBuffer.hh
+++ b/c++/src/BlockBuffer.hh
@@ -26,6 +26,7 @@
 namespace orc {
 
   class OutputStream;
+  struct WriterMetrics;
   /**
    * BlockBuffer implements a memory allocation policy based on
    * equal-length blocks. BlockBuffer will reserve multiple blocks
@@ -114,9 +115,10 @@ namespace orc {
     /**
      * Write the BlockBuffer content into OutputStream
      * @param output the output stream to write to
-     * @return the number of IO requests written to the OutputStream
+     * @param metrics the metrics of the writer
      */
-    uint64_t writeTo(OutputStream* output);
+    void writeTo(OutputStream* output,
+                 WriterMetrics* metrics);
   };
 }  // namespace orc
 

--- a/c++/src/BlockBuffer.hh
+++ b/c++/src/BlockBuffer.hh
@@ -66,6 +66,8 @@ namespace orc {
 
       Block() : data(nullptr), size(0) {}
       Block(char* _data, uint64_t _size) : data(_data), size(_size) {}
+      Block(const Block& block) = default;
+      ~Block() = default;
     };
 
     /**

--- a/c++/src/BlockBuffer.hh
+++ b/c++/src/BlockBuffer.hh
@@ -112,6 +112,7 @@ namespace orc {
     /**
      * Write the BlockBuffer content into OutputStream
      * @param output the output stream to write to
+     * @return the number of IO requests written to the OutputStream
      */
     uint64_t writeTo(OutputStream* output);
   };

--- a/c++/src/BlockBuffer.hh
+++ b/c++/src/BlockBuffer.hh
@@ -25,6 +25,7 @@
 
 namespace orc {
 
+  class OutputStream;
   /**
    * BlockBuffer implements a memory allocation policy based on
    * equal-length blocks. BlockBuffer will reserve multiple blocks
@@ -108,6 +109,11 @@ namespace orc {
      * @param newCapacity new capacity of BlockBuffer
      */
     void reserve(uint64_t newCapacity);
+    /**
+     * Write the BlockBuffer content into OutputStream
+     * @param output the output stream to write to
+     */
+    uint64_t writeTo(OutputStream* output);
   };
 }  // namespace orc
 

--- a/c++/src/BlockBuffer.hh
+++ b/c++/src/BlockBuffer.hh
@@ -65,8 +65,6 @@ namespace orc {
 
       Block() : data(nullptr), size(0) {}
       Block(char* _data, uint64_t _size) : data(_data), size(_size) {}
-      Block(const Block& block) = default;
-      ~Block() = default;
     };
 
     /**

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -98,7 +98,7 @@ namespace orc {
     int outputSize;
 
     // Compression block header pointer array
-    static const int HEADER_SIZE = 3;
+    static const uint32_t HEADER_SIZE = 3;
     std::array<char*, HEADER_SIZE> header;
   };
 
@@ -174,7 +174,7 @@ namespace orc {
 
   void CompressionStreamBase::ensureHeader() {
     // adjust 3 bytes for the compression header
-    for (int i = 0; i < HEADER_SIZE; ++i) {
+    for (uint32_t i = 0; i < HEADER_SIZE; ++i) {
       if (outputPosition >= outputSize) {
         if (!BufferedOutputStream::Next(
           reinterpret_cast<void **>(&outputBuffer),

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -163,7 +163,9 @@ namespace orc {
         throw std::logic_error("Write to an out-of-bound place!");
       }
       int currentSize = std::min(outputSize - outputPosition, size - offset);
-      memcpy(outputBuffer + outputPosition, data + offset, currentSize);
+      memcpy(outputBuffer + outputPosition,
+             data + offset,
+             static_cast<size_t>(currentSize));
       offset += currentSize;
       outputPosition += currentSize;
     }

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -67,10 +67,12 @@ namespace orc {
     virtual uint64_t getSize() const override;
 
   protected:
-    void writeHeader(char * buffer, size_t compressedSize, bool original) {
-      buffer[0] = static_cast<char>((compressedSize << 1) + (original ? 1 : 0));
-      buffer[1] = static_cast<char>(compressedSize >> 7);
-      buffer[2] = static_cast<char>(compressedSize >> 15);
+    void writeData(const unsigned char* data, int size);
+
+    void writeHeader(size_t compressedSize, bool original) {
+      *header[0] = static_cast<char>((compressedSize << 1) + (original ? 1 : 0));
+      *header[1] = static_cast<char>(compressedSize >> 7);
+      *header[2] = static_cast<char>(compressedSize >> 15);
     }
 
     // ensure enough room for compression block header
@@ -93,6 +95,10 @@ namespace orc {
 
     // Compress output buffer size
     int outputSize;
+
+    // Compression block header pointer array
+    static const int HEADER_SIZE = 3;
+    char* header[HEADER_SIZE];
   };
 
   CompressionStreamBase::CompressionStreamBase(OutputStream * outStream,
@@ -112,7 +118,10 @@ namespace orc {
                                                 bufferSize(0),
                                                 outputPosition(0),
                                                 outputSize(0) {
-    // PASS
+    // init header pointer array
+    for (int i = 0; i < HEADER_SIZE; ++i) {
+      header[i] = nullptr;
+    }
   }
 
   void CompressionStreamBase::BackUp(int count) {
@@ -138,19 +147,42 @@ namespace orc {
            static_cast<uint64_t>(outputSize - outputPosition);
   }
 
+  void CompressionStreamBase::writeData(const unsigned char* data, int size) {
+    int offset = 0;
+    while (offset < size) {
+      if (outputPosition == outputSize) {
+        if (!BufferedOutputStream::Next(
+          reinterpret_cast<void **>(&outputBuffer),
+          &outputSize)) {
+            throw std::runtime_error(
+                "Failed to get next output buffer from output stream.");
+        }
+        outputPosition = 0;
+      } else  if (outputPosition > outputSize) {
+        // this will unlikely happen, but we have seen a few on zstd v1.1.0
+        throw std::logic_error("Write to an out-of-bound place!");
+      }
+      int currentSize = std::min(outputSize - outputPosition, size - offset);
+      memcpy(outputBuffer + outputPosition, data + offset, currentSize);
+      offset += currentSize;
+      outputPosition += currentSize;
+    }
+  }
+
   void CompressionStreamBase::ensureHeader() {
     // adjust 3 bytes for the compression header
-    if (outputPosition + 3 >= outputSize) {
-      int newPosition = outputPosition + 3 - outputSize;
-      if (!BufferedOutputStream::Next(
-        reinterpret_cast<void **>(&outputBuffer),
-        &outputSize)) {
+    for (int i = 0; i < HEADER_SIZE; ++i) {
+      if (outputPosition >= outputSize) {
+        if (!BufferedOutputStream::Next(
+          reinterpret_cast<void **>(&outputBuffer),
+          &outputSize)) {
         throw std::runtime_error(
           "Failed to get next output buffer from output stream.");
+        }
+        outputPosition = 0;
       }
-      outputPosition = newPosition;
-    } else {
-      outputPosition += 3;
+      header[i] = outputBuffer + outputPosition;
+      ++outputPosition;
     }
   }
 
@@ -193,22 +225,20 @@ namespace orc {
     if (bufferSize != 0) {
       ensureHeader();
 
+      uint64_t preSize = getSize();
       uint64_t totalCompressedSize = doStreamingCompression();
-
-      char * header = outputBuffer + outputPosition - totalCompressedSize - 3;
       if (totalCompressedSize >= static_cast<unsigned long>(bufferSize)) {
-        writeHeader(header, static_cast<size_t>(bufferSize), true);
-        memcpy(
-          header + 3,
-          rawInputBuffer.data(),
-          static_cast<size_t>(bufferSize));
+        writeHeader(static_cast<size_t>(bufferSize), true);
+        // reset output buffer
+        outputBuffer = nullptr;
+        outputPosition = outputSize = 0;
+        uint64_t backup = getSize() - preSize;
+        BufferedOutputStream::BackUp(static_cast<int>(backup));
 
-        int backup = static_cast<int>(totalCompressedSize) - bufferSize;
-        BufferedOutputStream::BackUp(backup);
-        outputPosition -= backup;
-        outputSize -= backup;
+        // copy raw input buffer into block buffer
+        writeData(rawInputBuffer.data(), bufferSize);
       } else {
-        writeHeader(header, totalCompressedSize, false);
+        writeHeader(totalCompressedSize, false);
       }
     }
 
@@ -979,41 +1009,18 @@ DIAGNOSTIC_POP
 
       const unsigned char * dataToWrite = nullptr;
       int totalSizeToWrite = 0;
-      char * header = outputBuffer + outputPosition - 3;
 
       if (totalCompressedSize >= static_cast<size_t>(bufferSize)) {
-        writeHeader(header, static_cast<size_t>(bufferSize), true);
+        writeHeader(static_cast<size_t>(bufferSize), true);
         dataToWrite = rawInputBuffer.data();
         totalSizeToWrite = bufferSize;
       } else {
-        writeHeader(header, totalCompressedSize, false);
+        writeHeader(totalCompressedSize, false);
         dataToWrite = compressorBuffer.data();
         totalSizeToWrite = static_cast<int>(totalCompressedSize);
       }
 
-      char * dst = header + 3;
-      while (totalSizeToWrite > 0) {
-        if (outputPosition == outputSize) {
-          if (!BufferedOutputStream::Next(reinterpret_cast<void **>(&outputBuffer),
-                                          &outputSize)) {
-            throw std::logic_error(
-              "Failed to get next output buffer from output stream.");
-          }
-          outputPosition = 0;
-          dst = outputBuffer;
-        } else if (outputPosition > outputSize) {
-          // this will unlikely happen, but we have seen a few on zstd v1.1.0
-          throw std::logic_error("Write to an out-of-bound place!");
-        }
-
-        int sizeToWrite = std::min(totalSizeToWrite, outputSize - outputPosition);
-        std::memcpy(dst, dataToWrite, static_cast<size_t>(sizeToWrite));
-
-        outputPosition += sizeToWrite;
-        dataToWrite += sizeToWrite;
-        totalSizeToWrite -= sizeToWrite;
-        dst += sizeToWrite;
-      }
+      writeData(dataToWrite, totalSizeToWrite);
     }
 
     *data = rawInputBuffer.data();

--- a/c++/src/io/OutputStream.cc
+++ b/c++/src/io/OutputStream.cc
@@ -95,10 +95,7 @@ namespace orc {
     if (dataSize > 0)
     {
       SCOPED_STOPWATCH(metrics, IOBlockingLatencyUs, nullptr);
-      uint64_t IOCount = dataBuffer->writeTo(outputStream);
-      if (metrics != nullptr) {
-        metrics->IOCount.fetch_add(IOCount);
-      }
+      dataBuffer->writeTo(outputStream, metrics);
     }
     dataBuffer->resize(0);
     return dataSize;

--- a/c++/src/io/OutputStream.hh
+++ b/c++/src/io/OutputStream.hh
@@ -20,6 +20,7 @@
 #define ORC_OUTPUTSTREAM_HH
 
 #include "Adaptor.hh"
+#include "BlockBuffer.hh"
 #include "orc/OrcFile.hh"
 #include "wrap/zero-copy-stream-wrapper.h"
 
@@ -49,7 +50,7 @@ DIAGNOSTIC_PUSH
   class BufferedOutputStream: public google::protobuf::io::ZeroCopyOutputStream {
   private:
     OutputStream * outputStream;
-    std::unique_ptr<DataBuffer<char> > dataBuffer;
+    std::unique_ptr<BlockBuffer> dataBuffer;
     uint64_t blockSize;
     WriterMetrics* metrics;
 

--- a/c++/test/MemoryOutputStream.hh
+++ b/c++/test/MemoryOutputStream.hh
@@ -31,6 +31,7 @@ namespace orc {
     MemoryOutputStream(ssize_t capacity) : name("MemoryOutputStream") {
       data = new char[capacity];
       length = 0;
+      naturalWriteSize = 2048;
     }
 
     virtual ~MemoryOutputStream() override;

--- a/c++/test/TestBlockBuffer.cc
+++ b/c++/test/TestBlockBuffer.cc
@@ -99,7 +99,7 @@ namespace orc {
     }
     buffer.resize(totalBufferSize);
     // flush data buffer into output stream
-    buffer.writeTo(&outputStream);
+    buffer.writeTo(&outputStream, nullptr);
     // verify data buffer
     uint64_t dataIndex = 0;
     for (uint64_t i = 0; i < buffer.getBlockNumber(); ++i) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR can solve the huge memory taken by BufferedOutputStream and refactor the write data logic in class CompressionBase.

### Why are the changes needed?
This patch use BlockBuffer to replace DataBuffer  of class BufferedOutputStream in order to solve the [issue](https://github.com/apache/orc/issues/1240).

### How was this patch tested?
The UTs in TestBufferedOutputStream.cc and TestCompression.cc can cover this patch. Add the TestBlockBuffer.write_to UT.
