### PR TITLE
ORC-1310: Whitelist Support for plugin filter

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -194,11 +194,11 @@ public enum OrcConf {
                       + "order of application."),
 
   PLUGIN_FILTER_WHITELIST("orc.filter.plugin.whitelist",
-                      "orc.filter.plugin.whitelist",
-                      "",
-                      "A comma-separated list of whitelist classes. It is used to specify the "
-                      + "className which will be loaded as PluginFilterService. "
-                      + "Classes that not in the list will be ignored."),
+                          "orc.filter.plugin.whitelist",
+                          "",
+                          "A comma-separated list of whitelist classes. It is used to specify the "
+                          + "className which will be loaded as PluginFilterService. "
+                          + "Classes that not in the list will be ignored."),
 
   WRITE_VARIABLE_LENGTH_BLOCKS("orc.write.variable.length.blocks", null, false,
       "A boolean flag as to whether the ORC writer should write variable length\n"

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -196,9 +196,9 @@ public enum OrcConf {
   PLUGIN_FILTER_WHITELIST("orc.filter.plugin.whitelist",
                       "orc.filter.plugin.whitelist",
                       "",
-                      "A comma-separated list of whitelist classes. It is used to specify the " +
-                          "className which will be loaded as PluginFilterService. " +
-                          "Classes that not in the list will be ignored."),
+                      "A comma-separated list of whitelist classes. It is used to specify the "
+                          + "className which will be loaded as PluginFilterService. "
+                          + "Classes that not in the list will be ignored."),
 
   WRITE_VARIABLE_LENGTH_BLOCKS("orc.write.variable.length.blocks", null, false,
       "A boolean flag as to whether the ORC writer should write variable length\n"

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -197,7 +197,7 @@ public enum OrcConf {
                       "orc.filter.plugin.whitelist",
                       "",
                       "A comma-separated list of whitelist classes. It is used to specify the " +
-                          "className which will be loaded as org.apache.orc.filter.PluginFilterService. " +
+                          "className which will be loaded as PluginFilterService. " +
                           "Classes that not in the list will be ignored."),
 
   WRITE_VARIABLE_LENGTH_BLOCKS("orc.write.variable.length.blocks", null, false,

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -20,6 +20,8 @@ package org.apache.orc;
 
 import org.apache.hadoop.conf.Configuration;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -190,6 +192,14 @@ public enum OrcConf {
                       + "determined, they are combined using AND. The order of application is "
                       + "non-deterministic and the filter functionality should not depend on the "
                       + "order of application."),
+
+  PLUGIN_FILTER_WHITELIST("orc.filter.plugin.whitelist",
+                      "orc.filter.plugin.whitelist",
+                      "",
+                      "A comma-separated list of whitelist classes. It is used to specify the " +
+                          "className which will be loaded as org.apache.orc.filter.PluginFilterService. " +
+                          "Classes that not in the list will be ignored."),
+
   WRITE_VARIABLE_LENGTH_BLOCKS("orc.write.variable.length.blocks", null, false,
       "A boolean flag as to whether the ORC writer should write variable length\n"
       + "HDFS blocks."),
@@ -327,6 +337,10 @@ public enum OrcConf {
 
   public String getString(Configuration conf) {
     return getString(null, conf);
+  }
+
+  public List<String> getStringAsList(Configuration conf) {
+    return Arrays.asList(getString(null, conf).split(","));
   }
 
   public void setString(Configuration conf, String value) {

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -197,8 +197,8 @@ public enum OrcConf {
                       "orc.filter.plugin.whitelist",
                       "",
                       "A comma-separated list of whitelist classes. It is used to specify the "
-                          + "className which will be loaded as PluginFilterService. "
-                          + "Classes that not in the list will be ignored."),
+                      + "className which will be loaded as PluginFilterService. "
+                      + "Classes that not in the list will be ignored."),
 
   WRITE_VARIABLE_LENGTH_BLOCKS("orc.write.variable.length.blocks", null, false,
       "A boolean flag as to whether the ORC writer should write variable length\n"

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -234,6 +235,7 @@ public interface Reader extends Closeable {
     private boolean allowSARGToFilter = false;
     private boolean useSelected = false;
     private boolean allowPluginFilters = false;
+    private List<String> pluginWhiteListFilters = null;
     private int minSeekSize = (int) OrcConf.ORC_MIN_DISK_SEEK_SIZE.getDefaultValue();
     private double minSeekSizeTolerance = (double) OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE
         .getDefaultValue();
@@ -260,6 +262,7 @@ public interface Reader extends Closeable {
       allowSARGToFilter = OrcConf.ALLOW_SARG_TO_FILTER.getBoolean(conf);
       useSelected = OrcConf.READER_USE_SELECTED.getBoolean(conf);
       allowPluginFilters = OrcConf.ALLOW_PLUGIN_FILTER.getBoolean(conf);
+      pluginWhiteListFilters = OrcConf.PLUGIN_FILTER_WHITELIST.getStringAsList(conf);
       minSeekSize = OrcConf.ORC_MIN_DISK_SEEK_SIZE.getInt(conf);
       minSeekSizeTolerance = OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE.getDouble(conf);
       rowBatchSize = OrcConf.ROW_BATCH_SIZE.getInt(conf);
@@ -653,6 +656,15 @@ public interface Reader extends Closeable {
 
     public Options allowPluginFilters(boolean allowPluginFilters) {
       this.allowPluginFilters = allowPluginFilters;
+      return this;
+    }
+
+    public List<String> pluginWhiteListFilters() {
+      return pluginWhiteListFilters;
+    }
+
+    public Options pluginWhiteListFilters(String... whiteLists) {
+      this.pluginWhiteListFilters = Arrays.asList(whiteLists);
       return this;
     }
 

--- a/java/core/src/java/org/apache/orc/impl/filter/FilterFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/FilterFactory.java
@@ -72,7 +72,7 @@ public class FilterFactory {
     // 2. Process PluginFilter
     if (opts.allowPluginFilters()) {
       List<BatchFilter> pluginFilters = findPluginFilters(filePath, conf);
-      deleteFilterNotInWhiteList(pluginFilters, opts);
+      deleteFilterNotInWhiteList(pluginFilters, opts.pluginWhiteListFilters());
       if (!pluginFilters.isEmpty()) {
         LOG.debug("Added plugin filters {} to the read", pluginFilters);
         filters.addAll(pluginFilters);
@@ -191,10 +191,10 @@ public class FilterFactory {
    * Delete filter(s) which is not in the whitelist.
    *
    * @param filters fully filter list we load from class path.
-   * @param opts     reader configuration of ORC, can be used to configure the filter whiteList
+   * @param whiteList filter whiteList. The plugin service will not be
+   *                  loaded if it is not in whiteList.
    */
-  static void deleteFilterNotInWhiteList(List<BatchFilter> filters, Reader.Options opts) {
-    List<String> whiteList = opts.pluginWhiteListFilters();
+  static void deleteFilterNotInWhiteList(List<BatchFilter> filters, List<String> whiteList) {
     if (whiteList != null && whiteList.size() > 0) {
       Iterator<BatchFilter> iterator = filters.iterator();
       while (iterator.hasNext()) {

--- a/java/core/src/test/org/apache/orc/impl/filter/TestPluginFilterService.java
+++ b/java/core/src/test/org/apache/orc/impl/filter/TestPluginFilterService.java
@@ -25,7 +25,10 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestPluginFilterService {
   private final Configuration conf;


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is aimed to add whitelist support for plugin filter.

### Why are the changes needed?
**ServiceLoader** will load all the interfaces in current classpath. When we have two implementations of PluginFilterService, Both of them will be loaded as plugin filters. This PR will provide a configuration "orc.filter.plugin.whitelist". ORC reader will only load the class which is in the whitelist when the configuration is not null.

### How was this patch tested?
UT