### PR TITLE
ORC-1354: [C++] remove whitespace before the scope resolution operator

### DIFF
--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -179,7 +179,7 @@ namespace orc {
   }
 
   bool WriterOptions::getAlignedBitpacking() const {
-    return privateBits->compressionStrategy == CompressionStrategy ::CompressionStrategy_SPEED;
+    return privateBits->compressionStrategy == CompressionStrategy::CompressionStrategy_SPEED;
   }
 
   WriterOptions& WriterOptions::setPaddingTolerance(double tolerance) {


### PR DESCRIPTION

### What changes were proposed in this pull request?

remove whitespace before the scope resolution operator

### Why are the changes needed?

though spaces are allowed before/after the scope resolution operator, but this

is bad for the following case:

`CompressionStrategy ::CompressionStrategy_SPEED`


### How was this patch tested?

It doesn't introduce new features and passed all test cases.
