### PR TITLE
ORC-1352: [C++] Remove `ORC_[NOEXCEPT|NULLPTR|OVERRIDE|UNIQUE_PTR]` macro usages

### DIFF
--- a/c++/include/orc/ColumnPrinter.hh
+++ b/c++/include/orc/ColumnPrinter.hh
@@ -44,6 +44,6 @@ namespace orc {
     virtual void reset(const ColumnVectorBatch& batch);
   };
 
-  ORC_UNIQUE_PTR<ColumnPrinter> createColumnPrinter(std::string&, const Type* type);
+  std::unique_ptr<ColumnPrinter> createColumnPrinter(std::string&, const Type* type);
 }  // namespace orc
 #endif

--- a/c++/include/orc/Common.hh
+++ b/c++/include/orc/Common.hh
@@ -204,7 +204,7 @@ namespace orc {
     /**
      * Get the StreamInformation for the given stream.
      */
-    virtual ORC_UNIQUE_PTR<StreamInformation> getStreamInformation(uint64_t streamId) const = 0;
+    virtual std::unique_ptr<StreamInformation> getStreamInformation(uint64_t streamId) const = 0;
 
     /**
      * Get the column encoding for the given column.

--- a/c++/include/orc/Exceptions.hh
+++ b/c++/include/orc/Exceptions.hh
@@ -30,7 +30,7 @@ namespace orc {
    public:
     explicit NotImplementedYet(const std::string& what_arg);
     explicit NotImplementedYet(const char* what_arg);
-    virtual ~NotImplementedYet() ORC_NOEXCEPT;
+    virtual ~NotImplementedYet() noexcept;
     NotImplementedYet(const NotImplementedYet&);
 
    private:
@@ -41,7 +41,7 @@ namespace orc {
    public:
     explicit ParseError(const std::string& what_arg);
     explicit ParseError(const char* what_arg);
-    virtual ~ParseError() ORC_NOEXCEPT;
+    virtual ~ParseError() noexcept;
     ParseError(const ParseError&);
 
    private:
@@ -52,7 +52,7 @@ namespace orc {
    public:
     explicit InvalidArgument(const std::string& what_arg);
     explicit InvalidArgument(const char* what_arg);
-    virtual ~InvalidArgument() ORC_NOEXCEPT;
+    virtual ~InvalidArgument() noexcept;
     InvalidArgument(const InvalidArgument&);
 
    private:

--- a/c++/include/orc/MemoryPool.hh
+++ b/c++/include/orc/MemoryPool.hh
@@ -52,7 +52,7 @@ namespace orc {
    public:
     DataBuffer(MemoryPool& pool, uint64_t _size = 0);
 
-    DataBuffer(DataBuffer<T>&& buffer) ORC_NOEXCEPT;
+    DataBuffer(DataBuffer<T>&& buffer) noexcept;
 
     virtual ~DataBuffer();
 

--- a/c++/include/orc/OrcFile.hh
+++ b/c++/include/orc/OrcFile.hh
@@ -105,36 +105,36 @@ namespace orc {
    * @param path the name of the file in the local file system or HDFS
    * @param metrics the metrics of the reader
    */
-  ORC_UNIQUE_PTR<InputStream> readFile(const std::string& path, ReaderMetrics* metrics = nullptr);
+  std::unique_ptr<InputStream> readFile(const std::string& path, ReaderMetrics* metrics = nullptr);
 
   /**
    * Create a stream to a local file.
    * @param path the name of the file in the local file system
    * @param metrics the metrics of the reader
    */
-  ORC_UNIQUE_PTR<InputStream> readLocalFile(const std::string& path,
-                                            ReaderMetrics* metrics = nullptr);
+  std::unique_ptr<InputStream> readLocalFile(const std::string& path,
+                                             ReaderMetrics* metrics = nullptr);
 
   /**
    * Create a stream to an HDFS file.
    * @param path the uri of the file in HDFS
    * @param metrics the metrics of the reader
    */
-  ORC_UNIQUE_PTR<InputStream> readHdfsFile(const std::string& path,
-                                           ReaderMetrics* metrics = nullptr);
+  std::unique_ptr<InputStream> readHdfsFile(const std::string& path,
+                                            ReaderMetrics* metrics = nullptr);
 
   /**
    * Create a reader to read the ORC file.
    * @param stream the stream to read
    * @param options the options for reading the file
    */
-  ORC_UNIQUE_PTR<Reader> createReader(ORC_UNIQUE_PTR<InputStream> stream,
-                                      const ReaderOptions& options);
+  std::unique_ptr<Reader> createReader(std::unique_ptr<InputStream> stream,
+                                       const ReaderOptions& options);
   /**
    * Create a stream to write to a local file.
    * @param path the name of the file in the local file system
    */
-  ORC_UNIQUE_PTR<OutputStream> writeLocalFile(const std::string& path);
+  std::unique_ptr<OutputStream> writeLocalFile(const std::string& path);
 
   /**
    * Create a writer to write the ORC file.
@@ -142,8 +142,8 @@ namespace orc {
    * @param stream the stream to write to
    * @param options the options for writing the file
    */
-  ORC_UNIQUE_PTR<Writer> createWriter(const Type& type, OutputStream* stream,
-                                      const WriterOptions& options);
+  std::unique_ptr<Writer> createWriter(const Type& type, OutputStream* stream,
+                                       const WriterOptions& options);
 }  // namespace orc
 
 #endif

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -67,7 +67,7 @@ namespace orc {
    */
   class ReaderOptions {
    private:
-    ORC_UNIQUE_PTR<ReaderOptionsPrivate> privateBits;
+    std::unique_ptr<ReaderOptionsPrivate> privateBits;
 
    public:
     ReaderOptions();
@@ -145,7 +145,7 @@ namespace orc {
    */
   class RowReaderOptions {
    private:
-    ORC_UNIQUE_PTR<RowReaderOptionsPrivate> privateBits;
+    std::unique_ptr<RowReaderOptionsPrivate> privateBits;
 
    public:
     RowReaderOptions();
@@ -435,7 +435,7 @@ namespace orc {
      * @param stripeIndex the index of the stripe (0 to N-1) to get information about
      * @return the information about that stripe
      */
-    virtual ORC_UNIQUE_PTR<StripeInformation> getStripe(uint64_t stripeIndex) const = 0;
+    virtual std::unique_ptr<StripeInformation> getStripe(uint64_t stripeIndex) const = 0;
 
     /**
      * Get the number of stripe statistics in the file.
@@ -448,7 +448,7 @@ namespace orc {
      * @param stripeIndex the index of the stripe (0 to N-1) to get statistics about
      * @return the statistics about that stripe
      */
-    virtual ORC_UNIQUE_PTR<StripeStatistics> getStripeStatistics(uint64_t stripeIndex) const = 0;
+    virtual std::unique_ptr<StripeStatistics> getStripeStatistics(uint64_t stripeIndex) const = 0;
 
     /**
      * Get the length of the data stripes in the file.
@@ -484,14 +484,14 @@ namespace orc {
      * Get the statistics about the columns in the file.
      * @return the information about the column
      */
-    virtual ORC_UNIQUE_PTR<Statistics> getStatistics() const = 0;
+    virtual std::unique_ptr<Statistics> getStatistics() const = 0;
 
     /**
      * Get the statistics about a single column in the file.
      * @param columnId id of the column
      * @return the information about the column
      */
-    virtual ORC_UNIQUE_PTR<ColumnStatistics> getColumnStatistics(uint32_t columnId) const = 0;
+    virtual std::unique_ptr<ColumnStatistics> getColumnStatistics(uint32_t columnId) const = 0;
 
     /**
      * Check if the file has correct column statistics.
@@ -523,14 +523,14 @@ namespace orc {
      * Create a RowReader based on this reader with the default options.
      * @return a RowReader to read the rows
      */
-    virtual ORC_UNIQUE_PTR<RowReader> createRowReader() const = 0;
+    virtual std::unique_ptr<RowReader> createRowReader() const = 0;
 
     /**
      * Create a RowReader based on this reader.
      * @param options RowReader Options
      * @return a RowReader to read the rows
      */
-    virtual ORC_UNIQUE_PTR<RowReader> createRowReader(const RowReaderOptions& options) const = 0;
+    virtual std::unique_ptr<RowReader> createRowReader(const RowReaderOptions& options) const = 0;
 
     /**
      * Get the name of the input stream.
@@ -614,7 +614,7 @@ namespace orc {
      * @param size the number of rows to read
      * @return a new ColumnVectorBatch to read into
      */
-    virtual ORC_UNIQUE_PTR<ColumnVectorBatch> createRowBatch(uint64_t size) const = 0;
+    virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size) const = 0;
 
     /**
      * Read the next row batch from the current position.

--- a/c++/include/orc/Type.hh
+++ b/c++/include/orc/Type.hh
@@ -69,10 +69,10 @@ namespace orc {
     /**
      * Create a row batch for this type.
      */
-    virtual ORC_UNIQUE_PTR<ColumnVectorBatch> createRowBatch(uint64_t size, MemoryPool& pool,
-                                                             bool encoded = false) const = 0;
+    virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size, MemoryPool& pool,
+                                                              bool encoded = false) const = 0;
 
-    virtual ORC_UNIQUE_PTR<ColumnVectorBatch> createRowBatch(
+    virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(
         uint64_t size, MemoryPool& pool, bool encoded = false,
         bool useTightNumericVector = false) const = 0;
 
@@ -82,33 +82,33 @@ namespace orc {
      * @param fieldType the type of the new field
      * @return a reference to the struct type
      */
-    virtual Type* addStructField(const std::string& fieldName, ORC_UNIQUE_PTR<Type> fieldType) = 0;
+    virtual Type* addStructField(const std::string& fieldName, std::unique_ptr<Type> fieldType) = 0;
 
     /**
      * Add a new child to a union type.
      * @param fieldType the type of the new field
      * @return a reference to the union type
      */
-    virtual Type* addUnionChild(ORC_UNIQUE_PTR<Type> fieldType) = 0;
+    virtual Type* addUnionChild(std::unique_ptr<Type> fieldType) = 0;
 
     /**
      * Build a Type object from string text representation.
      */
-    static ORC_UNIQUE_PTR<Type> buildTypeFromString(const std::string& input);
+    static std::unique_ptr<Type> buildTypeFromString(const std::string& input);
   };
 
   const int64_t DEFAULT_DECIMAL_SCALE = 18;
   const int64_t DEFAULT_DECIMAL_PRECISION = 38;
 
-  ORC_UNIQUE_PTR<Type> createPrimitiveType(TypeKind kind);
-  ORC_UNIQUE_PTR<Type> createCharType(TypeKind kind, uint64_t maxLength);
-  ORC_UNIQUE_PTR<Type> createDecimalType(uint64_t precision = DEFAULT_DECIMAL_PRECISION,
-                                         uint64_t scale = DEFAULT_DECIMAL_SCALE);
+  std::unique_ptr<Type> createPrimitiveType(TypeKind kind);
+  std::unique_ptr<Type> createCharType(TypeKind kind, uint64_t maxLength);
+  std::unique_ptr<Type> createDecimalType(uint64_t precision = DEFAULT_DECIMAL_PRECISION,
+                                          uint64_t scale = DEFAULT_DECIMAL_SCALE);
 
-  ORC_UNIQUE_PTR<Type> createStructType();
-  ORC_UNIQUE_PTR<Type> createListType(ORC_UNIQUE_PTR<Type> elements);
-  ORC_UNIQUE_PTR<Type> createMapType(ORC_UNIQUE_PTR<Type> key, ORC_UNIQUE_PTR<Type> value);
-  ORC_UNIQUE_PTR<Type> createUnionType();
+  std::unique_ptr<Type> createStructType();
+  std::unique_ptr<Type> createListType(std::unique_ptr<Type> elements);
+  std::unique_ptr<Type> createMapType(std::unique_ptr<Type> key, std::unique_ptr<Type> value);
+  std::unique_ptr<Type> createUnionType();
 
 }  // namespace orc
 #endif

--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -277,7 +277,7 @@ namespace orc {
     DataBuffer<int64_t> offsets;
 
     // the concatenated elements
-    ORC_UNIQUE_PTR<ColumnVectorBatch> elements;
+    std::unique_ptr<ColumnVectorBatch> elements;
   };
 
   struct MapVectorBatch : public ColumnVectorBatch {
@@ -296,9 +296,9 @@ namespace orc {
     DataBuffer<int64_t> offsets;
 
     // the concatenated keys
-    ORC_UNIQUE_PTR<ColumnVectorBatch> keys;
+    std::unique_ptr<ColumnVectorBatch> keys;
     // the concatenated elements
-    ORC_UNIQUE_PTR<ColumnVectorBatch> elements;
+    std::unique_ptr<ColumnVectorBatch> elements;
   };
 
   struct UnionVectorBatch : public ColumnVectorBatch {

--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -55,7 +55,7 @@ namespace orc {
    */
   class WriterOptions {
    private:
-    ORC_UNIQUE_PTR<WriterOptionsPrivate> privateBits;
+    std::unique_ptr<WriterOptionsPrivate> privateBits;
 
    public:
     WriterOptions();
@@ -273,7 +273,7 @@ namespace orc {
      * @param size the number of rows to write.
      * @return a new ColumnVectorBatch to write into.
      */
-    virtual ORC_UNIQUE_PTR<ColumnVectorBatch> createRowBatch(uint64_t size) const = 0;
+    virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size) const = 0;
 
     /**
      * Add a row batch into current writer.

--- a/c++/include/orc/orc-config.hh.in
+++ b/c++/include/orc/orc-config.hh.in
@@ -25,6 +25,7 @@
   #include <stdint.h>
 #endif
 
+// Following MACROS should be keeped for backward compatibility.
 #define ORC_NOEXCEPT noexcept
 #define ORC_NULLPTR nullptr
 #define ORC_OVERRIDE override

--- a/c++/src/Exceptions.cc
+++ b/c++/src/Exceptions.cc
@@ -32,7 +32,7 @@ namespace orc {
     // PASS
   }
 
-  NotImplementedYet::~NotImplementedYet() ORC_NOEXCEPT {
+  NotImplementedYet::~NotImplementedYet() noexcept {
     // PASS
   }
 
@@ -48,7 +48,7 @@ namespace orc {
     // PASS
   }
 
-  ParseError::~ParseError() ORC_NOEXCEPT {
+  ParseError::~ParseError() noexcept {
     // PASS
   }
 
@@ -64,7 +64,7 @@ namespace orc {
     // PASS
   }
 
-  InvalidArgument::~InvalidArgument() ORC_NOEXCEPT {
+  InvalidArgument::~InvalidArgument() noexcept {
     // PASS
   }
 }  // namespace orc

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -670,7 +670,7 @@ namespace orc {
       return *(itr->second).get();
     }
     try {
-      ORC_UNIQUE_PTR<InputStream> file = readFile(filename);
+      std::unique_ptr<InputStream> file = readFile(filename);
       size_t size = static_cast<size_t>(file->getLength());
       std::vector<unsigned char> buffer(size);
       file->read(&buffer[0], size, 0);
@@ -887,7 +887,7 @@ namespace orc {
     // PASS
   }
 
-  TimezoneError::~TimezoneError() ORC_NOEXCEPT {
+  TimezoneError::~TimezoneError() noexcept {
     // PASS
   }
 

--- a/c++/src/Timezone.hh
+++ b/c++/src/Timezone.hh
@@ -109,7 +109,7 @@ namespace orc {
    public:
     TimezoneError(const std::string& what);
     TimezoneError(const TimezoneError&);
-    virtual ~TimezoneError() ORC_NOEXCEPT;
+    virtual ~TimezoneError() noexcept;
   };
 
   /**

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -565,9 +565,9 @@ namespace orc {
     return std::move(result);
   }
 
-  ORC_UNIQUE_PTR<Type> Type::buildTypeFromString(const std::string& input) {
+  std::unique_ptr<Type> Type::buildTypeFromString(const std::string& input) {
     size_t size = input.size();
-    std::pair<ORC_UNIQUE_PTR<Type>, size_t> res = TypeImpl::parseType(input, 0, size);
+    std::pair<std::unique_ptr<Type>, size_t> res = TypeImpl::parseType(input, 0, size);
     if (res.second != size) {
       throw std::logic_error("Invalid type string.");
     }
@@ -580,7 +580,7 @@ namespace orc {
     if (input[start] != '<') {
       throw std::logic_error("Missing < after array.");
     }
-    std::pair<ORC_UNIQUE_PTR<Type>, size_t> res = TypeImpl::parseType(input, start + 1, end);
+    std::pair<std::unique_ptr<Type>, size_t> res = TypeImpl::parseType(input, start + 1, end);
     if (res.second != end) {
       throw std::logic_error("Array type must contain exactly one sub type.");
     }
@@ -593,11 +593,11 @@ namespace orc {
     if (input[start] != '<') {
       throw std::logic_error("Missing < after map.");
     }
-    std::pair<ORC_UNIQUE_PTR<Type>, size_t> key = TypeImpl::parseType(input, start + 1, end);
+    std::pair<std::unique_ptr<Type>, size_t> key = TypeImpl::parseType(input, start + 1, end);
     if (input[key.second] != ',') {
       throw std::logic_error("Missing comma after key.");
     }
-    std::pair<ORC_UNIQUE_PTR<Type>, size_t> val = TypeImpl::parseType(input, key.second + 1, end);
+    std::pair<std::unique_ptr<Type>, size_t> val = TypeImpl::parseType(input, key.second + 1, end);
     if (val.second != end) {
       throw std::logic_error("Map type must contain exactly two sub types.");
     }
@@ -657,7 +657,7 @@ namespace orc {
       if (input[pos] != ':') {
         throw std::logic_error("Invalid struct type. No field name set.");
       }
-      std::pair<ORC_UNIQUE_PTR<Type>, size_t> typeRes = TypeImpl::parseType(input, ++pos, end);
+      std::pair<std::unique_ptr<Type>, size_t> typeRes = TypeImpl::parseType(input, ++pos, end);
       result->addStructField(nameRes.first, std::move(typeRes.first));
       pos = typeRes.second;
       if (pos != end && input[pos] != ',') {
@@ -677,7 +677,7 @@ namespace orc {
       throw std::logic_error("Missing < after uniontype.");
     }
     while (pos < end) {
-      std::pair<ORC_UNIQUE_PTR<Type>, size_t> res = TypeImpl::parseType(input, pos, end);
+      std::pair<std::unique_ptr<Type>, size_t> res = TypeImpl::parseType(input, pos, end);
       result->addChildType(std::move(res.first));
       pos = res.second;
       if (pos != end && input[pos] != ',') {
@@ -779,8 +779,8 @@ namespace orc {
     }
   }
 
-  std::pair<ORC_UNIQUE_PTR<Type>, size_t> TypeImpl::parseType(const std::string& input,
-                                                              size_t start, size_t end) {
+  std::pair<std::unique_ptr<Type>, size_t> TypeImpl::parseType(const std::string& input,
+                                                               size_t start, size_t end) {
     size_t pos = start;
     while (pos < end && (isalpha(input[pos]) || input[pos] == ' ')) {
       ++pos;

--- a/c++/src/TypeImpl.hh
+++ b/c++/src/TypeImpl.hh
@@ -108,8 +108,8 @@ namespace orc {
      */
     void addChildType(std::unique_ptr<Type> childType);
 
-    static std::pair<ORC_UNIQUE_PTR<Type>, size_t> parseType(const std::string& input, size_t start,
-                                                             size_t end);
+    static std::pair<std::unique_ptr<Type>, size_t> parseType(const std::string& input,
+                                                              size_t start, size_t end);
 
    private:
     /**

--- a/c++/test/TestType.cc
+++ b/c++/test/TestType.cc
@@ -276,7 +276,7 @@ namespace orc {
 
   void expectLogicErrorDuringParse(std::string typeStr, const char* errMsg) {
     try {
-      ORC_UNIQUE_PTR<Type> type = Type::buildTypeFromString(typeStr);
+      std::unique_ptr<Type> type = Type::buildTypeFromString(typeStr);
       FAIL() << "'" << typeStr << "'"
              << " should throw std::logic_error for invalid schema";
     } catch (std::logic_error& e) {
@@ -288,7 +288,7 @@ namespace orc {
 
   TEST(TestType, buildTypeFromString) {
     std::string typeStr = "struct<a:int,b:string,c:decimal(10,2),d:varchar(5)>";
-    ORC_UNIQUE_PTR<Type> type = Type::buildTypeFromString(typeStr);
+    std::unique_ptr<Type> type = Type::buildTypeFromString(typeStr);
     EXPECT_EQ(typeStr, type->toString());
 
     typeStr = "map<boolean,float>";
@@ -330,7 +330,7 @@ namespace orc {
   }
 
   TEST(TestType, quotedFieldNames) {
-    ORC_UNIQUE_PTR<Type> type = createStructType();
+    std::unique_ptr<Type> type = createStructType();
     type->addStructField("foo bar", createPrimitiveType(INT));
     type->addStructField("`some`thing`", createPrimitiveType(INT));
     type->addStructField("1234567890_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -94,7 +94,7 @@ namespace orc {
   TEST_P(WriterTest, writeEmptyFile) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
-    ORC_UNIQUE_PTR<Type> type(Type::buildTypeFromString("struct<col1:int>"));
+    std::unique_ptr<Type> type(Type::buildTypeFromString("struct<col1:int>"));
 
     uint64_t stripeSize = 16 * 1024;       // 16K
     uint64_t compressionBlockSize = 1024;  // 1k
@@ -122,7 +122,7 @@ namespace orc {
   TEST_P(WriterTest, writeIntFileOneStripe) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
-    ORC_UNIQUE_PTR<Type> type(Type::buildTypeFromString("struct<col1:int>"));
+    std::unique_ptr<Type> type(Type::buildTypeFromString("struct<col1:int>"));
 
     uint64_t stripeSize = 16 * 1024;       // 16K
     uint64_t compressionBlockSize = 1024;  // 1k
@@ -182,7 +182,7 @@ namespace orc {
   TEST_P(WriterTest, writeIntFileMultipleStripes) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
-    ORC_UNIQUE_PTR<Type> type(Type::buildTypeFromString("struct<col1:int>"));
+    std::unique_ptr<Type> type(Type::buildTypeFromString("struct<col1:int>"));
 
     uint64_t stripeSize = 1024;            // 1K
     uint64_t compressionBlockSize = 1024;  // 1k

--- a/site/_docs/core-cpp.md
+++ b/site/_docs/core-cpp.md
@@ -147,7 +147,7 @@ the data as a buffer of integers for the offsets and a
 ~~~ cpp
   struct ListVectorBatch: public ColumnVectorBatch {
     DataBuffer<int64_t> offsets;
-    ORC_UNIQUE_PTR<ColumnVectorBatch> elements;
+    std::unique_ptr<ColumnVectorBatch> elements;
     ...
   };
 ~~~
@@ -159,8 +159,8 @@ for the keys and values.
 ~~~ cpp
   struct MapVectorBatch: public ColumnVectorBatch {
     DataBuffer<int64_t> offsets;
-    ORC_UNIQUE_PTR<ColumnVectorBatch> keys;
-    ORC_UNIQUE_PTR<ColumnVectorBatch> elements;
+    std::unique_ptr<ColumnVectorBatch> keys;
+    std::unique_ptr<ColumnVectorBatch> elements;
     ...
   };
 ~~~
@@ -174,12 +174,12 @@ sets the required schema parameter, but there are many other
 options to control the ORC writer.
 
 ~~~ cpp
-ORC_UNIQUE_PTR<OutputStream> outStream =
+std::unique_ptr<OutputStream> outStream =
   writeLocalFile("my-file.orc");
-ORC_UNIQUE_PTR<Type> schema(
+std::unique_ptr<Type> schema(
   Type::buildTypeFromString("struct<x:int,y:int>"));
 WriterOptions options;
-ORC_UNIQUE_PTR<Writer> writer =
+std::unique_ptr<Writer> writer =
   createWriter(*schema, outStream.get(), options);
 ~~~
 
@@ -188,7 +188,7 @@ as the batch fills up. When the file is done, close the `Writer`.
 
 ~~~ cpp
 uint64_t batchSize = 1024, rowCount = 10000;
-ORC_UNIQUE_PTR<ColumnVectorBatch> batch =
+std::unique_ptr<ColumnVectorBatch> batch =
   writer->createRowBatch(batchSize);
 StructVectorBatch *root =
   dynamic_cast<StructVectorBatch *>(batch.get());
@@ -234,10 +234,10 @@ required. The reader has methods for getting the number of rows,
 schema, compression, etc. from the file.
 
 ~~~ cpp
-ORC_UNIQUE_PTR<InputStream> inStream =
+std::unique_ptr<InputStream> inStream =
   readLocalFile("my-file.orc");
 ReaderOptions options;
-ORC_UNIQUE_PTR<Reader> reader =
+std::unique_ptr<Reader> reader =
   createReader(inStream, options);
 ~~~
 
@@ -247,9 +247,9 @@ options to control the data that is read.
 
 ~~~ cpp
 RowReaderOptions rowReaderOptions;
-ORC_UNIQUE_PTR<RowReader> rowReader =
+std::unique_ptr<RowReader> rowReader =
   reader->createRowReader(rowReaderOptions);
-ORC_UNIQUE_PTR<ColumnVectorBatch> batch =
+std::unique_ptr<ColumnVectorBatch> batch =
   rowReader->createRowBatch(1024);
 ~~~
 

--- a/tools/src/FileMemory.cc
+++ b/tools/src/FileMemory.cc
@@ -30,7 +30,7 @@ class TestMemoryPool : public orc::MemoryPool {
   uint64_t maxMemory;
 
  public:
-  char* malloc(uint64_t size) ORC_OVERRIDE {
+  char* malloc(uint64_t size) override {
     char* p = static_cast<char*>(std::malloc(size));
     blocks[p] = size;
     totalMemory += size;
@@ -40,7 +40,7 @@ class TestMemoryPool : public orc::MemoryPool {
     return p;
   }
 
-  void free(char* p) ORC_OVERRIDE {
+  void free(char* p) override {
     std::free(p);
     totalMemory -= blocks[p];
     blocks.erase(p);
@@ -51,7 +51,7 @@ class TestMemoryPool : public orc::MemoryPool {
   }
 
   TestMemoryPool() : totalMemory(0), maxMemory(0) {}
-  ~TestMemoryPool() ORC_OVERRIDE;
+  ~TestMemoryPool() override;
 };
 
 TestMemoryPool::~TestMemoryPool() {}

--- a/tools/src/FileMetadata.cc
+++ b/tools/src/FileMetadata.cc
@@ -26,7 +26,7 @@
 #include "orc/Exceptions.hh"
 #include "orc/OrcFile.hh"
 
-//#include "Adaptor.hh"
+// #include "Adaptor.hh"
 #include "wrap/orc-proto-wrapper.hh"
 
 void printStripeInformation(std::ostream& out, uint64_t index, uint64_t columns,
@@ -57,7 +57,7 @@ void printStripeInformation(std::ostream& out, uint64_t index, uint64_t columns,
       if (str != 0) {
         out << ",\n";
       }
-      ORC_UNIQUE_PTR<orc::StreamInformation> stream = stripe->getStreamInformation(str);
+      std::unique_ptr<orc::StreamInformation> stream = stripe->getStreamInformation(str);
       out << "        { \"id\": " << str << ", \"column\": " << stream->getColumnId()
           << ", \"kind\": \"" << streamKindToString(stream->getKind())
           << "\", \"offset\": " << stream->getOffset() << ", \"length\": " << stream->getLength()
@@ -179,16 +179,16 @@ void printMetadata(std::ostream& out, const char* filename, bool verbose) {
 }
 
 int main(int argc, char* argv[]) {
-  static struct option longOptions[] = {{"help", no_argument, ORC_NULLPTR, 'h'},
-                                        {"raw", no_argument, ORC_NULLPTR, 'r'},
-                                        {"verbose", no_argument, ORC_NULLPTR, 'v'},
-                                        {ORC_NULLPTR, 0, ORC_NULLPTR, 0}};
+  static struct option longOptions[] = {{"help", no_argument, nullptr, 'h'},
+                                        {"raw", no_argument, nullptr, 'r'},
+                                        {"verbose", no_argument, nullptr, 'v'},
+                                        {nullptr, 0, nullptr, 0}};
   bool helpFlag = false;
   bool verboseFlag = false;
   bool rawFlag = false;
   int opt;
   do {
-    opt = getopt_long(argc, argv, "hrv", longOptions, ORC_NULLPTR);
+    opt = getopt_long(argc, argv, "hrv", longOptions, nullptr);
     switch (opt) {
       case '?':
       case 'h':

--- a/tools/src/FileStatistics.cc
+++ b/tools/src/FileStatistics.cc
@@ -63,15 +63,15 @@ void printStatistics(const char* filename, bool withIndex) {
 }
 
 int main(int argc, char* argv[]) {
-  static struct option longOptions[] = {{"help", no_argument, ORC_NULLPTR, 'h'},
-                                        {"withIndex", no_argument, ORC_NULLPTR, 'i'},
-                                        {ORC_NULLPTR, 0, ORC_NULLPTR, 0}};
-  const char* filename = ORC_NULLPTR;
+  static struct option longOptions[] = {{"help", no_argument, nullptr, 'h'},
+                                        {"withIndex", no_argument, nullptr, 'i'},
+                                        {nullptr, 0, nullptr, 0}};
+  const char* filename = nullptr;
   bool withIndex = false;
   bool helpFlag = false;
   int opt;
   do {
-    opt = getopt_long(argc, argv, "hi", longOptions, ORC_NULLPTR);
+    opt = getopt_long(argc, argv, "hi", longOptions, nullptr);
     switch (opt) {
       case '?':
       case 'h':

--- a/tools/src/ToolsHelper.cc
+++ b/tools/src/ToolsHelper.cc
@@ -32,19 +32,19 @@ void printOptions(std::ostream& out) {
 
 bool parseOptions(int* argc, char** argv[], uint64_t* batchSize,
                   orc::RowReaderOptions* rowReaderOpts, bool* showMetrics) {
-  static struct option longOptions[] = {{"help", no_argument, ORC_NULLPTR, 'h'},
-                                        {"batch", required_argument, ORC_NULLPTR, 'b'},
-                                        {"columns", required_argument, ORC_NULLPTR, 'c'},
-                                        {"columnTypeIds", required_argument, ORC_NULLPTR, 't'},
-                                        {"columnNames", required_argument, ORC_NULLPTR, 'n'},
-                                        {"metrics", no_argument, ORC_NULLPTR, 'm'},
-                                        {ORC_NULLPTR, 0, ORC_NULLPTR, 0}};
+  static struct option longOptions[] = {{"help", no_argument, nullptr, 'h'},
+                                        {"batch", required_argument, nullptr, 'b'},
+                                        {"columns", required_argument, nullptr, 'c'},
+                                        {"columnTypeIds", required_argument, nullptr, 't'},
+                                        {"columnNames", required_argument, nullptr, 'n'},
+                                        {"metrics", no_argument, nullptr, 'm'},
+                                        {nullptr, 0, nullptr, 0}};
   std::list<uint64_t> cols;
   std::list<std::string> colNames;
   int opt;
   char* tail;
   do {
-    opt = getopt_long(*argc, *argv, "hb:c:t:n:m", longOptions, ORC_NULLPTR);
+    opt = getopt_long(*argc, *argv, "hb:c:t:n:m", longOptions, nullptr);
     switch (opt) {
       case '?':
       case 'h':
@@ -68,7 +68,7 @@ bool parseOptions(int* argc, char** argv[], uint64_t* batchSize,
             cols.emplace_back(static_cast<uint64_t>(std::atoi(col)));
           }
           empty = false;
-          col = std::strtok(ORC_NULLPTR, ",");
+          col = std::strtok(nullptr, ",");
         }
         if (!empty) {
           if (opt == 'c') {


### PR DESCRIPTION
### What changes were proposed in this pull request?

the following macros could be removed from the main source code to make the code neat.

```
#define ORC_NOEXCEPT noexcept
#define ORC_NULLPTR nullptr
#define ORC_OVERRIDE override
#define ORC_UNIQUE_PTR std::unique_ptr
```

These macros should only be keeped in the `orc-config.hh.in` for backward compatiblity(in case any user use these marcros).


### Why are the changes needed?

to make the code more readable.

### How was this patch tested?

It doesn't introduce new features and passed all test cases.

