### PR TITLE
ORC-1481: [C++] Better error message when TZDB is unavailable

### DIFF
--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -678,8 +678,7 @@ namespace orc {
     if (!std::filesystem::exists(std::filesystem::path(filename))) {
       std::stringstream ss;
       ss << "Time zone file " << filename << " does not exist."
-         << " Please install IANA time zone database and set TZDIR env"
-         << " if it is not installed at /usr/share/zoneinfo";
+         << " Please install IANA time zone database and set TZDIR env.";
       throw TimezoneError(ss.str());
     }
     try {

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -678,8 +678,8 @@ namespace orc {
     if (!std::filesystem::exists(std::filesystem::path(filename))) {
       std::stringstream ss;
       ss << "Time zone file " << filename << " does not exist."
-         << " Please install IANA time zone database and set TZDIR env properly"
-         << " if not at /usr/share/zoneinfo";
+         << " Please install IANA time zone database and set TZDIR env"
+         << " if it is not installed at /usr/share/zoneinfo";
       throw TimezoneError(ss.str());
     }
     try {

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <iostream>
+#include <filesystem>
 #include <map>
 #include <sstream>
 
@@ -675,6 +675,13 @@ namespace orc {
     if (itr != timezoneCache.end()) {
       return *(itr->second).get();
     }
+    if (!std::filesystem::exists(std::filesystem::path(filename))) {
+      std::stringstream ss;
+      ss << "Time zone file " << filename << " does not exist."
+         << " Please install IANA time zone database and set TZDIR env properly"
+         << " if not at /usr/share/zoneinfo";
+      throw TimezoneError(ss.str());
+    }
     try {
       std::unique_ptr<InputStream> file = readFile(filename);
       size_t size = static_cast<size_t>(file->getLength());
@@ -880,8 +887,8 @@ namespace orc {
           strftime(buffer, sizeof(buffer), "%F %H:%M:%S", &timeStruct);
         }
       }
-      std::cout << "  Transition: " << (result == nullptr ? "null" : buffer) << " ("
-                << transitions[t] << ") -> " << variants[currentVariant[t]].name << "\n";
+      out << "  Transition: " << (result == nullptr ? "null" : buffer) << " (" << transitions[t]
+          << ") -> " << variants[currentVariant[t]].name << "\n";
     }
   }
 

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -407,11 +407,11 @@ namespace orc {
   TEST(TestTimezone, testMissingTZDB) {
     const char* tzDirBackup = std::getenv("TZDIR");
     setenv("TZDIR", "/path/to/wrong/tzdb", 1);
-    EXPECT_THAT(
-        []() { getTimezoneByName("America/Los_Angeles"); },
-        testing::ThrowsMessage<TimezoneError>(testing::HasSubstr(
-            "Time zone file /path/to/wrong/tzdb/America/Los_Angeles does not exist. Please install "
-            "IANA time zone database and set TZDIR env properly if not at /usr/share/zoneinfo")));
+    EXPECT_THAT([]() { getTimezoneByName("America/Los_Angeles"); },
+                testing::ThrowsMessage<TimezoneError>(testing::HasSubstr(
+                    "Time zone file /path/to/wrong/tzdb/America/Los_Angeles does not exist."
+                    " Please install IANA time zone database and set TZDIR env if it is not"
+                    " installed at /usr/share/zoneinfo")));
     if (tzDirBackup != nullptr) {
       setenv("TZDIR", tzDirBackup, 1);
     } else {

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -410,8 +410,7 @@ namespace orc {
     EXPECT_THAT([]() { getTimezoneByName("America/Los_Angeles"); },
                 testing::ThrowsMessage<TimezoneError>(testing::HasSubstr(
                     "Time zone file /path/to/wrong/tzdb/America/Los_Angeles does not exist."
-                    " Please install IANA time zone database and set TZDIR env if it is not"
-                    " installed at /usr/share/zoneinfo")));
+                    " Please install IANA time zone database and set TZDIR env.")));
     if (tzDirBackup != nullptr) {
       setenv("TZDIR", tzDirBackup, 1);
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Check the availability of TZDB and throw helpful error message before it crashes.

### Why are the changes needed?
When local IANA TZDB is unavailable or TZDIR env is not properly set, getTimezoneByName() simply fails without much helpful guidance on what to do.

### How was this patch tested?
Added a test case TestTimezone.testMissingTZDB to make sure error message is as expected.
