### PR TITLE
ORC-1315: [C++] Fix test failure when unsigned char is in effect

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -125,12 +125,11 @@ namespace orc {
    */
   template <typename T>
   void expandBytesToIntegers(T* buffer, uint64_t numValues) {
-    if (sizeof(T) == sizeof(char)) {
+    if (sizeof(T) == sizeof(int8_t)) {
       return;
     }
     for (uint64_t i = 0UL; i < numValues; ++i) {
-      buffer[numValues - 1 - i] =
-          static_cast<T>(reinterpret_cast<char*>(buffer)[numValues - 1 - i]);
+      buffer[numValues - 1 - i] = reinterpret_cast<int8_t*>(buffer)[numValues - 1 - i];
     }
   }
 

--- a/c++/test/TestColumnReader.cc
+++ b/c++/test/TestColumnReader.cc
@@ -259,7 +259,8 @@ namespace orc {
         EXPECT_EQ(0, longBatch->notNull[i]) << "Wrong value at " << i;
       } else {
         EXPECT_EQ(1, longBatch->notNull[i]) << "Wrong value at " << i;
-        EXPECT_EQ(static_cast<char>(next++), longBatch->data[i]) << "Wrong value at " << i;
+        EXPECT_EQ(static_cast<char>(next++), static_cast<char>(longBatch->data[i]))
+            << "Wrong value at " << i;
       }
     }
   }
@@ -318,7 +319,7 @@ namespace orc {
     ASSERT_EQ(true, !batch.hasNulls);
     ASSERT_EQ(5, longBatch->numElements);
     ASSERT_EQ(true, longBatch->hasNulls);
-    EXPECT_EQ(static_cast<char>(-1), longBatch->data[0]);
+    EXPECT_EQ(static_cast<char>(-1), static_cast<char>(longBatch->data[0]));
     EXPECT_EQ(true, !longBatch->notNull[1]);
     EXPECT_EQ(true, !longBatch->notNull[2]);
     EXPECT_EQ(true, !longBatch->notNull[3]);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Previous fix of ORC-1315 is not complete yet. This is a follow up commit to fix the remaining issues where unsigned chars may produce unexpected behavior.

### Why are the changes needed?
In the debian docker images, several test cases fail like below:
```
[----------] Global test environment tear-down
[==========] 87 tests from 10 test cases ran. (8039 ms total)
[  PASSED  ] 83 tests.
[  FAILED  ] 4 tests, listed below:
[  FAILED  ] TestMatch.selectColumns
[  FAILED  ] TestMatchParam/FileParam.Contents/7, where GetParam() = TestOrcFile.testSeek.orc
[  FAILED  ] TestMatchParam/FileParam.Contents/18, where GetParam() = nulls-at-end-snappy.orc
[  FAILED  ] TestMatchParam/FileParam.Contents/23, where GetParam() = over1k_bloom.orc
```

### How was this patch tested?
- Add `-funsigned-char` flag to compile manually to make sure all tests pass.
- All test cases pass on the debian docker images.
