### PR TITLE
ORC-1289: Refine DynamicArray

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -20,7 +20,6 @@ package org.apache.orc.impl;
 import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -123,29 +122,6 @@ public final class DynamicByteArray {
   }
 
   /**
-   * Read the entire stream into this array.
-   * @param in the stream to read from
-   * @throws IOException
-   */
-  public void readAll(InputStream in) throws IOException {
-    int currentChunk = length / chunkSize;
-    int currentOffset = length % chunkSize;
-    grow(currentChunk);
-    int currentLength = in.read(data[currentChunk], currentOffset,
-      chunkSize - currentOffset);
-    while (currentLength > 0) {
-      length += currentLength;
-      currentOffset = length % chunkSize;
-      if (currentOffset == 0) {
-        currentChunk = length / chunkSize;
-        grow(currentChunk);
-      }
-      currentLength = in.read(data[currentChunk], currentOffset,
-        chunkSize - currentOffset);
-    }
-  }
-
-  /**
    * Byte compare a set of bytes against the bytes in this dynamic array.
    * @param other source of the other bytes
    * @param otherOffset start offset in the other array
@@ -190,9 +166,7 @@ public final class DynamicByteArray {
    */
   public void clear() {
     length = 0;
-    for(int i=0; i < data.length; ++i) {
-      data[i] = null;
-    }
+    Arrays.fill(data, null);
     initializedChunks = 0;
   }
 
@@ -221,7 +195,7 @@ public final class DynamicByteArray {
    * @param out the stream to write to
    * @param offset the first offset to write
    * @param length the number of bytes to write
-   * @throws IOException
+   * @throws IOException if an I/O error occurs.
    */
   public void write(OutputStream out, int offset,
                     int length) throws IOException {
@@ -286,7 +260,6 @@ public final class DynamicByteArray {
         destOffset += currentLength;
         totalLength -= currentLength;
         currentChunk += 1;
-        currentOffset = 0;
         currentLength = Math.min(totalLength, chunkSize - currentOffset);
       }
     }

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl;
 import org.apache.hadoop.io.Text;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -122,6 +123,29 @@ public final class DynamicByteArray {
   }
 
   /**
+   * Read the entire stream into this array.
+   * @param in the stream to read from
+   * @throws IOException
+   */
+  public void readAll(InputStream in) throws IOException {
+    int currentChunk = length / chunkSize;
+    int currentOffset = length % chunkSize;
+    grow(currentChunk);
+    int currentLength = in.read(data[currentChunk], currentOffset,
+            chunkSize - currentOffset);
+    while (currentLength > 0) {
+      length += currentLength;
+      currentOffset = length % chunkSize;
+      if (currentOffset == 0) {
+        currentChunk = length / chunkSize;
+        grow(currentChunk);
+      }
+      currentLength = in.read(data[currentChunk], currentOffset,
+              chunkSize - currentOffset);
+    }
+  }
+
+  /**
    * Byte compare a set of bytes against the bytes in this dynamic array.
    * @param other source of the other bytes
    * @param otherOffset start offset in the other array
@@ -166,7 +190,9 @@ public final class DynamicByteArray {
    */
   public void clear() {
     length = 0;
-    Arrays.fill(data, null);
+    for(int i=0; i < data.length; ++i) {
+      data[i] = null;
+    }
     initializedChunks = 0;
   }
 

--- a/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
@@ -22,14 +22,14 @@ import java.util.Arrays;
 /**
  * Dynamic int array that uses primitive types and chunks to avoid copying
  * large number of integers when it resizes.
- *
+ * <p>
  * The motivation for this class is memory optimization, i.e. space efficient
  * storage of potentially huge arrays without good a-priori size guesses.
- *
+ * <p>
  * The API of this class is between a primitive array and a AbstractList. It's
  * not a Collection implementation because it handles primitive types, but the
  * API could be extended to support iterators and the like.
- *
+ * <p>
  * NOTE: Like standard Collection implementations/arrays, this class is not
  * synchronized.
  */
@@ -113,9 +113,7 @@ public final class DynamicIntArray {
 
   public void clear() {
     length = 0;
-    for(int i=0; i < data.length; ++i) {
-      data[i] = null;
-    }
+    Arrays.fill(data, null);
     initializedChunks = 0;
   }
 
@@ -137,8 +135,8 @@ public final class DynamicIntArray {
     return sb.append('}').toString();
   }
 
-  public int getSizeInBytes() {
-    return 4 * initializedChunks * chunkSize;
+  public long getSizeInBytes() {
+    return 4 * (long)initializedChunks * chunkSize;
   }
 }
 

--- a/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
@@ -113,7 +113,9 @@ public final class DynamicIntArray {
 
   public void clear() {
     length = 0;
-    Arrays.fill(data, null);
+    for(int i=0; i < data.length; ++i) {
+      data[i] = null;
+    }
     initializedChunks = 0;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refine DynamicIntArray and DynamicByteArray

### Why are the changes needed?
This PR introduces the following changes:
1. Removed unused methods DynamicByteArray#readAll
2. Use Arrays.fill to replace the original implementation
3. In DynamicIntArray#getSizeInBytes, the method should return long to avoid out of bounds.
4. Update some comments.


### How was this patch tested?
UT
