### PR TITLE
ORC-1540: Remove MacOS 11 from GitHub Action CI and docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,7 +29,6 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-11
           - macos-12
           - macos-13
         java:

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -11,7 +11,7 @@ The C++ library is supported on the following operating systems:
 
 * CentOS 7
 * Debian 10 to 12
-* MacOS 11.6 and 14.0
+* MacOS 12 to 14
 * Ubuntu 20.04 to 22.04
 
 You'll want to install the usual set of developer tools, but at least:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove MacOS 11 from `GitHub Action CI` and documentations for Apache ORC 2.

### Why are the changes needed?

Apache ORC has 3-year support policy. We had better focus on MacOS 12+.

### How was this patch tested?

Pass the CIs.