### PR TITLE
ORC-1459: Mark `DataBuffer::size()` and `DataBuffer::capacity()` as `const`

### DIFF
--- a/c++/include/orc/MemoryPool.hh
+++ b/c++/include/orc/MemoryPool.hh
@@ -64,11 +64,11 @@ namespace orc {
       return buf;
     }
 
-    uint64_t size() {
+    uint64_t size() const {
       return currentSize;
     }
 
-    uint64_t capacity() {
+    uint64_t capacity() const {
       return currentCapacity;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

These two accessors do not mutate the state, so they can be tagged as `const` to indicate this into callers.


### Why are the changes needed?

I am writing a Rust binding, and the methods not being `const` give me extra constraints.


### How was this patch tested?

`make test` passes.