### PR TITLE
ORC-1487: Enable `checkstyle` on `src/test` with `checkstyle-suppressions.xml`

### DIFF
--- a/java/checkstyle-suppressions.xml
+++ b/java/checkstyle-suppressions.xml
@@ -19,19 +19,19 @@
 <!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "https://checkstyle.org/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-    <!-- Ignore these rules in all test code always. -->
-    <suppress checks="LineLength" files="src/test/*"/>
-    <suppress checks="NewlineAtEndOfFile" files="src/test/*"/>
+  <!-- Ignore these rules in all test code always. -->
+  <suppress checks="LineLength" files="src/test/*"/>
+  <suppress checks="NewlineAtEndOfFile" files="src/test/*"/>
 
-    <suppress checks="UnusedImports" files="src/test/*"/>
-    <suppress checks="AvoidStarImport" files="src/test/*"/>
-    <suppress checks="CustomImportOrder" files="src/test/*"/>
+  <suppress checks="UnusedImports" files="src/test/*"/>
+  <suppress checks="AvoidStarImport" files="src/test/*"/>
+  <suppress checks="CustomImportOrder" files="src/test/*"/>
 
-    <!-- Remove the following rule when the test code clean up is completed. -->
-    <suppress checks="Indentation" files="src/test/*"/>
-    <suppress checks="RedundantModifier" files="src/test/*"/>
-    <suppress checks="ModifierOrder" files="src/test/*"/>
-    <suppress checks="UpperEll" files="src/test/*"/>
-    <suppress checks="NeedBraces" files="src/test/*"/>
-    <suppress checks="RegexpSingleline" files="src/test/*"/>
+  <!-- Remove the following rule when the test code clean up is completed. -->
+  <suppress checks="Indentation" files="src/test/*"/>
+  <suppress checks="RedundantModifier" files="src/test/*"/>
+  <suppress checks="ModifierOrder" files="src/test/*"/>
+  <suppress checks="UpperEll" files="src/test/*"/>
+  <suppress checks="NeedBraces" files="src/test/*"/>
+  <suppress checks="RegexpSingleline" files="src/test/*"/>
 </suppressions>

--- a/java/checkstyle-suppressions.xml
+++ b/java/checkstyle-suppressions.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" ?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN" "https://checkstyle.org/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <!-- Ignore these rules in all test code always. -->
+    <suppress checks="LineLength" files="src/test/*"/>
+    <suppress checks="NewlineAtEndOfFile" files="src/test/*"/>
+
+    <suppress checks="UnusedImports" files="src/test/*"/>
+    <suppress checks="AvoidStarImport" files="src/test/*"/>
+    <suppress checks="CustomImportOrder" files="src/test/*"/>
+
+    <!-- Remove the following rule when the test code clean up is completed. -->
+    <suppress checks="Indentation" files="src/test/*"/>
+    <suppress checks="RedundantModifier" files="src/test/*"/>
+    <suppress checks="ModifierOrder" files="src/test/*"/>
+    <suppress checks="UpperEll" files="src/test/*"/>
+    <suppress checks="NeedBraces" files="src/test/*"/>
+    <suppress checks="RegexpSingleline" files="src/test/*"/>
+</suppressions>

--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -15,6 +15,9 @@
 <!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.2//EN" "https://checkstyle.org/dtds/configuration_1_2.dtd">
 
 <module name="Checker">
+  <module name="SuppressionFilter">
+    <property name="file" value="checkstyle-suppressions.xml"/>
+  </module>
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
   </module>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -442,6 +442,7 @@
           <configuration>
             <sourceDirectories>
               <directory>${basedir}/src/java</directory>
+              <directory>${basedir}/src/test</directory>
             </sourceDirectories>
             <configLocation>checkstyle.xml</configLocation>
             <failOnViolation>true</failOnViolation>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable `checkstyle` on `src/test` directories to validate the recent PRs like #1590 .

### Why are the changes needed?

To help the recent community work, we permanently declare the following rules as exception in test source code.

```xml
     <suppress checks="LineLength" files="src/test/*"/>
     <suppress checks="NewlineAtEndOfFile" files="src/test/*"/>

     <suppress checks="UnusedImports" files="src/test/*"/>
     <suppress checks="AvoidStarImport" files="src/test/*"/>
     <suppress checks="CustomImportOrder" files="src/test/*"/>
```

The other suppressed rules will be removed after we finish the test code clean-ups.

### How was this patch tested?

Pass the CIs.