### PR TITLE
ORC-1332: Avoid NegativeArraySizeException when using searchArgument

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -237,7 +237,7 @@ public class RecordReaderImpl implements RecordReader {
     this.fileIncluded = evolution.getFileIncluded();
     SearchArgument sarg = options.getSearchArgument();
     boolean[] rowIndexCols = new boolean[evolution.getFileIncluded().length];
-    if (sarg != null && rowIndexStride != 0) {
+    if (sarg != null && rowIndexStride > 0) {
       sargApp = new SargApplier(sarg,
           rowIndexStride,
           evolution,

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -183,7 +183,11 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     this.encodingStrategy = opts.getEncodingStrategy();
     this.compressionStrategy = opts.getCompressionStrategy();
 
-    this.rowIndexStride = opts.getRowIndexStride();
+    if (opts.getRowIndexStride() >= 0) {
+      this.rowIndexStride = opts.getRowIndexStride();
+    } else {
+      this.rowIndexStride = 0;
+    }
 
     this.buildIndex = opts.isBuildIndex() && (rowIndexStride > 0);
     if (buildIndex && rowIndexStride < MIN_ROW_INDEX_STRIDE) {

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -2582,10 +2582,10 @@ public class TestRecordReaderImpl {
     fs.delete(testFilePath, true);
 
     TypeDescription schema =
-            TypeDescription.fromString("struct<str:string>");
+        TypeDescription.fromString("struct<str:string>");
     Writer writer = OrcFile.createWriter(
-            testFilePath,
-            OrcFile.writerOptions(conf).setSchema(schema).rowIndexStride(-1));
+        testFilePath,
+        OrcFile.writerOptions(conf).setSchema(schema).rowIndexStride(-1));
     VectorizedRowBatch batch = schema.createRowBatch();
     BytesColumnVector strVector = (BytesColumnVector) batch.cols[0];
     for (int i = 0; i < 32 * 1024; i++) {
@@ -2603,8 +2603,8 @@ public class TestRecordReaderImpl {
 
     Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf).filesystem(fs));
     SearchArgument sarg = SearchArgumentFactory.newBuilder(conf)
-            .startNot().isNull("str", PredicateLeaf.Type.STRING).end()
-            .build();
+        .startNot().isNull("str", PredicateLeaf.Type.STRING).end()
+        .build();
     RecordReader recordReader = reader.rows(reader.options().searchArgument(sarg, null));
     batch = reader.getSchema().createRowBatch();
     strVector = (BytesColumnVector) batch.cols[0];

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderImpl.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
@@ -65,6 +66,7 @@ import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.DateFormat;
@@ -2569,6 +2571,50 @@ public class TestRecordReaderImpl {
           assertEquals(expectedVal, readX.vector[i]);
         }
       }
+    }
+  }
+
+  @Test
+  public void testRowIndexStrideNegativeFilter() throws Exception {
+    Path testFilePath = new Path(workDir, "rowIndexStrideNegative.orc");
+    Configuration conf = new Configuration();
+    FileSystem fs = FileSystem.get(conf);
+    fs.delete(testFilePath, true);
+
+    TypeDescription schema =
+            TypeDescription.fromString("struct<str:string>");
+    Writer writer = OrcFile.createWriter(
+            testFilePath,
+            OrcFile.writerOptions(conf).setSchema(schema).rowIndexStride(-1));
+    VectorizedRowBatch batch = schema.createRowBatch();
+    BytesColumnVector strVector = (BytesColumnVector) batch.cols[0];
+    for (int i = 0; i < 32 * 1024; i++) {
+      if (batch.size == batch.getMaxSize()) {
+        writer.addRowBatch(batch);
+        batch.reset();
+      }
+      byte[] value = String.format("row %06d", i).getBytes(StandardCharsets.UTF_8);
+      strVector.setRef(batch.size, value, 0, value.length);
+      ++batch.size;
+    }
+    writer.addRowBatch(batch);
+    batch.reset();
+    writer.close();
+
+    Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf).filesystem(fs));
+    SearchArgument sarg = SearchArgumentFactory.newBuilder(conf)
+            .startNot().isNull("str", PredicateLeaf.Type.STRING).end()
+            .build();
+    RecordReader recordReader = reader.rows(reader.options().searchArgument(sarg, null));
+    batch = reader.getSchema().createRowBatch();
+    strVector = (BytesColumnVector) batch.cols[0];
+    long base = 0;
+    while (recordReader.nextBatch(batch)) {
+      for (int r = 0; r < batch.size; ++r) {
+        String value = String.format("row %06d", r + base);
+        assertEquals(value, strVector.toString(r), "row " + (r + base));
+      }
+      base += batch.size;
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
searchArgument takes effect only when rowIndexStride is greater than 0.

### Why are the changes needed?
When `orc.row.index.stride` is set to a negative number, using searchArgument will throw NegativeArraySizeException.

```java
Caused by: java.lang.NegativeArraySizeException
	at org.apache.orc.impl.RecordReaderImpl$SargApplier.pickRowGroups(RecordReaderImpl.java:1164)
	at org.apache.orc.impl.RecordReaderImpl.pickRowGroups(RecordReaderImpl.java:1273)
	at org.apache.orc.impl.RecordReaderImpl.readStripe(RecordReaderImpl.java:1293)
	at org.apache.orc.impl.RecordReaderImpl.advanceStripe(RecordReaderImpl.java:1345)
	at org.apache.orc.impl.RecordReaderImpl.advanceToNextRow(RecordReaderImpl.java:1388)
	at org.apache.orc.impl.RecordReaderImpl.<init>(RecordReaderImpl.java:367)
```


### How was this patch tested?
add UT
