### PR TITLE
ORC-1324: Use Java 19 instead of 18 in GHA

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,7 +37,7 @@ jobs:
             java: 1.8
             cxx: g++
           - os: ubuntu-20.04
-            java: 18
+            java: 19
             cxx: g++
     env:
       MAVEN_OPTS: -Xmx2g


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use Java 19 instead of Java 18 in GHA testing.


### Why are the changes needed?
Java 19 is the latest version. 


### How was this patch tested?
Pass the new CIs. 