### PR TITLE
ORC-1378: [Java] Optimize logging dependency definition

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -431,12 +431,6 @@
         <version>${slf4j.version}</version>
         <scope>runtime</scope>
       </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>runtime</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -103,11 +103,6 @@
       <artifactId>auto-service</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>auto-service</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -103,6 +103,11 @@
       <artifactId>auto-service</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -63,6 +63,11 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-storage-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -231,6 +231,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -286,6 +290,10 @@
           <exclusion>
             <groupId>xerces</groupId>
             <artifactId>xercesImpl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -382,6 +390,7 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
         <version>${slf4j.version}</version>
+        <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.threeten</groupId>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -100,7 +100,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>${slf4j.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to optimize logging dependency definition.

Here are the changes:
1. Add slf4j-simple as the logging implementation for SLF4J in example module to remove warnings:
```
SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
```

2. Exclude log4j from hadoop dependencies to remove warnings in example module:
```
log4j:WARN No appenders could be found for logger (org.apache.hadoop.util.Shell).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```

3. Set slf4j-simple to runtime scope to avoid accidentally binding ORC
project to a single logging implementation.

4. Remove slf4j-simple declaration from bench module cause it is redundant.

5. Remove version from tools module since it is redundant.

### Why are the changes needed?
When we run orc java examples, the following warning will show in output:
```
java -cp ./examples/target/orc-examples-1.9.0-SNAPSHOT-uber.jar org.apache.orc.examples.CoreWriter

SLF4J: No SLF4J providers were found.
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See https://www.slf4j.org/codes.html#noProviders for further details.
log4j:WARN No appenders could be found for logger (org.apache.hadoop.util.Shell).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info
```
This PR optimizes logging dependency definition.

After the PR:
```
java -cp ./examples/target/orc-examples-1.9.0-SNAPSHOT-uber.jar  org.apache.orc.examples.CoreWriter

org.apache.orc.examples.CoreWriter
Feb 23, 2023 7:03:48 PM org.apache.hadoop.util.NativeCodeLoader <clinit>
WARNING: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[main] INFO org.apache.orc.impl.HadoopShimsCurrent - Can't get KeyProvider for ORC encryption from hadoop.security.key.provider.path.
[main] INFO org.apache.orc.impl.PhysicalFsWriter - ORC writer created for path: my-file.orc with stripeSize: 67108864 blockSize: 268435456 compression: Compress: ZLIB buffer: 262144
[main] INFO org.apache.orc.impl.WriterImpl - ORC writer created for path: my-file.orc with stripeSize: 67108864 options: Compress: ZLIB buffer: 262144

```

### How was this patch tested?
manual testing.
