### PR TITLE
ORC-1329: Add `OrcConf.getStringAsList` method

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -18,8 +18,11 @@
 
 package org.apache.orc;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 /**
@@ -327,6 +330,21 @@ public enum OrcConf {
 
   public String getString(Configuration conf) {
     return getString(null, conf);
+  }
+
+  public List<String> getStringAsList(Configuration conf) {
+    String value = getString(null, conf);
+    List<String> confList = new ArrayList<>();
+    if (StringUtils.isEmpty(value)) {
+      return confList;
+    }
+    for (String str: value.split(",")) {
+      String trimStr = StringUtils.trim(str);
+      if (StringUtils.isNotEmpty(trimStr)) {
+        confList.add(trimStr);
+      }
+    }
+    return confList;
   }
 
   public void setString(Configuration conf, String value) {

--- a/java/core/src/test/org/apache/orc/TestOrcConf.java
+++ b/java/core/src/test/org/apache/orc/TestOrcConf.java
@@ -20,6 +20,7 @@ package org.apache.orc;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -138,5 +139,28 @@ public class TestOrcConf {
 
     conf.setInt(ORC_STRIPE_SIZE_CONF.getHiveConfName(), 2000);
     assertEquals(2000, ORC_STRIPE_SIZE_CONF.getLong(tableProperties, conf));
+  }
+
+  @Test
+  public void testGetStringAsList() {
+    Configuration conf = new Configuration();
+
+    conf.set(ORC_COMPRESS_CONF.getHiveConfName(), "a,,b,c, ,d,");
+    List<String> valueList1 =  ORC_COMPRESS_CONF.getStringAsList(conf);
+    assertEquals(valueList1.size(), 4);
+    assertEquals(valueList1.get(0), "a");
+    assertEquals(valueList1.get(1), "b");
+    assertEquals(valueList1.get(2), "c");
+    assertEquals(valueList1.get(3), "d");
+
+    conf.set(ORC_COMPRESS_CONF.getHiveConfName(), "");
+    List<String> valueList2 =  ORC_COMPRESS_CONF.getStringAsList(conf);
+    assertEquals(valueList2.size(), 0);
+
+    conf.set(ORC_COMPRESS_CONF.getHiveConfName(), " abc,  efg,  ");
+    List<String> valueList3 =  ORC_COMPRESS_CONF.getStringAsList(conf);
+    assertEquals(valueList3.size(), 2);
+    assertEquals(valueList3.get(0), "abc");
+    assertEquals(valueList3.get(1), "efg");
   }
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?
This PR is aimed to add a new OrcConf utility: getStringAsList.


### Why are the changes needed?
We need to support a new OrcConf utility - getStringAsList, which can handle the scenario where the configuration item is a String, but the parameter received by the orc is a List.


### How was this patch tested?
UT