### PR TITLE
[Documentation] updated maven version to 3.8.8 to reflect changes done via ORC-1429

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The subdirectories are:
 ### Building
 
 * Install java 1.8 or higher
-* Install maven 3.8.6 or higher
+* Install maven 3.8.8 or higher
 * Install cmake 3.12 or higher
 
 To build a release version with debug information:


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR proposes to update README to reflect the actual maven version to be used for build.
Current documentations says Maven version 3.8.6 or higher. However, the build fails with Maven 3.8.6 with error

```
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.3.0:enforce (enforce-maven) on project orc: 
[ERROR] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion failed with message:
[ERROR] Detected Maven Version: 3.8.6 is not in the allowed range [3.8.8,).

```

### Why are the changes needed?
The changes are need to keep documentation in sync with maven version used for build.


### How was this patch tested?
Documentation patch, no tests were done