### PR TITLE
ORC-1457: [C++] Fix ambiguous overload of Type::createRowBatch

### DIFF
--- a/c++/include/orc/Type.hh
+++ b/c++/include/orc/Type.hh
@@ -78,9 +78,9 @@ namespace orc {
     virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size, MemoryPool& pool,
                                                               bool encoded = false) const = 0;
 
-    virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(
-        uint64_t size, MemoryPool& pool, bool encoded = false,
-        bool useTightNumericVector = false) const = 0;
+    virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(uint64_t size, MemoryPool& pool,
+                                                              bool encoded,
+                                                              bool useTightNumericVector) const = 0;
 
     /**
      * Add a new field to a struct type.

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -279,7 +279,7 @@ namespace orc {
   std::unique_ptr<ColumnVectorBatch> TypeImpl::createRowBatch(uint64_t capacity,
                                                               MemoryPool& memoryPool,
                                                               bool encoded) const {
-    return createRowBatch(capacity, memoryPool, encoded, false);
+    return createRowBatch(capacity, memoryPool, encoded, /*useTightNumericVector=*/false);
   }
 
   std::unique_ptr<ColumnVectorBatch> TypeImpl::createRowBatch(uint64_t capacity,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove default parameters from one overload of Type::createRowBatch to eliminate ambiguity.

### Why are the changes needed?

The overloads of Type::createRowBatch are ambiguous when default parameters are used.
```cpp
virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(
  uint64_t size, MemoryPool& pool, bool encoded = false) const = 0;

virtual std::unique_ptr<ColumnVectorBatch> createRowBatch(
  uint64_t size, MemoryPool& pool, bool encoded = false,
  bool useTightNumericVector = false) const = 0;
```

### How was this patch tested?

Make sure all tests pass.
