### PR TITLE
ORC-1399 [C++] Return LongVectorBatch when createRowBatch for boolean type with useTightNumericVector option

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -171,10 +171,12 @@ namespace orc {
   }
 
   template <typename BatchType>
-  void BooleanColumnReader<BatchType>::next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
+  void BooleanColumnReader<BatchType>::next(ColumnVectorBatch& rowBatch, uint64_t numValues,
+                                            char* notNull) {
     ColumnReader::next(rowBatch, numValues, notNull);
-    // Since the byte rle places the output in a char*
-    // we cheat here and use the other type and then expand it in a second pass.
+    // Since the byte rle places the output in a char* and BatchType here may be
+    // LongVectorBatch with long*. We cheat here in that case and use the long*
+    // and then expand it in a second pass..
     auto* ptr = dynamic_cast<BatchType&>(rowBatch).data.data();
     rle->next(reinterpret_cast<char*>(ptr), numValues,
               rowBatch.hasNulls ? rowBatch.notNull.data() : nullptr);

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -133,6 +133,7 @@ namespace orc {
     }
   }
 
+  template <typename BatchType>
   class BooleanColumnReader : public ColumnReader {
    private:
     std::unique_ptr<orc::ByteRleDecoder> rle;
@@ -148,7 +149,8 @@ namespace orc {
     void seekToRowGroup(std::unordered_map<uint64_t, PositionProvider>& positions) override;
   };
 
-  BooleanColumnReader::BooleanColumnReader(const Type& type, StripeStreams& stripe)
+  template <typename BatchType>
+  BooleanColumnReader<BatchType>::BooleanColumnReader(const Type& type, StripeStreams& stripe)
       : ColumnReader(type, stripe) {
     std::unique_ptr<SeekableInputStream> stream =
         stripe.getStream(columnId, proto::Stream_Kind_DATA, true);
@@ -156,27 +158,31 @@ namespace orc {
     rle = createBooleanRleDecoder(std::move(stream), metrics);
   }
 
-  BooleanColumnReader::~BooleanColumnReader() {
+  template <typename BatchType>
+  BooleanColumnReader<BatchType>::~BooleanColumnReader() {
     // PASS
   }
 
-  uint64_t BooleanColumnReader::skip(uint64_t numValues) {
+  template <typename BatchType>
+  uint64_t BooleanColumnReader<BatchType>::skip(uint64_t numValues) {
     numValues = ColumnReader::skip(numValues);
     rle->skip(numValues);
     return numValues;
   }
 
-  void BooleanColumnReader::next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
+  template <typename BatchType>
+  void BooleanColumnReader<BatchType>::next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
     ColumnReader::next(rowBatch, numValues, notNull);
-    // Since the byte rle places the output in a char* instead of long*,
-    // we cheat here and use the long* and then expand it in a second pass.
-    int64_t* ptr = dynamic_cast<LongVectorBatch&>(rowBatch).data.data();
+    // Since the byte rle places the output in a char*
+    // we cheat here and use the other type and then expand it in a second pass.
+    auto* ptr = dynamic_cast<BatchType&>(rowBatch).data.data();
     rle->next(reinterpret_cast<char*>(ptr), numValues,
               rowBatch.hasNulls ? rowBatch.notNull.data() : nullptr);
     expandBytesToIntegers(ptr, numValues);
   }
 
-  void BooleanColumnReader::seekToRowGroup(
+  template <typename BatchType>
+  void BooleanColumnReader<BatchType>::seekToRowGroup(
       std::unordered_map<uint64_t, PositionProvider>& positions) {
     ColumnReader::seekToRowGroup(positions);
     rle->seek(positions.at(columnId));
@@ -1721,8 +1727,13 @@ namespace orc {
             throw NotImplementedYet("buildReader unhandled string encoding");
         }
 
-      case BOOLEAN:
-        return std::make_unique<BooleanColumnReader>(type, stripe);
+      case BOOLEAN: {
+        if (useTightNumericVector) {
+          return std::make_unique<BooleanColumnReader<ByteVectorBatch>>(type, stripe);
+        } else {
+          return std::make_unique<BooleanColumnReader<LongVectorBatch>>(type, stripe);
+        }
+      }
 
       case BYTE:
         if (useTightNumericVector) {

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -657,8 +657,9 @@ namespace orc {
   };
 
   template <typename BatchType>
-  BooleanColumnWriter<BatchType>::BooleanColumnWriter(const Type& type, const StreamsFactory& factory,
-                                           const WriterOptions& options)
+  BooleanColumnWriter<BatchType>::BooleanColumnWriter(const Type& type,
+                                                      const StreamsFactory& factory,
+                                                      const WriterOptions& options)
       : ColumnWriter(type, factory, options) {
     std::unique_ptr<BufferedOutputStream> dataStream =
         factory.createStream(proto::Stream_Kind_DATA);
@@ -670,11 +671,13 @@ namespace orc {
   }
 
   template <typename BatchType>
-  void BooleanColumnWriter<BatchType>::add(ColumnVectorBatch& rowBatch, uint64_t offset, uint64_t numValues,
-                                const char* incomingMask) {
+  void BooleanColumnWriter<BatchType>::add(ColumnVectorBatch& rowBatch, uint64_t offset,
+                                           uint64_t numValues, const char* incomingMask) {
     BatchType* byteBatch = dynamic_cast<BatchType*>(&rowBatch);
     if (byteBatch == nullptr) {
-      throw InvalidArgument("Failed to cast to BooleanVectorBatch");
+      std::stringstream ss;
+      ss << "Failed to cast to " << typeid(BatchType).name();
+      throw InvalidArgument(ss.str());
     }
     BooleanColumnStatisticsImpl* boolStats =
         dynamic_cast<BooleanColumnStatisticsImpl*>(colIndexStatistics.get());
@@ -728,7 +731,8 @@ namespace orc {
   }
 
   template <typename BatchType>
-  void BooleanColumnWriter<BatchType>::getColumnEncoding(std::vector<proto::ColumnEncoding>& encodings) const {
+  void BooleanColumnWriter<BatchType>::getColumnEncoding(
+      std::vector<proto::ColumnEncoding>& encodings) const {
     proto::ColumnEncoding encoding;
     encoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
     encoding.set_dictionarysize(0);

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -635,6 +635,7 @@ namespace orc {
     byteRleEncoder->recordPosition(rowIndexPosition.get());
   }
 
+  template <typename BatchType>
   class BooleanColumnWriter : public ColumnWriter {
    public:
     BooleanColumnWriter(const Type& type, const StreamsFactory& factory,
@@ -655,7 +656,8 @@ namespace orc {
     std::unique_ptr<ByteRleEncoder> rleEncoder;
   };
 
-  BooleanColumnWriter::BooleanColumnWriter(const Type& type, const StreamsFactory& factory,
+  template <typename BatchType>
+  BooleanColumnWriter<BatchType>::BooleanColumnWriter(const Type& type, const StreamsFactory& factory,
                                            const WriterOptions& options)
       : ColumnWriter(type, factory, options) {
     std::unique_ptr<BufferedOutputStream> dataStream =
@@ -667,11 +669,12 @@ namespace orc {
     }
   }
 
-  void BooleanColumnWriter::add(ColumnVectorBatch& rowBatch, uint64_t offset, uint64_t numValues,
+  template <typename BatchType>
+  void BooleanColumnWriter<BatchType>::add(ColumnVectorBatch& rowBatch, uint64_t offset, uint64_t numValues,
                                 const char* incomingMask) {
-    LongVectorBatch* byteBatch = dynamic_cast<LongVectorBatch*>(&rowBatch);
+    BatchType* byteBatch = dynamic_cast<BatchType*>(&rowBatch);
     if (byteBatch == nullptr) {
-      throw InvalidArgument("Failed to cast to LongVectorBatch");
+      throw InvalidArgument("Failed to cast to BooleanVectorBatch");
     }
     BooleanColumnStatisticsImpl* boolStats =
         dynamic_cast<BooleanColumnStatisticsImpl*>(colIndexStatistics.get());
@@ -681,7 +684,7 @@ namespace orc {
 
     ColumnWriter::add(rowBatch, offset, numValues, incomingMask);
 
-    int64_t* data = byteBatch->data.data() + offset;
+    auto* data = byteBatch->data.data() + offset;
     const char* notNull = byteBatch->hasNulls ? byteBatch->notNull.data() + offset : nullptr;
 
     char* byteData = reinterpret_cast<char*>(data);
@@ -706,7 +709,8 @@ namespace orc {
     }
   }
 
-  void BooleanColumnWriter::flush(std::vector<proto::Stream>& streams) {
+  template <typename BatchType>
+  void BooleanColumnWriter<BatchType>::flush(std::vector<proto::Stream>& streams) {
     ColumnWriter::flush(streams);
 
     proto::Stream stream;
@@ -716,13 +720,15 @@ namespace orc {
     streams.push_back(stream);
   }
 
-  uint64_t BooleanColumnWriter::getEstimatedSize() const {
+  template <typename BatchType>
+  uint64_t BooleanColumnWriter<BatchType>::getEstimatedSize() const {
     uint64_t size = ColumnWriter::getEstimatedSize();
     size += rleEncoder->getBufferSize();
     return size;
   }
 
-  void BooleanColumnWriter::getColumnEncoding(std::vector<proto::ColumnEncoding>& encodings) const {
+  template <typename BatchType>
+  void BooleanColumnWriter<BatchType>::getColumnEncoding(std::vector<proto::ColumnEncoding>& encodings) const {
     proto::ColumnEncoding encoding;
     encoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
     encoding.set_dictionarysize(0);
@@ -732,7 +738,8 @@ namespace orc {
     encodings.push_back(encoding);
   }
 
-  void BooleanColumnWriter::recordPosition() const {
+  template <typename BatchType>
+  void BooleanColumnWriter<BatchType>::recordPosition() const {
     ColumnWriter::recordPosition();
     rleEncoder->recordPosition(rowIndexPosition.get());
   }
@@ -2824,8 +2831,13 @@ namespace orc {
           return std::make_unique<ByteColumnWriter<ByteVectorBatch>>(type, factory, options);
         }
         return std::make_unique<ByteColumnWriter<LongVectorBatch>>(type, factory, options);
-      case BOOLEAN:
-        return std::make_unique<BooleanColumnWriter>(type, factory, options);
+      case BOOLEAN: {
+        if (options.getUseTightNumericVector()) {
+          return std::make_unique<BooleanColumnWriter<ByteVectorBatch>>(type, factory, options);
+        } else {
+          return std::make_unique<BooleanColumnWriter<LongVectorBatch>>(type, factory, options);
+        }
+      }
       case DOUBLE:
         return std::make_unique<FloatingColumnWriter<double, DoubleVectorBatch>>(type, factory,
                                                                                  options, false);

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -287,7 +287,9 @@ namespace orc {
                                                               bool useTightNumericVector) const {
     switch (static_cast<int64_t>(kind)) {
       case BOOLEAN: {
-        return std::make_unique<LongVectorBatch>(capacity, memoryPool);
+        if (useTightNumericVector) {
+          return std::make_unique<ByteVectorBatch>(capacity, memoryPool);
+        }
       }
       case BYTE: {
         if (useTightNumericVector) {

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -286,7 +286,9 @@ namespace orc {
                                                               MemoryPool& memoryPool, bool encoded,
                                                               bool useTightNumericVector) const {
     switch (static_cast<int64_t>(kind)) {
-      case BOOLEAN:
+      case BOOLEAN: {
+        return std::make_unique<LongVectorBatch>(capacity, memoryPool);
+      }
       case BYTE: {
         if (useTightNumericVector) {
           return std::make_unique<ByteVectorBatch>(capacity, memoryPool);

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -1898,7 +1898,7 @@ namespace orc {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
     std::unique_ptr<Type> type(Type::buildTypeFromString(
-        "struct<col1:double,col2:float,col3:int,col4:smallint,col5:tinyint,col6:bigint>"));
+        "struct<col1:double,col2:float,col3:int,col4:smallint,col5:tinyint,col6:bigint,col7:boolean>"));
 
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
@@ -1921,6 +1921,7 @@ namespace orc {
     ShortVectorBatch* shortBatch = dynamic_cast<ShortVectorBatch*>(structBatch->fields[3]);
     ByteVectorBatch* byteBatch = dynamic_cast<ByteVectorBatch*>(structBatch->fields[4]);
     LongVectorBatch* longBatch = dynamic_cast<LongVectorBatch*>(structBatch->fields[5]);
+    ByteVectorBatch* boolBatch = dynamic_cast<ByteVectorBatch*>(structBatch->fields[6]);
     structBatch->resize(rowCount);
     doubleBatch->resize(rowCount);
     floatBatch->resize(rowCount);
@@ -1928,6 +1929,7 @@ namespace orc {
     shortBatch->resize(rowCount);
     byteBatch->resize(rowCount);
     longBatch->resize(rowCount);
+    boolBatch->resize(rowCount);
 
     for (uint64_t i = 0; i < rowCount; ++i) {
       structBatch->notNull[i] = 1;
@@ -1937,6 +1939,7 @@ namespace orc {
       shortBatch->notNull[i] = 1;
       byteBatch->notNull[i] = 1;
       longBatch->notNull[i] = 1;
+      boolBatch->notNull[i] = 1;
 
       doubleBatch->data[i] = data[i];
       floatBatch->data[i] = static_cast<float>(data[i]);
@@ -1944,6 +1947,7 @@ namespace orc {
       shortBatch->data[i] = static_cast<int16_t>(i);
       byteBatch->data[i] = static_cast<int8_t>(i);
       longBatch->data[i] = static_cast<int64_t>(i);
+      boolBatch->data[i] = static_cast<bool>((i % 17) % 2);
     }
 
     structBatch->numElements = rowCount;
@@ -1953,6 +1957,7 @@ namespace orc {
     shortBatch->numElements = rowCount;
     byteBatch->numElements = rowCount;
     longBatch->numElements = rowCount;
+    boolBatch->numElements = rowCount;
 
     writer->add(*batch);
     writer->close();
@@ -1974,6 +1979,7 @@ namespace orc {
     shortBatch = dynamic_cast<ShortVectorBatch*>(structBatch->fields[3]);
     byteBatch = dynamic_cast<ByteVectorBatch*>(structBatch->fields[4]);
     longBatch = dynamic_cast<LongVectorBatch*>(structBatch->fields[5]);
+    boolBatch = dynamic_cast<ByteVectorBatch*>(structBatch->fields[6]);
     for (uint64_t i = 0; i < rowCount; ++i) {
       EXPECT_TRUE(std::abs(data[i] - doubleBatch->data[i]) < 0.000001);
       EXPECT_TRUE(std::abs(static_cast<float>(data[i]) - static_cast<float>(floatBatch->data[i])) <
@@ -1982,6 +1988,7 @@ namespace orc {
       EXPECT_EQ(shortBatch->data[i], static_cast<int16_t>(i));
       EXPECT_EQ(byteBatch->data[i], static_cast<int8_t>(i));
       EXPECT_EQ(longBatch->data[i], static_cast<int64_t>(i));
+      EXPECT_EQ(boolBatch->data[i], static_cast<bool>((i % 17) % 2));
     }
     EXPECT_FALSE(rowReader->next(*batch));
   }

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -1897,8 +1897,9 @@ namespace orc {
   TEST_P(WriterTest, testWriteFixedWidthNumericVectorBatch) {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
-    std::unique_ptr<Type> type(Type::buildTypeFromString(
-        "struct<col1:double,col2:float,col3:int,col4:smallint,col5:tinyint,col6:bigint,col7:boolean>"));
+    std::unique_ptr<Type> type(
+        Type::buildTypeFromString("struct<col1:double,col2:float,col3:int,col4:smallint,col5:"
+                                  "tinyint,col6:bigint,col7:boolean>"));
 
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;


### PR DESCRIPTION
### What changes were proposed in this pull request?
Return LongVectorBatch when create a RowBatch for BOOLEAN type with useTightNumericVector option, instead of ByteVectorBatch.

### Why are the changes needed?
If a ByteVectorBatch is returned, BooleanColumnReader/Writer would crash because they only accept LongVectorBatch.


### How was this patch tested?
no test
