### PR TITLE
ORC-1344: Skip SBOM generation during CMake

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
             java: 19
             cxx: g++
     env:
-      MAVEN_OPTS: -Xmx2g -Dcyclonedx.skip
+      MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true
     steps:
     - name: Checkout

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -40,7 +40,7 @@ jobs:
             java: 19
             cxx: g++
     env:
-      MAVEN_OPTS: -Xmx2g
+      MAVEN_OPTS: -Xmx2g -Dcyclonedx.skip
       MAVEN_SKIP_RC: true
     steps:
     - name: Checkout

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -62,7 +62,7 @@ add_custom_target(java_build ALL DEPENDS ${ORC_JARS})
 add_test(
   NAME java-test
   COMMAND ./mvnw ${NO_DOWNLOAD_MSG} -Pcmake
-           -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} -Dcyclonedx.skip test
+           -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # TOOD(ORC-1003)

--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 add_custom_command(
    OUTPUT ${ORC_JARS}
    COMMAND ./mvnw ${NO_DOWNLOAD_MSG} ${JAVA_PROFILE}
-             -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} -DskipTests package
+             -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} -Dcyclonedx.skip -DskipTests package
    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
    COMMENT "Build the java directory"
    VERBATIM)
@@ -62,7 +62,7 @@ add_custom_target(java_build ALL DEPENDS ${ORC_JARS})
 add_test(
   NAME java-test
   COMMAND ./mvnw ${NO_DOWNLOAD_MSG} -Pcmake
-           -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} test
+           -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} -Dcyclonedx.skip test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 # TOOD(ORC-1003)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip `SBOM` generation during CMake.
In the community, Apache ORC release and GitHub Action publishing job uses `mvnw` directly.

### Why are the changes needed?

During testing, we don't need SBOM.
Only snapshot CI job requires to publish SBOM.

### How was this patch tested?

Manually check the log of GitHub Action jobs in this PR.