### PR TITLE
ORC-1322: Upgrade centos7 docker image to use gcc 9

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -326,6 +326,7 @@ if (BUILD_CPP_TESTS)
 
     set(GTEST_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
                          -DCMAKE_INSTALL_PREFIX=${GTEST_PREFIX}
+                         -DCMAKE_INSTALL_LIBDIR=lib
                          -Dgtest_force_shared_crt=ON
                          -DCMAKE_CXX_FLAGS=${GTEST_CMAKE_CXX_FLAGS})
 

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -56,6 +56,12 @@ RUN yum install -y \
 # Our scripts assume that cmake is called 'cmake'
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 
+# Install gcc-9
+RUN yum install -y centos-release-scl
+RUN yum install -y devtoolset-9
+RUN echo "source /opt/rh/devtoolset-9/enable" >> /etc/bashrc
+SHELL ["/bin/bash", "--login", "-c"]
+
 ENV TZ=America/Los_Angeles
 WORKDIR /root
 VOLUME /root/.m2/repository

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -28,8 +28,6 @@ RUN yum install -y \
   curl-devel \
   cyrus-sasl-devel \
   expat-devel \
-  gcc \
-  gcc-c++ \
   gettext-devel \
   git \
   libtool \

--- a/docker/run-one.sh
+++ b/docker/run-one.sh
@@ -37,7 +37,7 @@ else
 
   echo "Started $GITHUB_USER/$BRANCH on $BUILD at $(date)"
 
-  docker run $VOLUME "$TAG" /bin/bash -c \
+  docker run $VOLUME "$TAG" /bin/bash --login -c \
      "$CLONE && $MAKEDIR && cmake $OPTS .. && make package test-out" \
        || failure
 fi


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade centos7 docker image to use gcc9 instead of gcc4. After this change, the C++ build on centos7 is fully recovered.

### Why are the changes needed?
ORC-1301 recently enabled C++17 to the C++ code base and build on centos7 fails like the following.
```
CMake Error at CMakeLists.txt:134 (message):
  A c++17-compliant compiler is required, please use at least GCC 5
-- compiler GNU version 4.8.5
-- Configuring incomplete, errors occurred!
See also "/root/build/CMakeFiles/CMakeOutput.log".
FAILED centos7
```

### How was this patch tested?
Test it manually that all tests pass.