### PR TITLE
ORC-1452: Use the latest OS versions in variant tests

### DIFF
--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,6 +4,6 @@ debian11
 ubuntu20
 ubuntu22
 fedora37
-debian10_jdk=11
-ubuntu20_jdk=11
-ubuntu20_jdk=11_cc=clang
+debian11_jdk=11
+ubuntu22_jdk=11
+ubuntu22_jdk=11_cc=clang


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the latest Debian and Ubuntu OS versions in the variant tests.

### Why are the changes needed?

To test more on the latest OSes.

### How was this patch tested?

Manual tests.

```
$ cd docker

$ ./reinit.sh
Target: centos7 debian10 debian11 ubuntu20 ubuntu22 fedora37 debian11_jdk=11 ubuntu22_jdk=11 ubuntu22_jdk=11_cc=clang
Re-initialize apache/orc-dev:centos7
...
Start: Thu Jun 22 00:55:59 PDT 2023
End: Thu Jun 22 01:12:53 PDT 2023

$ docker images
REPOSITORY       TAG                        IMAGE ID       CREATED              SIZE
apache/orc-dev   ubuntu22_jdk-11_cc-clang   2cf37cad8161   17 seconds ago       1.57GB
apache/orc-dev   ubuntu22_jdk-11            d9828aa51f94   About a minute ago   955MB
apache/orc-dev   debian11_jdk-11            cdf4a25c7b13   3 minutes ago        1.12GB
apache/orc-dev   fedora37                   58678c600209   3 minutes ago        1.55GB
apache/orc-dev   ubuntu22                   ebbc5ab5f558   5 minutes ago        1.06GB
apache/orc-dev   ubuntu20                   93bd390838ae   8 minutes ago        985MB
apache/orc-dev   debian11                   c60190aa726e   9 minutes ago        1.06GB
apache/orc-dev   debian10                   b2306f1adbef   13 minutes ago       984MB
apache/orc-dev   centos7                    4794db36fac0   14 minutes ago       1.79GB

$ docker run -it --rm apache/orc-dev:ubuntu22_jdk-11_cc-clang clang --version
Ubuntu clang version 14.0.0-1ubuntu1
Target: aarch64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
```