### PR TITLE
ORC-1528: Fix readBytes potential overflow in RecordReaderUtils.ChunkReader#create

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/IOUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/IOUtils.java
@@ -31,6 +31,11 @@ public final class IOUtils {
   public static final int DEFAULT_BUFFER_SIZE = 8192;
 
   /**
+   * The maximum size of array to allocate, value being the same as {@link java.util.Hashtable}
+   */
+  public static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
+  /**
    * Returns a new byte array of size {@link #DEFAULT_BUFFER_SIZE}.
    *
    * @return a new byte array of size {@link #DEFAULT_BUFFER_SIZE}.

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -792,11 +792,11 @@ public class RecordReaderUtils {
         current = (BufferChunk) current.next;
       }
       reqBytes += ef - cf;
-      if (reqBytes >= IOUtils.MAX_ARRAY_SIZE) {
+      if (reqBytes > IOUtils.MAX_ARRAY_SIZE) {
         throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + IOUtils.MAX_ARRAY_SIZE);
       }
       long readBytes = e - f;
-      if (readBytes >= IOUtils.MAX_ARRAY_SIZE) {
+      if (readBytes > IOUtils.MAX_ARRAY_SIZE) {
         throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + IOUtils.MAX_ARRAY_SIZE);
       }
       return new ChunkReader(from, to, (int) readBytes, (int) reqBytes);

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -770,32 +770,32 @@ public class RecordReaderUtils {
     }
 
     static ChunkReader create(BufferChunk from, BufferChunk to) {
-      long f = Long.MAX_VALUE;
-      long e = Long.MIN_VALUE;
+      long start = Long.MAX_VALUE;
+      long end = Long.MIN_VALUE;
 
-      long cf = Long.MAX_VALUE;
-      long ef = Long.MIN_VALUE;
+      long currentStart = Long.MAX_VALUE;
+      long currentEnd = Long.MIN_VALUE;
       long reqBytes = 0L;
 
       BufferChunk current = from;
       while (current != to.next) {
-        f = Math.min(f, current.getOffset());
-        e = Math.max(e, current.getEnd());
-        if (ef == Long.MIN_VALUE || current.getOffset() <= ef) {
-          cf = Math.min(cf, current.getOffset());
-          ef = Math.max(ef, current.getEnd());
+        start = Math.min(start, current.getOffset());
+        end = Math.max(end, current.getEnd());
+        if (currentEnd == Long.MIN_VALUE || current.getOffset() <= currentEnd) {
+          currentStart = Math.min(currentStart, current.getOffset());
+          currentEnd = Math.max(currentEnd, current.getEnd());
         } else {
-          reqBytes += ef - cf;
-          cf = current.getOffset();
-          ef = current.getEnd();
+          reqBytes += currentEnd - currentStart;
+          currentStart = current.getOffset();
+          currentEnd = current.getEnd();
         }
         current = (BufferChunk) current.next;
       }
-      reqBytes += ef - cf;
+      reqBytes += currentEnd - currentStart;
       if (reqBytes >= Integer.MAX_VALUE) {
         throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + Integer.MAX_VALUE);
       }
-      long readBytes = e - f;
+      long readBytes = end - start;
       if (readBytes >= Integer.MAX_VALUE) {
         throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + Integer.MAX_VALUE);
       }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -792,12 +792,12 @@ public class RecordReaderUtils {
         current = (BufferChunk) current.next;
       }
       reqBytes += ef - cf;
-      if (reqBytes >= Integer.MAX_VALUE) {
-        throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + Integer.MAX_VALUE);
+      if (reqBytes >= IOUtils.MAX_ARRAY_SIZE) {
+        throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + IOUtils.MAX_ARRAY_SIZE);
       }
       long readBytes = e - f;
-      if (readBytes >= Integer.MAX_VALUE) {
-        throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + Integer.MAX_VALUE);
+      if (readBytes >= IOUtils.MAX_ARRAY_SIZE) {
+        throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + IOUtils.MAX_ARRAY_SIZE);
       }
       return new ChunkReader(from, to, (int) readBytes, (int) reqBytes);
     }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -770,18 +770,18 @@ public class RecordReaderUtils {
     }
 
     static ChunkReader create(BufferChunk from, BufferChunk to) {
-      long f = Integer.MAX_VALUE;
-      long e = Integer.MIN_VALUE;
+      long f = Long.MAX_VALUE;
+      long e = Long.MIN_VALUE;
 
-      long cf = Integer.MAX_VALUE;
-      long ef = Integer.MIN_VALUE;
-      int reqBytes = 0;
+      long cf = Long.MAX_VALUE;
+      long ef = Long.MIN_VALUE;
+      long reqBytes = 0L;
 
       BufferChunk current = from;
       while (current != to.next) {
         f = Math.min(f, current.getOffset());
         e = Math.max(e, current.getEnd());
-        if (ef == Integer.MIN_VALUE || current.getOffset() <= ef) {
+        if (ef == Long.MIN_VALUE || current.getOffset() <= ef) {
           cf = Math.min(cf, current.getOffset());
           ef = Math.max(ef, current.getEnd());
         } else {
@@ -792,7 +792,14 @@ public class RecordReaderUtils {
         current = (BufferChunk) current.next;
       }
       reqBytes += ef - cf;
-      return new ChunkReader(from, to, (int) (e - f), reqBytes);
+      if (reqBytes >= Integer.MAX_VALUE) {
+        throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + Integer.MAX_VALUE);
+      }
+      long readBytes = e - f;
+      if (readBytes >= Integer.MAX_VALUE) {
+        throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + Integer.MAX_VALUE);
+      }
+      return new ChunkReader(from, to, (int) readBytes, (int) reqBytes);
     }
 
     static ChunkReader create(BufferChunk from, int minSeekSize) {

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -770,32 +770,32 @@ public class RecordReaderUtils {
     }
 
     static ChunkReader create(BufferChunk from, BufferChunk to) {
-      long start = Long.MAX_VALUE;
-      long end = Long.MIN_VALUE;
+      long f = Long.MAX_VALUE;
+      long e = Long.MIN_VALUE;
 
-      long currentStart = Long.MAX_VALUE;
-      long currentEnd = Long.MIN_VALUE;
+      long cf = Long.MAX_VALUE;
+      long ef = Long.MIN_VALUE;
       long reqBytes = 0L;
 
       BufferChunk current = from;
       while (current != to.next) {
-        start = Math.min(start, current.getOffset());
-        end = Math.max(end, current.getEnd());
-        if (currentEnd == Long.MIN_VALUE || current.getOffset() <= currentEnd) {
-          currentStart = Math.min(currentStart, current.getOffset());
-          currentEnd = Math.max(currentEnd, current.getEnd());
+        f = Math.min(f, current.getOffset());
+        e = Math.max(e, current.getEnd());
+        if (ef == Long.MIN_VALUE || current.getOffset() <= ef) {
+          cf = Math.min(cf, current.getOffset());
+          ef = Math.max(ef, current.getEnd());
         } else {
-          reqBytes += currentEnd - currentStart;
-          currentStart = current.getOffset();
-          currentEnd = current.getEnd();
+          reqBytes += ef - cf;
+          cf = current.getOffset();
+          ef = current.getEnd();
         }
         current = (BufferChunk) current.next;
       }
-      reqBytes += currentEnd - currentStart;
+      reqBytes += ef - cf;
       if (reqBytes >= Integer.MAX_VALUE) {
         throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + Integer.MAX_VALUE);
       }
-      long readBytes = end - start;
+      long readBytes = e - f;
       if (readBytes >= Integer.MAX_VALUE) {
         throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + Integer.MAX_VALUE);
       }

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
@@ -179,7 +179,7 @@ class TestRecordReaderUtils {
   }
 
   @Test
-  public void testBufferChunkOffsetExceedsMaxInt() {
+  public void testChunkReaderCreateOffsetExceedsMaxInt() {
     List<long[]> mockData = Arrays.asList(
       new long[]{15032282586L, 15032298848L},
       new long[]{15032298848L, 15032299844L},
@@ -208,7 +208,7 @@ class TestRecordReaderUtils {
   }
 
   @Test
-  public void testBufferChunkCreateReqBytesReadBytesValidation() {
+  public void testChunkReaderCreateReqBytesAndReadBytesValidation() {
     BufferChunkList rangeList = new TestOrcLargeStripe.RangeBuilder()
       .range(0, IOUtils.MAX_ARRAY_SIZE)
       .range(1L + IOUtils.MAX_ARRAY_SIZE, IOUtils.MAX_ARRAY_SIZE + 1)

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
@@ -181,28 +181,27 @@ class TestRecordReaderUtils {
   @Test
   public void testBufferChunkOffsetExceedsMaxInt() {
     List<long[]> mockData = Arrays.asList(
-            new long[]{15032282586L, 15032298848L}
-            , new long[]{15032298848L, 15032299844L}
-            , new long[]{15032299844L, 15032377804L}
-            , new long[]{15058260587L, 15058261632L}
-            , new long[]{15058261632L, 15058288409L}
-            , new long[]{15058288409L, 15058288862L}
-            , new long[]{15058339730L, 15058340775L}
-            , new long[]{15058340775L, 15058342439L}
-            , new long[]{15058449794L, 15058449982L}
-            , new long[]{15058449982L, 15058451700L}
-            , new long[]{15058451700L, 15058451749L}
-            , new long[]{15058484358L, 15058484422L}
-            , new long[]{15058484422L, 15058484862L}
-            , new long[]{15058484862L, 15058484878L}
+        new long[]{15032282586L, 15032298848L},
+        new long[]{15032298848L, 15032299844L},
+        new long[]{15032299844L, 15032377804L},
+        new long[]{15058260587L, 15058261632L},
+        new long[]{15058261632L, 15058288409L},
+        new long[]{15058288409L, 15058288862L},
+        new long[]{15058339730L, 15058340775L},
+        new long[]{15058340775L, 15058342439L},
+        new long[]{15058449794L, 15058449982L},
+        new long[]{15058449982L, 15058451700L},
+        new long[]{15058451700L, 15058451749L},
+        new long[]{15058484358L, 15058484422L},
+        new long[]{15058484422L, 15058484862L},
+        new long[]{15058484862L, 15058484878L}
     );
     TestOrcLargeStripe.RangeBuilder rangeBuilder = new TestOrcLargeStripe.RangeBuilder();
     mockData.forEach(e -> rangeBuilder.range(e[0], (int) (e[1] - e[0])));
     BufferChunkList rangeList = rangeBuilder.build();
 
     RecordReaderUtils.ChunkReader chunkReader =
-            RecordReaderUtils.ChunkReader.create(rangeList.get(),
-                    134217728);
+        RecordReaderUtils.ChunkReader.create(rangeList.get(), 134217728);
     long readBytes = mockData.get(mockData.size() - 1)[1] - mockData.get(0)[0];
     long reqBytes = mockData.stream().mapToLong(e -> (int) (e[1] - e[0])).sum();
     assertEquals(chunkReader.getReadBytes(), readBytes);


### PR DESCRIPTION
### What changes were proposed in this pull request?

- I have adjusted the calculation of `reqBytes` and `readBytes` ranges in the `org.apache.orc.impl.RecordReaderUtils.ChunkReader#create` method from `Integer` to `Long`, and added validation for `Integer` overflow

- Adds more test cases

### Why are the changes needed?

This PR aims to fix [ORC-1528](https://issues.apache.org/jira/browse/ORC-1528) 


### How was this patch tested?

org.apache.orc.impl.TestRecordReaderUtils#testBufferChunkOffsetExceedsMaxInt
