### PR TITLE
ORC-1541: Add `Ubuntu 24.04 LTS` Docker Test

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 * Debian 11 and 12
 * Fedora 37
-* Ubuntu 20 and 22
+* Ubuntu 20, 22, 24
 
 ## Pre-built Images
 

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -2,6 +2,7 @@ debian11
 debian12
 ubuntu20
 ubuntu22
+ubuntu24
 fedora37
 ubuntu22_jdk=21
 ubuntu22_jdk=21_cc=clang

--- a/docker/ubuntu24/Dockerfile
+++ b/docker/ubuntu24/Dockerfile
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Ubuntu 24
+#
+
+FROM ubuntu:24.04
+LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+ARG jdk=21
+ARG cc=gcc
+
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+RUN apt-get update
+RUN apt-get install -y \
+  cmake \
+  git \
+  libsasl2-dev \
+  libssl-dev \
+  make \
+  curl \
+  maven \
+  openjdk-${jdk}-jdk \
+  tzdata; \
+  if [ "${cc}" = "gcc" ] ; then \
+    apt-get install -y \
+    gcc \
+    g++ \
+  ; else \
+    apt-get install -y \
+    clang \
+    && \
+    update-alternatives --set cc  /usr/bin/clang && \
+    update-alternatives --set c++ /usr/bin/clang++ \
+  ; fi
+RUN update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
+    update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk})
+
+ENV CC=cc
+ENV CXX=c++
+
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/docker/ubuntu24/Dockerfile
+++ b/docker/ubuntu24/Dockerfile
@@ -22,7 +22,6 @@ LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
 ARG jdk=21
 ARG cc=gcc
 
-RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update
 RUN apt-get install -y \
   cmake \
@@ -51,6 +50,9 @@ RUN update-alternatives --set java $(update-alternatives --list java | grep ${jd
 ENV CC=cc
 ENV CXX=c++
 
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+RUN mkdir -p /usr/share/zoneinfo/US
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /usr/share/zoneinfo/US/Pacific
 WORKDIR /root
 VOLUME /root/.m2/repository
 

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -12,7 +12,7 @@ The C++ library is supported on the following operating systems:
 * CentOS 7
 * Debian 10 to 12
 * MacOS 12 to 14
-* Ubuntu 20.04 to 22.04
+* Ubuntu 20.04 to 24.04
 
 You'll want to install the usual set of developer tools, but at least:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Ubuntu 24.04 LTS` Docker Test.

### Why are the changes needed?

Although the official `Ubuntu 24.04 LTS` will arrive on April 2024, we can start to track it from the official docker dev image.

- GNU C/CXX compiler: 13.2.0


### How was this patch tested?

Manual review.
```
$ ./reinit.sh ubuntu24
$ ./run-one.sh local ORC-1541 ubuntu24
...
Test project /root/build
    Start 1: orc-test
1/8 Test #1: orc-test .........................   Passed    4.53 sec
    Start 2: java-test
2/8 Test #2: java-test ........................   Passed  104.55 sec
    Start 3: java-tools-test
3/8 Test #3: java-tools-test ..................   Passed    0.07 sec
    Start 4: java-bench-gen-test
4/8 Test #4: java-bench-gen-test ..............   Passed    0.74 sec
    Start 5: java-bench-scan-test
5/8 Test #5: java-bench-scan-test .............   Passed    0.69 sec
    Start 6: java-bench-hive-test
6/8 Test #6: java-bench-hive-test .............   Passed   11.21 sec
    Start 7: java-bench-spark-test
7/8 Test #7: java-bench-spark-test ............   Passed    3.36 sec
    Start 8: tool-test
8/8 Test #8: tool-test ........................   Passed    6.94 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) = 132.08 sec
Built target test-out
Finished ubuntu24 at Fri Dec  8 23:34:01 PST 2023
```

This closes #1501 .