### PR TITLE
ORC-1515: Skip publishing `orc-example` module

### DIFF
--- a/java/examples/pom.xml
+++ b/java/examples/pom.xml
@@ -107,6 +107,20 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
     <sourceDirectory>${basedir}/src/java</sourceDirectory>
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to skip publishing `orc-example` module to Maven Central from Apache ORC 2.0.0.

### Why are the changes needed?

1. Although ORC example code is meaningful for developers as a source code, we don't need it at Maven Central.
2. We can reduce ORC distribution footprint from **131MB** to **74M**.

### How was this patch tested?

Manual test.

**BEFORE**
```
$ du -h ~/.m2/repository/org/apache/orc
 57M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-examples/2.0.0-SNAPSHOT
 57M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-examples
120K	/Users/dongjoon/.m2/repository/org/apache/orc/orc-shims/2.0.0-SNAPSHOT
124K	/Users/dongjoon/.m2/repository/org/apache/orc/orc-shims
3.9M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-mapreduce/2.0.0-SNAPSHOT
3.9M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-mapreduce
 48K	/Users/dongjoon/.m2/repository/org/apache/orc/orc/2.0.0-SNAPSHOT
 52K	/Users/dongjoon/.m2/repository/org/apache/orc/orc
 62M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-tools/2.0.0-SNAPSHOT
 62M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-tools
8.1M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-core/2.0.0-SNAPSHOT
8.1M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-core
131M	/Users/dongjoon/.m2/repository/org/apache/orc
```

**AFTER**
```
$ du -h ~/.m2/repository/org/apache/orc
120K	/Users/dongjoon/.m2/repository/org/apache/orc/orc-shims/2.0.0-SNAPSHOT
124K	/Users/dongjoon/.m2/repository/org/apache/orc/orc-shims
3.9M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-mapreduce/2.0.0-SNAPSHOT
3.9M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-mapreduce
 48K	/Users/dongjoon/.m2/repository/org/apache/orc/orc/2.0.0-SNAPSHOT
 52K	/Users/dongjoon/.m2/repository/org/apache/orc/orc
 62M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-tools/2.0.0-SNAPSHOT
 62M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-tools
8.1M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-core/2.0.0-SNAPSHOT
8.1M	/Users/dongjoon/.m2/repository/org/apache/orc/orc-core
 74M	/Users/dongjoon/.m2/repository/org/apache/orc
```