### PR TITLE
ORC-1428: Setup GitHub Action CI on `branch-1.9`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -6,13 +6,13 @@ on:
     - 'docker'
     - 'site/**'
     branches:
-    - main
+    - branch-1.9
   pull_request:
     paths-ignore:
     - 'docker'
     - 'site/**'
     branches:
-    - main
+    - branch-1.9
 
 # Cancel previous PR build and test
 concurrency:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `GitHub Action CI` on `branch-1.9`.

### Why are the changes needed?

The GitHub Action is not triggered currently on `branch-1.9`.
- Commit: https://github.com/apache/orc/commit/e1c3ef5ebd721f4b9ab5da358b4508041e787e1b, 

### How was this patch tested?

This should be verified after merging.