### PR TITLE
ORC-1364: Pin `spotless` to 2.30.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,6 @@ updates:
       # Pin mockito to 4.x
       - dependency-name: "org.mockito"
         versions: "[5.0.0,)"
+      # Pin spotless to 2.30.0 due to Java 8 support
+      - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
+        versions: "[2.31.0,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR pins `spotless` to 2.30.0.

### Why are the changes needed?

`spotless` dropped Java 8 support at 2.31.0.
- https://github.com/diffplug/spotless/pull/1514
- #1392

### How was this patch tested?
Manual review.