### PR TITLE
ORC-1461: Mark `Int128::getHighBits()` and `Int128::getLowBits()` as `const`

### DIFF
--- a/c++/include/orc/Int128.hh
+++ b/c++/include/orc/Int128.hh
@@ -325,14 +325,14 @@ namespace orc {
     /**
      * Get the high bits of the twos complement representation of the number.
      */
-    int64_t getHighBits() {
+    int64_t getHighBits() const {
       return highbits;
     }
 
     /**
      * Get the low bits of the twos complement representation of the number.
      */
-    uint64_t getLowBits() {
+    uint64_t getLowBits() const {
       return lowbits;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

These two accessors do not mutate the state, so they can be tagged as `const` to indicate this into callers.


### Why are the changes needed?

Same motivation as #1558: I am writing a Rust binding, and the methods not being `const` give me extra constraints.


### How was this patch tested?

`make test` passes.