### PR TITLE
ORC-1488: [Java] Mark getFileMetadata as deprecated

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -358,6 +358,9 @@ public class OrcFile {
       return this;
     }
 
+    /**
+     * @deprecated Use {@link #orcTail(OrcTail)} instead.
+     */
     public FileMetadata getFileMetadata() {
       return fileMetadata;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR is aimed to mark `getFileMetadata `as deprecated.
This PR targets for ORC 1.9.x.
For ORC 2.0, please see #1588

### Why are the changes needed?
1.FileMetadata has been marked as deprecated in ORC 1.6.0 [Jira](https://issues.apache.org/jira/browse/ORC-520) [PR](https://github.com/apache/orc/pull/423/files#diff-7873f5bef8fbe71c6f99481532462b30a899f6425867e561df09982aa361b9d5R27)
2.FileMetadata does not have any class to implement it, and inside ORC apache1.9, getFileMetadata always returns null.

### How was this patch tested?
Exist UT