### PR TITLE
ORC-1538: Unpin and upgrade `maven-dependency-plugin` to 3.6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,9 +29,6 @@ updates:
       # Pin scala-library to 2.12.15
       - dependency-name: "org.scala-lang:scala-library"
         versions: "[2.12.16,)"
-      # Pin maven-dependency-plugin to 3.1.2 due to MDEP-753, MDEP-757, MDEP-759
-      - dependency-name: "org.apache.maven.plugins:maven-dependency-plugin"
-        versions: "[3.2.0,)"
       # Pin protobuf-java to 3.22.3
       - dependency-name: "com.google.protobuf:protobuf-java"
         versions: "[3.22.4,)"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -67,7 +67,7 @@
     <javadoc.location>${project.basedir}/../target/javadoc</javadoc.location>
     <junit.version>5.10.1</junit.version>
     <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
-    <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
+    <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to unpin and upgrade `maven-dependency-plugin` to 3.6.1.

### Why are the changes needed?

To keep `maven-dependency-plugin` up-to-date from Apache ORC 2.

### How was this patch tested?

Pass the CIs.