### PR TITLE
ORC-1500: [C++] The partition field does not support English special characters

### DIFF
--- a/c++/src/OrcHdfsFile.cc
+++ b/c++/src/OrcHdfsFile.cc
@@ -115,17 +115,17 @@ namespace orc {
       }
 
       hdfs::FileHandle* file_raw = nullptr;
-      status = file_system->Open(uri.get_path(), &file_raw);
+      status = file_system->Open(uri.get_path(true), &file_raw);
       if (!status.ok()) {
-        throw ParseError("Can't open " + uri.get_path() + ". " + status.ToString());
+        throw ParseError("Can't open " + uri.get_path(true) + ". " + status.ToString());
       }
       // Wrapping file_raw into a unique pointer to guarantee deletion
       file.reset(file_raw);
 
       hdfs::StatInfo stat_info;
-      status = file_system->GetFileInfo(uri.get_path(), stat_info);
+      status = file_system->GetFileInfo(uri.get_path(true), stat_info);
       if (!status.ok()) {
-        throw ParseError("Can't stat " + uri.get_path() + ". " + status.ToString());
+        throw ParseError("Can't stat " + uri.get_path(true) + ". " + status.ToString());
       }
       totalLength = stat_info.length;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The URI encoding is deleted during the initialization of OrcHdfsFile

### Why are the changes needed?
For the context of [ORC-1500](https://issues.apache.org/jira/browse/ORC-1500), the C++ orc reader does not support the partition field containing English special characters. As a result, the SQL job fails to be executed and no execution result is displayed.

### How was this patch tested?
No new tests were added.