### PR TITLE
ORC-1385: [C++] Support schema evolution of numeric types

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -336,6 +336,16 @@ namespace orc {
      * @return if not set, the default is false
      */
     bool getUseTightNumericVector() const;
+
+    /**
+     * Set read type for schema evolution
+     */
+    RowReaderOptions& setReadType(std::shared_ptr<Type>& type);
+
+    /**
+     * Get read type for schema evolution
+     */
+    std::shared_ptr<Type>& getReadType() const;
   };
 
   class RowReader;

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -340,12 +340,22 @@ namespace orc {
     /**
      * Set read type for schema evolution
      */
-    RowReaderOptions& setReadType(std::shared_ptr<Type>& type);
+    RowReaderOptions& setReadType(std::shared_ptr<Type> type);
 
     /**
      * Get read type for schema evolution
      */
     std::shared_ptr<Type>& getReadType() const;
+
+    /**
+     * Set should reader throw a exception on conversion between different data types overflow
+     */
+    RowReaderOptions& throwOnSchemaEvolutionOverflow(bool shouldThrow);
+
+    /**
+     * Get should reader throw a exception on conversion between different data types overflow
+     */
+    bool getThrowOnSchemaEvolutionOverflow() const;
   };
 
   class RowReader;

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -348,12 +348,12 @@ namespace orc {
     std::shared_ptr<Type>& getReadType() const;
 
     /**
-     * Set should reader throw a exception on conversion between different data types overflow
+     * Set whether reader throws or returns null when value overflows for schema evolution.
      */
     RowReaderOptions& throwOnSchemaEvolutionOverflow(bool shouldThrow);
 
     /**
-     * Get should reader throw a exception on conversion between different data types overflow
+     * Whether reader throws or returns null when value overflows for schema evolution.
      */
     bool getThrowOnSchemaEvolutionOverflow() const;
   };

