### PR TITLE
ORC-1309: Eliminate the redundant `{}` in the Case syntax

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcUtils.java
+++ b/java/core/src/java/org/apache/orc/OrcUtils.java
@@ -316,7 +316,7 @@ public class OrcUtils {
       case DATE:
         result = TypeDescription.createDate();
         break;
-      case DECIMAL: {
+      case DECIMAL:
         result = TypeDescription.createDecimal();
         if (type.hasScale()) {
           result.withScale(type.getScale());
@@ -324,8 +324,7 @@ public class OrcUtils {
         if (type.hasPrecision()) {
           result.withPrecision(type.getPrecision());
         }
-      }
-      break;
+        break;
       case LIST:
         if (type.getSubtypesCount() != 1) {
           throw new FileFormatException("LIST type should contain exactly " +
@@ -343,7 +342,7 @@ public class OrcUtils {
             convertTypeFromProtobuf(types, type.getSubtypes(0)),
             convertTypeFromProtobuf(types, type.getSubtypes(1)));
         break;
-      case STRUCT: {
+      case STRUCT:
         result = TypeDescription.createStruct();
         for(int f=0; f < type.getSubtypesCount(); ++f) {
           String name = type.getFieldNames(f);
@@ -351,9 +350,8 @@ public class OrcUtils {
           String fieldName = ParserUtils.parseName(new ParserUtils.StringPosition(name));
           result.addField(fieldName, convertTypeFromProtobuf(types, type.getSubtypes(f)));
         }
-      }
-      break;
-      case UNION: {
+        break;
+      case UNION:
         if (type.getSubtypesCount() == 0) {
           throw new FileFormatException("UNION type should contain at least" +
                 " one subtype but has none");
@@ -363,8 +361,7 @@ public class OrcUtils {
           result.addUnionChild(
               convertTypeFromProtobuf(types, type.getSubtypes(f)));
         }
-      }
-      break;
+        break;
       default:
         throw new IllegalArgumentException("Unknown ORC type " + type.getKind());
     }

--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -130,18 +130,16 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         case STRING:
           bytesColVector.setVal(elementNum, bytes, start, length);
           break;
-        case CHAR: {
-          int adjustedDownLen =
+        case CHAR:
+          int charAdjustedDownLen =
               StringExpr.rightTrimAndTruncate(bytes, start, length, readerType.getMaxLength());
-          bytesColVector.setVal(elementNum, bytes, start, adjustedDownLen);
-        }
-        break;
-        case VARCHAR: {
-          int adjustedDownLen =
+          bytesColVector.setVal(elementNum, bytes, start, charAdjustedDownLen);
+          break;
+        case VARCHAR:
+          int varcharAdjustedDownLen =
               StringExpr.truncate(bytes, start, length, readerType.getMaxLength());
-          bytesColVector.setVal(elementNum, bytes, start, adjustedDownLen);
-        }
-        break;
+          bytesColVector.setVal(elementNum, bytes, start, varcharAdjustedDownLen);
+          break;
         default:
           throw new RuntimeException("Unexpected type kind " + readerType.getCategory().name());
       }
@@ -153,28 +151,26 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
         case STRING:
           // No conversion needed.
           break;
-        case CHAR: {
-          int length = bytesColVector.length[elementNum];
-          int adjustedDownLen = StringExpr
+        case CHAR:
+          int charLength = bytesColVector.length[elementNum];
+          int charAdjustedDownLen = StringExpr
               .rightTrimAndTruncate(bytesColVector.vector[elementNum],
-                  bytesColVector.start[elementNum], length,
+                  bytesColVector.start[elementNum], charLength,
                   readerType.getMaxLength());
-          if (adjustedDownLen < length) {
-            bytesColVector.length[elementNum] = adjustedDownLen;
+          if (charAdjustedDownLen < charLength) {
+            bytesColVector.length[elementNum] = charAdjustedDownLen;
           }
-        }
-        break;
-        case VARCHAR: {
-          int length = bytesColVector.length[elementNum];
-          int adjustedDownLen = StringExpr
+          break;
+        case VARCHAR:
+          int varcharLength = bytesColVector.length[elementNum];
+          int varcharAdjustedDownLen = StringExpr
               .truncate(bytesColVector.vector[elementNum],
-                  bytesColVector.start[elementNum], length,
+                  bytesColVector.start[elementNum], varcharLength,
                   readerType.getMaxLength());
-          if (adjustedDownLen < length) {
-            bytesColVector.length[elementNum] = adjustedDownLen;
+          if (varcharAdjustedDownLen < varcharLength) {
+            bytesColVector.length[elementNum] = varcharAdjustedDownLen;
           }
-        }
-        break;
+          break;
         default:
           throw new RuntimeException("Unexpected type kind " + readerType.getCategory().name());
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This pr aims to eliminate the redundant `{}` in the case syntax.  

### Why are the changes needed?
The code has been modified in ORC-1306 to pass the check. But the indentation in the case syntax is weird. The patch for the 1.8 branch merge already fixes it. So you need to fix the main branch separately pr.

### How was this patch tested?
Checking with maven-check-plugin.
