### PR TITLE
ORC-1401: [C++] allow writing an intermediate footer

### DIFF
--- a/c++/include/orc/OrcFile.hh
+++ b/c++/include/orc/OrcFile.hh
@@ -102,7 +102,9 @@ namespace orc {
     /**
      * Flush any pending data to the disk.
      */
-    virtual void flush() = 0;
+    virtual void flush() {
+      throw NotImplementedYet("Not supported");
+    }
   };
 
   /**

--- a/c++/include/orc/OrcFile.hh
+++ b/c++/include/orc/OrcFile.hh
@@ -98,6 +98,11 @@ namespace orc {
      * Close the stream and flush any pending data to the disk.
      */
     virtual void close() = 0;
+
+    /**
+     * Flush any pending data to the disk.
+     */
+    virtual void flush() = 0;
   };
 
   /**

--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -309,7 +309,7 @@ namespace orc {
      * truncated to the returned offset, it would be a valid ORC file.
      * @return the offset that would be a valid end location for an ORC file
      */
-    virtual long writeIntermediateFooter() = 0;
+    virtual int64_t writeIntermediateFooter() = 0;
   };
 }  // namespace orc
 

--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -303,6 +303,13 @@ namespace orc {
      * Add user metadata to the writer.
      */
     virtual void addUserMetadata(const std::string& name, const std::string& value) = 0;
+
+    /**
+     * Write an intermediate footer on the file such that if the file is
+     * truncated to the returned offset, it would be a valid ORC file.
+     * @return the offset that would be a valid end location for an ORC file
+     */
+    virtual long writeIntermediateFooter() = 0;
   };
 }  // namespace orc
 

--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -309,7 +309,7 @@ namespace orc {
      * truncated to the returned offset, it would be a valid ORC file.
      * @return the offset that would be a valid end location for an ORC file
      */
-    virtual int64_t writeIntermediateFooter() = 0;
+    virtual uint64_t writeIntermediateFooter() = 0;
   };
 }  // namespace orc
 

--- a/c++/src/OrcFile.cc
+++ b/c++/src/OrcFile.cc
@@ -33,6 +33,7 @@
 #define S_IWUSR _S_IWRITE
 #define stat _stat64
 #define fstat _fstat64
+#define fsync _commit
 #else
 #include <unistd.h>
 #define O_BINARY 0

--- a/c++/src/OrcFile.cc
+++ b/c++/src/OrcFile.cc
@@ -175,6 +175,12 @@ namespace orc {
         closed = true;
       }
     }
