### PR TITLE
ORC-1351: Update PR Labeler definition

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,10 +20,11 @@
 INFRA:
   - ".github/**/*"
   - "appveyor.yml"
-  - ".travis.yml"
   - ".asf.yaml"
   - ".gitignore"
+  - "dev/**/*"
   - "docker/**/*"
+  - ".clang-format"
 BUILD:
   - "CMakeLists.txt"
   - "cmake_modules/**/*"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR is an accumulated change to make the PR labeler up-to-date.
- Remove `.travis.yml` (#991)
- Add `dev` folder (#1136)
- Add `.clang-format` (#1308)

### Why are the changes needed?

To make the PR labeler up-to-date.

### How was this patch tested?

Manual review.