### PR TITLE
ORC-1323: Make `docker/reinit.sh` support target OS arguments

### DIFF
--- a/docker/reinit.sh
+++ b/docker/reinit.sh
@@ -16,7 +16,11 @@
 # limitations under the License.
 
 start=`date`
-for build in `cat os-list.txt`; do
+
+TARGET=${@:-`cat os-list.txt`}
+echo "Target:" $TARGET
+
+for build in $TARGET; do
   OS=$(echo "$build" | cut -d '_' -f1)
   REST=$(echo "$build" | cut -d '_' -f2- -s)
   if [ -z "$REST" ]; then


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support target OS arguments in `docker/reinit.sh`.

### Why are the changes needed?

Currently, it re-generates all Ones.

### How was this patch tested?

Manually.
```
$ cd docker

$ ./reinit.sh centos7
Target: centos7
Re-initialize apache/orc-dev:centos7
...

$ ./reinit.sh centos7 ubuntu22
Target: centos7 ubuntu22
Re-initialize apache/orc-dev:centos7
...

$ ./reinit.sh
Target: centos7 debian10 debian11 ubuntu18 ubuntu20 ubuntu22 fedora37 debian10_jdk=11 ubuntu20_jdk=11 ubuntu20_jdk=11_cc=clang
Re-initialize apache/orc-dev:centos7
...
```