+
+    void flush() override {
+      if (!closed) {
+        ::fsync(file);
+      }
+    }
   };
 
   FileOutputStream::~FileOutputStream() {

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -307,7 +307,6 @@ namespace orc {
     static const char* magicId;
     static const WriterId writerId;
     bool useTightNumericVector;
-    long numStripes;
     long stripesAtLastFlush;
     long lastFlushOffset;
 
@@ -345,7 +344,7 @@ namespace orc {
     columnWriter = buildWriter(type, *streamsFactory, options);
     stripeRows = totalRows = indexRows = 0;
     currentOffset = 0;
-    numStripes = stripesAtLastFlush = lastFlushOffset = 0;
+    stripesAtLastFlush = lastFlushOffset = 0;
 
     useTightNumericVector = opts.getUseTightNumericVector();
 
@@ -410,10 +409,10 @@ namespace orc {
     if (stripeRows > 0) {
       writeStripe();
     }
-    if (stripesAtLastFlush != numStripes) {
+    if (stripesAtLastFlush != fileFooter.stripes_size()) {
       writeMetadata();
       writeFileFooter();
-      stripesAtLastFlush = numStripes;
+      stripesAtLastFlush = fileFooter.stripes_size();
       writePostscript();
       outStream->flush();
       lastFlushOffset = outStream->getLength();
@@ -548,8 +547,6 @@ namespace orc {
     totalRows += stripeRows;
 
     columnWriter->reset();
-
-    numStripes += 1;
 
     initStripe();
   }

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -307,8 +307,8 @@ namespace orc {
     static const char* magicId;
     static const WriterId writerId;
     bool useTightNumericVector;
-    long stripesAtLastFlush;
-    long lastFlushOffset;
+    int32_t stripesAtLastFlush;
+    int64_t lastFlushOffset;
 
    public:
     WriterImpl(const Type& type, OutputStream* stream, const WriterOptions& options);
@@ -321,7 +321,7 @@ namespace orc {
 
     void addUserMetadata(const std::string& name, const std::string& value) override;
 
-    long writeIntermediateFooter() override;
+    int64_t writeIntermediateFooter() override;
 
    private:
     void init();
@@ -344,7 +344,8 @@ namespace orc {
     columnWriter = buildWriter(type, *streamsFactory, options);
     stripeRows = totalRows = indexRows = 0;
     currentOffset = 0;
-    stripesAtLastFlush = lastFlushOffset = 0;
+    stripesAtLastFlush = 0;
+    lastFlushOffset = 0;
 
     useTightNumericVector = opts.getUseTightNumericVector();
 

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -421,7 +421,7 @@ namespace orc {
       // init stripe now that we adjusted the currentOffset
       initStripe();
     }
-    return stripesAtLastFlush;
+    return lastFlushOffset;
   }
 
   void WriterImpl::addUserMetadata(const std::string& name, const std::string& value) {

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -307,6 +307,9 @@ namespace orc {
     static const char* magicId;
     static const WriterId writerId;
     bool useTightNumericVector;
+    long numStripes;
+    long stripesAtLastFlush;
+    long lastFlushOffset;
 
    public:
     WriterImpl(const Type& type, OutputStream* stream, const WriterOptions& options);
@@ -318,6 +321,8 @@ namespace orc {
     void close() override;
 
     void addUserMetadata(const std::string& name, const std::string& value) override;
+
+    long writeIntermediateFooter() override;
 
    private:
     void init();
@@ -340,6 +345,7 @@ namespace orc {
     columnWriter = buildWriter(type, *streamsFactory, options);
     stripeRows = totalRows = indexRows = 0;
     currentOffset = 0;
+    numStripes = stripesAtLastFlush = lastFlushOffset = 0;
 
     useTightNumericVector = opts.getUseTightNumericVector();
 
@@ -398,6 +404,24 @@ namespace orc {
     writeFileFooter();
     writePostscript();
     outStream->close();
+  }
+
+  long WriterImpl::writeIntermediateFooter() {
+    if (stripeRows > 0) {
+      writeStripe();
+    }
+    if (stripesAtLastFlush != numStripes) {
+      writeMetadata();
+      writeFileFooter();
+      stripesAtLastFlush = numStripes;
+      writePostscript();
+      outStream->flush();
+      lastFlushOffset = outStream->getLength();
+      currentOffset = lastFlushOffset;
+      // init stripe now that we adjusted the currentOffset
+      initStripe();
+    }
+    return stripesAtLastFlush;
   }
 
   void WriterImpl::addUserMetadata(const std::string& name, const std::string& value) {
@@ -525,6 +549,8 @@ namespace orc {
 
     columnWriter->reset();
 
+    numStripes += 1;
+
     initStripe();
   }
 
@@ -542,6 +568,7 @@ namespace orc {
     // update file statistics
     std::vector<proto::ColumnStatistics> colStats;
     columnWriter->getFileStatistics(colStats);
+    fileFooter.clear_statistics();
     for (uint32_t i = 0; i != colStats.size(); ++i) {
       *fileFooter.add_statistics() = colStats[i];
     }

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -412,8 +412,8 @@ namespace orc {
     if (stripesAtLastFlush != fileFooter.stripes_size()) {
       writeMetadata();
       writeFileFooter();
-      stripesAtLastFlush = fileFooter.stripes_size();
       writePostscript();
+      stripesAtLastFlush = fileFooter.stripes_size();
       outStream->flush();
       lastFlushOffset = outStream->getLength();
       currentOffset = lastFlushOffset;

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -308,7 +308,7 @@ namespace orc {
     static const WriterId writerId;
     bool useTightNumericVector;
     int32_t stripesAtLastFlush;
-    int64_t lastFlushOffset;
+    uint64_t lastFlushOffset;
 
    public:
     WriterImpl(const Type& type, OutputStream* stream, const WriterOptions& options);

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -321,7 +321,7 @@ namespace orc {
 
     void addUserMetadata(const std::string& name, const std::string& value) override;
 
-    int64_t writeIntermediateFooter() override;
+    uint64_t writeIntermediateFooter() override;
 
    private:
     void init();
@@ -406,7 +406,7 @@ namespace orc {
     outStream->close();
   }
 
-  long WriterImpl::writeIntermediateFooter() {
+  uint64_t WriterImpl::writeIntermediateFooter() {
     if (stripeRows > 0) {
       writeStripe();
     }

--- a/c++/test/MemoryOutputStream.hh
+++ b/c++/test/MemoryOutputStream.hh
@@ -56,6 +56,8 @@ namespace orc {
 
     void close() override {}
 
+    void flush() override {}
+
     void reset() {
       length = 0;
     }

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -2018,7 +2018,7 @@ namespace orc {
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
     LongVectorBatch* longBatch = dynamic_cast<LongVectorBatch*>(structBatch->fields[0]);
 
-    std::vector<int64_t> offsets;
+    std::vector<uint64_t> offsets;
     for (uint64_t j = 0; j < 10; ++j) {
       for (uint64_t i = 0; i < 65535; ++i) {
         longBatch->data[i] = static_cast<int64_t>(i);
@@ -2073,7 +2073,7 @@ namespace orc {
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
     LongVectorBatch* longBatch = dynamic_cast<LongVectorBatch*>(structBatch->fields[0]);
 
-    std::vector<int64_t> offsets;
+    std::vector<uint64_t> offsets;
     for (uint64_t j = 0; j < 10; ++j) {
       for (uint64_t i = 0; i < 65535; ++i) {
         longBatch->data[i] = static_cast<int64_t>(i);

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -2027,7 +2027,7 @@ namespace orc {
 
       writer->add(*batch);
       // force writing a stripe
-      int64_t offset = writer->writeIntermediateFooter();
+      uint64_t offset = writer->writeIntermediateFooter();
       offsets.push_back(offset);
     }
 
@@ -2081,7 +2081,7 @@ namespace orc {
       writer->add(*batch);
       if (j < 8) {
         // force writing a stripe
-        int64_t offset = writer->writeIntermediateFooter();
+        uint64_t offset = writer->writeIntermediateFooter();
         offsets.push_back(offset);
       }
     }

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -67,7 +67,8 @@ namespace orc {
   }
 
   std::unique_ptr<Reader> createReaderWithTailLocation(MemoryPool* memoryPool,
-                                       std::unique_ptr<InputStream> stream, uint64_t tailLocation) {
+                                                       std::unique_ptr<InputStream> stream,
+                                                       uint64_t tailLocation) {
     ReaderOptions options;
     options.setMemoryPool(*memoryPool);
     options.setTailLocation(tailLocation);
@@ -2034,14 +2035,16 @@ namespace orc {
     writer->close();
 
     for (uint64_t o = 0; o < 10; ++o) {
-      auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
-      std::unique_ptr<Reader> reader = createReaderWithTailLocation(pool, std::move(inStream), offsets[o]);
+      auto inStream =
+          std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
+      std::unique_ptr<Reader> reader =
+          createReaderWithTailLocation(pool, std::move(inStream), offsets[o]);
       std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
-      EXPECT_EQ(o+1, reader->getNumberOfStripes());
-      EXPECT_EQ(65535*(o+1), reader->getNumberOfRows());
+      EXPECT_EQ(o + 1, reader->getNumberOfStripes());
+      EXPECT_EQ(65535 * (o + 1), reader->getNumberOfRows());
 
       batch = rowReader->createRowBatch(65535);
-      for (uint64_t j = 0; j < o+1; ++j) {
+      for (uint64_t j = 0; j < o + 1; ++j) {
         EXPECT_TRUE(rowReader->next(*batch));
         EXPECT_EQ(65535, batch->numElements);
 
@@ -2090,10 +2093,11 @@ namespace orc {
     // writer->close();
 
     auto inStream = std::make_unique<MemoryInputStream>(memStream.getData(), memStream.getLength());
-    std::unique_ptr<Reader> reader = createReaderWithTailLocation(pool, std::move(inStream), offsets.back());
+    std::unique_ptr<Reader> reader =
+        createReaderWithTailLocation(pool, std::move(inStream), offsets.back());
     std::unique_ptr<RowReader> rowReader = createRowReader(reader.get());
     EXPECT_EQ(8, reader->getNumberOfStripes());
-    EXPECT_EQ(8*65535, reader->getNumberOfRows());
+    EXPECT_EQ(8 * 65535, reader->getNumberOfRows());
 
     batch = rowReader->createRowBatch(65535);
     for (uint64_t j = 0; j < 8; ++j) {


### PR DESCRIPTION
Current C++ code base does not support writing intermediate footers as Java code base does.

It would be beneficial to the C++ based writers to have an ability to write intermediate footer(s) to the opened file while streaming data into it. The benefit is not losing the so far persisted data (after flushing stripes) in case of writer failure in closing the file (application crash).

The writer that wants to support the feature would follow similar approach as Hive does in writing a side file with the latest footer offsets. The reader would be able to determine the location of the last valid footer by using the last footer location from the side file (instead of assuming that the footer is at the end of the file).

The change was tested by creating a small ORC file writer test application that calls newly added `WriterImpl::writeIntermediateFooter()` after adding a batch of rows:

```
        writer->add(*batch);
        writer->writeIntermediateFooter();
```

The resulting ORC file is readable by the provided stock C++ and Java tools. The preliminary C++ test code and results from the tools are attached to this PR here [notes.txt](https://github.com/apache/orc/files/11105096/notes.txt).

Not all aspects of the possible use were tested yet namely unclean writer app shutdown, writing of the side file, loading of the side file, reading of the last valid footer when file was not properly closed.

This is a draft PR. No proper tests are added at the moment because of incomplete PR.

I'm looking for opinions from the ORC experts in order to finish up the PR.