### PR TITLE
ORC-1251:Support Vectored IO in ORC [Draft]

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -231,7 +231,11 @@ public enum OrcConf {
   ROW_BATCH_CHILD_LIMIT("orc.row.child.limit", "orc.row.child.limit",
       1024 * 32, "The maximum number of child elements to buffer before "+
       "the ORC row writer writes the batch to the file."
-      )
+      ),
+  ORC_VECTORED_READ("orc.vectored.read",
+      "hive.exec.orc.vectored.read",
+      false,
+      "Data will be read in asynch mode through vectored IO.")
   ;
 
   private final String attribute;

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -238,6 +238,7 @@ public interface Reader extends Closeable {
     private double minSeekSizeTolerance = (double) OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE
       .getDefaultValue();
     private int rowBatchSize = (int) OrcConf.ROW_BATCH_SIZE.getDefaultValue();
+    private boolean isVectoredRead = false;
 
     /**
      * @since 1.1.0
@@ -263,6 +264,7 @@ public interface Reader extends Closeable {
       minSeekSize = OrcConf.ORC_MIN_DISK_SEEK_SIZE.getInt(conf);
       minSeekSizeTolerance = OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE.getDouble(conf);
       rowBatchSize = OrcConf.ROW_BATCH_SIZE.getInt(conf);
+      isVectoredRead = OrcConf.ORC_VECTORED_READ.getBoolean(conf);
     }
 
     /**
@@ -569,6 +571,8 @@ public interface Reader extends Closeable {
     public boolean getIncludeAcidColumns() {
       return includeAcidColumns;
     }
+
+    public boolean getIsVectoredRead() { return isVectoredRead;}
 
     /**
      * @since 1.1.0

--- a/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
+++ b/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
@@ -34,6 +34,7 @@ public final class DataReaderProperties {
   private final int maxDiskRangeChunkLimit;
   private final int minSeekSize;
   private final double minSeekSizeTolerance;
+  private final boolean isVectoredRead;
 
   private DataReaderProperties(Builder builder) {
     this.fileSystemSupplier = builder.fileSystemSupplier;
@@ -44,6 +45,7 @@ public final class DataReaderProperties {
     this.maxDiskRangeChunkLimit = builder.maxDiskRangeChunkLimit;
     this.minSeekSize = builder.minSeekSize;
     this.minSeekSizeTolerance = builder.minSeekSizeTolerance;
+    this.isVectoredRead = builder.isVectoredRead;
   }
 
   public Supplier<FileSystem> getFileSystemSupplier() {
@@ -82,6 +84,8 @@ public final class DataReaderProperties {
     return minSeekSizeTolerance;
   }
 
+  public boolean getIsVectoredRead() { return isVectoredRead; }
+
   public static class Builder {
 
     private Supplier<FileSystem> fileSystemSupplier;
@@ -94,6 +98,7 @@ public final class DataReaderProperties {
     private int minSeekSize = (int) OrcConf.ORC_MIN_DISK_SEEK_SIZE.getDefaultValue();
     private double minSeekSizeTolerance = (double) OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE
       .getDefaultValue();
+    private boolean isVectoredRead;
 
     private Builder() {
 
@@ -141,6 +146,11 @@ public final class DataReaderProperties {
 
     public Builder withMinSeekSizeTolerance(double value) {
       minSeekSizeTolerance = value;
+      return this;
+    }
+
+    public Builder withVectoredRead(boolean isVectored){
+      this.isVectoredRead = isVectored;
       return this;
     }
 

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -283,7 +283,8 @@ public class RecordReaderImpl implements RecordReader {
               .withMaxDiskRangeChunkLimit(maxDiskRangeChunkLimit)
               .withZeroCopy(zeroCopy)
               .withMinSeekSize(options.minSeekSize())
-              .withMinSeekSizeTolerance(options.minSeekSizeTolerance());
+              .withMinSeekSizeTolerance(options.minSeekSizeTolerance())
+              .withVectoredRead(options.getIsVectoredRead());
       FSDataInputStream file = fileReader.takeFile();
       if (file != null) {
         builder.withFile(file);

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -70,8 +70,8 @@
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
     <example.dir>${project.basedir}/../../examples</example.dir>
 
-    <min.hadoop.version>2.7.3</min.hadoop.version>
-    <hadoop.version>2.7.3</hadoop.version>
+    <min.hadoop.version>3.3.9-SNAPSHOT</min.hadoop.version>
+    <hadoop.version>3.3.9-SNAPSHOT</hadoop.version>
     <tools.hadoop.version>2.10.2</tools.hadoop.version>
     <storage-api.version>2.8.1</storage-api.version>
     <zookeeper.version>3.8.0</zookeeper.version>

--- a/java/shims/pom.xml
+++ b/java/shims/pom.xml
@@ -59,6 +59,12 @@
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+          <version>3.3.9-SNAPSHOT</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
Support the new fast Vectored Read API in ORC for parallel reads. 
The patch was tested internally along with S3