### PR TITLE
ORC-1446: Publish snapshot from branch-1.9

### DIFF
--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -3,7 +3,7 @@ name: Publish Snapshot
 on:
   push:
     branches:
-    - main
+    - branch-1.9
 
 jobs:
   publish-snapshot:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to publish snapshot from `branch-1.9`.

### Why are the changes needed?

We missed this when we create `branch-1.9`.

### How was this patch tested?

We need to verify this after merging.