### PR TITLE
ORC-1473: Fix zero copy read bugs

### DIFF
--- a/java/core/src/java/org/apache/orc/DataReader.java
+++ b/java/core/src/java/org/apache/orc/DataReader.java
@@ -52,11 +52,11 @@ public interface DataReader extends AutoCloseable, Cloneable {
   boolean isTrackingDiskRanges();
 
   /**
-   * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
-   * incorrectly added and shouldn't be used anymore.
-   *
    * Releases buffers created by readFileData. See readFileData javadoc.
    * @param toRelease The buffer to release.
+   *
+   * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
+   * incorrectly added and shouldn't be used anymore.
    */
   @Deprecated
   void releaseBuffer(ByteBuffer toRelease);

--- a/java/core/src/java/org/apache/orc/DataReader.java
+++ b/java/core/src/java/org/apache/orc/DataReader.java
@@ -52,6 +52,13 @@ public interface DataReader extends AutoCloseable, Cloneable {
   boolean isTrackingDiskRanges();
 
   /**
+   * Releases buffers created by readFileData. See readFileData javadoc.
+   * @param toRelease The buffer to release.
+   */
+  @Deprecated
+  void releaseBuffer(ByteBuffer toRelease);
+
+  /**
    * Releases all buffers created by readFileData. See readFileData javadoc.
    */
   void releaseAllBuffers();

--- a/java/core/src/java/org/apache/orc/DataReader.java
+++ b/java/core/src/java/org/apache/orc/DataReader.java
@@ -52,6 +52,9 @@ public interface DataReader extends AutoCloseable, Cloneable {
   boolean isTrackingDiskRanges();
 
   /**
+   * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
+   * incorrectly added and shouldn't be used anymore.
+   *
    * Releases buffers created by readFileData. See readFileData javadoc.
    * @param toRelease The buffer to release.
    */

--- a/java/core/src/java/org/apache/orc/DataReader.java
+++ b/java/core/src/java/org/apache/orc/DataReader.java
@@ -56,7 +56,7 @@ public interface DataReader extends AutoCloseable, Cloneable {
    * @param toRelease The buffer to release.
    *
    * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
-   * incorrectly added and shouldn't be used anymore.
+   * incorrectly used by upper level code and shouldn't be used anymore.
    */
   @Deprecated
   void releaseBuffer(ByteBuffer toRelease);

--- a/java/core/src/java/org/apache/orc/DataReader.java
+++ b/java/core/src/java/org/apache/orc/DataReader.java
@@ -52,10 +52,9 @@ public interface DataReader extends AutoCloseable, Cloneable {
   boolean isTrackingDiskRanges();
 
   /**
-   * Releases buffers created by readFileData. See readFileData javadoc.
-   * @param toRelease The buffer to release.
+   * Releases all buffers created by readFileData. See readFileData javadoc.
    */
-  void releaseBuffer(ByteBuffer toRelease);
+  void releaseAllBuffers();
 
   /**
    * Clone the entire state of the DataReader with the assumption that the

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -131,6 +131,10 @@ public class RecordReaderUtils {
       return zcr != null;
     }
 
+    /**
+     * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
+     * incorrectly added and shouldn't be used anymore.
+     */
     @Deprecated
     @Override
     public void releaseBuffer(ByteBuffer buffer) {

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -133,7 +133,7 @@ public class RecordReaderUtils {
 
     /**
      * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
-     * incorrectly added and shouldn't be used anymore.
+     * incorrectly used by upper level code and shouldn't be used anymore.
      */
     @Deprecated
     @Override

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -132,8 +132,8 @@ public class RecordReaderUtils {
     }
 
     @Override
-    public void releaseBuffer(ByteBuffer buffer) {
-      zcr.releaseBuffer(buffer);
+    public void releaseAllBuffers() {
+      zcr.releaseAllBuffers();
     }
 
     @Override
@@ -374,7 +374,7 @@ public class RecordReaderUtils {
 
       // did we get the current range in a single read?
       if (currentOffset + currentBuffer.remaining() >= current.getEnd()) {
-        ByteBuffer copy = currentBuffer.duplicate();
+        ByteBuffer copy = currentBuffer.slice();
         copy.position((int) (current.getOffset() - currentOffset));
         copy.limit(copy.position() + current.getLength());
         current.setChunk(copy);
@@ -385,7 +385,7 @@ public class RecordReaderUtils {
                               ? ByteBuffer.allocateDirect(current.getLength())
                               : ByteBuffer.allocate(current.getLength());
         // we know that the range spans buffers
-        ByteBuffer copy = currentBuffer.duplicate();
+        ByteBuffer copy = currentBuffer.slice();
         // skip over the front matter
         copy.position((int) (current.getOffset() - currentOffset));
         result.put(copy);
@@ -394,11 +394,11 @@ public class RecordReaderUtils {
         currentBuffer = buffers.next();
         while (result.hasRemaining()) {
           if (result.remaining() > currentBuffer.remaining()) {
-            result.put(currentBuffer.duplicate());
+            result.put(currentBuffer.slice());
             currentOffset += currentBuffer.remaining();
             currentBuffer = buffers.next();
           } else {
-            copy = currentBuffer.duplicate();
+            copy = currentBuffer.slice();
             copy.limit(result.remaining());
             result.put(copy);
           }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -131,6 +131,12 @@ public class RecordReaderUtils {
       return zcr != null;
     }
 
+    @Deprecated
+    @Override
+    public void releaseBuffer(ByteBuffer buffer) {
+      zcr.releaseBuffer(buffer);
+    }
+
     @Override
     public void releaseAllBuffers() {
       zcr.releaseAllBuffers();

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -613,5 +613,19 @@ public class StripePlanner {
       this.offset = offset;
       this.length = length;
     }
+
+    @Deprecated
+    void releaseBuffers(DataReader reader) {
+      long end = offset + length;
+      BufferChunk ptr = firstChunk;
+      while (ptr != null && ptr.getOffset() < end) {
+        ByteBuffer buffer = ptr.getData();
+        if (buffer != null) {
+          reader.releaseBuffer(buffer);
+          ptr.setChunk(null);
+        }
+        ptr = (BufferChunk) ptr.next;
+      }
+    }
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -214,12 +214,7 @@ public class StripePlanner {
    */
   public void clearStreams() {
     if (dataReader.isTrackingDiskRanges()) {
-      for (StreamInformation stream : indexStreams) {
-        stream.releaseBuffers(dataReader);
-      }
-      for (StreamInformation stream : dataStreams) {
-        stream.releaseBuffers(dataReader);
-      }
+      dataReader.releaseAllBuffers();
     }
     indexStreams.clear();
     dataStreams.clear();
@@ -617,19 +612,6 @@ public class StripePlanner {
       this.column = column;
       this.offset = offset;
       this.length = length;
-    }
-
-    void releaseBuffers(DataReader reader) {
-      long end = offset + length;
-      BufferChunk ptr = firstChunk;
-      while (ptr != null && ptr.getOffset() < end) {
-        ByteBuffer buffer = ptr.getData();
-        if (buffer != null) {
-          reader.releaseBuffer(buffer);
-          ptr.setChunk(null);
-        }
-        ptr = (BufferChunk) ptr.next;
-      }
     }
   }
 }

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -614,6 +614,10 @@ public class StripePlanner {
       this.length = length;
     }
 
+    /**
+     * @deprecated Use {@link DataReader#releaseAllBuffers()} instead. This method was
+     * incorrectly added and shouldn't be used anymore.
+     */
     @Deprecated
     void releaseBuffers(DataReader reader) {
       long end = offset + length;

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -28,6 +28,7 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.BufferChunk;
 import org.apache.orc.impl.BufferChunkList;
 import org.apache.orc.impl.CryptoUtils;
+import org.apache.orc.impl.HadoopShims;
 import org.apache.orc.impl.InStream;
 import org.apache.orc.impl.OrcIndex;
 import org.apache.orc.impl.PhysicalFsWriter;
@@ -615,8 +616,10 @@ public class StripePlanner {
     }
 
     /**
-     * @deprecated Use {@link DataReader#releaseAllBuffers()} instead. This method was
-     * incorrectly added and shouldn't be used anymore.
+     * @deprecated The buffer returned by {@link BufferChunk#getData()} is not the original buffer
+     * from {@link HadoopShims.ZeroCopyReaderShim#readBuffer(int, boolean)}, it is the slice()
+     * or duplicate() of the original buffer. So this releaseBuffers() is incorrect and we should
+     * use {@link DataReader#releaseAllBuffers()} instead.
      */
     @Deprecated
     void releaseBuffers(DataReader reader) {

--- a/java/core/src/test/org/apache/orc/impl/MockDFSDataInputStream.java
+++ b/java/core/src/test/org/apache/orc/impl/MockDFSDataInputStream.java
@@ -63,7 +63,7 @@ public class MockDFSDataInputStream extends InputStream implements Seekable, Pos
   public void releaseBuffer(ByteBuffer byteBuffer) {
     Object val = bufferStore.remove(byteBuffer);
     if (val == null) {
-      throw new IllegalArgumentException("tried to release a buffer " + "that was not created by this stream, " + byteBuffer);
+      throw new IllegalArgumentException("tried to release a buffer that was not created by this stream, " + byteBuffer);
     }
   }
 

--- a/java/core/src/test/org/apache/orc/impl/MockDFSDataInputStream.java
+++ b/java/core/src/test/org/apache/orc/impl/MockDFSDataInputStream.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.orc.impl;
 
 import org.apache.hadoop.fs.HasEnhancedByteBufferAccess;

--- a/java/core/src/test/org/apache/orc/impl/MockDFSDataInputStream.java
+++ b/java/core/src/test/org/apache/orc/impl/MockDFSDataInputStream.java
@@ -36,7 +36,7 @@ public class MockDFSDataInputStream extends InputStream implements Seekable, Pos
     ByteBuffer copy = hdfsBlockBuffer.duplicate();
     copy.limit(copy.position() + i);
     currentPosition += i;
-    hdfsBlockBuffer.position(hdfsBlockBuffer.position() + i);
+    hdfsBlockBuffer.position(currentPosition - startPosition);
     bufferStore.put(copy, byteBufferPool);
     return copy;
   }
@@ -51,8 +51,8 @@ public class MockDFSDataInputStream extends InputStream implements Seekable, Pos
 
   @Override
   public void seek(long l) throws IOException {
-    currentPosition += (l - startPosition);
-    hdfsBlockBuffer.position((int) l - startPosition);
+    currentPosition = (int) l;
+    hdfsBlockBuffer.position(currentPosition - startPosition);
   }
 
   @Override
@@ -62,7 +62,7 @@ public class MockDFSDataInputStream extends InputStream implements Seekable, Pos
 
   @Override
   public boolean seekToNewSource(long l) throws IOException {
-    return false;
+    throw new RuntimeException("unsupported");
   }
 
   public boolean isAllReleased() {
@@ -71,16 +71,16 @@ public class MockDFSDataInputStream extends InputStream implements Seekable, Pos
 
   @Override
   public int read(long l, byte[] bytes, int i, int i1) throws IOException {
-    return 0;
+    throw new RuntimeException("unsupported");
   }
 
   @Override
   public void readFully(long l, byte[] bytes, int i, int i1) throws IOException {
-
+    throw new RuntimeException("unsupported");
   }
 
   @Override
   public void readFully(long l, byte[] bytes) throws IOException {
-
+    throw new RuntimeException("unsupported");
   }
 }

--- a/java/core/src/test/org/apache/orc/impl/MockDataReader.java
+++ b/java/core/src/test/org/apache/orc/impl/MockDataReader.java
@@ -100,7 +100,7 @@ public class MockDataReader implements DataReader {
 
   /**
    * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
-   * incorrectly added and shouldn't be used anymore.
+   * incorrectly used by upper level code and shouldn't be used anymore.
    */
   @Deprecated
   @Override

--- a/java/core/src/test/org/apache/orc/impl/MockDataReader.java
+++ b/java/core/src/test/org/apache/orc/impl/MockDataReader.java
@@ -98,6 +98,10 @@ public class MockDataReader implements DataReader {
     return true;
   }
 
+  /**
+   * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
+   * incorrectly added and shouldn't be used anymore.
+   */
   @Deprecated
   @Override
   public void releaseBuffer(ByteBuffer toRelease) {

--- a/java/core/src/test/org/apache/orc/impl/MockDataReader.java
+++ b/java/core/src/test/org/apache/orc/impl/MockDataReader.java
@@ -98,9 +98,15 @@ public class MockDataReader implements DataReader {
     return true;
   }
 
+  @Deprecated
   @Override
   public void releaseBuffer(ByteBuffer toRelease) {
     outBuffers.remove(toRelease);
+  }
+
+  @Override
+  public void releaseAllBuffers() {
+    outBuffers.clear();
   }
 
   @Override

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
@@ -178,7 +178,7 @@ class TestRecordReaderUtils {
   }
 
   private static byte[] byteBufferToArray(ByteBuffer buf) {
-    byte resultArray[] = new byte[buf.remaining()];
+    byte[] resultArray = new byte[buf.remaining()];
     ByteBuffer buffer = buf.slice();
     buffer.get(resultArray);
     return resultArray;

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
@@ -19,13 +19,10 @@
 package org.apache.orc.impl;
 
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
-import sun.nio.ch.DirectBuffer;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Objects;
@@ -33,6 +30,8 @@ import java.util.Objects;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 
 class TestRecordReaderUtils {
 
@@ -162,11 +161,11 @@ class TestRecordReaderUtils {
             .range(7000, 500).build();
     RecordReaderUtils.zeroCopyReadRanges(fis, zrc, rangeList.get(0), rangeList.get(2), false);
 
-    Assertions.assertArrayEquals(Arrays.copyOfRange(hdfsBlockMMapBuffer.array(), 5000 - blockStartPosition, 5000 - blockStartPosition + 1000), byteBufferToArray(rangeList.get(0).getData()));
-    Assertions.assertArrayEquals(Arrays.copyOfRange(hdfsBlockMMapBuffer.array(), 6000 - blockStartPosition, 6000 - blockStartPosition + 1000), byteBufferToArray(rangeList.get(1).getData()));
-    Assertions.assertArrayEquals(Arrays.copyOfRange(hdfsBlockMMapBuffer.array(), 7000 - blockStartPosition, 7000 - blockStartPosition + 500), byteBufferToArray(rangeList.get(2).getData()));
+    assertArrayEquals(Arrays.copyOfRange(hdfsBlockMMapBuffer.array(), 5000 - blockStartPosition, 5000 - blockStartPosition + 1000), byteBufferToArray(rangeList.get(0).getData()));
+    assertArrayEquals(Arrays.copyOfRange(hdfsBlockMMapBuffer.array(), 6000 - blockStartPosition, 6000 - blockStartPosition + 1000), byteBufferToArray(rangeList.get(1).getData()));
+    assertArrayEquals(Arrays.copyOfRange(hdfsBlockMMapBuffer.array(), 7000 - blockStartPosition, 7000 - blockStartPosition + 500), byteBufferToArray(rangeList.get(2).getData()));
 
-    Assertions.assertThrowsExactly(IllegalArgumentException.class, new Executable() {
+    assertThrowsExactly(IllegalArgumentException.class, new Executable() {
       @Override
       public void execute() throws Throwable {
         zrc.releaseBuffer(rangeList.get(0).getData());
@@ -175,7 +174,7 @@ class TestRecordReaderUtils {
 
     zrc.releaseAllBuffers();
 
-    Assertions.assertTrue(dis.isAllReleased());
+    assertTrue(dis.isAllReleased());
   }
 
   private static byte[] byteBufferToArray(ByteBuffer buf) {

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -101,11 +101,11 @@ public interface HadoopShims {
                           boolean verifyChecksums) throws IOException;
 
     /**
-     * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
-     * incorrectly added and shouldn't be used anymore.
-     *
      * Release a ByteBuffer obtained from a readBuffer on this
      * ZeroCopyReaderShim.
+     *
+     * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
+     * incorrectly added and shouldn't be used anymore.
      */
     @Deprecated
     void releaseBuffer(ByteBuffer buffer);

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -105,7 +105,7 @@ public interface HadoopShims {
      * ZeroCopyReaderShim.
      *
      * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
-     * incorrectly added and shouldn't be used anymore.
+     * incorrectly used by upper level code and shouldn't be used anymore.
      */
     @Deprecated
     void releaseBuffer(ByteBuffer buffer);

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -101,10 +101,10 @@ public interface HadoopShims {
                           boolean verifyChecksums) throws IOException;
 
     /**
-     * Release a ByteBuffer obtained from a readBuffer on this
+     * Release all ByteBuffers obtained from readBuffer on this
      * ZeroCopyReaderShim.
      */
-    void releaseBuffer(ByteBuffer buffer);
+    void releaseAllBuffers();
 
     /**
      * Close the underlying stream.

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -101,6 +101,9 @@ public interface HadoopShims {
                           boolean verifyChecksums) throws IOException;
 
     /**
+     * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
+     * incorrectly added and shouldn't be used anymore.
+     *
      * Release a ByteBuffer obtained from a readBuffer on this
      * ZeroCopyReaderShim.
      */

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -101,6 +101,13 @@ public interface HadoopShims {
                           boolean verifyChecksums) throws IOException;
 
     /**
+     * Release a ByteBuffer obtained from a readBuffer on this
+     * ZeroCopyReaderShim.
+     */
+    @Deprecated
+    void releaseBuffer(ByteBuffer buffer);
+
+    /**
      * Release all ByteBuffers obtained from readBuffer on this
      * ZeroCopyReaderShim.
      */

--- a/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
@@ -101,6 +101,7 @@ class ZeroCopyShims {
 
     @Override
     public void close() throws IOException {
+      releaseAllBuffers();
       this.in.close();
     }
   }

--- a/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
@@ -52,6 +52,10 @@ class ZeroCopyShims {
         .noneOf(ReadOption.class);
     private static final EnumSet<ReadOption> NO_CHECK_SUM = EnumSet
         .of(ReadOption.SKIP_CHECKSUMS);
+
+    // Use IdentityHashMap like hadoop's IdentityHashStore.
+    // It compares keys using {@link System#identityHashCode(Object)} and the identity operator.
+    // This is useful for types like ByteBuffer which have expensive hashCode and equals operators.
     private final IdentityHashMap<ByteBuffer, Object> readBuffers = new IdentityHashMap<>(0);
 
     ZeroCopyAdapter(FSDataInputStream in,

--- a/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
@@ -77,6 +77,10 @@ class ZeroCopyShims {
       return bb;
     }
 
+    /**
+     * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
+     * incorrectly added and shouldn't be used anymore.
+     */
     @Deprecated
     @Override
     public void releaseBuffer(ByteBuffer buffer) {

--- a/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
@@ -77,6 +77,12 @@ class ZeroCopyShims {
       return bb;
     }
 
+    @Deprecated
+    @Override
+    public void releaseBuffer(ByteBuffer buffer) {
+      this.in.releaseBuffer(buffer);
+    }
+
     @Override
     public void releaseAllBuffers() {
       readBuffers.forEach((k, v) -> {

--- a/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/ZeroCopyShims.java
@@ -83,7 +83,7 @@ class ZeroCopyShims {
 
     /**
      * @deprecated Use {@link #releaseAllBuffers()} instead. This method was
-     * incorrectly added and shouldn't be used anymore.
+     * incorrectly used by upper level code and shouldn't be used anymore.
      */
     @Deprecated
     @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
#### org.apache.orc.impl.RecordReaderUtils#zeroCopyReadRanges
`ByteBuffer copy = currentBuffer.duplicate();
copy.position((int) (current.getOffset() - currentOffset)); `
if currentBuffer position is not 0, copy.position() will set a uncorrect position.
We should use slice() replace duplicate().

#### org.apache.orc.impl.reader.StripePlanner.StreamInformation#releaseBuffers
The buffer returned by BufferChunk#getData() is not the original buffer from HadoopShims.ZeroCopyReaderShim#readBuffer(int, boolean), it is the slice() or duplicate() of the original buffer. So releaseBuffer() will throw a `IllegalArgumentException `


### Why are the changes needed?
fix bugs


### How was this patch tested?
I have mocked a `MockDFSDataInputStream` and added a UT to reproduct and test the bugs.
Or you can test manually with a hdfs cluster.
