### PR TITLE
ORC-1429: Upgrade Maven to 3.8.8

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -69,7 +69,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-    <maven.version>3.8.6</maven.version>
+    <maven.version>3.8.8</maven.version>
 
     <min.hadoop.version>2.7.3</min.hadoop.version>
     <mockito.version>4.11.0</mockito.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Maven to 3.8.8 for Apache ORC 2.0.

### Why are the changes needed?

Apache Maven 3.8.8 is the latest bug fixed versions in 3.8.x line.
- https://maven.apache.org/docs/history.html

### How was this patch tested?

Pass the CIs.