### PR TITLE
ORC-1350: Upgrade `setup-java` to v3

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,14 +27,14 @@ jobs:
           - macos-11
           - macos-12
         java:
-          - 1.8
+          - 8
           - 11
           - 17
         cxx:
           - clang++
         include:
           - os: ubuntu-20.04
-            java: 1.8
+            java: 8
             cxx: g++
           - os: ubuntu-20.04
             java: 19
@@ -97,11 +97,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Install Java 1.8
+    - name: Install Java 8
       uses: actions/setup-java@v3
       with:
         distribution: temurin
-        java-version: 1.8
+        java-version: 8
     - name: "javadoc"
       run: |
         mkdir -p ~/.m2

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -53,8 +53,9 @@ jobs:
         restore-keys: |
           ${{ matrix.java }}-maven-
     - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: ${{ matrix.java }}
     - name: "Test"
       run: |
@@ -97,8 +98,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Install Java 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: 1.8
     - name: "javadoc"
       run: |

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -12,8 +12,9 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: 8
 
     - name: Publish snapshot


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `setup-java` from `v1` to `v3`. `v3` has two breaking changes.
1. JDK distribution field is required
2. `1.8` is not accepted. We need to use `8` instead.

### Why are the changes needed?

Currently, we are using `v1` which is too old and shows warnings like the following.
- https://github.com/apache/orc/actions/runs/3871285820/jobs/6598946894
```
Warning: The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The latest one is v3.9.0. We will use it.
- https://github.com/actions/setup-java/releases/tag/v3.9.0

Note that Node.js is upgraded since v3.0.
https://github.com/actions/setup-java/releases/tag/v3.0.0
> In scope of this release we changed version of the runtime Node.js for the setup-java action and updated package-lock.json file to v2.

### How was this patch tested?

Manually check the GitHub Action logs.