### PR TITLE
ORC-1432: Add MacOS 13 GitHub Action Job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,7 @@ jobs:
           - ubuntu-22.04
           - macos-11
           - macos-12
+          - macos-13
         java:
           - 8
           - 11


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `MacOS 13` GitHub Action Job.

### Why are the changes needed?

`MacOS 13 Ventura` is the latest MacOS. 
- https://en.wikipedia.org/wiki/MacOS_Ventura

### How was this patch tested?

Pass the CIs.