### PR TITLE
ORC-1514: Remove zookeeper runtime dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -80,7 +80,6 @@
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
-    <zookeeper.version>3.8.1</zookeeper.version>
   </properties>
 
   <dependencyManagement>
@@ -172,26 +171,6 @@
           <exclusion>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-hdfs</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.zookeeper</groupId>
-        <artifactId>zookeeper</artifactId>
-        <version>${zookeeper.version}</version>
-        <scope>runtime</scope>
-        <exclusions>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove Apache Zookeeper Runtime dependency for Apache ORC 2.0.0.

### Why are the changes needed?

Apache ORC 1.4.0 added Zookeeper depdency to the pom file to reduce the uber file size because Zookeeper is used by Hadoop Common module at that time.
- #96 

After ORC-1430, Apache ORC 2.0.0 uses Hadoop shaded clients which shaded Zookeeper runtime dependency. We can remove Zookeeper dependency.

- #1509
- #1554

### How was this patch tested?

Pass the CIs.

This closes #1572 .
