### PR TITLE
ORC-1499: Add MacOS 13 and 14 to `building.md`

### DIFF
--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -11,7 +11,7 @@ The C++ library is supported on the following operating systems:
 
 * CentOS 7
 * Debian 10 to 12
-* MacOS 11.6 and 12.5
+* MacOS 11.6 and 14.0
 * Ubuntu 20.04 to 22.04
 
 You'll want to install the usual set of developer tools, but at least:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add MacOS 13 and 14 to `building.md`.

### Why are the changes needed?

- #1511 added MacOS 13 test coverage .
- I verified MacOS 14 manually on Apple Silicon.

### How was this patch tested?

Manual review because this is a doc-only change.