### PR TITLE
ORC-1328: Exclude the proto files from the shaded protobuf jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -463,6 +463,7 @@
                       <exclude>META-INF/DEPENDENCIES</exclude>
                       <exclude>META-INF/LICENSE</exclude>
                       <exclude>META-INF/NOTICE</exclude>
+                      <exclude>google/protobuf/**</exclude>
                     </excludes>
                   </filter>
                 </filters>


### PR DESCRIPTION
### Why are the changes needed?

It looks like the shaded-protobuf.jar has the same issue that was fixed in https://github.com/apache/orc/pull/1334

### What changes were proposed in this pull request?

Exclude the proto files

### How was this patch tested?

Test manually.