### PR TITLE
ORC-1474: replaced deprecated `getMinimum/Maximum` in TestColumnStatistics

### DIFF
--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -19,6 +19,7 @@
 package org.apache.orc;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -27,7 +28,6 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.shaded.org.apache.commons.text.StringEscapeUtils;
 import org.apache.orc.impl.ColumnStatisticsImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -19,7 +19,6 @@
 package org.apache.orc;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,6 +27,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.shaded.org.apache.commons.text.StringEscapeUtils;
 import org.apache.orc.impl.ColumnStatisticsImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -408,15 +408,15 @@ public class TestColumnStatistics {
     stats2.increment(2);
     stats1.merge(stats2);
     DateColumnStatistics typed = (DateColumnStatistics) stats1;
-    assertEquals(new DateWritable(10).get(), typed.getMinimum());
-    assertEquals(new DateWritable(2000).get(), typed.getMaximum());
+    assertEquals(10, typed.getMinimumLocalDate().toEpochDay());
+    assertEquals(2000, typed.getMaximumLocalDate().toEpochDay());
     stats1.reset();
     stats1.updateDate(new DateWritable(-10));
     stats1.updateDate(new DateWritable(10000));
     stats1.increment(2);
     stats1.merge(stats2);
-    assertEquals(new DateWritable(-10).get(), typed.getMinimum());
-    assertEquals(new DateWritable(10000).get(), typed.getMaximum());
+    assertEquals(-10, typed.getMinimumLocalDate().toEpochDay());
+    assertEquals(10000, typed.getMaximumLocalDate().toEpochDay());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
As part of ORC-661, getMinimum/getMaximum were deprecated.
TestColumnStatistics uses these deprecated methods.
We need to replace them as
getMinimum -> getMinimumLocalDate
getMaximum -> getMaximumLocalDate

### Why are the changes needed?
Updated deprecated methods to keep tests in sync with implementation and preventing failure when deprecated methods are removed from dependencies


### How was this patch tested?
The Unit test case passes