### PR TITLE
ORC-1496: Use iterator to suggest backporting branches

### DIFF
--- a/dev/merge_orc_pr.py
+++ b/dev/merge_orc_pr.py
@@ -412,7 +412,8 @@ def main():
     branches = get_json("%s/branches" % GITHUB_API_BASE)
     branch_names = list(filter(lambda x: x.startswith("branch-"), [x["name"] for x in branches]))
     # Assumes branch names can be sorted lexicographically
-    latest_branch = sorted(branch_names, reverse=True)[0]
+    branch_names = sorted(branch_names, reverse=True)
+    branch_iter = iter(branch_names)
 
     pr_num = input("Which pull request would you like to merge? (e.g. 34): ")
     pr = get_json("%s/pulls/%s" % (GITHUB_API_BASE, pr_num))
@@ -469,7 +470,7 @@ def main():
             fail("Couldn't find any merge commit for #%s, you may need to update HEAD." % pr_num)
 
         print("Found commit %s:\n%s" % (merge_hash, message))
-        cherry_pick(pr_num, merge_hash, latest_branch)
+        cherry_pick(pr_num, merge_hash, next(branch_iter, branch_names[0]))
         sys.exit(0)
 
     if not bool(pr["mergeable"]):
@@ -489,7 +490,9 @@ def main():
 
     pick_prompt = "Would you like to pick %s into another branch?" % merge_hash
     while input("\n%s (y/n): " % pick_prompt).lower() == "y":
-        merged_refs = merged_refs + [cherry_pick(pr_num, merge_hash, latest_branch)]
+        merged_refs = merged_refs + [
+            cherry_pick(pr_num, merge_hash, next(branch_iter, branch_names[0]))
+        ]
 
     if JIRA_IMPORTED:
         if JIRA_ACCESS_TOKEN:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use iterator to suggest backporting branches.

### Why are the changes needed?

Previously, only `branch-1.9` was suggested. After this PR, the script will suggest `branch-1.9` and `branch-1.8` and so on.

### How was this patch tested?

Manually.