### PR TITLE
ORC-1373: Provide directional exceptions instead of NPE in case of `DynamicByteArray` length overflow

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -53,8 +53,16 @@ public final class DynamicByteArray {
 
   /**
    * Ensure that the given index is valid.
+   * Throws an exception if chunkIndex is negative.
    */
   private void grow(int chunkIndex) {
+    if (chunkIndex < 0) {
+      throw new RuntimeException(String.format("chunkIndex overflow:%d. " +
+        "You can set %s=columnName, or %s=0 to turn off dictionary encoding.",
+        chunkIndex,
+        OrcConf.DIRECT_ENCODING_COLUMNS.getAttribute(),
+        OrcConf.DICTIONARY_KEY_SIZE_THRESHOLD.getAttribute()));
+    }
     if (chunkIndex >= initializedChunks) {
       if (chunkIndex >= data.length) {
         int newSize = Math.max(chunkIndex + 1, 2 * data.length);
@@ -64,12 +72,6 @@ public final class DynamicByteArray {
         data[i] = new byte[chunkSize];
       }
       initializedChunks = chunkIndex + 1;
-    } else if (chunkIndex < 0) {
-      throw new RuntimeException(String.format("chunkIndex overflow:%d. " +
-        "You can set %s=columnName, or %s=0 to turn off dictionary encoding.",
-        chunkIndex,
-        OrcConf.DIRECT_ENCODING_COLUMNS.getAttribute(),
-        OrcConf.DICTIONARY_KEY_SIZE_THRESHOLD.getAttribute()));
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -18,6 +18,9 @@
 package org.apache.orc.impl;
 
 import org.apache.hadoop.io.Text;
+import org.apache.orc.OrcConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +33,9 @@ import java.util.Arrays;
  * chunks that are allocated when needed.
  */
 public final class DynamicByteArray {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DynamicByteArray.class);
+
   static final int DEFAULT_CHUNKSIZE = 32 * 1024;
   static final int DEFAULT_NUM_CHUNKS = 128;
 
@@ -59,10 +65,16 @@ public final class DynamicByteArray {
         int newSize = Math.max(chunkIndex + 1, 2 * data.length);
         data = Arrays.copyOf(data, newSize);
       }
-      for(int i=initializedChunks; i <= chunkIndex; ++i) {
+      for (int i = initializedChunks; i <= chunkIndex; ++i) {
         data[i] = new byte[chunkSize];
       }
       initializedChunks = chunkIndex + 1;
+    } else if (chunkIndex < 0) {
+      LOG.error("chunkIndex overflow:{}. You can adjust the relevant configuration: {},{}.",
+          chunkIndex,
+          OrcConf.DIRECT_ENCODING_COLUMNS.getAttribute(),
+          OrcConf.DICTIONARY_KEY_SIZE_THRESHOLD.getAttribute()
+      );
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -70,11 +70,11 @@ public final class DynamicByteArray {
       }
       initializedChunks = chunkIndex + 1;
     } else if (chunkIndex < 0) {
-      LOG.error("chunkIndex overflow:{}. You can adjust the relevant configuration: {},{}.",
-          chunkIndex,
-          OrcConf.DIRECT_ENCODING_COLUMNS.getAttribute(),
-          OrcConf.DICTIONARY_KEY_SIZE_THRESHOLD.getAttribute()
-      );
+      throw new RuntimeException(String.format("chunkIndex overflow:%d. " +
+        "You can set %s=columnName, or %s=0 to turn off dictionary encoding.",
+        chunkIndex,
+        OrcConf.DIRECT_ENCODING_COLUMNS.getAttribute(),
+        OrcConf.DICTIONARY_KEY_SIZE_THRESHOLD.getAttribute()));
     }
   }
 

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
  * chunks that are allocated when needed.
  */
 public final class DynamicByteArray {
-
   static final int DEFAULT_CHUNKSIZE = 32 * 1024;
   static final int DEFAULT_NUM_CHUNKS = 128;
 

--- a/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicByteArray.java
@@ -19,8 +19,6 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.io.Text;
 import org.apache.orc.OrcConf;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,8 +31,6 @@ import java.util.Arrays;
  * chunks that are allocated when needed.
  */
 public final class DynamicByteArray {
-
-  private static final Logger LOG = LoggerFactory.getLogger(DynamicByteArray.class);
 
   static final int DEFAULT_CHUNKSIZE = 32 * 1024;
   static final int DEFAULT_NUM_CHUNKS = 128;

--- a/java/core/src/test/org/apache/orc/impl/TestDynamicArray.java
+++ b/java/core/src/test/org/apache/orc/impl/TestDynamicArray.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TestDynamicArray {
 
@@ -90,5 +91,26 @@ public class TestDynamicArray {
   public void testEmptyIntArrayToString() {
     DynamicIntArray dia = new DynamicIntArray();
     assertEquals("{}", dia.toString());
+  }
+
+  @Test
+  public void testByteArrayOverflow() {
+    DynamicByteArray dba = new DynamicByteArray();
+
+    byte[] val = new byte[1024];
+    dba.add(val, 0, val.length);
+
+    byte[] bigVal = new byte[2048];
+    RuntimeException exception = assertThrows(
+      RuntimeException.class,
+      // Need to construct a large array, limited by the heap limit of UT, may cause OOM.
+      // The add method does not check whether byte[] and length are consistent,
+      // so it is a bit hacky.
+      () -> dba.add(bigVal, 0, Integer.MAX_VALUE - 16));
+
+    assertEquals("chunkIndex overflow:-65535. " +
+      "You can set orc.column.encoding.direct=columnName, " +
+      "or orc.dictionary.key.threshold=0 to turn off dictionary encoding.",
+      exception.getMessage());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

When `DynamicByteArray` calculates `chunkIndex` overflow, it will throw NPE.
We can throw exception to remind users to avoid this problem by configuring what ORC parameters.

### Why are the changes needed?

When the written string is very large, the grow calculation may overflow, causing the array data not to be expanded, and then NPE.

org.apache.orc.impl.DynamicByteArray#add(byte[], int, int)
```java
grow((length + valueLength) / chunkSize);
```

#### Log

```java
Caused by: java.lang.NullPointerException
	at java.lang.System.arraycopy(Native Method)
	at org.apache.orc.impl.DynamicByteArray.add(DynamicByteArray.java:115)
	at org.apache.orc.impl.StringRedBlackTree.addNewKey(StringRedBlackTree.java:48)
	at org.apache.orc.impl.StringRedBlackTree.add(StringRedBlackTree.java:60)
	at org.apache.orc.impl.writer.StringTreeWriter.writeBatch(StringTreeWriter.java:69)
	at org.apache.orc.impl.writer.StructTreeWriter.writeRootBatch(StructTreeWriter.java:56)
	at org.apache.orc.impl.WriterImpl.addRowBatch(WriterImpl.java:696)
```

### How was this patch tested?

#### Local Test
org.apache.orc.impl.TestDynamicArray#testBigByteArray
```java
 @Test
  public void testBigByteArray() {
    DynamicByteArray dba = new DynamicByteArray(128, 32 * 1024);

    byte[] val = new byte[1024];
    dba.add(val, 0, val.length);

    byte[] bigVal = new byte[Integer.MAX_VALUE - 16];
    dba.add(bigVal, 0, bigVal.length);
  }
```

#### Output

```java
java.lang.RuntimeException: chunkIndex overflow:-65535. You can set orc.column.encoding.direct=columnName, or orc.dictionary.key.threshold=0 to turn off dictionary encoding.
	at org.apache.orc.impl.DynamicByteArray.grow(DynamicByteArray.java:73)
	at org.apache.orc.impl.DynamicByteArray.add(DynamicByteArray.java:122)
	at org.apache.orc.impl.TestDynamicArray.testBigByteArray(TestDynamicArray.java:36)
```



