### PR TITLE
ORC-1410: [C++] Bump zstd to v1.5.5

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -20,7 +20,7 @@ set(SNAPPY_VERSION "1.1.7")
 set(ZLIB_VERSION "1.2.11")
 set(GTEST_VERSION "1.12.1")
 set(PROTOBUF_VERSION "3.5.1")
-set(ZSTD_VERSION "1.5.4")
+set(ZSTD_VERSION "1.5.5")
 
 option(ORC_PREFER_STATIC_PROTOBUF "Prefer static protobuf library, if available" ON)
 option(ORC_PREFER_STATIC_SNAPPY   "Prefer static snappy library, if available"   ON)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade zstd to v1.5.5 for the C++ library.

### Why are the changes needed?
The most recent release of zstd has fixed a rare corruption bug and brings some speed improvements.
see also https://github.com/facebook/zstd/releases/tag/v1.5.5


### How was this patch tested?
All UT passed