### PR TITLE
ORC-1384: Fix `ArrayIndexOutOfBoundsException` when reading dictionary stream bigger then dictionary

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -2292,10 +2292,15 @@ public class TreeReaderFactory {
           int dictionaryBufferSize = dictionaryOffsets[dictionaryOffsets.length - 1];
           dictionaryBuffer = new byte[dictionaryBufferSize];
           int pos = 0;
-          int chunkSize = in.available();
-          byte[] chunkBytes = new byte[chunkSize];
+          //check if dictionary size is smaller than available stream size
+          // to avoid ArrayIndexOutOfBoundsException
+          int readSize = Math.min(in.available(), dictionaryBufferSize);
+          byte[] chunkBytes = new byte[readSize];
           while (pos < dictionaryBufferSize) {
-            int currentLength = in.read(chunkBytes, 0, chunkSize);
+            int currentLength = in.read(chunkBytes, 0, readSize);
+            //check if dictionary size is smaller than available stream size
+            // to avoid ArrayIndexOutOfBoundsException
+            currentLength = Math.min(currentLength, dictionaryBufferSize - pos);
             System.arraycopy(chunkBytes, 0, dictionaryBuffer, pos, currentLength);
             pos += currentLength;
           }

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -2292,13 +2292,13 @@ public class TreeReaderFactory {
           int dictionaryBufferSize = dictionaryOffsets[dictionaryOffsets.length - 1];
           dictionaryBuffer = new byte[dictionaryBufferSize];
           int pos = 0;
-          //check if dictionary size is smaller than available stream size
+          // check if dictionary size is smaller than available stream size
           // to avoid ArrayIndexOutOfBoundsException
           int readSize = Math.min(in.available(), dictionaryBufferSize);
           byte[] chunkBytes = new byte[readSize];
           while (pos < dictionaryBufferSize) {
             int currentLength = in.read(chunkBytes, 0, readSize);
-            //check if dictionary size is smaller than available stream size
+            // check if dictionary size is smaller than available stream size
             // to avoid ArrayIndexOutOfBoundsException
             currentLength = Math.min(currentLength, dictionaryBufferSize - pos);
             System.arraycopy(chunkBytes, 0, dictionaryBuffer, pos, currentLength);


### PR DESCRIPTION
### What changes were proposed in this pull request? 
Avoid  ArrayIndexOutOfBoundsException when reading dictionary stream bigger then dictionary. Check the size of the dictionary and input and read only the min of those.

### Why are the changes needed?
In Hive when reading with LLAP data is read in 4kB blocks which leads to ArrayIndexOutOfBoundsException when the dictionary is smaller.

### How was this patch tested?
It is tested with HIVE's qtest, since here we do not have the necessary subclasses.
