### PR TITLE
ORC-1421. Use PyArrow 12.0.0 in document

### DIFF
--- a/site/_docs/pyarrow.md
+++ b/site/_docs/pyarrow.md
@@ -9,7 +9,7 @@ permalink: /docs/pyarrow.html
 [Apache Arrow](https://arrow.apache.org) project's [PyArrow](https://pypi.org/project/pyarrow/) is the recommended package.
 
 ```
-pip3 install pyarrow==10.0.1
+pip3 install pyarrow==12.0.0
 pip3 install pandas
 ```
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a document update PR to use `PyArrow 12.0.0` for Apache ORC 1.9.0 preparation.

### Why are the changes needed?

Apache Arrow 12.0.0 has a fix for ORC CHAR type mapping

https://github.com/apache/arrow/commit/ce94fbabae53fb53fef600f224dd44fc69b713b4

### How was this patch tested?

Manual review.