### PR TITLE
ORC-1403: ORC supports reading empty field name

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ParserUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/ParserUtils.java
@@ -110,8 +110,6 @@ public class ParserUtils {
       if (!closed) {
         source.position = start;
         throw new IllegalArgumentException("Unmatched quote at " + source);
-      } else if (buffer.length() == 0) {
-        throw new IllegalArgumentException("Empty quoted field name at " + source);
       }
       return buffer.toString();
     } else {

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -523,4 +523,9 @@ public class TestTypeDescription {
     // Should not throw NPE
     TypeDescription.fromString("int").hashCode();
   }
+
+  @Test
+  public void testEmptyFieldName() {
+    TypeDescription.fromString("struct<``:string>");
+  }
 }

--- a/java/core/src/test/org/apache/orc/TestTypeDescription.java
+++ b/java/core/src/test/org/apache/orc/TestTypeDescription.java
@@ -175,14 +175,6 @@ public class TestTypeDescription {
   }
 
   @Test
-  public void testQuotedField2() {
-    IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
-      TypeDescription.fromString("struct<``:int>");
-    });
-    assertTrue(e.getMessage().contains("Empty quoted field name at 'struct<``^:int>'"));
-  }
-
-  @Test
   public void testParserUnknownCategory() {
     IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
       TypeDescription.fromString("FOOBAR");


### PR DESCRIPTION
### What changes were proposed in this pull request?
`ParserUtils` removes empty check


### Why are the changes needed?

https://github.com/apache/spark/pull/35253#issuecomment-1321866542

```java
java.lang.IllegalArgumentException: Empty quoted field name at 'struct<``^:string>'
    at org.apache.orc.impl.ParserUtils.parseName(ParserUtils.java:114)
    at org.apache.orc.impl.ParserUtils.parseStruct(ParserUtils.java:170)
    at org.apache.orc.impl.ParserUtils.parseType(ParserUtils.java:228)
    at org.apache.orc.TypeDescription.fromString(TypeDescription.java:202)
    at org.apache.orc.mapred.OrcInputFormat.buildOptions(OrcInputFormat.java:122)
    at org.apache.spark.sql.execution.datasources.orc.OrcColumnarBatchReader.initialize(OrcColumnarBatchReader.java:130)
    at org.apache.spark.sql.execution.datasources.orc.OrcFileFormat.$anonfun$buildReaderWithPartitionValues$2(OrcFileFormat.scala:207) 
```

### How was this patch tested?
add UT
