### PR TITLE
ORC-1345: Use `makeBom` and skip snapshot check in GitHub Action `publish_snapshot` job

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         cd java
         echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
-        ./mvnw --settings settings.xml -DskipTests deploy
+        ./mvnw --settings settings.xml --no-snapshot-updates -DskipTests deploy

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         cd java
         echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
-        ./mvnw --settings settings.xml --no-snapshot-updates -DskipTests deploy
+        ./mvnw --settings settings.xml -nsu -ntp -DskipTests deploy

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -273,7 +273,7 @@
           <execution>
             <phase>package</phase>
             <goals>
-              <goal>makeAggregateBom</goal>
+              <goal>makeBom</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve GitHub Action `publish_snapshot` job by using `makeBom` and skipping checking snapshot versions. In addition, the download transfer progress is also disabled to reduce the log size.

### Why are the changes needed?

`publish_snapshot` is always generating new set of snapshot files.

### How was this patch tested?

Manual review. This should be verified after merging.

https://github.com/apache/orc/blob/eee67e192017ee78fa89061ffc8a013c0daf14c7/.github/workflows/publish_snapshot.yml#L3-L6