--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -53,6 +53,10 @@ namespace orc {
     // whether the vector batch is encoded
     bool isEncoded;
 
+    // whether the vector is not a numeric vector
+    // or it's created with the option useTightNumericVector
+    bool isTight = true;
+
     // custom memory pool
     MemoryPool& memoryPool;
 

--- a/c++/include/orc/Vector.hh
+++ b/c++/include/orc/Vector.hh
@@ -53,10 +53,6 @@ namespace orc {
     // whether the vector batch is encoded
     bool isEncoded;
 
-    // whether the vector is not a numeric vector
-    // or it's created with the option useTightNumericVector
-    bool isTight = true;
-
     // custom memory pool
     MemoryPool& memoryPool;
 

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -172,6 +172,7 @@ set(SOURCE_FILES
   ColumnWriter.cc
   Common.cc
   Compression.cc
+  ConvertColumnReader.cc
   Exceptions.cc
   Int128.cc
   LzoDecompressor.cc

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -1715,16 +1715,10 @@ namespace orc {
                                             bool useTightNumericVector,
                                             bool throwOnSchemaEvolutionOverflow,
                                             bool convertToReadType) {
-    if (convertToReadType && stripe.getSchemaEvolution()) {
-      if (stripe.getSchemaEvolution()->needConvert(type)) {
-        if (!useTightNumericVector) {
-          throw SchemaEvolutionError(
-              "SchemaEvolution only support tight vector, please create ColumnVectorBatch with "
-              "option "
-              "useTightNumericVector");
-        }
-        return buildConvertReader(type, stripe, throwOnSchemaEvolutionOverflow);
-      }
+    if (convertToReadType && stripe.getSchemaEvolution() &&
+        stripe.getSchemaEvolution()->needConvert(type)) {
+      return buildConvertReader(type, stripe, useTightNumericVector,
+                                throwOnSchemaEvolutionOverflow);
     }
 
     switch (static_cast<int64_t>(type.getKind())) {

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -830,7 +830,8 @@ namespace orc {
     std::vector<std::unique_ptr<ColumnReader>> children;
 
    public:
-    StructColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false);
+    StructColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false,
+                       bool throwOnSchemaEvolutionOverflow = false);
 
     uint64_t skip(uint64_t numValues) override;
 
@@ -846,7 +847,8 @@ namespace orc {
   };
 
   StructColumnReader::StructColumnReader(const Type& type, StripeStreams& stripe,
-                                         bool useTightNumericVector)
+                                         bool useTightNumericVector,
+                                         bool throwOnSchemaEvolutionOverflow)
       : ColumnReader(type, stripe) {
     // count the number of selected sub-columns
     const std::vector<bool> selectedColumns = stripe.getSelectedColumns();
@@ -855,7 +857,8 @@ namespace orc {
         for (unsigned int i = 0; i < type.getSubtypeCount(); ++i) {
           const Type& child = *type.getSubtype(i);
           if (selectedColumns[static_cast<uint64_t>(child.getColumnId())]) {
-            children.push_back(buildReader(child, stripe, useTightNumericVector));
+            children.push_back(
+                buildReader(child, stripe, useTightNumericVector, throwOnSchemaEvolutionOverflow));
           }
         }
         break;
@@ -915,7 +918,8 @@ namespace orc {
     std::unique_ptr<RleDecoder> rle;
 
    public:
-    ListColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false);
+    ListColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false,
+                     bool throwOnSchemaEvolutionOverflow = false);
     ~ListColumnReader() override;
 
     uint64_t skip(uint64_t numValues) override;
@@ -932,7 +936,8 @@ namespace orc {
   };
 
   ListColumnReader::ListColumnReader(const Type& type, StripeStreams& stripe,
-                                     bool useTightNumericVector)
+                                     bool useTightNumericVector,
+                                     bool throwOnSchemaEvolutionOverflow)
       : ColumnReader(type, stripe) {
     // count the number of selected sub-columns
     const std::vector<bool> selectedColumns = stripe.getSelectedColumns();
@@ -943,7 +948,7 @@ namespace orc {
     rle = createRleDecoder(std::move(stream), false, vers, memoryPool, metrics);
     const Type& childType = *type.getSubtype(0);
     if (selectedColumns[static_cast<uint64_t>(childType.getColumnId())]) {
-      child = buildReader(childType, stripe, useTightNumericVector);
+      child = buildReader(childType, stripe, useTightNumericVector, throwOnSchemaEvolutionOverflow);
     }
   }
 
@@ -1035,7 +1040,8 @@ namespace orc {
     std::unique_ptr<RleDecoder> rle;
 
    public:
-    MapColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false);
+    MapColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false,
+                    bool throwOnSchemaEvolutionOverflow = false);
     ~MapColumnReader() override;
 
     uint64_t skip(uint64_t numValues) override;
@@ -1052,7 +1058,7 @@ namespace orc {
   };
 
   MapColumnReader::MapColumnReader(const Type& type, StripeStreams& stripe,
-                                   bool useTightNumericVector)
+                                   bool useTightNumericVector, bool throwOnSchemaEvolutionOverflow)
       : ColumnReader(type, stripe) {
     // Determine if the key and/or value columns are selected
     const std::vector<bool> selectedColumns = stripe.getSelectedColumns();
@@ -1063,11 +1069,13 @@ namespace orc {
     rle = createRleDecoder(std::move(stream), false, vers, memoryPool, metrics);
     const Type& keyType = *type.getSubtype(0);
     if (selectedColumns[static_cast<uint64_t>(keyType.getColumnId())]) {
-      keyReader = buildReader(keyType, stripe, useTightNumericVector);
+      keyReader =
+          buildReader(keyType, stripe, useTightNumericVector, throwOnSchemaEvolutionOverflow);
     }
     const Type& elementType = *type.getSubtype(1);
     if (selectedColumns[static_cast<uint64_t>(elementType.getColumnId())]) {
-      elementReader = buildReader(elementType, stripe, useTightNumericVector);
+      elementReader =
+          buildReader(elementType, stripe, useTightNumericVector, throwOnSchemaEvolutionOverflow);
     }
   }
 
@@ -1177,7 +1185,8 @@ namespace orc {
     uint64_t numChildren;
 
    public:
-    UnionColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false);
+    UnionColumnReader(const Type& type, StripeStreams& stipe, bool useTightNumericVector = false,
+                      bool throwOnSchemaEvolutionOverflow = false);
 
     uint64_t skip(uint64_t numValues) override;
 
@@ -1193,7 +1202,8 @@ namespace orc {
   };
 
   UnionColumnReader::UnionColumnReader(const Type& type, StripeStreams& stripe,
-                                       bool useTightNumericVector)
+                                       bool useTightNumericVector,
+                                       bool throwOnSchemaEvolutionOverflow)
       : ColumnReader(type, stripe) {
     numChildren = type.getSubtypeCount();
     childrenReader.resize(numChildren);
@@ -1208,7 +1218,8 @@ namespace orc {
     for (unsigned int i = 0; i < numChildren; ++i) {
       const Type& child = *type.getSubtype(i);
       if (selectedColumns[static_cast<size_t>(child.getColumnId())]) {
-        childrenReader[i] = buildReader(child, stripe, useTightNumericVector);
+        childrenReader[i] =
+            buildReader(child, stripe, useTightNumericVector, throwOnSchemaEvolutionOverflow);
       }
     }
   }
@@ -1701,10 +1712,18 @@ namespace orc {
    * Create a reader for the given stripe.
    */
   std::unique_ptr<ColumnReader> buildReader(const Type& type, StripeStreams& stripe,
-                                            bool useTightNumericVector, bool convertToReadType) {
+                                            bool useTightNumericVector,
+                                            bool throwOnSchemaEvolutionOverflow,
+                                            bool convertToReadType) {
     if (convertToReadType && stripe.getSchemaEvolution()) {
       if (stripe.getSchemaEvolution()->needConvert(type)) {
-        return buildConvertReader(type, stripe, useTightNumericVector);
+        if (!useTightNumericVector) {
+          throw SchemaEvolutionError(
+              "SchemaEvolution only support tight vector, please create ColumnVectorBatch with "
+              "option "
+              "useTightNumericVector");
+        }
+        return buildConvertReader(type, stripe, throwOnSchemaEvolutionOverflow);
       }
     }
 
@@ -1752,16 +1771,20 @@ namespace orc {
         return std::make_unique<ByteColumnReader<LongVectorBatch>>(type, stripe);
 
       case LIST:
-        return std::make_unique<ListColumnReader>(type, stripe, useTightNumericVector);
+        return std::make_unique<ListColumnReader>(type, stripe, useTightNumericVector,
+                                                  throwOnSchemaEvolutionOverflow);
 
       case MAP:
-        return std::make_unique<MapColumnReader>(type, stripe, useTightNumericVector);
+        return std::make_unique<MapColumnReader>(type, stripe, useTightNumericVector,
+                                                 throwOnSchemaEvolutionOverflow);
 
       case UNION:
-        return std::make_unique<UnionColumnReader>(type, stripe, useTightNumericVector);
+        return std::make_unique<UnionColumnReader>(type, stripe, useTightNumericVector,
+                                                   throwOnSchemaEvolutionOverflow);
 
       case STRUCT:
-        return std::make_unique<StructColumnReader>(type, stripe, useTightNumericVector);
+        return std::make_unique<StructColumnReader>(type, stripe, useTightNumericVector,
+                                                    throwOnSchemaEvolutionOverflow);
 
       case FLOAT: {
         if (useTightNumericVector) {

--- a/c++/src/ColumnReader.hh
+++ b/c++/src/ColumnReader.hh
@@ -106,7 +106,6 @@ namespace orc {
 
     /**
      * @return get schema evolution utility object
-     *
      */
     virtual const SchemaEvolution* getSchemaEvolution() const = 0;
   };
@@ -168,6 +167,7 @@ namespace orc {
    */
   std::unique_ptr<ColumnReader> buildReader(const Type& type, StripeStreams& stripe,
                                             bool useTightNumericVector = false,
+                                            bool throwOnSchemaEvolutionOverflow = false,
                                             bool convertToReadType = true);
 }  // namespace orc
 

--- a/c++/src/ColumnReader.hh
+++ b/c++/src/ColumnReader.hh
@@ -30,6 +30,8 @@
 
 namespace orc {
 
+  class SchemaEvolution;
+
   class StripeStreams {
    public:
     virtual ~StripeStreams();
@@ -101,6 +103,12 @@ namespace orc {
      * encoded in RLE.
      */
     virtual bool isDecimalAsLong() const = 0;
+
+    /**
+     * @return get schema evolution utility object
+     *
+     */
+    virtual const SchemaEvolution* getSchemaEvolution() const = 0;
   };
 
   /**
@@ -159,7 +167,8 @@ namespace orc {
    * Create a reader for the given stripe.
    */
   std::unique_ptr<ColumnReader> buildReader(const Type& type, StripeStreams& stripe,
-                                            bool useTightNumericVector = false);
+                                            bool useTightNumericVector = false,
+                                            bool convertToReadType = true);
 }  // namespace orc
 
 #endif

--- a/c++/src/ConvertColumnReader.cc
+++ b/c++/src/ConvertColumnReader.cc
@@ -1,0 +1,415 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ConvertColumnReader.hh"
+
+namespace orc {
+
+  // Assume that we are using tight numeric vector batch
+  using BooleanVectorBatch = ByteVectorBatch;
+
+  ConvertColumnReader::ConvertColumnReader(const Type& _readType, const Type& fileType,
+                                           StripeStreams& stripe)
+      : ColumnReader(_readType, stripe), readType(_readType) {
+    reader = buildReader(fileType, stripe, true, false);
+    data = fileType.createRowBatch(0, memoryPool, false, true);
+  }
+
+  void ConvertColumnReader::next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) {
+    reader->next(*data, numValues, notNull);
+    rowBatch.resize(data->capacity);
+    rowBatch.numElements = data->numElements;
+    rowBatch.hasNulls = data->hasNulls;
+    if (!rowBatch.hasNulls) {
+      memset(rowBatch.notNull.data(), 1, data->notNull.size());
+    } else {
+      memcpy(rowBatch.notNull.data(), data->notNull.data(), data->notNull.size());
+    }
+  }
+
+  uint64_t ConvertColumnReader::skip(uint64_t numValues) {
+    return reader->skip(numValues);
+  }
+
+  void ConvertColumnReader::seekToRowGroup(
+      std::unordered_map<uint64_t, PositionProvider>& positions) {
+    reader->seekToRowGroup(positions);
+  }
+
+  static inline bool canFitInLong(double value) {
+    constexpr double MIN_LONG_AS_DOUBLE = -0x1p63;
+    constexpr double MAX_LONG_AS_DOUBLE_PLUS_ONE = 0x1p63;
+    return ((MIN_LONG_AS_DOUBLE - value < 1.0) && (value < MAX_LONG_AS_DOUBLE_PLUS_ONE));
+  }
+
+  static inline void setNull(ColumnVectorBatch& dstBatch, uint64_t idx) {
+    dstBatch.notNull.data()[idx] = 0;
+    dstBatch.hasNulls = true;
+  }
+
+  // return false if overflow
+  template <typename ReadType>
+  static bool downCastToInteger(ReadType& dstValue, int64_t inputLong) {
+    dstValue = static_cast<ReadType>(inputLong);
+    if (std::is_same<ReadType, int64_t>::value) {
+      return true;
+    }
+    if (static_cast<int64_t>(dstValue) != inputLong) {
+      return false;
+    }
+    return true;
+  }
+
+  // set null if overflow
+  template <typename ReadType, typename FileType>
+  static inline void convertNumericElement(const FileType& srcValue, ReadType& destValue,
+                                           ColumnVectorBatch& destBatch, uint64_t idx) {
+    constexpr bool isFileTypeFloatingPoint(std::is_floating_point<FileType>::value);
+    constexpr bool isReadTypeFloatingPoint(std::is_floating_point<ReadType>::value);
+    int64_t longValue = static_cast<int64_t>(srcValue);
+    if (isFileTypeFloatingPoint) {
+      if (isReadTypeFloatingPoint) {
+        destValue = static_cast<ReadType>(srcValue);
+      } else {
+        if (!canFitInLong(static_cast<double>(srcValue)) ||
+            !downCastToInteger(destValue, longValue)) {
+          setNull(destBatch, idx);
+          return;
+        }
+      }
+    } else {
+      if (isReadTypeFloatingPoint) {
+        destValue = static_cast<ReadType>(srcValue);
+        if (destValue != destValue) {  // check is NaN
+          setNull(destBatch, idx);
+        }
+      } else {
+        if (!downCastToInteger(destValue, static_cast<int64_t>(srcValue))) {
+          setNull(destBatch, idx);
+        }
+      }
+    }
+  }
+
+  // { boolean, byte, short, int, long, float, double } ->
+  // { byte, short, int, long, float, double }
+  template <typename FileTypeBatch, typename ReadTypeBatch, typename ReadType>
+  class NumericConvertColumnReader : public ConvertColumnReader {
+   public:
+    NumericConvertColumnReader(const Type& _readType, const Type& fileType, StripeStreams& stripe)
+        : ConvertColumnReader(_readType, fileType, stripe) {}
+
+    void next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override {
+      ConvertColumnReader::next(rowBatch, numValues, notNull);
+      const auto& srcBatch = dynamic_cast<const FileTypeBatch&>(*data);
+      auto& dstBatch = dynamic_cast<ReadTypeBatch&>(rowBatch);
+      if (rowBatch.hasNulls) {
+        for (uint64_t i = 0; i < rowBatch.numElements; ++i) {
+          if (rowBatch.notNull[i]) {
+            convertNumericElement<ReadType>(srcBatch.data[i], dstBatch.data[i], rowBatch, i);
+          }
+        }
+      } else {
+        for (uint64_t i = 0; i < rowBatch.numElements; ++i) {
+          convertNumericElement<ReadType>(srcBatch.data[i], dstBatch.data[i], rowBatch, i);
+        }
+      }
+    }
+  };
+
+  // { boolean, byte, short, int, long, float, double } -> { boolean }
+  template <typename FileTypeBatch>
+  class NumericConvertColumnReader<FileTypeBatch, BooleanVectorBatch, bool>
+      : public ConvertColumnReader {
+   public:
+    NumericConvertColumnReader(const Type& _readType, const Type& fileType, StripeStreams& stripe)
+        : ConvertColumnReader(_readType, fileType, stripe) {}
+
+    void next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override {
+      ConvertColumnReader::next(rowBatch, numValues, notNull);
+      const auto& srcBatch = dynamic_cast<const FileTypeBatch&>(*data);
+      auto& dstBatch = dynamic_cast<BooleanVectorBatch&>(rowBatch);
+      if (rowBatch.hasNulls) {
+        for (uint64_t i = 0; i < rowBatch.numElements; ++i) {
+          if (rowBatch.notNull[i]) {
+            dstBatch.data[i] = (static_cast<int64_t>(srcBatch.data[i]) == 0 ? 0 : 1);
+          }
+        }
+      } else {
+        for (uint64_t i = 0; i < rowBatch.numElements; ++i) {
+          dstBatch.data[i] = (static_cast<int64_t>(srcBatch.data[i]) == 0 ? 0 : 1);
+        }
+      }
+    }
+  };
+
+#define DEFINE_NUMERIC_CONVERT_READER(FROM, TO, TYPE) \
+  using FROM##To##TO##ColumnReader =                  \
+      NumericConvertColumnReader<FROM##VectorBatch, TO##VectorBatch, TYPE>;
+
+  DEFINE_NUMERIC_CONVERT_READER(Boolean, Byte, int8_t)
+  DEFINE_NUMERIC_CONVERT_READER(Boolean, Short, int16_t)
+  DEFINE_NUMERIC_CONVERT_READER(Boolean, Int, int32_t)
+  DEFINE_NUMERIC_CONVERT_READER(Boolean, Long, int64_t)
+  DEFINE_NUMERIC_CONVERT_READER(Byte, Short, int16_t)
+  DEFINE_NUMERIC_CONVERT_READER(Byte, Int, int32_t)
+  DEFINE_NUMERIC_CONVERT_READER(Byte, Long, int64_t)
+  DEFINE_NUMERIC_CONVERT_READER(Short, Int, int32_t)
+  DEFINE_NUMERIC_CONVERT_READER(Short, Long, int64_t)
+  DEFINE_NUMERIC_CONVERT_READER(Int, Long, int64_t)
+  DEFINE_NUMERIC_CONVERT_READER(Float, Double, double)
+  DEFINE_NUMERIC_CONVERT_READER(Byte, Boolean, bool)
+  DEFINE_NUMERIC_CONVERT_READER(Short, Boolean, bool)
+  DEFINE_NUMERIC_CONVERT_READER(Short, Byte, int8_t)
+  DEFINE_NUMERIC_CONVERT_READER(Int, Boolean, bool)
+  DEFINE_NUMERIC_CONVERT_READER(Int, Byte, int8_t)
+  DEFINE_NUMERIC_CONVERT_READER(Int, Short, int16_t)
+  DEFINE_NUMERIC_CONVERT_READER(Long, Boolean, bool)
+  DEFINE_NUMERIC_CONVERT_READER(Long, Byte, int8_t)
+  DEFINE_NUMERIC_CONVERT_READER(Long, Short, int16_t)
+  DEFINE_NUMERIC_CONVERT_READER(Long, Int, int32_t)
+  DEFINE_NUMERIC_CONVERT_READER(Double, Float, float)
+  // Floating to integer
+  DEFINE_NUMERIC_CONVERT_READER(Float, Boolean, bool)
+  DEFINE_NUMERIC_CONVERT_READER(Float, Byte, int8_t)
+  DEFINE_NUMERIC_CONVERT_READER(Float, Short, int16_t)
+  DEFINE_NUMERIC_CONVERT_READER(Float, Int, int32_t)
+  DEFINE_NUMERIC_CONVERT_READER(Float, Long, int64_t)
+  DEFINE_NUMERIC_CONVERT_READER(Double, Boolean, bool)
+  DEFINE_NUMERIC_CONVERT_READER(Double, Byte, int8_t)
+  DEFINE_NUMERIC_CONVERT_READER(Double, Short, int16_t)
+  DEFINE_NUMERIC_CONVERT_READER(Double, Int, int32_t)
+  DEFINE_NUMERIC_CONVERT_READER(Double, Long, int64_t)
+  // Integer to Floating
+  DEFINE_NUMERIC_CONVERT_READER(Boolean, Float, float)
+  DEFINE_NUMERIC_CONVERT_READER(Byte, Float, float)
+  DEFINE_NUMERIC_CONVERT_READER(Short, Float, float)
+  DEFINE_NUMERIC_CONVERT_READER(Int, Float, float)
+  DEFINE_NUMERIC_CONVERT_READER(Long, Float, float)
+  DEFINE_NUMERIC_CONVERT_READER(Boolean, Double, double)
+  DEFINE_NUMERIC_CONVERT_READER(Byte, Double, double)
+  DEFINE_NUMERIC_CONVERT_READER(Short, Double, double)
+  DEFINE_NUMERIC_CONVERT_READER(Int, Double, double)
+  DEFINE_NUMERIC_CONVERT_READER(Long, Double, double)
+
+#define CASE_CREATE_READER(TYPE, CONVERT) \
+  case TYPE:                              \
+    return std::make_unique<CONVERT##ColumnReader>(_readType, fileType, stripe);
+
+#define CASE_EXCEPTION                                                                 \
+  default:                                                                             \
+    throw SchemaEvolutionError("Cannot convert from " + fileType.toString() + " to " + \
+                               _readType.toString());
+
+  std::unique_ptr<ColumnReader> buildConvertReader(const Type& fileType, StripeStreams& stripe,
+                                                   bool _useTightNumericVector) {
+    if (!_useTightNumericVector) {
+      throw SchemaEvolutionError("Schema Evolution only support tight numeric vector");
+    }
+    const auto& _readType = *stripe.getSchemaEvolution()->getReadType(fileType);
+
+    switch (fileType.getKind()) {
+      case BOOLEAN: {
+        switch (_readType.getKind()) {
+          CASE_CREATE_READER(BYTE, BooleanToByte);
+          CASE_CREATE_READER(SHORT, BooleanToShort);
+          CASE_CREATE_READER(INT, BooleanToInt);
+          CASE_CREATE_READER(LONG, BooleanToLong);
+          CASE_CREATE_READER(FLOAT, BooleanToFloat);
+          CASE_CREATE_READER(DOUBLE, BooleanToDouble);
+          case BOOLEAN:
+          case STRING:
+          case BINARY:
+          case TIMESTAMP:
+          case LIST:
+          case MAP:
+          case STRUCT:
+          case UNION:
+          case DECIMAL:
+          case DATE:
+          case VARCHAR:
+          case CHAR:
+          case TIMESTAMP_INSTANT:
+            CASE_EXCEPTION
+        }
+      }
+      case BYTE: {
+        switch (_readType.getKind()) {
+          CASE_CREATE_READER(BOOLEAN, ByteToBoolean);
+          CASE_CREATE_READER(SHORT, ByteToShort);
+          CASE_CREATE_READER(INT, ByteToInt);
+          CASE_CREATE_READER(LONG, ByteToLong);
+          CASE_CREATE_READER(FLOAT, ByteToFloat);
+          CASE_CREATE_READER(DOUBLE, ByteToDouble);
+          case BYTE:
+          case STRING:
+          case BINARY:
+          case TIMESTAMP:
+          case LIST:
+          case MAP:
+          case STRUCT:
+          case UNION:
+          case DECIMAL:
+          case DATE:
+          case VARCHAR:
+          case CHAR:
+          case TIMESTAMP_INSTANT:
+            CASE_EXCEPTION
+        }
+      }
+      case SHORT: {
+        switch (_readType.getKind()) {
+          CASE_CREATE_READER(BOOLEAN, ShortToBoolean);
+          CASE_CREATE_READER(BYTE, ShortToByte);
+          CASE_CREATE_READER(INT, ShortToInt);
+          CASE_CREATE_READER(LONG, ShortToLong);
+          CASE_CREATE_READER(FLOAT, ShortToFloat);
+          CASE_CREATE_READER(DOUBLE, ShortToDouble);
+          case SHORT:
+          case STRING:
+          case BINARY:
+          case TIMESTAMP:
+          case LIST:
+          case MAP:
+          case STRUCT:
+          case UNION:
+          case DECIMAL:
+          case DATE:
+          case VARCHAR:
+          case CHAR:
+          case TIMESTAMP_INSTANT:
+            CASE_EXCEPTION
+        }
+      }
+      case INT: {
+        switch (_readType.getKind()) {
+          CASE_CREATE_READER(BOOLEAN, IntToBoolean);
+          CASE_CREATE_READER(BYTE, IntToByte);
+          CASE_CREATE_READER(SHORT, IntToShort);
+          CASE_CREATE_READER(LONG, IntToLong);
+          CASE_CREATE_READER(FLOAT, IntToFloat);
+          CASE_CREATE_READER(DOUBLE, IntToDouble);
+          case INT:
+          case STRING:
+          case BINARY:
+          case TIMESTAMP:
+          case LIST:
+          case MAP:
+          case STRUCT:
+          case UNION:
+          case DECIMAL:
+          case DATE:
+          case VARCHAR:
+          case CHAR:
+          case TIMESTAMP_INSTANT:
+            CASE_EXCEPTION
+        }
+      }
+      case LONG: {
+        switch (_readType.getKind()) {
+          CASE_CREATE_READER(BOOLEAN, LongToBoolean);
+          CASE_CREATE_READER(BYTE, LongToByte);
+          CASE_CREATE_READER(SHORT, LongToShort);
+          CASE_CREATE_READER(INT, LongToInt);
+          CASE_CREATE_READER(FLOAT, LongToFloat);
+          CASE_CREATE_READER(DOUBLE, LongToDouble);
+          case LONG:
+          case STRING:
+          case BINARY:
+          case TIMESTAMP:
+          case LIST:
+          case MAP:
+          case STRUCT:
+          case UNION:
+          case DECIMAL:
+          case DATE:
+          case VARCHAR:
+          case CHAR:
+          case TIMESTAMP_INSTANT:
+            CASE_EXCEPTION
+        }
+      }
+      case FLOAT: {
+        switch (_readType.getKind()) {
+          CASE_CREATE_READER(BOOLEAN, FloatToBoolean);
+          CASE_CREATE_READER(BYTE, FloatToByte);
+          CASE_CREATE_READER(SHORT, FloatToShort);
+          CASE_CREATE_READER(INT, FloatToInt);
+          CASE_CREATE_READER(LONG, FloatToLong);
+          CASE_CREATE_READER(DOUBLE, FloatToDouble);
+          case FLOAT:
+          case STRING:
+          case BINARY:
+          case TIMESTAMP:
+          case LIST:
+          case MAP:
+          case STRUCT:
+          case UNION:
+          case DECIMAL:
+          case DATE:
+          case VARCHAR:
+          case CHAR:
+          case TIMESTAMP_INSTANT:
+            CASE_EXCEPTION
+        }
+      }
+      case DOUBLE: {
+        switch (_readType.getKind()) {
+          CASE_CREATE_READER(BOOLEAN, DoubleToBoolean);
+          CASE_CREATE_READER(BYTE, DoubleToByte);
+          CASE_CREATE_READER(SHORT, DoubleToShort);
+          CASE_CREATE_READER(INT, DoubleToInt);
+          CASE_CREATE_READER(LONG, DoubleToLong);
+          CASE_CREATE_READER(FLOAT, DoubleToFloat);
+          case DOUBLE:
+          case STRING:
+          case BINARY:
+          case TIMESTAMP:
+          case LIST:
+          case MAP:
+          case STRUCT:
+          case UNION:
+          case DECIMAL:
+          case DATE:
+          case VARCHAR:
+          case CHAR:
+          case TIMESTAMP_INSTANT:
+            CASE_EXCEPTION
+        }
+      }
+      case STRING:
+      case BINARY:
+      case TIMESTAMP:
+      case LIST:
+      case MAP:
+      case STRUCT:
+      case UNION:
+      case DECIMAL:
+      case DATE:
+      case VARCHAR:
+      case CHAR:
+      case TIMESTAMP_INSTANT:
+        CASE_EXCEPTION
+    }
+  }
+
+#undef DEFINE_NUMERIC_CONVERT_READER
+#undef CASE_CREATE_READER
+#undef CASE_EXCEPTION
+
+}  // namespace orc

--- a/c++/src/ConvertColumnReader.hh
+++ b/c++/src/ConvertColumnReader.hh
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_CONVERT_COLUMN_READER_HH
+#define ORC_CONVERT_COLUMN_READER_HH
+
+#include "ColumnReader.hh"
+#include "SchemaEvolution.hh"
+
+namespace orc {
+
+  class ConvertColumnReader : public ColumnReader {
+   public:
+    ConvertColumnReader(const Type& readType, const Type& fileType, StripeStreams& stripe);
+
+    // override next() to implement convert logic, and inherit nextEncoded(),
+    // nextLazy() and nextLazyEncoded() from ColumnReader. override them only
+    // required.
+    void next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;
+
+    uint64_t skip(uint64_t numValues) override;
+
+    void seekToRowGroup(std::unordered_map<uint64_t, PositionProvider>& positions) override;
+
+   protected:
+    bool useTightNumericVector;
+    const Type& readType;
+    std::unique_ptr<ColumnReader> reader;
+    std::unique_ptr<ColumnVectorBatch> data;
+  };
+
+  std::unique_ptr<ColumnReader> buildConvertReader(const Type& fileType, StripeStreams& stripe,
+                                                   bool useTightNumericVector);
+
+}  // namespace orc
+
+#endif  // ORC_CONVERT_COLUMN_READER_HH

--- a/c++/src/ConvertColumnReader.hh
+++ b/c++/src/ConvertColumnReader.hh
@@ -45,6 +45,7 @@ namespace orc {
   };
 
   std::unique_ptr<ColumnReader> buildConvertReader(const Type& fileType, StripeStreams& stripe,
+                                                   bool useTightNumericVector,
                                                    bool throwOnOverflow);
 
 }  // namespace orc

--- a/c++/src/ConvertColumnReader.hh
+++ b/c++/src/ConvertColumnReader.hh
@@ -26,11 +26,10 @@ namespace orc {
 
   class ConvertColumnReader : public ColumnReader {
    public:
-    ConvertColumnReader(const Type& readType, const Type& fileType, StripeStreams& stripe);
+    ConvertColumnReader(const Type& readType, const Type& fileType, StripeStreams& stripe,
+                        bool throwOnOverflow);
 
-    // override next() to implement convert logic, and inherit nextEncoded(),
-    // nextLazy() and nextLazyEncoded() from ColumnReader. override them only
-    // required.
+    // override next() to implement convert logic
     void next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override;
 
     uint64_t skip(uint64_t numValues) override;
@@ -42,10 +41,11 @@ namespace orc {
     const Type& readType;
     std::unique_ptr<ColumnReader> reader;
     std::unique_ptr<ColumnVectorBatch> data;
+    const bool throwOnOverflow;
   };
 
   std::unique_ptr<ColumnReader> buildConvertReader(const Type& fileType, StripeStreams& stripe,
-                                                   bool useTightNumericVector);
+                                                   bool throwOnOverflow);
 
 }  // namespace orc
 

--- a/c++/src/Options.hh
+++ b/c++/src/Options.hh
@@ -140,6 +140,7 @@ namespace orc {
     RowReaderOptions::IdReadIntentMap idReadIntentMap;
     bool useTightNumericVector;
     std::shared_ptr<Type> readType;
+    bool throwOnSchemaEvolutionOverflow;
 
     RowReaderOptionsPrivate() {
       selection = ColumnSelection_NONE;
@@ -150,6 +151,7 @@ namespace orc {
       enableLazyDecoding = false;
       readerTimezone = "GMT";
       useTightNumericVector = false;
+      throwOnSchemaEvolutionOverflow = false;
     }
   };
 
@@ -258,6 +260,15 @@ namespace orc {
     return privateBits->throwOnHive11DecimalOverflow;
   }
 
+  RowReaderOptions& RowReaderOptions::throwOnSchemaEvolutionOverflow(bool shouldThrow) {
+    privateBits->throwOnSchemaEvolutionOverflow = shouldThrow;
+    return *this;
+  }
+
+  bool RowReaderOptions::getThrowOnSchemaEvolutionOverflow() const {
+    return privateBits->throwOnSchemaEvolutionOverflow;
+  }
+
   RowReaderOptions& RowReaderOptions::forcedScaleOnHive11Decimal(int32_t forcedScale) {
     privateBits->forcedScaleOnHive11Decimal = forcedScale;
     return *this;
@@ -307,8 +318,8 @@ namespace orc {
     return privateBits->useTightNumericVector;
   }
 
-  RowReaderOptions& RowReaderOptions::setReadType(std::shared_ptr<Type>& type) {
-    privateBits->readType = type;
+  RowReaderOptions& RowReaderOptions::setReadType(std::shared_ptr<Type> type) {
+    privateBits->readType = std::move(type);
     return *this;
   }
 

--- a/c++/src/Options.hh
+++ b/c++/src/Options.hh
@@ -139,6 +139,7 @@ namespace orc {
     std::string readerTimezone;
     RowReaderOptions::IdReadIntentMap idReadIntentMap;
     bool useTightNumericVector;
+    std::shared_ptr<Type> readType;
 
     RowReaderOptionsPrivate() {
       selection = ColumnSelection_NONE;
@@ -304,6 +305,15 @@ namespace orc {
 
   bool RowReaderOptions::getUseTightNumericVector() const {
     return privateBits->useTightNumericVector;
+  }
+
+  RowReaderOptions& RowReaderOptions::setReadType(std::shared_ptr<Type>& type) {
+    privateBits->readType = type;
+    return *this;
+  }
+
+  std::shared_ptr<Type>& RowReaderOptions::getReadType() const {
+    return privateBits->readType;
   }
 }  // namespace orc
 

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -172,6 +172,9 @@ namespace orc {
     // desired timezone to return data of timestamp types.
     const Timezone& readerTimezone;
 
+    // match read and file types
+    SchemaEvolution schemaEvolution;
+
     // load stripe index if not done so
     void loadStripeIndex();
 
@@ -237,6 +240,10 @@ namespace orc {
     bool getThrowOnHive11DecimalOverflow() const;
     bool getIsDecimalAsLong() const;
     int32_t getForcedScaleOnHive11Decimal() const;
+
+    const SchemaEvolution& getSchemaEvolution() const {
+      return schemaEvolution;
+    }
   };
 
   class ReaderImpl : public Reader {

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -242,8 +242,8 @@ namespace orc {
     bool getIsDecimalAsLong() const;
     int32_t getForcedScaleOnHive11Decimal() const;
 
-    const SchemaEvolution& getSchemaEvolution() const {
-      return schemaEvolution;
+    const SchemaEvolution* getSchemaEvolution() const {
+      return &schemaEvolution;
     }
   };
 

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -159,6 +159,7 @@ namespace orc {
 
     bool enableEncodedBlock;
     bool useTightNumericVector;
+    bool throwOnSchemaEvolutionOverflow;
     // internal methods
     void startNextStripe();
     inline void markEndOfFile();
@@ -244,6 +245,8 @@ namespace orc {
     const SchemaEvolution& getSchemaEvolution() const {
       return schemaEvolution;
     }
+
+    void getReadColumns(const Type* readType, std::set<uint64_t>& readColumns) const;
   };
 
   class ReaderImpl : public Reader {

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -245,8 +245,6 @@ namespace orc {
     const SchemaEvolution& getSchemaEvolution() const {
       return schemaEvolution;
     }
-
-    void getReadColumns(const Type* readType, std::set<uint64_t>& readColumns) const;
   };
 
   class ReaderImpl : public Reader {

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-#include <iostream>
-
 #include "SchemaEvolution.hh"
 #include "orc/Exceptions.hh"
 

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+#include <iostream>
+
 #include "SchemaEvolution.hh"
 #include "orc/Exceptions.hh"
 
@@ -49,19 +51,10 @@ namespace orc {
     }
   };
 
-  // map from file type to read type. it does not contain identity mapping.
-  using TypeSet = std::unordered_set<TypeKind, EnumClassHash>;
-  using ConvertMap = std::unordered_map<TypeKind, TypeSet, EnumClassHash>;
-
-  inline bool supportConversion(const Type& readType, const Type& fileType) {
-    static const ConvertMap& SUPPORTED_CONVERSIONS = *new ConvertMap{
-        // support nothing now
-    };
-    auto iter = SUPPORTED_CONVERSIONS.find(fileType.getKind());
-    if (iter == SUPPORTED_CONVERSIONS.cend()) {
-      return false;
-    }
-    return iter->second.find(readType.getKind()) != iter->second.cend();
+  bool isNumeric(const Type& type) {
+    auto kind = type.getKind();
+    return kind == BOOLEAN || kind == BYTE || kind == SHORT || kind == INT || kind == LONG ||
+           kind == FLOAT || kind == DOUBLE;
   }
 
   struct ConversionCheckResult {
@@ -74,10 +67,10 @@ namespace orc {
     if (readType.getKind() == fileType.getKind()) {
       ret.isValid = true;
       if (fileType.getKind() == CHAR || fileType.getKind() == VARCHAR) {
-        ret.needConvert = readType.getMaximumLength() < fileType.getMaximumLength();
+        ret.isValid = readType.getMaximumLength() == fileType.getMaximumLength();
       } else if (fileType.getKind() == DECIMAL) {
-        ret.needConvert = readType.getPrecision() != fileType.getPrecision() ||
-                          readType.getScale() != fileType.getScale();
+        ret.isValid = readType.getPrecision() == fileType.getPrecision() &&
+                      readType.getScale() == fileType.getScale();
       }
     } else {
       switch (fileType.getKind()) {
@@ -87,48 +80,19 @@ namespace orc {
         case INT:
         case LONG:
         case FLOAT:
-        case DOUBLE:
-        case DECIMAL: {
-          ret.isValid = ret.needConvert =
-              (readType.getKind() != DATE && readType.getKind() != BINARY);
+        case DOUBLE: {
+          ret.isValid = ret.needConvert = isNumeric(readType);
           break;
         }
-        case STRING: {
-          ret.isValid = ret.needConvert = true;
-          break;
-        }
+        case DECIMAL:
+        case STRING:
         case CHAR:
-        case VARCHAR: {
-          ret.isValid = true;
-          if (readType.getKind() == STRING) {
-            ret.needConvert = false;
-          } else if (readType.getKind() == CHAR || readType.getKind() == VARCHAR) {
-            ret.needConvert = readType.getMaximumLength() < fileType.getMaximumLength();
-          } else {
-            ret.needConvert = true;
-          }
-          break;
-        }
+        case VARCHAR:
         case TIMESTAMP:
-        case TIMESTAMP_INSTANT: {
-          if (readType.getKind() == TIMESTAMP || readType.getKind() == TIMESTAMP_INSTANT) {
-            ret = {true, false};
-          } else {
-            ret.isValid = ret.needConvert = (readType.getKind() != BINARY);
-          }
-          break;
-        }
-        case DATE: {
-          ret.isValid = ret.needConvert =
-              readType.getKind() == STRING || readType.getKind() == CHAR ||
-              readType.getKind() == VARCHAR || readType.getKind() == TIMESTAMP ||
-              readType.getKind() == TIMESTAMP_INSTANT;
-          break;
-        }
+        case TIMESTAMP_INSTANT:
+        case DATE:
         case BINARY: {
-          ret.isValid = ret.needConvert = readType.getKind() == STRING ||
-                                          readType.getKind() == CHAR ||
-                                          readType.getKind() == VARCHAR;
+          // Not support
           break;
         }
         case STRUCT:

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -130,7 +130,7 @@ namespace orc {
   }
 
   const SchemaEvolution* StripeStreamsImpl::getSchemaEvolution() const {
-    return &reader.getSchemaEvolution();
+    return reader.getSchemaEvolution();
   }
 
   void StripeInformationImpl::ensureStripeFooterLoaded() const {

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -129,6 +129,10 @@ namespace orc {
     return reader.getForcedScaleOnHive11Decimal();
   }
 
+  const SchemaEvolution* StripeStreamsImpl::getSchemaEvolution() const {
+    return &reader.getSchemaEvolution();
+  }
+
   void StripeInformationImpl::ensureStripeFooterLoaded() const {
     if (stripeFooter.get() == nullptr) {
       std::unique_ptr<SeekableInputStream> pbStream =

--- a/c++/src/StripeStream.hh
+++ b/c++/src/StripeStream.hh
@@ -77,6 +77,8 @@ namespace orc {
     bool isDecimalAsLong() const override;
 
     int32_t getForcedScaleOnHive11Decimal() const override;
+
+    const SchemaEvolution* getSchemaEvolution() const override;
   };
 
   /**

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -307,15 +307,21 @@ namespace orc {
         }
       }
       case LONG:
-      case DATE:
-        return std::make_unique<LongVectorBatch>(capacity, memoryPool);
+      case DATE: {
+        auto result = std::make_unique<LongVectorBatch>(capacity, memoryPool);
+        result->isTight = useTightNumericVector || kind == LONG || kind == DATE;
+        return result;
+      }
 
       case FLOAT:
         if (useTightNumericVector) {
           return std::make_unique<FloatVectorBatch>(capacity, memoryPool);
         }
-      case DOUBLE:
-        return std::make_unique<DoubleVectorBatch>(capacity, memoryPool);
+      case DOUBLE: {
+        auto result = std::make_unique<DoubleVectorBatch>(capacity, memoryPool);
+        result->isTight = useTightNumericVector || kind == DOUBLE;
+        return result;
+      }
 
       case STRING:
       case BINARY:

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -308,9 +308,7 @@ namespace orc {
       }
       case LONG:
       case DATE: {
-        auto result = std::make_unique<LongVectorBatch>(capacity, memoryPool);
-        result->isTight = useTightNumericVector || kind == LONG || kind == DATE;
-        return result;
+        return std::make_unique<LongVectorBatch>(capacity, memoryPool);
       }
 
       case FLOAT:
@@ -318,9 +316,7 @@ namespace orc {
           return std::make_unique<FloatVectorBatch>(capacity, memoryPool);
         }
       case DOUBLE: {
-        auto result = std::make_unique<DoubleVectorBatch>(capacity, memoryPool);
-        result->isTight = useTightNumericVector || kind == DOUBLE;
-        return result;
+        return std::make_unique<DoubleVectorBatch>(capacity, memoryPool);
       }
 
       case STRING:

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -26,6 +26,7 @@ set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX17_FLAGS} ${WARN_FLAGS}")
 add_executable (orc-test
   MemoryInputStream.cc
   MemoryOutputStream.cc
+  MockStripeStreams.cc
   TestAttributes.cc
   TestBlockBuffer.cc
   TestBufferedOutputStream.cc
@@ -36,6 +37,7 @@ add_executable (orc-test
   TestColumnReader.cc
   TestColumnStatistics.cc
   TestCompression.cc
+  TestConvertColumnReader.cc
   TestDecompression.cc
   TestDecimal.cc
   TestDictionaryEncoding.cc
@@ -50,6 +52,7 @@ add_executable (orc-test
   TestRLEV2Util.cc
   TestSargsApplier.cc
   TestSearchArgument.cc
+  TestSchemaEvolution.cc
   TestStripeIndexStatistics.cc
   TestTimestampStatistics.cc
   TestTimezone.cc

--- a/c++/test/MockStripeStreams.cc
+++ b/c++/test/MockStripeStreams.cc
@@ -1,0 +1,26 @@
+#include "MockStripeStreams.hh"
+
+namespace orc {
+  MemoryPool& MockStripeStreams::getMemoryPool() const {
+    return *getDefaultPool();
+  }
+
+  ReaderMetrics* MockStripeStreams::getReaderMetrics() const {
+    return getDefaultReaderMetrics();
+  }
+
+  const Timezone& MockStripeStreams::getWriterTimezone() const {
+    return getTimezoneByName("America/Los_Angeles");
+  }
+
+  const Timezone& MockStripeStreams::getReaderTimezone() const {
+    return getTimezoneByName("GMT");
+  }
+
+  std::unique_ptr<SeekableInputStream> MockStripeStreams::getStream(uint64_t columnId,
+                                                                    proto::Stream_Kind kind,
+                                                                    bool stream) const {
+    return std::unique_ptr<SeekableInputStream>(getStreamProxy(columnId, kind, stream));
+  }
+
+}  // namespace orc

--- a/c++/test/MockStripeStreams.cc
+++ b/c++/test/MockStripeStreams.cc
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "MockStripeStreams.hh"
 
 namespace orc {

--- a/c++/test/MockStripeStreams.hh
+++ b/c++/test/MockStripeStreams.hh
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ORC_MOCKSTRIPESTREAM_HH
+#define ORC_MOCKSTRIPESTREAM_HH
+
+#include "ColumnReader.hh"
+
+#include "wrap/gmock.h"
+#include "wrap/gtest-wrapper.h"
+#include "wrap/orc-proto-wrapper.hh"
+
+namespace orc {
+  class MockStripeStreams : public StripeStreams {
+   public:
+    ~MockStripeStreams() override {}
+
+    std::unique_ptr<SeekableInputStream> getStream(uint64_t columnId, proto::Stream_Kind kind,
+                                                   bool stream) const override;
+
+    MOCK_CONST_METHOD0(getSelectedColumns, const std::vector<bool>());
+    MOCK_CONST_METHOD1(getEncoding, proto::ColumnEncoding(uint64_t));
+    MOCK_CONST_METHOD3(getStreamProxy, SeekableInputStream*(uint64_t, proto::Stream_Kind, bool));
+    MOCK_CONST_METHOD0(getErrorStream, std::ostream*());
+    MOCK_CONST_METHOD0(getThrowOnHive11DecimalOverflow, bool());
+    MOCK_CONST_METHOD0(getForcedScaleOnHive11Decimal, int32_t());
+    MOCK_CONST_METHOD0(isDecimalAsLong, bool());
+    MOCK_CONST_METHOD0(getSchemaEvolution, const SchemaEvolution*());
+
+    MemoryPool& getMemoryPool() const override;
+
+    ReaderMetrics* getReaderMetrics() const override;
+
+    const Timezone& getWriterTimezone() const override;
+
+    const Timezone& getReaderTimezone() const override;
+  };
+
+}  // namespace orc
+
+#endif

--- a/c++/test/TestColumnReader.cc
+++ b/c++/test/TestColumnReader.cc
@@ -18,12 +18,9 @@
 
 #include "Adaptor.hh"
 #include "ColumnReader.hh"
+#include "MockStripeStreams.hh"
 #include "OrcTest.hh"
 #include "orc/Exceptions.hh"
-
-#include "wrap/gmock.h"
-#include "wrap/gtest-wrapper.h"
-#include "wrap/orc-proto-wrapper.hh"
 
 #include <cmath>
 #include <iostream>
@@ -40,52 +37,6 @@ DIAGNOSTIC_IGNORE("-Wparentheses")
 namespace orc {
   using ::testing::TestWithParam;
   using ::testing::Values;
-
-  class MockStripeStreams : public StripeStreams {
-   public:
-    ~MockStripeStreams() override;
-
-    std::unique_ptr<SeekableInputStream> getStream(uint64_t columnId, proto::Stream_Kind kind,
-                                                   bool stream) const override;
-
-    MOCK_CONST_METHOD0(getSelectedColumns,
-
-                       const std::vector<bool>()
-
-    );
-    MOCK_CONST_METHOD1(getEncoding, proto::ColumnEncoding(uint64_t));
-    MOCK_CONST_METHOD3(getStreamProxy, SeekableInputStream*(uint64_t, proto::Stream_Kind, bool));
-    MOCK_CONST_METHOD0(getErrorStream, std::ostream*());
-    MOCK_CONST_METHOD0(getThrowOnHive11DecimalOverflow, bool());
-    MOCK_CONST_METHOD0(getForcedScaleOnHive11Decimal, int32_t());
-    MOCK_CONST_METHOD0(isDecimalAsLong, bool());
-
-    MemoryPool& getMemoryPool() const override {
-      return *getDefaultPool();
-    }
-
-    ReaderMetrics* getReaderMetrics() const override {
-      return getDefaultReaderMetrics();
-    }
-
-    const Timezone& getWriterTimezone() const override {
-      return getTimezoneByName("America/Los_Angeles");
-    }
-
-    const Timezone& getReaderTimezone() const override {
-      return getTimezoneByName("GMT");
-    }
-  };
-
-  MockStripeStreams::~MockStripeStreams() {
-    // PASS
-  }
-
-  std::unique_ptr<SeekableInputStream> MockStripeStreams::getStream(uint64_t columnId,
-                                                                    proto::Stream_Kind kind,
-                                                                    bool shouldStream) const {
-    return std::unique_ptr<SeekableInputStream>(getStreamProxy(columnId, kind, shouldStream));
-  }
 
   bool isNotNull(tm* timeptr) {
     return timeptr != nullptr;

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "orc/Type.hh"
+#include "wrap/gtest-wrapper.h"
+
+#include "MockStripeStreams.hh"
+#include "OrcTest.hh"
+#include "SchemaEvolution.hh"
+
+#include "ConvertColumnReader.hh"
+#include "MemoryInputStream.hh"
+#include "MemoryOutputStream.hh"
+
+namespace orc {
+
+  static std::unique_ptr<Reader> createReader(MemoryPool& memoryPool,
+                                              std::unique_ptr<InputStream> stream) {
+    ReaderOptions options;
+    options.setMemoryPool(memoryPool);
+    return createReader(std::move(stream), options);
+  }
+
+  TEST(ConvertColumnReader, betweenNumericWithoutOverflows) {
+    constexpr int DEFAULT_MEM_STREAM_SIZE = 10 * 1024;
+    constexpr int TEST_CASES = 1024;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+    std::unique_ptr<Type> fileType(
+        Type::buildTypeFromString("struct<t1:boolean,t2:int,t3:double,t4:float>"));
+    std::shared_ptr<Type> readType(
+        Type::buildTypeFromString("struct<t1:int,t2:boolean,t3:bigint,t4:boolean>"));
+    WriterOptions options;
+    options.setUseTightNumericVector(true);
+    auto writer = createWriter(*fileType, &memStream, options);
+    auto batch = writer->createRowBatch(TEST_CASES);
+    auto& structBatch = dynamic_cast<StructVectorBatch&>(*batch);
+    auto& c0 = dynamic_cast<ByteVectorBatch&>(*structBatch.fields[0]);
+    auto& c1 = dynamic_cast<IntVectorBatch&>(*structBatch.fields[1]);
+    auto& c2 = dynamic_cast<DoubleVectorBatch&>(*structBatch.fields[2]);
+    auto& c3 = dynamic_cast<FloatVectorBatch&>(*structBatch.fields[3]);
+
+    structBatch.numElements = c0.numElements = c1.numElements = c2.numElements = c3.numElements =
+        TEST_CASES;
+
+    for (size_t i = 0; i < TEST_CASES; i++) {
+      c0.data[i] = i % 2 || i % 3 ? true : false;
+      c1.data[i] = static_cast<int>((TEST_CASES / 2 - i) * TEST_CASES);
+      c2.data[i] = (TEST_CASES - i) / (TEST_CASES / 2);
+      c3.data[i] = (TEST_CASES - i) / (TEST_CASES / 2);
+    }
+
+    writer->add(*batch);
+    writer->close();
+
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
+    auto pool = getDefaultPool();
+    auto reader = createReader(*pool, std::move(inStream));
+    RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setReadType(readType);
+    rowReaderOpts.setUseTightNumericVector(true);
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+    auto readBatch = rowReader->createRowBatch(TEST_CASES);
+    EXPECT_EQ(true, rowReader->next(*readBatch));
+    auto& readStructBatch = dynamic_cast<StructVectorBatch&>(*readBatch);
+    auto& readC0 = dynamic_cast<IntVectorBatch&>(*readStructBatch.fields[0]);
+    auto& readC1 = dynamic_cast<ByteVectorBatch&>(*readStructBatch.fields[1]);
+    auto& readC2 = dynamic_cast<LongVectorBatch&>(*readStructBatch.fields[2]);
+    auto& readC3 = dynamic_cast<ByteVectorBatch&>(*readStructBatch.fields[3]);
+
+    for (size_t i = 0; i < TEST_CASES; i++) {
+      EXPECT_EQ(readC0.data[i], i % 2 || i % 3 ? 1 : 0);
+      EXPECT_TRUE(readC1.data[i] == true || i == TEST_CASES / 2);
+      EXPECT_EQ(readC2.data[i],
+                i > TEST_CASES / 2 ? 0 : static_cast<int64_t>((TEST_CASES - i) / (TEST_CASES / 2)));
+      EXPECT_TRUE(readC3.data[i] == true || i > TEST_CASES / 2);
+    }
+  }
+
+  TEST(ConvertColumnReader, betweenNumricOverflows) {
+    constexpr int DEFAULT_MEM_STREAM_SIZE = 10 * 1024;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+    std::unique_ptr<Type> fileType(
+        Type::buildTypeFromString("struct<t1:double,t2:bigint,t3:bigint>"));
+    std::shared_ptr<Type> readType(Type::buildTypeFromString("struct<t1:int,t2:int,t3:float>"));
+    WriterOptions options;
+    auto writer = createWriter(*fileType, &memStream, options);
+    auto batch = writer->createRowBatch(2);
+    auto& structBatch = dynamic_cast<StructVectorBatch&>(*batch);
+    auto& c0 = dynamic_cast<DoubleVectorBatch&>(*structBatch.fields[0]);
+    auto& c1 = dynamic_cast<LongVectorBatch&>(*structBatch.fields[1]);
+    auto& c2 = dynamic_cast<LongVectorBatch&>(*structBatch.fields[2]);
+
+    c0.data[0] = 1e35;
+    c0.data[1] = 1e9 + 7;
+    c1.data[0] = (1LL << 31);
+    c1.data[1] = (1LL << 31) - 1;
+    c2.data[0] = (1LL << 62) + 112312;
+    c2.data[1] = (1LL << 20) + 77553;
+
+    structBatch.numElements = c0.numElements = c1.numElements = c2.numElements = 2;
+    writer->add(*batch);
+    writer->close();
+
+    auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
+    auto pool = getDefaultPool();
+    auto reader = createReader(*pool, std::move(inStream));
+    RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setReadType(readType);
+    rowReaderOpts.setUseTightNumericVector(true);
+    auto rowReader = reader->createRowReader(rowReaderOpts);
+    auto readBatch = rowReader->createRowBatch(2);
+    EXPECT_EQ(true, rowReader->next(*readBatch));
+    auto& readStructBatch = dynamic_cast<StructVectorBatch&>(*readBatch);
+    auto& readC0 = dynamic_cast<IntVectorBatch&>(*readStructBatch.fields[0]);
+    auto& readC1 = dynamic_cast<IntVectorBatch&>(*readStructBatch.fields[1]);
+    auto& readC2 = dynamic_cast<FloatVectorBatch&>(*readStructBatch.fields[2]);
+    EXPECT_EQ(readC0.notNull[0], false);
+    EXPECT_EQ(readC1.notNull[0], false);
+    EXPECT_EQ(readC2.notNull[0], true);
+    EXPECT_TRUE(readC0.notNull[1]);
+    EXPECT_TRUE(readC1.notNull[1]);
+    EXPECT_TRUE(readC2.notNull[1]);
+  }
+}  // namespace orc

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -60,8 +60,8 @@ namespace orc {
     for (size_t i = 0; i < TEST_CASES; i++) {
       c0.data[i] = i % 2 || i % 3 ? true : false;
       c1.data[i] = static_cast<int>((TEST_CASES / 2 - i) * TEST_CASES);
-      c2.data[i] = (TEST_CASES - i) / (TEST_CASES / 2);
-      c3.data[i] = (TEST_CASES - i) / (TEST_CASES / 2);
+      c2.data[i] = 1.0 * (TEST_CASES - i) / (TEST_CASES / 2);
+      c3.data[i] = 1.0f * (TEST_CASES - i) / (TEST_CASES / 2);
     }
 
     writer->add(*batch);
@@ -89,6 +89,11 @@ namespace orc {
                 i > TEST_CASES / 2 ? 0 : static_cast<int64_t>((TEST_CASES - i) / (TEST_CASES / 2)));
       EXPECT_TRUE(readC3.data[i] == true || i > TEST_CASES / 2);
     }
+
+    rowReaderOpts.setUseTightNumericVector(false);
+    rowReader = reader->createRowReader(rowReaderOpts);
+    readBatch = rowReader->createRowBatch(TEST_CASES);
+    EXPECT_THROW(rowReader->next(*readBatch), SchemaEvolutionError);
   }
 
   TEST(ConvertColumnReader, betweenNumricOverflows) {
@@ -135,5 +140,10 @@ namespace orc {
     EXPECT_TRUE(readC0.notNull[1]);
     EXPECT_TRUE(readC1.notNull[1]);
     EXPECT_TRUE(readC2.notNull[1]);
+
+    rowReaderOpts.throwOnSchemaEvolutionOverflow(true);
+    rowReader = reader->createRowReader(rowReaderOpts);
+    readBatch = rowReader->createRowBatch(2);
+    EXPECT_THROW(rowReader->next(*readBatch), SchemaEvolutionError);
   }
 }  // namespace orc

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -60,8 +60,8 @@ namespace orc {
     for (size_t i = 0; i < TEST_CASES; i++) {
       c0.data[i] = i % 2 || i % 3 ? true : false;
       c1.data[i] = static_cast<int>((TEST_CASES / 2 - i) * TEST_CASES);
-      c2.data[i] = 1.0 * (TEST_CASES - i) / (TEST_CASES / 2);
-      c3.data[i] = 1.0f * (TEST_CASES - i) / (TEST_CASES / 2);
+      c2.data[i] = static_cast<double>(TEST_CASES - i) / (TEST_CASES / 2);
+      c3.data[i] = static_cast<float>(TEST_CASES - i) / (TEST_CASES / 2);
     }
 
     writer->add(*batch);

--- a/c++/test/TestSchemaEvolution.cc
+++ b/c++/test/TestSchemaEvolution.cc
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "MockStripeStreams.hh"
+#include "SchemaEvolution.hh"
+#include "TypeImpl.hh"
+
+#include "wrap/gtest-wrapper.h"
+
+namespace orc {
+
+  bool testConvertReader(const std::string file, const std::string& read, bool can, bool need) {
+    auto fileType = std::shared_ptr<Type>(Type::buildTypeFromString(file).release());
+    auto readType = std::shared_ptr<Type>(Type::buildTypeFromString(read).release());
+
+    if (!can) {
+      EXPECT_THROW(SchemaEvolution(readType, fileType.get()), SchemaEvolutionError)
+          << "fileType: " << fileType->toString() << "\nreadType: " << readType->toString();
+    } else {
+      // if can convert, check that there are no excepted be thrown and
+      // we can create reader successfully
+      SchemaEvolution se(readType, fileType.get());
+      EXPECT_FALSE(se.needConvert(*fileType));
+      EXPECT_EQ(need, se.needConvert(*fileType->getSubtype(0)))
+          << "fileType: " << fileType->toString() << "\nreadType: " << readType->toString();
+      MockStripeStreams streams;
+      std::vector<bool> selectedColumns(2);
+      EXPECT_CALL(streams, getSelectedColumns()).WillRepeatedly(testing::Return(selectedColumns));
+      proto::ColumnEncoding directEncoding;
+      directEncoding.set_kind(proto::ColumnEncoding_Kind_DIRECT);
+      EXPECT_CALL(streams, getEncoding(testing::_)).WillRepeatedly(testing::Return(directEncoding));
+
+      EXPECT_CALL(streams, getStreamProxy(testing::_, testing::_, testing::_))
+          .WillRepeatedly(testing::Return(nullptr));
+
+      std::string dummyStream("dummy");
+      ON_CALL(streams, getStreamProxy(1, proto::Stream_Kind_SECONDARY, testing::_))
+          .WillByDefault(testing::Return(
+              new SeekableArrayInputStream(dummyStream.c_str(), dummyStream.length())));
+
+      EXPECT_CALL(streams, getSchemaEvolution()).WillRepeatedly(testing::Return(&se));
+
+      EXPECT_TRUE(buildReader(*fileType, streams) != nullptr);
+    }
+    return true;
+  }
+
+  TEST(SchemaEvolution, createConvertReader) {
+    std::map<size_t, std::string> types = {
+        {0, "struct<t1:boolean>"},        {1, "struct<t1:tinyint>"},
+        {2, "struct<t1:smallint>"},       {3, "struct<t1:int>"},
+        {4, "struct<t1:bigint>"},         {5, "struct<t1:float>"},
+        {6, "struct<t1:double>"},         {7, "struct<t1:string>"},
+        {8, "struct<t1:char(5)>"},        {9, "struct<t1:varchar(5)>"},
+        {10, "struct<t1:char(3)>"},       {11, "struct<t1:varchar(3)>"},
+        {12, "struct<t1:decimal(25,2)>"}, {13, "struct<t1:decimal(15,2)>"},
+        {14, "struct<t1:timestamp>"},     {15, "struct<t1:timestamp with local time zone>"},
+        {16, "struct<t1:date>"}};
+
+    size_t typesSize = types.size();
+    std::vector<std::vector<bool>> needConvert(typesSize, std::vector<bool>(typesSize, 0));
+    std::vector<std::vector<bool>> canConvert(typesSize, std::vector<bool>(typesSize, 0));
+
+    // all types can convert to itselfs
+    for (size_t i = 0; i < types.size(); i++) {
+      canConvert[i][i] = true;
+    }
+
+    // conversion from numeric to numeric
+    for (size_t i = 0; i <= 6; i++) {
+      for (size_t j = 0; j <= 6; j++) {
+        canConvert[i][j] = true;
+        needConvert[i][j] = (i != j);
+      }
+    }
+
+    for (size_t i = 0; i < typesSize; i++) {
+      for (size_t j = 0; j < typesSize; j++) {
+        testConvertReader(types[i], types[j], canConvert[i][j], needConvert[i][j]);
+      }
+    }
+  }
+
+}  // namespace orc


### PR DESCRIPTION
### What changes were proposed in this pull request?
support schema evolution converting between types within {boolean, tinyint, smallint, int, bigint, float, double}


### Why are the changes needed?
To support shecma evolution in c++

### How was this patch tested?
UT passed