### PR TITLE
ORC-1308: Add `AvoidStarImport` checkstyle rule

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -31,6 +31,10 @@
   <module name="TreeWalker">
     <module name="OuterTypeFilename"/>
     <module name="CommentsIndentation"/>
+    <module name="AvoidStarImport">
+      <property name="allowClassImports" value="false"/>
+      <property name="allowStaticMemberImports" value="false"/>
+    </module>
     <module name="UnusedImports"/>
     <module name="RedundantImport"/>
     <!-- https://checkstyle.sourceforge.io/config_imports.html#ImportOrder IntelliJ default example -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is aimed to avoid importing all classes from a package or static members from a class leads.

### Why are the changes needed?
For codestyle:

After the PR, stat import will be forbidden as following:
- class imports like import java.util.*;
- static member imports like import static org.junit.Assert.*;.

https://checkstyle.sourceforge.io/config_imports.html#AvoidStarImport


### How was this patch tested?
UT

