### PR TITLE
ORC-1498: Add `Debian 12` Docker test

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,7 +1,7 @@
 ## Supported OSes
 
 * CentOS 7
-* Debian 10 and 11
+* Debian 10, 11, and 12
 * Fedora 37
 * Ubuntu 20 and 22
 

--- a/docker/debian12/Dockerfile
+++ b/docker/debian12/Dockerfile
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Debian 12
+#
+
+FROM debian:bookworm
+LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+ARG jdk=17
+
+RUN apt-get update
+RUN apt-get install -y \
+  cmake \
+  gcc \
+  g++ \
+  git \
+  libsasl2-dev \
+  libssl-dev \
+  make \
+  curl \
+  maven \
+  openjdk-${jdk}-jdk; \
+
+WORKDIR /root
+
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/docker/debian12/Dockerfile
+++ b/docker/debian12/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get install -y \
   make \
   curl \
   maven \
-  openjdk-${jdk}-jdk; \
+  openjdk-${jdk}-jdk
 
 WORKDIR /root
 

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -1,6 +1,7 @@
 centos7
 debian10
 debian11
+debian12
 ubuntu20
 ubuntu22
 fedora37

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -10,7 +10,7 @@ dockerUrl: https://github.com/apache/orc/blob/main/docker
 The C++ library is supported on the following operating systems:
 
 * CentOS 7
-* Debian 10 to 11
+* Debian 10 to 12
 * MacOS 11.6 and 12.5
 * Ubuntu 20.04 to 22.04
 
@@ -28,6 +28,7 @@ is in the docker subdirectory, for the list of packages required to build ORC:
 * [CentOS 7]({{ page.dockerUrl }}/centos7/Dockerfile)
 * [Debian 10]({{ page.dockerUrl }}/debian10/Dockerfile)
 * [Debian 11]({{ page.dockerUrl }}/debian11/Dockerfile)
+* [Debian 12]({{ page.dockerUrl }}/debian12/Dockerfile)
 * [Ubuntu 20]({{ page.dockerUrl }}/ubuntu20/Dockerfile)
 * [Ubuntu 22]({{ page.dockerUrl }}/ubuntu22/Dockerfile)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Debian 12` Docker test.

### Why are the changes needed?

To improve the test coverage for the new Debian OS environment.

### How was this patch tested?

Run the docker tests.

```
$ cd docker
$ ./run-one.sh local ORC-1498 debian12
Started local run for ORC-1498 on debian12 at Tue Aug 29 23:50:19 PDT 2023
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
...
Java version: 17.0.8, vendor: Debian, runtime: /usr/lib/jvm/java-17-openjdk-arm64
...
Run CPack packaging tool...
CPack: Create package using TGZ
CPack: Install projects
CPack: - Run preinstall target for: ORC
CPack: - Install project: ORC []
CPack: Create package
CPack: - package: /root/build/ORC-2.0.0-SNAPSHOT-Linux.tar.gz generated.
Test project /root/build
    Start 1: orc-test
1/8 Test #1: orc-test .........................   Passed    4.61 sec
    Start 2: java-test
2/8 Test #2: java-test ........................   Passed  105.33 sec
    Start 3: java-tools-test
3/8 Test #3: java-tools-test ..................   Passed    0.08 sec
    Start 4: java-bench-gen-test
4/8 Test #4: java-bench-gen-test ..............   Passed    0.73 sec
    Start 5: java-bench-scan-test
5/8 Test #5: java-bench-scan-test .............   Passed    0.65 sec
    Start 6: java-bench-hive-test
6/8 Test #6: java-bench-hive-test .............   Passed   11.11 sec
    Start 7: java-bench-spark-test
7/8 Test #7: java-bench-spark-test ............   Passed    3.23 sec
    Start 8: tool-test
8/8 Test #8: tool-test ........................   Passed    6.70 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) = 132.45 sec
Built target test-out
Finished debian12 at Wed Aug 30 00:02:14 PDT 2023
```