### PR TITLE
ORC-1371: Remove unsupported SLF4J bindings from classpath

### DIFF
--- a/java/mapreduce/pom.xml
+++ b/java/mapreduce/pom.xml
@@ -69,7 +69,6 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
-      <version>${min.hadoop.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -227,6 +227,10 @@
             <groupId>tomcat</groupId>
             <artifactId>jasper-runtime</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -315,6 +319,22 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
+        <version>${min.hadoop.version}</version>
+        <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -341,6 +361,10 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport-native-epoll</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
* Exclude `slf4j-log4j12` from Hadoop dependencies
* Exclude `logback-classic` from Zookeeper

### Why are the changes needed?
Running `./mvnw clean install` shows a lot of warnings of the following form:
```
SLF4J: Class path contains SLF4J bindings targeting slf4j-api versions 1.7.x or earlier.
SLF4J: Ignoring binding found at [jar:file:/home/stamatis/.m2/repository/org/slf4j/slf4j-log4j12/1.7.10/slf4j-log4j12-1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Ignoring binding found at [jar:file:/home/stamatis/.m2/repository/ch/qos/logback/logback-classic/1.2.10/logback-classic-1.2.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: See https://www.slf4j.org/codes.html#ignoredBindings for an explanation.
```

The problem is that slf4j-log4j12-1.7.10.jar and logback-classic-1.2.10.jar are in the classpath but are incompatible with the current version of slf4j-api that ORC uses.

### How was this patch tested?
`./mvnw clean install 2>&1 | grep "Class path contains SLF4J bindings" | wc -l`

Before: 74
After: 0
