### PR TITLE
ORC-1484: Use `JIRA_ACCESS_TOKEN` in `merge_orc_pr.py`

### DIFF
--- a/dev/merge_orc_pr.py
+++ b/dev/merge_orc_pr.py
@@ -46,10 +46,12 @@ except ImportError:
 PR_REMOTE_NAME = os.environ.get("PR_REMOTE_NAME", "apache")
 # Remote name which points to Apache git
 PUSH_REMOTE_NAME = os.environ.get("PUSH_REMOTE_NAME", "apache")
-# ASF JIRA username
-JIRA_USERNAME = os.environ.get("JIRA_USERNAME", "")
-# ASF JIRA password
-JIRA_PASSWORD = os.environ.get("JIRA_PASSWORD", "")
+# ASF JIRA access token
+# If it is configured, username and password are dismissed
+# Go to https://issues.apache.org/jira/secure/ViewProfile.jspa -> Personal Access Tokens for
+# your own token management.
+JIRA_ACCESS_TOKEN = os.environ.get("JIRA_ACCESS_TOKEN")
+
 # OAuth key used for issuing requests against the GitHub API. If this is not defined, then requests
 # will be unauthenticated. You should only need to configure this if you find yourself regularly
 # exceeding your IP's unauthenticated request rate limit. You can create an OAuth key at
@@ -246,7 +248,8 @@ def fix_version_from_branch(branch, versions):
 
 def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     asf_jira = jira.client.JIRA(
-        {"server": JIRA_API_BASE}, basic_auth=(JIRA_USERNAME, JIRA_PASSWORD)
+        {"server": JIRA_API_BASE},
+        token_auth=JIRA_ACCESS_TOKEN
     )
 
     jira_id = input("Enter a JIRA id [%s]: " % default_jira_id)
@@ -403,8 +406,8 @@ def main():
     original_head = get_current_ref()
 
     # Check this up front to avoid failing the JIRA update at the very end
-    if not JIRA_USERNAME or not JIRA_PASSWORD:
-        continue_maybe("The env-vars JIRA_USERNAME and/or JIRA_PASSWORD are not set. Continue?")
+    if not JIRA_ACCESS_TOKEN:
+        continue_maybe("The env-var JIRA_ACCESS_TOKEN is not set. Continue?")
 
     branches = get_json("%s/branches" % GITHUB_API_BASE)
     branch_names = list(filter(lambda x: x.startswith("branch-"), [x["name"] for x in branches]))
@@ -489,7 +492,7 @@ def main():
         merged_refs = merged_refs + [cherry_pick(pr_num, merge_hash, latest_branch)]
 
     if JIRA_IMPORTED:
-        if JIRA_USERNAME and JIRA_PASSWORD:
+        if JIRA_ACCESS_TOKEN:
             continue_maybe("Would you like to update an associated JIRA?")
             jira_comment = "Issue resolved by pull request %s\n[%s/%s]" % (
                 pr_num,
@@ -498,7 +501,7 @@ def main():
             )
             resolve_jira_issues(title, merged_refs, jira_comment)
         else:
-            print("JIRA_USERNAME and JIRA_PASSWORD not set")
+            print("JIRA_ACCESS_TOKEN not set")
             print("Exiting without trying to close the associated JIRA.")
     else:
         print("Could not find jira-python library. Run 'sudo pip3 install jira' to install.")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `JIRA_ACCESS_TOKEN` instead of a pair of JIRA_USERNAME and JIRA_PASSWORD.

### Why are the changes needed?

To reduce the security vulnerability for the committers, we had better use `Access Tokens` instead of user ID and password.

Personal Access Tokens are available here.
- https://issues.apache.org/jira/secure/ViewProfile.jspa

### How was this patch tested?

Manual.

I used this script when I merge #1586 .