### PR TITLE
Improve Specification documents

### DIFF
--- a/site/specification/ORCv0.md
+++ b/site/specification/ORCv0.md
@@ -623,8 +623,8 @@ DIRECT        | PRESENT         | Yes      | Boolean RLE
               | LENGTH          | No       | Unsigned Integer RLE v1
 DICTIONARY    | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unsigned Integer RLE v1
-              | DICTIONARY_DATA | No       | String contents
-              | LENGTH          | No       | Unsigned Integer RLE v1
+              | LENGTH          | Yes      | Unsigned Integer RLE v1
+              | DICTIONARY_DATA | Yes      | String contents
 
 ## Boolean Columns
 
@@ -689,11 +689,16 @@ records non-null values, a DATA stream that records the number of
 seconds after 1 January 2015, and a SECONDARY stream that records the
 number of nanoseconds.
 
-Because the number of nanoseconds often has a large number of trailing
-zeros, the number has trailing decimal zero digits removed and the
-last three bits are used to record how many zeros were removed. if the
-trailing zeros are more than 2. Thus 1000 nanoseconds would be
-serialized as 0x0a and 100000 would be serialized as 0x0c.
+Because the number of nanoseconds often has a large number of
+trailing zeros, further encoding is employed before unsigned integer
+run length encoding.  When the number of trailing zero digits is 2
+or more, these trailing zero digits are removed and the last three
+bits are used to record how many zeros were removed, relative to 1.
+If there are fewer than 2 trailing zero digits, the last three
+bits are 0, and the raw nanoseconds are bit shifted by 3.  Thus
+1000 nanoseconds would be serialized as 0x0a; 100000 would be
+serialized as 0x0c; and 21 nanoseconds would be serialized as 0xA8.
+
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -1052,15 +1052,15 @@ DIRECT        | PRESENT         | Yes      | Boolean RLE
               | LENGTH          | No       | Unsigned Integer RLE v1
 DICTIONARY    | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unsigned Integer RLE v1
-              | DICTIONARY_DATA | No       | String contents
-              | LENGTH          | No       | Unsigned Integer RLE v1
+              | LENGTH          | Yes      | Unsigned Integer RLE v1
+              | DICTIONARY_DATA | Yes      | String contents
 DIRECT_V2     | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | String contents
               | LENGTH          | No       | Unsigned Integer RLE v2
 DICTIONARY_V2 | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unsigned Integer RLE v2
-              | DICTIONARY_DATA | No       | String contents
-              | LENGTH          | No       | Unsigned Integer RLE v2
+              | LENGTH          | Yes      | Unsigned Integer RLE v2
+              | DICTIONARY_DATA | Yes      | String contents
 
 ## Boolean Columns
 
@@ -1133,11 +1133,15 @@ records non-null values, a DATA stream that records the number of
 seconds after 1 January 2015, and a SECONDARY stream that records the
 number of nanoseconds.
 
-Because the number of nanoseconds often has a large number of trailing
-zeros, the number has trailing decimal zero digits removed and the
-last three bits are used to record how many zeros were removed. if the
-trailing zeros are more than 2. Thus 1000 nanoseconds would be
-serialized as 0x0a and 100000 would be serialized as 0x0c.
+Because the number of nanoseconds often has a large number of
+trailing zeros, further encoding is employed before unsigned integer
+run length encoding.  When the number of trailing zero digits is 2
+or more, these trailing zero digits are removed and the last three
+bits are used to record how many zeros were removed, relative to 1.
+If there are fewer than 2 trailing zero digits, the last three
+bits are 0, and the raw nanoseconds are bit shifted by 3.  Thus
+1000 nanoseconds would be serialized as 0x0a; 100000 would be
+serialized as 0x0c; and 21 nanoseconds would be serialized as 0xA8.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -1071,15 +1071,15 @@ DIRECT        | PRESENT         | Yes      | Boolean RLE
               | LENGTH          | No       | Unsigned Integer RLE v1
 DICTIONARY    | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unsigned Integer RLE v1
-              | DICTIONARY_DATA | No       | String contents
-              | LENGTH          | No       | Unsigned Integer RLE v1
+              | LENGTH          | Yes      | Unsigned Integer RLE v1
+              | DICTIONARY_DATA | Yes      | String contents
 DIRECT_V2     | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | String contents
               | LENGTH          | No       | Unsigned Integer RLE v2
 DICTIONARY_V2 | PRESENT         | Yes      | Boolean RLE
               | DATA            | No       | Unsigned Integer RLE v2
-              | DICTIONARY_DATA | No       | String contents
-              | LENGTH          | No       | Unsigned Integer RLE v2
+              | LENGTH          | Yes      | Unsigned Integer RLE v2
+              | DICTIONARY_DATA | Yes      | String contents
 
 ## Boolean Columns
 
@@ -1149,11 +1149,15 @@ records non-null values, a DATA stream that records the number of
 seconds after 1 January 2015, and a SECONDARY stream that records the
 number of nanoseconds.
 
-Because the number of nanoseconds often has a large number of trailing
-zeros, the number has trailing decimal zero digits removed and the
-last three bits are used to record how many zeros were removed. if the
-trailing zeros are more than 2. Thus 1000 nanoseconds would be
-serialized as 0x0a and 100000 would be serialized as 0x0c.
+Because the number of nanoseconds often has a large number of
+trailing zeros, further encoding is employed before unsigned integer
+run length encoding.  When the number of trailing zero digits is 2
+or more, these trailing zero digits are removed and the last three
+bits are used to record how many zeros were removed, relative to 1.
+If there are fewer than 2 trailing zero digits, the last three
+bits are 0, and the raw nanoseconds are bit shifted by 3.  Thus
+1000 nanoseconds would be serialized as 0x0a; 100000 would be
+serialized as 0x0c; and 21 nanoseconds would be serialized as 0xA8.
 
 Encoding      | Stream Kind     | Optional | Contents
 :------------ | :-------------- | :------- | :-------


### PR DESCRIPTION
The order of the data dictionary and length streams in dictionary columns is backwards compared to what all current writers emit; also, the readers gracefully handle absent streams (they're actually optional, as observed in the example files).

The documentation for nanosecond encoding was unclear and had broken sentences.

### What changes were proposed in this pull request?

Improvement of documentation in specification documents.

