### PR TITLE
ORC-1360: Pin `mockito` to 4.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,6 @@ updates:
       # Pin annotations to 17.0.0
       - dependency-name: "org.jetbrains.annotations"
         versions: "[17.0.1,)"
+      # Pin mockito to 4.x
+      - dependency-name: "org.mockito"
+        versions: "[5.0.0,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `Mockito` to 4.x.

### Why are the changes needed?

5.x is a major version change which is incompatible. We can revisit this later.

### How was this patch tested?

Closes #1381