### PR TITLE
ORC-1503: Updated `README.md` with Maven version 3.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The subdirectories are:
 ### Building
 
 * Install java 1.8 or higher
-* Install maven 3.8.8 or higher
+* Install maven 3.9.4 or higher
 * Install cmake 3.12 or higher
 
 To build a release version with debug information:


### PR DESCRIPTION
ORC-1503: Update README.md to use Maven 3.9.4

### What changes were proposed in this pull request?
This PR aims to update documentation to use Maven 3.9.4, upgraded as part of ORC-1502


### Why are the changes needed?
The changes are need to keep documentation in sync with maven version used for build


### How was this patch tested?
Documentation patch, no tests were done
