### PR TITLE
ORC-1476: Fix maven build on M1 Mac

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -75,6 +75,7 @@
     <mockito.version>4.11.0</mockito.version>
     <!-- Build Properties -->
     <project.build.outputTimestamp>2023-05-15T16:29:49Z</project.build.outputTimestamp>
+    <protoc.version>3.17.3</protoc.version>
     <slf4j.version>2.0.7</slf4j.version>
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.0.0-M5</surefire.version>
@@ -508,7 +509,8 @@
               </goals>
               <phase>generate-sources</phase>
               <configuration>
-                <protocVersion>3.17.3</protocVersion>
+                <protocVersion>${protoc.version}</protocVersion>
+                <protocArtifact>com.google.protobuf:protoc:${protoc.version}</protocArtifact>
                 <addSources>none</addSources>
                 <includeDirectories>
                   <include>../../proto</include>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Explicitly set protoc artifact in the pom file.

### Why are the changes needed?
On M1 Mac, Maven build fails with [ERROR] Failed to execute goal com.github.os72:protoc-jar-maven-plugin:3.11.4:run (default) on project orc-core: Error extracting protoc for version 3.17.3: Unsupported platform: protoc-3.17.3-osx-aarch_64.exe

### How was this patch tested?
Test it manually on M1 Mac.
