### PR TITLE
ORC-1431: Use parquet to 1.13.1 in bench module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -38,7 +38,7 @@
     <jmh.version>1.20</jmh.version>
     <junit.version>5.9.3</junit.version>
     <orc.version>${project.version}</orc.version>
-    <parquet.version>1.13.0</parquet.version>
+    <parquet.version>1.13.1</parquet.version>
     <spark.version>3.4.0</spark.version>
   </properties>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Parquet 1.13.1 in `bench` module.

### Why are the changes needed?

Apache Parquet 1.13.1 is released.
- https://parquet.apache.org/blog/2023/05/18/1.13.1/

### How was this patch tested?

Pass the CIs.