### PR TITLE
ORC-1336: Protect `.asf.yaml`, `api`, `ORC-Deep-Dive-2020.pptx` files in website

### DIFF
--- a/site/_config.yml
+++ b/site/_config.yml
@@ -12,7 +12,7 @@ tag_url: https://github.com/apache/orc/releases/tag/rel
 dist_archive: https://archive.apache.org/dist/orc
 destination: target
 exclude: [README.md, Gemfile*, Dockerfile]
-keep_files: [.git]
+keep_files: [.git, .asf.yaml, api, talks/ORC-Deep-Dive-2020.pptx]
 highlight_color: "#67cf56"
 
 collections:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to protect `.asf.yaml` and `api` and `pptx` files during website generations.

### Why are the changes needed?

`.asf.yaml` and `pptx` files were added directly long time ago. And, `api` documents are updated only during releasing.
```
$ cd site

$ docker run -d --name orc-container -p 4000:4000 -v $PWD:/home/orc/site apache/orc-dev:site

$ cd target

$ git status
On branch asf-site
Your branch is up to date with 'origin/asf-site'.

Changes not staged for commit:
  (use "git add/rm <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	deleted:    .asf.yaml
	deleted:    api/apidocs/org/apache/orc/examples/CompressionWriter.html
	deleted:    api/apidocs/org/apache/orc/examples/InMemoryEncryptionReader.html
	deleted:    api/apidocs/org/apache/orc/examples/InMemoryEncryptionWriter.html
	deleted:    api/apidocs/org/apache/orc/examples/class-use/CompressionWriter.html
	deleted:    api/apidocs/org/apache/orc/examples/class-use/InMemoryEncryptionReader.html
	deleted:    api/apidocs/org/apache/orc/examples/class-use/InMemoryEncryptionWriter.html
	deleted:    talks/ORC-Deep-Dive-2020.pptx
```

### How was this patch tested?

Manually.