### PR TITLE
ORC-1480: [C++] Fix build break w/ BUILD_CPP_ENABLE_METRICS=ON

### DIFF
--- a/c++/src/io/OutputStream.cc
+++ b/c++/src/io/OutputStream.cc
@@ -87,7 +87,7 @@ namespace orc {
     uint64_t dataSize = dataBuffer->size();
     // flush data buffer into outputStream
     if (dataSize > 0) {
-      SCOPED_STOPWATCH(metrics, IOBlockingLatencyUs, nullptr);
+      SCOPED_STOPWATCH(metrics, IOBlockingLatencyUs, IOCount);
       dataBuffer->writeTo(outputStream, metrics);
     }
     dataBuffer->resize(0);

--- a/c++/test/TestBufferedOutputStream.cc
+++ b/c++/test/TestBufferedOutputStream.cc
@@ -46,7 +46,7 @@ namespace orc {
       EXPECT_EQ(memStream.getData()[i], 'a' + i % 10);
     }
 #if ENABLE_METRICS
-    EXPECT_EQ(metrics.IOCount.load(), 1);
+    EXPECT_EQ(metrics.IOCount.load(), 2);
 #endif
   }
 
@@ -95,7 +95,7 @@ namespace orc {
       EXPECT_EQ(memStream.getData()[i + 7], 'a' + i);
     }
 #if ENABLE_METRICS
-    EXPECT_EQ(metrics.IOCount.load(), 2);
+    EXPECT_EQ(metrics.IOCount.load(), 4);
 #endif
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Pass IOCount to SCOPED_STOPWATCH when counting I/Os.

### Why are the changes needed?
SCOPED_STOPWATCH macro was not correctly called when counting I/Os. This breaks build when BUILD_CPP_ENABLE_METRICS is set to ON and fails the unit test as well.

### How was this patch tested?
Failed test cases are fixed and all cases pass.
