### PR TITLE
ORC-1346: Remove `-nsu` option in publish-snapshot job

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -23,4 +23,4 @@ jobs:
       run: |
         cd java
         echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
-        ./mvnw --settings settings.xml -nsu -ntp -DskipTests deploy
+        ./mvnw --settings settings.xml -ntp -DskipTests deploy


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is a partial revert of ORC-1345 by removing `-nsu` option in `publish-snapshot` job.

### Why are the changes needed?

During ORC-1345, it was missed that `default-deploy` is ignored.
```
[INFO] --- maven-install-plugin:2.5.2:install (default-install) @ orc ---
[INFO] Installing /home/runner/work/orc/orc/java/pom.xml to /home/runner/.m2/repository/org/apache/orc/orc/1.8.2-SNAPSHOT/orc-1.8.2-SNAPSHOT.pom
[INFO] Installing /home/runner/work/orc/orc/java/target/bom.xml to /home/runner/.m2/repository/org/apache/orc/orc/1.8.2-SNAPSHOT/orc-1.8.2-SNAPSHOT-cyclonedx.xml
[INFO] Installing /home/runner/work/orc/orc/java/target/bom.json to /home/runner/.m2/repository/org/apache/orc/orc/1.8.2-SNAPSHOT/orc-1.8.2-SNAPSHOT-cyclonedx.json
[INFO] 
[INFO] --- maven-deploy-plugin:2.8.2:deploy (default-deploy) @ orc ---
[INFO] 
[INFO] ----------------------< org.apache.orc:orc-shims >----------------------
```

### How was this patch tested?

N/A