### PR TITLE
ORC-1504: Add lower bound check for get() in DynamicIntArray

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
+++ b/java/core/src/java/org/apache/orc/impl/DynamicIntArray.java
@@ -69,7 +69,7 @@ public final class DynamicIntArray {
   }
 
   public int get(int index) {
-    if (index >= length) {
+    if (index < 0 || index >= length) {
       throw new IndexOutOfBoundsException("Index " + index +
                                             " is outside of 0.." +
                                             (length - 1));

--- a/java/core/src/test/org/apache/orc/impl/TestDynamicIntArray.java
+++ b/java/core/src/test/org/apache/orc/impl/TestDynamicIntArray.java
@@ -75,6 +75,14 @@ public class TestDynamicIntArray {
     public void testInvalidGetIndex() {
         DynamicIntArray dynamicIntArray = new DynamicIntArray(10);
         dynamicIntArray.add(10);
-        assertThrows(IndexOutOfBoundsException.class, () -> dynamicIntArray.get(11));
+        dynamicIntArray.add(11);
+        IndexOutOfBoundsException indexOutOfBoundsException =
+            assertThrows(IndexOutOfBoundsException.class, () -> dynamicIntArray.get(11));
+        assertEquals("Index 11 is outside of 0..1", indexOutOfBoundsException.getMessage());
+
+        indexOutOfBoundsException =
+            assertThrows(IndexOutOfBoundsException.class, () -> dynamicIntArray.get(-1));
+        assertEquals("Index -1 is outside of 0..1", indexOutOfBoundsException.getMessage());
+
     }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
The PR proposes adding check for lower bound for index passed to get() in DynamicIntArray


### Why are the changes needed?
In the absence of lower bound check, the code fails later with ArrayIndexOutOfBoundException. The code doesn't break, however the user behavior is different. This PR unifies the exception user gets, when the index is not in range


### How was this patch tested?
Unit Test case was enhanced to add the test to validate the scenario
