### PR TITLE
ORC-1372: [C++] Bump zstd to v1.5.4

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -15,7 +15,7 @@ set(SNAPPY_VERSION "1.1.7")
 set(ZLIB_VERSION "1.2.11")
 set(GTEST_VERSION "1.12.1")
 set(PROTOBUF_VERSION "3.5.1")
-set(ZSTD_VERSION "1.5.2")
+set(ZSTD_VERSION "1.5.4")
 
 option(ORC_PREFER_STATIC_PROTOBUF "Prefer static protobuf library, if available" ON)
 option(ORC_PREFER_STATIC_SNAPPY   "Prefer static snappy library, if available"   ON)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade zstd to v1.5.4 for the C++ library.

### Why are the changes needed?

The most recent release of zstd is v1.5.4: https://github.com/facebook/zstd/releases/tag/v1.5.4.

It brings promising performance boost.

### How was this patch tested?

Make sure all tests pass.
