### PR TITLE
ORC-1415: Add Java 20 to GitHub CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
             java: 8
             cxx: g++
           - os: ubuntu-20.04
-            java: 19
+            java: 20
             cxx: g++
     env:
       MAVEN_OPTS: -Xmx2g


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add Java 20 to GitHub CI tests.


### Why are the changes needed?
To ensure the readiness of the next LTS Java version: 21.
- https://www.oracle.com/java/technologies/javase/20all-relnotes.html

### How was this patch tested?
Pass the CIs.
