### PR TITLE
ORC-1294: Fix build error when skip tests build

### DIFF
--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -63,13 +63,13 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
     </dependency>
+
+    <!-- test inter-project -->
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <!-- test inter-project -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-jobclient</artifactId>

--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -66,6 +66,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <!-- test inter-project -->

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -384,6 +384,7 @@
           </executions>
           <configuration>
             <failOnWarning>true</failOnWarning>
+            <ignoreNonCompile>true</ignoreNonCompile>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix build error when skip tests build. It has two modifications:
- Add `ignoreNonCompile` in maven-dependency-plugin to skip all Runtime/Provided/Test/System scope dependency checking.
- change slf4j-api scope to test.

### Why are the changes needed?
The root cause of building failed is that -Dmaven.test.skip=true does not compile the test classes.
Apache Maven Dependency Plugin will throw an error if a dependency is not used. We can use ignoreNonCompile defined in https://maven.apache.org/plugins/maven-dependency-plugin/analyze-only-mojo.html#ignoreNonCompile to avoid the problem.

After adding this tag, I found that we have some classes such as slf4j-api in MapReduce module that only appear in test but scope is defined as compile. I adjusted its scope to test.

For a related discussion, see https://github.com/apache/orc/issues/1277

### How was this patch tested?
UT
