### PR TITLE
ORC-1376: [C++] Scaffolding of schema evolution

### DIFF
--- a/c++/include/orc/Exceptions.hh
+++ b/c++/include/orc/Exceptions.hh
@@ -58,6 +58,15 @@ namespace orc {
    private:
     InvalidArgument& operator=(const InvalidArgument&);
   };
+
+  class SchemaEvolutionError : public std::logic_error {
+   public:
+    explicit SchemaEvolutionError(const std::string& what_arg);
+    explicit SchemaEvolutionError(const char* what_arg);
+    virtual ~SchemaEvolutionError() noexcept override;
+    SchemaEvolutionError(const SchemaEvolutionError&);
+    SchemaEvolutionError& operator=(const SchemaEvolutionError&) = delete;
+  };
 }  // namespace orc
 
 #endif

--- a/c++/include/orc/Type.hh
+++ b/c++/include/orc/Type.hh
@@ -23,8 +23,6 @@
 #include "orc/Vector.hh"
 #include "orc/orc-config.hh"
 
-#include <optional>
-
 namespace orc {
 
   enum TypeKind {
@@ -67,7 +65,12 @@ namespace orc {
     virtual std::vector<std::string> getAttributeKeys() const = 0;
     virtual std::string getAttributeValue(const std::string& key) const = 0;
     virtual std::string toString() const = 0;
-    virtual std::optional<const Type*> getTypeByColumnId(uint64_t colId) const = 0;
+    /**
+     * Get the Type with the given column ID
+     * @param colId the column ID
+     * @return the type corresponding to the column Id, nullptr if not exists
+     */
+    virtual const Type* getTypeByColumnId(uint64_t colId) const = 0;
 
     /**
      * Create a row batch for this type.

--- a/c++/include/orc/Type.hh
+++ b/c++/include/orc/Type.hh
@@ -23,6 +23,8 @@
 #include "orc/Vector.hh"
 #include "orc/orc-config.hh"
 
+#include <optional>
+
 namespace orc {
 
   enum TypeKind {
@@ -65,6 +67,7 @@ namespace orc {
     virtual std::vector<std::string> getAttributeKeys() const = 0;
     virtual std::string getAttributeValue(const std::string& key) const = 0;
     virtual std::string toString() const = 0;
+    virtual std::optional<const Type*> getTypeByColumnId(uint64_t colId) const = 0;
 
     /**
      * Create a row batch for this type.

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -179,6 +179,7 @@ set(SOURCE_FILES
   RleDecoderV2.cc
   RleEncoderV2.cc
   RLE.cc
+  SchemaEvolution.cc
   Statistics.cc
   StripeStream.cc
   Timezone.cc

--- a/c++/src/Exceptions.cc
+++ b/c++/src/Exceptions.cc
@@ -67,4 +67,21 @@ namespace orc {
   InvalidArgument::~InvalidArgument() noexcept {
     // PASS
   }
+
+  SchemaEvolutionError::SchemaEvolutionError(const std::string& what_arg) : logic_error(what_arg) {
+    // PASS
+  }
+
+  SchemaEvolutionError::SchemaEvolutionError(const char* what_arg) : logic_error(what_arg) {
+    // PASS
+  }
+
+  SchemaEvolutionError::SchemaEvolutionError(const SchemaEvolutionError& error)
+      : logic_error(error) {
+    // PASS
+  }
+
+  SchemaEvolutionError::~SchemaEvolutionError() noexcept {
+    // PASS
+  }
 }  // namespace orc

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -303,9 +303,9 @@ namespace orc {
     // prepare SargsApplier if SearchArgument is available
     if (opts.getSearchArgument() && footer->rowindexstride() > 0) {
       sargs = opts.getSearchArgument();
-      sargsApplier.reset(
-          new SargsApplier(*contents->schema, sargs.get(), footer->rowindexstride(),
-                           getWriterVersionImpl(_contents.get()), contents->readerMetrics));
+      sargsApplier.reset(new SargsApplier(*contents->schema, sargs.get(), footer->rowindexstride(),
+                                          getWriterVersionImpl(_contents.get()),
+                                          contents->readerMetrics));
     }
 
     skipBloomFilters = hasBadBloomFilters();

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -303,9 +303,9 @@ namespace orc {
     // prepare SargsApplier if SearchArgument is available
     if (opts.getSearchArgument() && footer->rowindexstride() > 0) {
       sargs = opts.getSearchArgument();
-      sargsApplier.reset(new SargsApplier(*contents->schema, sargs.get(), footer->rowindexstride(),
-                                          getWriterVersionImpl(_contents.get()),
-                                          contents->readerMetrics));
+      sargsApplier.reset(
+          new SargsApplier(*contents->schema, sargs.get(), nullptr, footer->rowindexstride(),
+                           getWriterVersionImpl(_contents.get()), contents->readerMetrics));
     }
 
     skipBloomFilters = hasBadBloomFilters();

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -304,7 +304,7 @@ namespace orc {
     if (opts.getSearchArgument() && footer->rowindexstride() > 0) {
       sargs = opts.getSearchArgument();
       sargsApplier.reset(
-          new SargsApplier(*contents->schema, sargs.get(), nullptr, footer->rowindexstride(),
+          new SargsApplier(*contents->schema, sargs.get(), footer->rowindexstride(),
                            getWriterVersionImpl(_contents.get()), contents->readerMetrics));
     }
 

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -26,6 +26,7 @@
 
 #include "ColumnReader.hh"
 #include "RLE.hh"
+#include "SchemaEvolution.hh"
 #include "TypeImpl.hh"
 #include "sargs/SargsApplier.hh"
 

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -1,0 +1,259 @@
+#include "SchemaEvolution.hh"
+#include "orc/Exceptions.hh"
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace orc {
+
+  SchemaEvolution::SchemaEvolution(const std::shared_ptr<Type>& _readType, const Type* fileType)
+      : readType(_readType) {
+    if (readType) {
+      buildConversion(readType.get(), fileType);
+    } else {
+      for (uint64_t i = 0; i <= fileType->getMaximumColumnId(); ++i) {
+        safePPDConversionMap.insert(i);
+      }
+    }
+  }
+
+  const Type* SchemaEvolution::getReadType(const Type& fileType) const {
+    auto ret = readTypeMap.find(fileType.getColumnId());
+    return ret == readTypeMap.cend() ? &fileType : ret->second;
+  }
+
+  inline void invalidConversion(const Type* readType, const Type* fileType) {
+    throw SchemaEvolutionError("Cannot convert from " + fileType->toString() + " to " +
+                               readType->toString());
+  }
+
+  struct EnumClassHash {
+    template <typename T>
+    std::size_t operator()(T t) const {
+      return static_cast<std::size_t>(t);
+    }
+  };
+
+  // map from file type to read type. it does not contain identity mapping.
+  using TypeSet = std::unordered_set<TypeKind, EnumClassHash>;
+  using ConvertMap = std::unordered_map<TypeKind, TypeSet, EnumClassHash>;
+
+  inline bool supportConversion(const Type& readType, const Type& fileType) {
+    static const ConvertMap& SUPPORTED_CONVERSIONS = *new ConvertMap{
+        // support nothing now
+    };
+    auto iter = SUPPORTED_CONVERSIONS.find(fileType.getKind());
+    if (iter == SUPPORTED_CONVERSIONS.cend()) {
+      return false;
+    }
+    return iter->second.find(readType.getKind()) != iter->second.cend();
+  }
+
+  struct ConversionCheckResult {
+    bool isValid;
+    bool needConvert;
+  };
+
+  ConversionCheckResult checkConversion(const Type& readType, const Type& fileType) {
+    ConversionCheckResult ret = {false, false};
+    if (readType.getKind() == fileType.getKind()) {
+      ret.isValid = true;
+      if (fileType.getKind() == CHAR || fileType.getKind() == VARCHAR) {
+        ret.needConvert = readType.getMaximumLength() < fileType.getMaximumLength();
+      } else if (fileType.getKind() == DECIMAL) {
+        ret.needConvert = readType.getPrecision() != fileType.getPrecision() ||
+                          readType.getScale() != fileType.getScale();
+      }
+    } else {
+      switch (fileType.getKind()) {
+        case BOOLEAN:
+        case BYTE:
+        case SHORT:
+        case INT:
+        case LONG:
+        case FLOAT:
+        case DOUBLE:
+        case DECIMAL: {
+          ret.isValid = ret.needConvert =
+              (readType.getKind() != DATE && readType.getKind() != BINARY);
+          break;
+        }
+        case STRING: {
+          ret.isValid = ret.needConvert = true;
+          break;
+        }
+        case CHAR:
+        case VARCHAR: {
+          ret.isValid = true;
+          if (readType.getKind() == STRING) {
+            ret.needConvert = false;
+          } else if (readType.getKind() == CHAR || readType.getKind() == VARCHAR) {
+            ret.needConvert = readType.getMaximumLength() < fileType.getMaximumLength();
+          } else {
+            ret.needConvert = true;
+          }
+          break;
+        }
+        case TIMESTAMP:
+        case TIMESTAMP_INSTANT: {
+          if (readType.getKind() == TIMESTAMP || readType.getKind() == TIMESTAMP_INSTANT) {
+            ret = {true, false};
+          } else {
+            ret.isValid = ret.needConvert = (readType.getKind() != BINARY);
+          }
+          break;
+        }
+        case DATE: {
+          ret.isValid = ret.needConvert =
+              readType.getKind() == STRING || readType.getKind() == CHAR ||
+              readType.getKind() == VARCHAR || readType.getKind() == TIMESTAMP ||
+              readType.getKind() == TIMESTAMP_INSTANT;
+          break;
+        }
+        case BINARY: {
+          ret.isValid = ret.needConvert = readType.getKind() == STRING ||
+                                          readType.getKind() == CHAR ||
+                                          readType.getKind() == VARCHAR;
+          break;
+        }
+        case STRUCT:
+        case LIST:
+        case MAP:
+        case UNION: {
+          ret.isValid = ret.needConvert = false;
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    return ret;
+  }
+
+  void SchemaEvolution::buildConversion(const Type* _readType, const Type* fileType) {
+    if (fileType == nullptr) {
+      throw SchemaEvolutionError("File does not have " + _readType->toString());
+    }
+
+    auto [valid, convert] = checkConversion(*_readType, *fileType);
+    if (!valid) {
+      invalidConversion(_readType, fileType);
+    }
+    readTypeMap.emplace(_readType->getColumnId(), convert ? _readType : fileType);
+
+    // check whether PPD conversion is safe
+    buildSafePPDConversionMap(_readType, fileType);
+
+    for (uint64_t i = 0; i < _readType->getSubtypeCount(); ++i) {
+      auto subType = _readType->getSubtype(i);
+      if (subType) {
+        // null subType means that this is a sub column of map/list type
+        // and it does not exist in the file. simply skip it.
+        buildConversion(subType, fileType->getTypeByColumnId(subType->getColumnId()).value());
+      }
+    }
+  }
+
+  bool SchemaEvolution::needConvert(const Type& fileType) const {
+    auto _readType = getReadType(fileType);
+    if (_readType == &fileType) {
+      return false;
+    }
+    // it does not check valid here as verified by buildConversion()
+    return checkConversion(*_readType, fileType).needConvert;
+  }
+
+  inline bool isPrimitive(const Type* type) {
+    auto kind = type->getKind();
+    return kind != STRUCT && kind != MAP && kind != LIST && kind != UNION;
+  }
+
+  void SchemaEvolution::buildSafePPDConversionMap(const Type* _readType, const Type* fileType) {
+    if (_readType == nullptr || !isPrimitive(_readType) || fileType == nullptr ||
+        !isPrimitive(fileType)) {
+      return;
+    }
+
+    bool isSafe = false;
+    if (_readType == fileType) {
+      // short cut for same type
+      isSafe = true;
+    } else if (_readType->getKind() == DECIMAL && fileType->getKind() == DECIMAL) {
+      // for decimals alone do equality check to not mess up with precision change
+      if (fileType->getPrecision() == readType->getPrecision() &&
+          fileType->getScale() == readType->getScale()) {
+        isSafe = true;
+      }
+    } else {
+      // only integer and string evolutions are safe
+      // byte -> short -> int -> long
+      // string <-> char <-> varchar
+      // NOTE: Float to double evolution is not safe as floats are stored as
+      // doubles in ORC's internal index, but when doing predicate evaluation
+      // for queries like "select * from orc_float where f = 74.72" the constant
+      // on the filter is converted from string -> double so the precisions will
+      // be different and the comparison will fail.
+      // Soon, we should convert all sargs that compare equality between floats
+      // or doubles to range predicates.
+      // Similarly string -> char and varchar -> char and vice versa is impossible
+      // as ORC stores char with padded spaces in its internal index.
+      switch (fileType->getKind()) {
+        case BYTE: {
+          if (readType->getKind() == SHORT || readType->getKind() == INT ||
+              readType->getKind() == LONG) {
+            isSafe = true;
+          }
+          break;
+        }
+        case SHORT: {
+          if (readType->getKind() == INT || readType->getKind() == LONG) {
+            isSafe = true;
+          }
+          break;
+        }
+        case INT: {
+          if (readType->getKind() == LONG) {
+            isSafe = true;
+          }
+          break;
+        }
+        case STRING: {
+          if (readType->getKind() == VARCHAR) {
+            isSafe = true;
+          }
+          break;
+        }
+        case VARCHAR: {
+          if (readType->getKind() == STRING) {
+            isSafe = true;
+          }
+          break;
+        }
+        case BOOLEAN:
+        case LONG:
+        case FLOAT:
+        case DOUBLE:
+        case BINARY:
+        case TIMESTAMP:
+        case LIST:
+        case MAP:
+        case STRUCT:
+        case UNION:
+        case DECIMAL:
+        case DATE:
+        case CHAR:
+        case TIMESTAMP_INSTANT:
+          break;
+      }
+    }
+
+    if (isSafe) {
+      safePPDConversionMap.insert(fileType->getColumnId());
+    }
+  }
+
+  bool SchemaEvolution::isSafePPDConversion(uint64_t columnId) const {
+    return safePPDConversionMap.find(columnId) != safePPDConversionMap.cend();
+  }
+
+}  // namespace orc

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -1,9 +1,6 @@
 #include "SchemaEvolution.hh"
 #include "orc/Exceptions.hh"
 
-#include <unordered_map>
-#include <unordered_set>
-
 namespace orc {
 
   SchemaEvolution::SchemaEvolution(const std::shared_ptr<Type>& _readType, const Type* fileType)

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -149,7 +149,7 @@ namespace orc {
       if (subType) {
         // null subType means that this is a sub column of map/list type
         // and it does not exist in the file. simply skip it.
-        buildConversion(subType, fileType->getTypeByColumnId(subType->getColumnId()).value());
+        buildConversion(subType, fileType->getTypeByColumnId(subType->getColumnId()));
       }
     }
   }

--- a/c++/src/SchemaEvolution.hh
+++ b/c++/src/SchemaEvolution.hh
@@ -1,9 +1,10 @@
 #ifndef ORC_SCHEMA_EVOLUTION_HH
 #define ORC_SCHEMA_EVOLUTION_HH
 
+#include "orc/Type.hh"
+
 #include <unordered_map>
 #include <unordered_set>
-#include "orc/Type.hh"
 
 namespace orc {
 

--- a/c++/src/SchemaEvolution.hh
+++ b/c++/src/SchemaEvolution.hh
@@ -1,0 +1,45 @@
+#ifndef ORC_SCHEMA_EVOLUTION_HH
+#define ORC_SCHEMA_EVOLUTION_HH
+
+#include <unordered_map>
+#include <unordered_set>
+#include "orc/Type.hh"
+
+namespace orc {
+
+  /**
+   * Utility class to compare read type and file type to match their columns
+   * and check type conversion.
+   */
+  class SchemaEvolution {
+   public:
+    SchemaEvolution(const std::shared_ptr<Type>& readType, const Type* fileType);
+
+    // get read type by column id from file type. or return the file type if
+    // read type is not provided (i.e. no schema evolution requested).
+    const Type* getReadType(const Type& fileType) const;
+
+    // check if we need to convert file type to read type for primitive type.
+    bool needConvert(const Type& fileType) const;
+
+    // check if the PPD conversion is safe
+    bool isSafePPDConversion(uint64_t columnId) const;
+
+    // return selected read type
+    const Type* getReadType() const {
+      return readType.get();
+    }
+
+   private:
+    void buildConversion(const Type* readType, const Type* fileType);
+    void buildSafePPDConversionMap(const Type* readType, const Type* fileType);
+
+   private:
+    const std::shared_ptr<Type> readType;
+    std::unordered_map<uint64_t, const Type*> readTypeMap;
+    std::unordered_set<uint64_t> safePPDConversionMap;
+  };
+
+}  // namespace orc
+
+#endif  // ORC_SCHEMA_EVOLUTION_HH

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -818,4 +818,18 @@ namespace orc {
     return std::make_pair(parseCategory(category, input, pos, nextPos), endPos);
   }
 
+  std::optional<const Type*> TypeImpl::getTypeByColumnId(uint64_t colIdx) const {
+    if (getColumnId() == colIdx) {
+      return this;
+    }
+
+    for (uint64_t i = 0; i != getSubtypeCount(); ++i) {
+      const Type* ret = getSubtype(i)->getTypeByColumnId(colIdx).value();
+      if (ret != nullptr) {
+        return ret;
+      }
+    }
+    return std::nullopt;
+  }
+
 }  // namespace orc

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -818,18 +818,18 @@ namespace orc {
     return std::make_pair(parseCategory(category, input, pos, nextPos), endPos);
   }
 
-  std::optional<const Type*> TypeImpl::getTypeByColumnId(uint64_t colIdx) const {
+  const Type* TypeImpl::getTypeByColumnId(uint64_t colIdx) const {
     if (getColumnId() == colIdx) {
       return this;
     }
 
     for (uint64_t i = 0; i != getSubtypeCount(); ++i) {
-      const Type* ret = getSubtype(i)->getTypeByColumnId(colIdx).value();
+      const Type* ret = getSubtype(i)->getTypeByColumnId(colIdx);
       if (ret != nullptr) {
         return ret;
       }
     }
-    return std::nullopt;
+    return nullptr;
   }
 
 }  // namespace orc

--- a/c++/src/TypeImpl.hh
+++ b/c++/src/TypeImpl.hh
@@ -88,7 +88,7 @@ namespace orc {
 
     std::string toString() const override;
 
-    std::optional<const Type*> getTypeByColumnId(uint64_t colIdx) const override;
+    const Type* getTypeByColumnId(uint64_t colIdx) const override;
     Type* addStructField(const std::string& fieldName, std::unique_ptr<Type> fieldType) override;
     Type* addUnionChild(std::unique_ptr<Type> fieldType) override;
 

--- a/c++/src/TypeImpl.hh
+++ b/c++/src/TypeImpl.hh
@@ -88,6 +88,7 @@ namespace orc {
 
     std::string toString() const override;
 
+    std::optional<const Type*> getTypeByColumnId(uint64_t colIdx) const override;
     Type* addStructField(const std::string& fieldName, std::unique_ptr<Type> fieldType) override;
     Type* addUnionChild(std::unique_ptr<Type> fieldType) override;
 

--- a/c++/src/sargs/SargsApplier.cc
+++ b/c++/src/sargs/SargsApplier.cc
@@ -38,8 +38,8 @@ namespace orc {
   }
 
   SargsApplier::SargsApplier(const Type& type, const SearchArgument* searchArgument,
-                             const SchemaEvolution* schemaEvolution, uint64_t rowIndexStride,
-                             WriterVersion writerVersion, ReaderMetrics* metrics)
+                             uint64_t rowIndexStride, WriterVersion writerVersion,
+                             ReaderMetrics* metrics, const SchemaEvolution* schemaEvolution)
       : mType(type),
         mSearchArgument(searchArgument),
         mSchemaEvolution(schemaEvolution),

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -27,13 +27,16 @@
 
 #include "sargs/SearchArgument.hh"
 
+#include "SchemaEvolution.hh"
+
 #include <unordered_map>
 
 namespace orc {
 
   class SargsApplier {
    public:
-    SargsApplier(const Type& type, const SearchArgument* searchArgument, uint64_t rowIndexStride,
+    SargsApplier(const Type& type, const SearchArgument* searchArgument,
+                 const SchemaEvolution* schemaEvolution, uint64_t rowIndexStride,
                  WriterVersion writerVersion, ReaderMetrics* metrics);
 
     /**
@@ -124,6 +127,7 @@ namespace orc {
    private:
     const Type& mType;
     const SearchArgument* mSearchArgument;
+    const SchemaEvolution* mSchemaEvolution;
     uint64_t mRowIndexStride;
     WriterVersion mWriterVersion;
     // column ids for each predicate leaf in the search argument

--- a/c++/src/sargs/SargsApplier.hh
+++ b/c++/src/sargs/SargsApplier.hh
@@ -35,9 +35,9 @@ namespace orc {
 
   class SargsApplier {
    public:
-    SargsApplier(const Type& type, const SearchArgument* searchArgument,
-                 const SchemaEvolution* schemaEvolution, uint64_t rowIndexStride,
-                 WriterVersion writerVersion, ReaderMetrics* metrics);
+    SargsApplier(const Type& type, const SearchArgument* searchArgument, uint64_t rowIndexStride,
+                 WriterVersion writerVersion, ReaderMetrics* metrics,
+                 const SchemaEvolution* schemaEvolution = nullptr);
 
     /**
      * Evaluate search argument on file statistics

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -92,7 +92,8 @@ namespace orc {
 
     // evaluate row group index
     ReaderMetrics metrics;
-    SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
+    SchemaEvolution se(nullptr, type.get());
+    SargsApplier applier(*type, sarg.get(), &se, 1000, WriterVersion_ORC_135, &metrics);
     EXPECT_TRUE(applier.pickRowGroups(4000, rowIndexes, {}));
     const auto& nextSkippedRows = applier.getNextSkippedRows();
     EXPECT_EQ(4, nextSkippedRows.size());
@@ -121,7 +122,7 @@ namespace orc {
       *stripeStats.add_colstats() = createIntStats(0L, 10L);
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_FALSE(applier.evaluateStripeStatistics(stripeStats, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 1);
@@ -135,7 +136,7 @@ namespace orc {
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_TRUE(applier.evaluateStripeStatistics(stripeStats, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 0);
@@ -149,7 +150,7 @@ namespace orc {
       *footer.add_statistics() = createIntStats(0L, 10L);
       *footer.add_statistics() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_FALSE(applier.evaluateFileStatistics(footer, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 1);
@@ -163,7 +164,7 @@ namespace orc {
       *footer.add_statistics() = createIntStats(0L, 50L);
       *footer.add_statistics() = createIntStats(0L, 30L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_FALSE(applier.evaluateFileStatistics(footer, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 1);
@@ -177,7 +178,7 @@ namespace orc {
       *footer.add_statistics() = createIntStats(0L, 50L);
       *footer.add_statistics() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_TRUE(applier.evaluateFileStatistics(footer, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 0);

--- a/c++/test/TestSargsApplier.cc
+++ b/c++/test/TestSargsApplier.cc
@@ -93,7 +93,7 @@ namespace orc {
     // evaluate row group index
     ReaderMetrics metrics;
     SchemaEvolution se(nullptr, type.get());
-    SargsApplier applier(*type, sarg.get(), &se, 1000, WriterVersion_ORC_135, &metrics);
+    SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics, &se);
     EXPECT_TRUE(applier.pickRowGroups(4000, rowIndexes, {}));
     const auto& nextSkippedRows = applier.getNextSkippedRows();
     EXPECT_EQ(4, nextSkippedRows.size());
@@ -122,7 +122,7 @@ namespace orc {
       *stripeStats.add_colstats() = createIntStats(0L, 10L);
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_FALSE(applier.evaluateStripeStatistics(stripeStats, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 1);
@@ -136,7 +136,7 @@ namespace orc {
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       *stripeStats.add_colstats() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_TRUE(applier.evaluateStripeStatistics(stripeStats, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 0);
@@ -150,7 +150,7 @@ namespace orc {
       *footer.add_statistics() = createIntStats(0L, 10L);
       *footer.add_statistics() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_FALSE(applier.evaluateFileStatistics(footer, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 1);
@@ -164,7 +164,7 @@ namespace orc {
       *footer.add_statistics() = createIntStats(0L, 50L);
       *footer.add_statistics() = createIntStats(0L, 30L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_FALSE(applier.evaluateFileStatistics(footer, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 1);
@@ -178,7 +178,7 @@ namespace orc {
       *footer.add_statistics() = createIntStats(0L, 50L);
       *footer.add_statistics() = createIntStats(0L, 50L);
       ReaderMetrics metrics;
-      SargsApplier applier(*type, sarg.get(), nullptr, 1000, WriterVersion_ORC_135, &metrics);
+      SargsApplier applier(*type, sarg.get(), 1000, WriterVersion_ORC_135, &metrics);
       EXPECT_TRUE(applier.evaluateFileStatistics(footer, 1));
       EXPECT_EQ(metrics.SelectedRowGroupCount.load(), 0);
       EXPECT_EQ(metrics.EvaluatedRowGroupCount.load(), 0);


### PR DESCRIPTION
Add schema evolution and check PPD security

### What changes were proposed in this pull request?

This pr adds a class `schema evolution` which checks validity and  PDD security of a type conversion. The convertions would be finished later.

### Why are the changes needed?

To support schema evolution in c++


### How was this patch tested?
UT
