### PR TITLE
ORC-1426: Use Java `21-ea` instead of `20` in GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -42,7 +42,7 @@ jobs:
             java: 8
             cxx: g++
           - os: ubuntu-20.04
-            java: 20
+            java: 21-ea
             cxx: g++
     env:
       MAVEN_OPTS: -Xmx2g


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump Java 20 GitHub Action job to Java 21-ea.

### Why are the changes needed?

To be ready and monitor Java module for Java 21 support later.

Java 21 Early Access Build was released on 2023/5/11.
- https://jdk.java.net/21/

### How was this patch tested?

Pass the CI.

![Screenshot 2023-05-17 at 3 02 21 PM](https://github.com/apache/orc/assets/9700541/bc54abaa-2b8e-47f3-8534-d04ec4ffc863)
