### PR TITLE
ORC-1349: [C++] remove useless bufStream definition

### DIFF
--- a/c++/test/TestByteRLEEncoder.cc
+++ b/c++/test/TestByteRLEEncoder.cc
@@ -105,7 +105,6 @@ namespace orc {
 
     uint64_t capacity = 500 * 1024;
     uint64_t block = 1024;
-    BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
     auto outStream =
         std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
@@ -127,7 +126,6 @@ namespace orc {
 
     uint64_t capacity = 500 * 1024;
     uint64_t block = 1024;
-    BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
     auto outStream =
         std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
@@ -151,7 +149,6 @@ namespace orc {
 
     uint64_t capacity = 500 * 1024;
     uint64_t block = 1024;
-    BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
     auto outStream =
         std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
@@ -173,7 +170,6 @@ namespace orc {
 
     uint64_t capacity = 500 * 1024;
     uint64_t block = 1024;
-    BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
     auto outStream =
         std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);
@@ -195,7 +191,6 @@ namespace orc {
 
     uint64_t capacity = 500 * 1024;
     uint64_t block = 1024;
-    BufferedOutputStream bufStream(*pool, &memStream, capacity, block, nullptr);
 
     auto outStream =
         std::make_unique<BufferedOutputStream>(*pool, &memStream, capacity, block, nullptr);


### PR DESCRIPTION
### What changes were proposed in this pull request?

In `TestByteRLEEncoder.cc`, bufStream was defined but not used, so remove those useless definitions.

### Why are the changes needed?

the definitions are useless.

### How was this patch tested?

It doesn't introduce new features and passed all test cases.