### PR TITLE
ORC-1434: Remove `org.apache.hadoop` from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,13 +26,6 @@ updates:
       # Pin jmh to 1.20
       - dependency-name: "org.openjdk.jmh:jmh-core"
         versions: "[1.21,)"
-      # Pin minimum support Hadoop version to 2.2.0
-      - dependency-name: "org.apache.hadoop:hadoop-common"
-        versions: "[2.2.1,)"
-      - dependency-name: "org.apache.hadoop:hadoop-hdfs"
-        versions: "[2.2.1,)"
-      - dependency-name: "org.apache.hadoop:hadoop-mapreduce-client-core"
-        versions: "[2.2.1,)"
       # Pin scala-library to 2.12.15
       - dependency-name: "org.scala-lang:scala-library"
         versions: "[2.12.16,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `org.apache.hadoop` from `dependabot.yml.`

### Why are the changes needed?

After ORC-1430, Apache ORC can use te latest Apache Hadoop always.

### How was this patch tested?

Since this is a dependabot setting, this is irrelevant to CI (Java/C++).