### PR TITLE
ORC-1342: Publish SBOM artifacts

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -265,6 +265,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.cyclonedx</groupId>
+        <artifactId>cyclonedx-maven-plugin</artifactId>
+        <version>2.7.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>makeAggregateBom</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to publish `SBOM` artifacts.

### Why are the changes needed?

Here is an article to give some context.
- https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

This PR uses [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin), a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis.

For example, `orc-core-1.9.0-SNAPSHOT-cyclonedx.json` and `orc-core-1.9.0-SNAPSHOT-cyclonedx.xml` are attached like the following.
```
$ tree ~/.m2/repository/org/apache/orc/orc-core
/Users/dongjoon/.m2/repository/org/apache/orc/orc-core
├── 1.9.0-SNAPSHOT
│   ├── _remote.repositories
│   ├── maven-metadata-apache.snapshots.xml
│   ├── maven-metadata-apache.snapshots.xml.sha1
│   ├── maven-metadata-local.xml
│   ├── orc-core-1.9.0-20230103.231254-184.jar
│   ├── orc-core-1.9.0-20230103.231254-184.jar.sha1
│   ├── orc-core-1.9.0-20230103.231254-184.pom
│   ├── orc-core-1.9.0-20230103.231254-184.pom.sha1
│   ├── orc-core-1.9.0-SNAPSHOT-cyclonedx.json
│   ├── orc-core-1.9.0-SNAPSHOT-cyclonedx.xml
│   ├── orc-core-1.9.0-SNAPSHOT-nohive.jar
│   ├── orc-core-1.9.0-SNAPSHOT-shaded-protobuf.jar
│   ├── orc-core-1.9.0-SNAPSHOT-sources.jar
│   ├── orc-core-1.9.0-SNAPSHOT-test-sources.jar
│   ├── orc-core-1.9.0-SNAPSHOT-tests.jar
│   ├── orc-core-1.9.0-SNAPSHOT.jar
│   ├── orc-core-1.9.0-SNAPSHOT.pom
│   └── resolver-status.properties
└── maven-metadata-local.xml
```

### How was this patch tested?

After installing locally and check the `*cyclonedx.*` files.
```
$ mvn install -DskipTests
```
