### PR TITLE
ORC-1416: Upgrade Jackson dependency to 2.14.2 in `bench` module

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -32,7 +32,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Spark Jackson version may not be same as ORC -->
-    <spark.jackson.version>2.13.4</spark.jackson.version>
+    <spark.jackson.version>2.14.2</spark.jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Jackson dependency to 2.14.2 in bench module.

### Why are the changes needed?

To match with Apache Spark 3.4.0.

### How was this patch tested?

Pass the CIs.

Closes #1476 