### PR TITLE
ORC-1505: Upgrade Spark to 3.5.0

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -39,7 +39,7 @@
     <junit.version>5.10.0</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.13.1</parquet.version>
-    <spark.version>3.4.1</spark.version>
+    <spark.version>3.5.0</spark.version>
   </properties>
 
   <dependencyManagement>
@@ -90,7 +90,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.86.Final</version>
+        <version>4.1.96.Final</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
@@ -354,7 +354,7 @@
       <dependency>
         <groupId>org.scala-lang</groupId>
         <artifactId>scala-library</artifactId>
-        <version>2.12.15</version>
+        <version>2.12.18</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>

--- a/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
+++ b/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
@@ -202,7 +202,8 @@ public class SparkBenchmark implements OrcBenchmark {
             JavaConverters.collectionAsScalaIterableConverter(filters).asScala().toSeq(),
             scalaMap, source.conf);
     PartitionedFile file = new PartitionedFile(InternalRow.empty(),
-        SparkPath.fromPath(source.path), 0, Long.MAX_VALUE, new String[0], 0L, 0L);
+        SparkPath.fromPath(source.path), 0, Long.MAX_VALUE, new String[0], 0L, 0L,
+        Map$.MODULE$.empty());
     processReader(factory.apply(file), statistics, counters, blackhole);
   }
 
@@ -250,7 +251,8 @@ public class SparkBenchmark implements OrcBenchmark {
             JavaConverters.collectionAsScalaIterableConverter(filters).asScala().toSeq(),
             scalaMap, source.conf);
     PartitionedFile file = new PartitionedFile(InternalRow.empty(),
-        SparkPath.fromPath(source.path), 0, Long.MAX_VALUE, new String[0], 0L, 0L);
+        SparkPath.fromPath(source.path), 0, Long.MAX_VALUE, new String[0], 0L, 0L,
+        Map$.MODULE$.empty());
     processReader(factory.apply(file), statistics, counters, blackhole);
   }
 
@@ -302,7 +304,8 @@ public class SparkBenchmark implements OrcBenchmark {
             JavaConverters.collectionAsScalaIterableConverter(filters).asScala().toSeq(),
             scalaMap, source.conf);
     PartitionedFile file = new PartitionedFile(InternalRow.empty(),
-        SparkPath.fromPath(source.path), 0, Long.MAX_VALUE, new String[0], 0L, 0L);
+        SparkPath.fromPath(source.path), 0, Long.MAX_VALUE, new String[0], 0L, 0L,
+        Map$.MODULE$.empty());
     processReader(factory.apply(file), statistics, counters, blackhole);
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the benchmark module to use Spark 3.5.0 and its dependencies.

### Why are the changes needed?

Since Apache ORC 1.9.x is maintained for Apache Spark 3.5.0, we had better have a test coverage for Apache Spark 3.5.0.

### How was this patch tested?

Pass the CIs.