### PR TITLE
ORC-1343: Disable ENABLE_INDEXES

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -188,7 +188,8 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
       this.rowIndexStride = 0;
     }
 
-    this.buildIndex = opts.isBuildIndex() && (rowIndexStride > 0);
+    // ORC-1343: We ignore `opts.isBuildIndex` due to the lack of reader support
+    this.buildIndex = rowIndexStride > 0;
     if (buildIndex && rowIndexStride < MIN_ROW_INDEX_STRIDE) {
       throw new IllegalArgumentException("Row stride must be at least " +
           MIN_ROW_INDEX_STRIDE);

--- a/java/core/src/test/org/apache/orc/impl/TestWriterImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestWriterImpl.java
@@ -32,6 +32,7 @@ import org.apache.orc.Writer;
 import org.apache.orc.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -93,6 +94,7 @@ public class TestWriterImpl {
     w.close();
   }
 
+  @Disabled("ORC-1343: Disable ENABLE_INDEXES tests until reader supports it properly")
   @Test
   public void testNoIndexIfEnableIndexIsFalse() throws Exception {
     conf.set(OrcConf.OVERWRITE_OUTPUT_FILE.getAttribute(), "true");


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a partial revert of ORC-1283.

### Why are the changes needed?

ORC reader assumes built-in indexes always so far.

### How was this patch tested?

N/A