### PR TITLE
ORC-1382: Fix secondary config names `org.sarg.*` to `orc.sarg.*`

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -154,7 +154,7 @@ public enum OrcConf {
       "The kryo and base64 encoded SearchArgument for predicate pushdown."),
   KRYO_SARG_BUFFER("orc.kryo.sarg.buffer", null, 8192,
       "The kryo buffer size for SearchArgument for predicate pushdown."),
-  SARG_COLUMNS("orc.sarg.column.names", "org.sarg.column.names", null,
+  SARG_COLUMNS("orc.sarg.column.names", "orc.sarg.column.names", null,
       "The list of column names for the SearchArgument."),
   FORCE_POSITIONAL_EVOLUTION("orc.force.positional.evolution",
       "orc.force.positional.evolution", false,
@@ -176,7 +176,7 @@ public enum OrcConf {
       "orc.schema.evolution.case.sensitive", true,
       "A boolean flag to determine if the comparision of field names " +
       "in schema evolution is case sensitive .\n"),
-  ALLOW_SARG_TO_FILTER("orc.sarg.to.filter", "org.sarg.to.filter", false,
+  ALLOW_SARG_TO_FILTER("orc.sarg.to.filter", "orc.sarg.to.filter", false,
                        "A boolean flag to determine if a SArg is allowed to become a filter"),
   READER_USE_SELECTED("orc.filter.use.selected", "orc.filter.use.selected", false,
                         "A boolean flag to determine if the selected vector is supported by\n"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix the typos in the secondary config names by switching `org.sarg.*` to `orc.sarg.*`.

Note that these are the secondary names supposed to be not used in favor of the main names.

### Why are the changes needed?

These are typos from ORC-1 and ORC-743.
- https://github.com/apache/orc/pull/23/files#diff-820865cad31c3a05d53723d44c305d3f09640cc857543a8d84b6d6c008486e03R112

https://github.com/apache/orc/blob/627fa296b9d973483cd54a6fc07c13ee60acc0c2/java/core/src/java/org/apache/orc/OrcConf.java#L157

- https://github.com/apache/orc/commit/aa9166dc88af08dd09543adfed90f6863f12ba08#diff-820865cad31c3a05d53723d44c305d3f09640cc857543a8d84b6d6c008486e03R168

https://github.com/apache/orc/blob/627fa296b9d973483cd54a6fc07c13ee60acc0c2/java/core/src/java/org/apache/orc/OrcConf.java#L179
### How was this patch tested?

Pass the CIs.