### PR TITLE
ORC-1288: [C++] fix the bug that invalid memory freeing with zlib compression.

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -62,6 +62,7 @@ namespace orc {
 
     virtual std::string getName() const override = 0;
     virtual uint64_t flush() override;
+    virtual void suppress() override;
 
     virtual bool isCompressed() const override { return true; }
     virtual uint64_t getSize() const override;
@@ -131,6 +132,12 @@ namespace orc {
     BufferedOutputStream::BackUp(outputSize - outputPosition);
     bufferSize = outputSize = outputPosition = 0;
     return BufferedOutputStream::flush();
+  }
+
+  void CompressionStreamBase::suppress() {
+    outputBuffer = nullptr;
+    bufferSize = outputPosition = outputSize = 0;
+    BufferedOutputStream::suppress();
   }
 
   uint64_t CompressionStreamBase::getSize() const {
@@ -956,6 +963,7 @@ DIAGNOSTIC_POP
     }
 
     virtual bool Next(void** data, int*size) override;
+    virtual void suppress() override;
     virtual std::string getName() const override = 0;
 
   protected:
@@ -1022,6 +1030,11 @@ DIAGNOSTIC_POP
     compressorBuffer.resize(estimateMaxCompressionSize());
 
     return true;
+  }
+
+  void BlockCompressionStream::suppress() {
+    compressorBuffer.resize(0);
+    CompressionStreamBase::suppress();
   }
 
   /**

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -1996,6 +1996,10 @@ namespace orc {
     }
   }
 
+  // Before the fix of ORC-1288, this case will trigger the bug about
+  // invalid memory freeing with zlib compression when writing a orc file
+  // that contains multiple stripes, and each stripe contains multiple columns
+  // with no null values.
   void testSuppressPresentStream(orc::CompressionKind kind) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -1996,5 +1996,49 @@ namespace orc {
     }
   }
 
+  void testSuppressPresentStream(orc::CompressionKind kind) {
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+    MemoryPool* pool = getDefaultPool();
+    uint64_t rowCount = 5000000;
+    auto type = std::unique_ptr<Type>(
+      Type::buildTypeFromString("struct<c0:int>"));
+    WriterOptions options;
+    options.setStripeSize(1024)
+      .setCompressionBlockSize(1024)
+      .setCompression(kind)
+      .setMemoryPool(pool);
+
+    auto writer = createWriter(*type, &memStream, options);
+    auto batch = writer->createRowBatch(rowCount);
+    auto& structBatch = dynamic_cast<StructVectorBatch&>(*batch);
+    auto& longBatch = dynamic_cast<LongVectorBatch&>(*structBatch.fields[0]);
+    uint64_t rows = 0;
+    uint64_t batchSize = 10000;
+    for (uint64_t i = 0; i < rowCount; ++i) {
+      longBatch.data[i] = i;
+      ++rows;
+      if (rows == batchSize) {
+        structBatch.numElements = rows;
+        longBatch.numElements = rows;
+        writer->add(*batch);
+        rows = 0;
+      }
+    }
+    if (rows != 0) {
+      structBatch.numElements = rows;
+      longBatch.numElements = rows;
+      writer->add(*batch);
+      rows = 0;
+    }
+    writer->close();
+  }
+
+  TEST(WriterTest, suppressPresentStreamWithCompressionKinds) {
+    testSuppressPresentStream(CompressionKind_ZLIB);
+    testSuppressPresentStream(CompressionKind_ZSTD);
+    testSuppressPresentStream(CompressionKind_LZ4);
+    testSuppressPresentStream(CompressionKind_SNAPPY);
+  }
+
   INSTANTIATE_TEST_CASE_P(OrcTest, WriterTest, Values(FileVersion::v_0_11(), FileVersion::v_0_12(), FileVersion::UNSTABLE_PRE_2_0()));
 }

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -2015,7 +2015,7 @@ namespace orc {
     uint64_t rows = 0;
     uint64_t batchSize = 10000;
     for (uint64_t i = 0; i < rowCount; ++i) {
-      longBatch.data[i] = i;
+      longBatch.data[i] = static_cast<int64_t>(i);
       ++rows;
       if (rows == batchSize) {
         structBatch.numElements = rows;


### PR DESCRIPTION
### What changes were proposed in this pull request?
This bug can be triggered when writing a orc file that contains multiple stripes, and each stripe contains columns with no null values. The bug is caused by the fact that the member variables in class CompressionStream is not reset after the suppress function is called.

### Why are the changes needed?
The patch can fix the bug about invalid memory freeing with multiple compression kinds.


### How was this patch tested?
Added new UT WriterTest.suppressPresentStreamWithCompressionKinds.
