### PR TITLE
ORC-1516: Fixed minor typo in IOUtils

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/IOUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/IOUtils.java
@@ -125,7 +125,7 @@ public final class IOUtils {
     /*
      * N.B. no need to synchronize access to SKIP_BYTE_BUFFER: - we don't care if the buffer is created multiple
      * times (the data is ignored) - we always use the same size buffer, so if it is recreated it will still be
-     * OK (if the buffer size were variable, we would need to synch. to ensure some other thread did not create a
+     * OK (if the buffer size were variable, we would need to sync to ensure some other thread did not create a
      * smaller one)
      */
     long remain = toSkip;

--- a/java/core/src/java/org/apache/orc/impl/IOUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/IOUtils.java
@@ -124,7 +124,7 @@ public final class IOUtils {
     }
     /*
      * N.B. no need to synchronize access to SKIP_BYTE_BUFFER: - we don't care if the buffer is created multiple
-     * times (the data is ignored) - we always use the same size buffer, so if it it is recreated it will still be
+     * times (the data is ignored) - we always use the same size buffer, so if it is recreated it will still be
      * OK (if the buffer size were variable, we would need to synch. to ensure some other thread did not create a
      * smaller one)
      */


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR fixes a minor typo in comments section in org.apache.orc.impl.IOUtils at Line 127.

### Why are the changes needed?
The changes are more cosmetic and corrects the statement


### How was this patch tested?
Change is within code comment, no Test updates needed.
