### PR TITLE
ORC-1400: Use Hadoop 3.3.5 on Java 17+ and benchmark

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <avro.version>1.11.1</avro.version>
-    <hadoop.version>3.3.4</hadoop.version>
+    <hadoop.version>3.3.5</hadoop.version>
     <hive.version>3.1.3</hive.version>
     <jmh.version>1.20</jmh.version>
     <junit.version>5.9.0</junit.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -973,9 +973,9 @@
         <jdk>[17,)</jdk>
       </activation>
       <properties>
-        <hadoop.version>3.3.4</hadoop.version>
-        <min.hadoop.version>3.3.4</min.hadoop.version>
-        <tools.hadoop.version>3.3.4</tools.hadoop.version>
+        <hadoop.version>3.3.5</hadoop.version>
+        <min.hadoop.version>3.3.5</min.hadoop.version>
+        <tools.hadoop.version>3.3.5</tools.hadoop.version>
       </properties>
     </profile>
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Hadoop to 3.3.5 on Java 17+ and benchmark module

### Why are the changes needed?

To bring the latest bug fixes.
- https://hadoop.apache.org/release/3.3.5.html

### How was this patch tested?

Pass the CIs.