### PR TITLE
ORC-1355: [C++] Use const references in `addUserMetadata|printAttributes|stripPrefix`

### DIFF
--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -289,7 +289,7 @@ namespace orc {
     /**
      * Add user metadata to the writer.
      */
-    virtual void addUserMetadata(const std::string name, const std::string value) = 0;
+    virtual void addUserMetadata(const std::string& name, const std::string& value) = 0;
   };
 }  // namespace orc
 

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -306,7 +306,7 @@ namespace orc {
 
     void close() override;
 
-    void addUserMetadata(const std::string name, const std::string value) override;
+    void addUserMetadata(const std::string& name, const std::string& value) override;
 
    private:
     void init();
@@ -389,7 +389,7 @@ namespace orc {
     outStream->close();
   }
 
-  void WriterImpl::addUserMetadata(const std::string name, const std::string value) {
+  void WriterImpl::addUserMetadata(const std::string& name, const std::string& value) {
     proto::UserMetadataItem* userMetadataItem = fileFooter.add_metadata();
     userMetadataItem->set_name(name);
     userMetadataItem->set_value(value);

--- a/tools/src/FileMetadata.cc
+++ b/tools/src/FileMetadata.cc
@@ -85,7 +85,7 @@ void printRawTail(std::ostream& out, const char* filename) {
   out << tail.DebugString();
 }
 
-void printAttributes(std::ostream& out, const orc::Type& type, const std::string name,
+void printAttributes(std::ostream& out, const orc::Type& type, const std::string& name,
                      bool* hasAnyAttributes) {
   const auto& attributeKeys = type.getAttributeKeys();
   bool typeHasAttrs = !attributeKeys.empty();

--- a/tools/test/TestFileScan.cc
+++ b/tools/test/TestFileScan.cc
@@ -72,7 +72,7 @@ TEST(TestFileScan, testNominal) {
  * stripPrefix("abcdef", "cd") -> "cdef"
  * stripPrefix("abcdef", "xx") -> "abcdef"
  */
-std::string stripPrefix(const std::string& input, const std::string goal) {
+std::string stripPrefix(const std::string& input, const std::string& goal) {
   size_t loc = input.find(goal);
   if (loc == std::string::npos) {
     return input;


### PR DESCRIPTION

### What changes were proposed in this pull request?

change `void addUserMetadata(const std::string name, const std::string value) override;`
    to `void addUserMetadata(const std::string& name, const std::string& value) override;`
to reduce copy construct.


### Why are the changes needed?

performance improvement.


### How was this patch tested?

This patch introduces no new features and all the exist test cases passed.
