### PR TITLE
ORC-1447: [C++] Fix a bug in CpuInfoUtil.cc to support ARM platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,12 @@ enable_testing()
 
 INCLUDE(CheckSourceCompiles)
 INCLUDE(ThirdpartyToolchain)
+
+if (BUILD_ENABLE_AVX512 AND NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|X86|x86|i[3456]86|x64"))
+  message(WARNING "Only X86 platform support AVX512")
+  set (BUILD_ENABLE_AVX512 "OFF")
+endif ()
+
 message(STATUS "BUILD_ENABLE_AVX512: ${BUILD_ENABLE_AVX512}")
 #
 # macOS doesn't fully support AVX512, it has a different way dealing with AVX512 than Windows and Linux.

--- a/c++/src/CpuInfoUtil.cc
+++ b/c++/src/CpuInfoUtil.cc
@@ -476,8 +476,8 @@ namespace orc {
     }
 
     void ArchVerifyCpuRequirements(const CpuInfo* ci) {
-      if (!ci->IsDetected(CpuInfo::ASIMD)) {
-        DCHECK(false) << "CPU does not support the Armv8 Neon instruction set";
+      if (!ci->isDetected(CpuInfo::ASIMD)) {
+        throw ParseError("CPU does not support the Armv8 Neon instruction set");
       }
     }
 

--- a/c++/src/CpuInfoUtil.cc
+++ b/c++/src/CpuInfoUtil.cc
@@ -51,11 +51,14 @@
 
 #undef CPUINFO_ARCH_X86
 #undef CPUINFO_ARCH_ARM
+#undef CPUINFO_ARCH_PPC
 
 #if defined(__i386) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_X64)
 #define CPUINFO_ARCH_X86
 #elif defined(_M_ARM64) || defined(__aarch64__) || defined(__arm64__)
 #define CPUINFO_ARCH_ARM
+#elif defined(__PPC64__) || defined(__PPC64LE__) || defined(__ppc64__) || defined(__powerpc64__)
+#define CPUINFO_ARCH_PPC
 #endif
 
 #ifndef ORC_HAVE_RUNTIME_AVX512
@@ -481,7 +484,15 @@ namespace orc {
       }
     }
 
-#endif  // X86, ARM
+#else
+    //------------------------------ PPC, ... ------------------------------//
+    bool ArchParseUserSimdLevel(const std::string& simd_level, int64_t* hardware_flags) {
+      return true;
+    }
+
+    void ArchVerifyCpuRequirements(const CpuInfo* ci) {}
+
+#endif  // X86, ARM, PPC
 
   }  // namespace
 
@@ -576,3 +587,4 @@ namespace orc {
 
 #undef CPUINFO_ARCH_X86
 #undef CPUINFO_ARCH_ARM
+#undef CPUINFO_ARCH_PPC

--- a/c++/src/CpuInfoUtil.hh
+++ b/c++/src/CpuInfoUtil.hh
@@ -55,6 +55,9 @@ namespace orc {
     static constexpr int64_t BMI1 = (1LL << 11);
     static constexpr int64_t BMI2 = (1LL << 12);
 
+    /// Arm features
+    static constexpr int64_t ASIMD = (1LL << 32);
+
     // Cache enums for L1 (data), L2 and L3
     enum class CacheLevel { L1 = 0, L2, L3, Last = L3 };
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
To fix a bug reported in https://github.com/apache/orc/issues/1534
The bug is that some CpuInfoUtil.cc functions don't support the ARM platform. In this PR, try to fix this bug.

### Why are the changes needed?
Currently, ORC can't build success on the ARM platform without this PR.


### How was this patch tested?
We can build ORC on the ARM platform directly to check if it can succeed.
If user enabled -DBUILD_ENABLE_AVX512=ON in the cmake process, it will get the below warning message, and BUILD_ENABLE_AVX512 will be changed back to OFF.
CMake Warning at CMakeLists.txt:183 (message):
  Only X86 platform support AVX512
