### PR TITLE
ORC-1374: Update Spark to 3.3.2

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,7 +40,7 @@
     <junit.version>5.9.0</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.12.3</parquet.version>
-    <spark.version>3.3.1</spark.version>
+    <spark.version>3.3.2</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Java benchmark module to use Apache Spark 3.3.2 which is the latest version.

### Why are the changes needed?

To run the benchmark.

### How was this patch tested?

Pass the CIs.