### PR TITLE
ORC-1506: Replacing deprecated valueOf() with recommended forNumber()

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -612,7 +612,7 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     HadoopShims.KeyMetadata meta = key.getMetadata();
     result.setKeyName(meta.getKeyName());
     result.setKeyVersion(meta.getVersion());
-    result.setAlgorithm(OrcProto.EncryptionAlgorithm.valueOf(
+    result.setAlgorithm(OrcProto.EncryptionAlgorithm.forNumber(
         meta.getAlgorithm().getSerialization()));
     return result;
   }
@@ -646,7 +646,7 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
     for(WriterEncryptionVariant variant: encryption) {
       encrypt.addVariants(writeEncryptionVariant(variant));
     }
-    encrypt.setKeyProvider(OrcProto.KeyProviderKind.valueOf(
+    encrypt.setKeyProvider(OrcProto.KeyProviderKind.forNumber(
         keyProvider.getKind().getValue()));
     return encrypt;
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
The PR aims at replacing deprecated valueOf() with recommended forNumber().
valueOf() has been deprecated for a while and shall be removed in future versions. We are only removing it from the code we have written, it still exists in auto-generated code. Autogenerate code shall be compliant with version upgrade in future.

Couldn't find the exact PR for the change, however the reason seems to be performance related from search about the change


### Why are the changes needed?
The change helps protect against the removal of deprecated API in future releases.


### How was this patch tested?
No new tests were added, current tests pass
