### PR TITLE
ORC-1479: Enhance examples usage message to use uber jar

### DIFF
--- a/java/examples/src/java/org/apache/orc/examples/Driver.java
+++ b/java/examples/src/java/org/apache/orc/examples/Driver.java
@@ -67,7 +67,7 @@ public class Driver {
     if (options.command == null) {
       System.err.println("ORC Java Examples");
       System.err.println();
-      System.err.println("usage: java -jar orc-examples-*.jar [--help]" +
+      System.err.println("usage: java -jar orc-examples-*-uber.jar [--help]" +
           " [--define X=Y] <command> <args>");
       System.err.println();
       System.err.println("Commands:");


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR aims to enhance the message printed when using examples.
From examples/target directory, if we run the command it gives an error

```
bash-5.1$ java -jar orc-examples-*.jar --help
no main manifest attribute, in orc-examples-2.0.0-SNAPSHOT-sources.jar
```

If we replace the usage with following, the error goes away

```
$java -jar orc-examples-*-uber.jar [--help]
```

### Why are the changes needed?
The change shall make it more user friendly, avoiding the error message


### How was this patch tested?
Manually tested. Following is the result post

![example_usage_fix](https://github.com/apache/orc/assets/548559/acd3bc5b-14a1-4dff-93f5-ab80edadfa42)
