### PR TITLE
ORC-1420: Pin `net.bytebuddy` package to 1.12.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,9 @@ updates:
       # Pin mockito to 4.x
       - dependency-name: "org.mockito"
         versions: "[5.0.0,)"
+      # Pin byte-buddy to 1.12.x aline with mockito
+      - dependency-name: "net.bytebuddy"
+        versions: "[1.13.0,)"
       # Pin spotless to 2.30.0 due to Java 8 support
       - dependency-name: "com.diffplug.spotless:spotless-maven-plugin"
         versions: "[2.31.0,)"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -442,6 +442,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>1.12.23</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.auto.service</groupId>
         <artifactId>auto-service</artifactId>
         <version>1.0.1</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to pin `net.bytebuddy` package to 1.12.x.

### Why are the changes needed?

`byte-buddy` is a transitive dependency from `Mockito` and currently we have inconsistency among byte-buddy libraries like the following.

```
$ mvn dependency:tree | grep byte
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.12.23:test
[INFO] |  +- net.bytebuddy:byte-buddy-agent:jar:1.12.19:test
```

Since ORC-1360 pinned `Mockito` at 4.x, we had better pin them 1.12.x with the same latest version, `1.12.23`.

### How was this patch tested?

Pass the CIs.


Closes #1461