### PR TITLE
ORC-1542: Use Java 16 `Pattern Matching for instanceof` (JEP-394)

### DIFF
--- a/java/core/src/java/org/apache/orc/TypeDescription.java
+++ b/java/core/src/java/org/apache/orc/TypeDescription.java
@@ -411,13 +411,12 @@ public class TypeDescription
    *         argument; {@code false} otherwise.
    */
   public boolean equals(Object other, boolean checkAttributes) {
-    if (other == null || !(other instanceof TypeDescription)) {
+    if (other == null || !(other instanceof TypeDescription castOther)) {
       return false;
     }
     if (other == this) {
       return true;
     }
-    TypeDescription castOther = (TypeDescription) other;
     if (category != castOther.category ||
         maxLength != castOther.maxLength ||
         scale != castOther.scale ||

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -52,11 +52,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ColumnStatisticsImpl)) {
+    if (!(o instanceof ColumnStatisticsImpl that)) {
       return false;
     }
-
-    ColumnStatisticsImpl that = (ColumnStatisticsImpl) o;
 
     if (count != that.count) {
       return false;
@@ -102,8 +100,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof BooleanStatisticsImpl) {
-        BooleanStatisticsImpl bkt = (BooleanStatisticsImpl) other;
+      if (other instanceof BooleanStatisticsImpl bkt) {
         trueCount += bkt.trueCount;
       } else {
         if (isStatsExists() && trueCount != 0) {
@@ -143,14 +140,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof BooleanStatisticsImpl)) {
+      if (!(o instanceof BooleanStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      BooleanStatisticsImpl that = (BooleanStatisticsImpl) o;
 
       return trueCount == that.trueCount;
     }
@@ -213,8 +208,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof CollectionColumnStatisticsImpl) {
-        CollectionColumnStatisticsImpl otherColl = (CollectionColumnStatisticsImpl) other;
+      if (other instanceof CollectionColumnStatisticsImpl otherColl) {
 
         if(count == 0) {
           minimum = otherColl.minimum;
@@ -272,14 +266,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof CollectionColumnStatisticsImpl)) {
+      if (!(o instanceof CollectionColumnStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      CollectionColumnStatisticsImpl that = (CollectionColumnStatisticsImpl) o;
 
       if (minimum != that.minimum) {
         return false;
@@ -383,8 +375,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof IntegerStatisticsImpl) {
-        IntegerStatisticsImpl otherInt = (IntegerStatisticsImpl) other;
+      if (other instanceof IntegerStatisticsImpl otherInt) {
         if (!hasMinimum) {
           hasMinimum = otherInt.hasMinimum;
           minimum = otherInt.minimum;
@@ -471,14 +462,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof IntegerStatisticsImpl)) {
+      if (!(o instanceof IntegerStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      IntegerStatisticsImpl that = (IntegerStatisticsImpl) o;
 
       if (minimum != that.minimum) {
         return false;
@@ -557,8 +546,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof DoubleStatisticsImpl) {
-        DoubleStatisticsImpl dbl = (DoubleStatisticsImpl) other;
+      if (other instanceof DoubleStatisticsImpl dbl) {
         if (!hasMinimum) {
           hasMinimum = dbl.hasMinimum;
           minimum = dbl.minimum;
@@ -628,14 +616,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof DoubleStatisticsImpl)) {
+      if (!(o instanceof DoubleStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      DoubleStatisticsImpl that = (DoubleStatisticsImpl) o;
 
       if (hasMinimum != that.hasMinimum) {
         return false;
@@ -753,8 +739,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof StringStatisticsImpl) {
-        StringStatisticsImpl str = (StringStatisticsImpl) other;
+      if (other instanceof StringStatisticsImpl str) {
         if (count == 0) {
           if (str.count != 0) {
             minimum = new Text(str.minimum);
@@ -884,14 +869,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof StringStatisticsImpl)) {
+      if (!(o instanceof StringStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      StringStatisticsImpl that = (StringStatisticsImpl) o;
 
       if (sum != that.sum) {
         return false;
@@ -1050,14 +1033,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof BinaryStatisticsImpl)) {
+      if (!(o instanceof BinaryStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      BinaryStatisticsImpl that = (BinaryStatisticsImpl) o;
 
       return sum == that.sum;
     }
@@ -1129,8 +1110,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof DecimalStatisticsImpl) {
-        DecimalStatisticsImpl dec = (DecimalStatisticsImpl) other;
+      if (other instanceof DecimalStatisticsImpl dec) {
         if (minimum == null) {
           minimum = (dec.minimum != null ? new HiveDecimalWritable(dec.minimum) : null);
           maximum = (dec.maximum != null ? new HiveDecimalWritable(dec.maximum) : null);
@@ -1209,14 +1189,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof DecimalStatisticsImpl)) {
+      if (!(o instanceof DecimalStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      DecimalStatisticsImpl that = (DecimalStatisticsImpl) o;
 
       if (minimum != null ? !minimum.equals(that.minimum) : that.minimum != null) {
         return false;
@@ -1323,8 +1301,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof Decimal64StatisticsImpl) {
-        Decimal64StatisticsImpl dec = (Decimal64StatisticsImpl) other;
+      if (other instanceof Decimal64StatisticsImpl dec) {
         if (getNumberOfValues() == 0) {
           minimum = dec.minimum;
           maximum = dec.maximum;
@@ -1420,14 +1397,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof Decimal64StatisticsImpl)) {
+      if (!(o instanceof Decimal64StatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      Decimal64StatisticsImpl that = (Decimal64StatisticsImpl) o;
 
       if (minimum != that.minimum ||
           maximum != that.maximum ||
@@ -1508,8 +1483,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof DateStatisticsImpl) {
-        DateStatisticsImpl dateStats = (DateStatisticsImpl) other;
+      if (other instanceof DateStatisticsImpl dateStats) {
         minimum = Math.min(minimum, dateStats.minimum);
         maximum = Math.max(maximum, dateStats.maximum);
       } else {
@@ -1588,14 +1562,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof DateStatisticsImpl)) {
+      if (!(o instanceof DateStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      DateStatisticsImpl that = (DateStatisticsImpl) o;
 
       if (minimum != that.minimum) {
         return false;
@@ -1702,8 +1674,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof TimestampStatisticsImpl) {
-        TimestampStatisticsImpl timestampStats = (TimestampStatisticsImpl) other;
+      if (other instanceof TimestampStatisticsImpl timestampStats) {
         if (count == 0) {
           if (timestampStats.count != 0) {
             minimum = timestampStats.minimum;
@@ -1817,14 +1788,12 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof TimestampStatisticsImpl)) {
+      if (!(o instanceof TimestampStatisticsImpl that)) {
         return false;
       }
       if (!super.equals(o)) {
         return false;
       }
-
-      TimestampStatisticsImpl that = (TimestampStatisticsImpl) o;
 
       return minimum == that.minimum && maximum == that.maximum &&
           minNanos == that.minNanos && maxNanos == that.maxNanos;

--- a/java/core/src/java/org/apache/orc/impl/ParserUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/ParserUtils.java
@@ -450,8 +450,7 @@ public class ParserUtils {
         return ((StructColumnVector) parent).fields[posn];
       } else if (parent instanceof UnionColumnVector) {
         return ((UnionColumnVector) parent).fields[posn];
-      } else if (parent instanceof MapColumnVector) {
-        MapColumnVector m = (MapColumnVector) parent;
+      } else if (parent instanceof MapColumnVector m) {
         return posn == 0 ? m.keys : m.values;
       }
       throw new IllegalArgumentException("Unknown complex column vector " + parent.getClass());

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -696,8 +696,7 @@ public class RecordReaderImpl implements RecordReader {
           predicate.getColumnName(), writerVersion);
       return TruthValue.YES_NO_NULL;
     } else if ((category == TypeDescription.Category.DOUBLE ||
-        category == TypeDescription.Category.FLOAT) && cs instanceof DoubleColumnStatistics) {
-      DoubleColumnStatistics dstas = (DoubleColumnStatistics) cs;
+        category == TypeDescription.Category.FLOAT) && cs instanceof DoubleColumnStatistics dstas) {
       if (Double.isNaN(dstas.getSum())) {
         LOG.debug("Not using predication pushdown on {} because stats contain NaN values",
                 predicate.getColumnName());
@@ -1048,8 +1047,7 @@ public class RecordReaderImpl implements RecordReader {
         }
         break;
       case STRING:
-        if (obj instanceof ChronoLocalDate) {
-          ChronoLocalDate date = (ChronoLocalDate) obj;
+        if (obj instanceof ChronoLocalDate date) {
           return date.format(DateTimeFormatter.ISO_LOCAL_DATE
               .withChronology(date.getChronology()));
         }

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -583,8 +583,7 @@ public class RecordReaderUtils {
 
       @Override
       public boolean equals(Object rhs) {
-        if (rhs instanceof Key) {
-          Key o = (Key) rhs;
+        if (rhs instanceof Key o) {
           return 0 == compareTo(o);
         }
         return false;

--- a/java/core/src/java/org/apache/orc/impl/StreamName.java
+++ b/java/core/src/java/org/apache/orc/impl/StreamName.java
@@ -49,8 +49,7 @@ public class StreamName implements Comparable<StreamName> {
 
   @Override
   public boolean equals(Object obj) {
-    if (obj instanceof  StreamName) {
-      StreamName other = (StreamName) obj;
+    if (obj instanceof StreamName other) {
       return other.column == column && other.kind == kind &&
                  encryption == other.encryption;
     } else {

--- a/java/core/src/java/org/threeten/extra/chrono/HybridDate.java
+++ b/java/core/src/java/org/threeten/extra/chrono/HybridDate.java
@@ -523,8 +523,7 @@ public final class HybridDate
     if (this == obj) {
       return true;
     }
-    if (obj instanceof HybridDate) {
-      HybridDate otherDate = (HybridDate) obj;
+    if (obj instanceof HybridDate otherDate) {
       return this.isoDate.equals(otherDate.isoDate);
     }
     return false;

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
@@ -118,8 +118,7 @@ public class HadoopShimsCurrent implements HadoopShims {
 
   @Override
   public boolean endVariableLengthBlock(OutputStream output) throws IOException {
-    if (output instanceof HdfsDataOutputStream) {
-      HdfsDataOutputStream hdfs = (HdfsDataOutputStream) output;
+    if (output instanceof HdfsDataOutputStream hdfs) {
       hdfs.hsync(EnumSet.of(HdfsDataOutputStream.SyncFlag.END_BLOCK));
       return true;
     }

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -179,8 +179,7 @@ public final class FileDump {
     final boolean sideFileExists = fs.exists(sideFile);
     boolean openDataFile = false;
     boolean openSideFile = false;
-    if (fs instanceof DistributedFileSystem) {
-      DistributedFileSystem dfs = (DistributedFileSystem) fs;
+    if (fs instanceof DistributedFileSystem dfs) {
       openDataFile = !dfs.isFileClosed(path);
       openSideFile = sideFileExists && !dfs.isFileClosed(sideFile);
     }

--- a/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/CsvReader.java
@@ -293,12 +293,10 @@ public class CsvReader implements RecordReader {
         TemporalAccessor temporalAccessor =
             dateTimeFormatter.parseBest(values[offset],
                 ZonedDateTime::from, OffsetDateTime::from, LocalDateTime::from);
-        if (temporalAccessor instanceof ZonedDateTime) {
-          ZonedDateTime zonedDateTime = ((ZonedDateTime) temporalAccessor);
+        if (temporalAccessor instanceof ZonedDateTime zonedDateTime) {
           Timestamp timestamp = Timestamp.from(zonedDateTime.toInstant());
           vector.set(row, timestamp);
-        } else if (temporalAccessor instanceof OffsetDateTime) {
-          OffsetDateTime offsetDateTime = (OffsetDateTime) temporalAccessor;
+        } else if (temporalAccessor instanceof OffsetDateTime offsetDateTime) {
           Timestamp timestamp = Timestamp.from(offsetDateTime.toInstant());
           vector.set(row, timestamp);
         } else if (temporalAccessor instanceof LocalDateTime) {

--- a/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/JsonReader.java
@@ -171,12 +171,10 @@ public class JsonReader implements RecordReader {
         TimestampColumnVector vector = (TimestampColumnVector) vect;
         TemporalAccessor temporalAccessor = dateTimeFormatter.parseBest(value.getAsString(),
             ZonedDateTime::from, OffsetDateTime::from, LocalDateTime::from);
-        if (temporalAccessor instanceof ZonedDateTime) {
-          ZonedDateTime zonedDateTime = ((ZonedDateTime) temporalAccessor);
+        if (temporalAccessor instanceof ZonedDateTime zonedDateTime) {
           Timestamp timestamp = Timestamp.from(zonedDateTime.toInstant());
           vector.set(row, timestamp);
-        } else if (temporalAccessor instanceof OffsetDateTime) {
-          OffsetDateTime offsetDateTime = (OffsetDateTime) temporalAccessor;
+        } else if (temporalAccessor instanceof OffsetDateTime offsetDateTime) {
           Timestamp timestamp = Timestamp.from(offsetDateTime.toInstant());
           vector.set(row, timestamp);
         } else if (temporalAccessor instanceof LocalDateTime) {

--- a/java/tools/src/java/org/apache/orc/tools/json/ListType.java
+++ b/java/tools/src/java/org/apache/orc/tools/json/ListType.java
@@ -63,8 +63,7 @@ class ListType extends HiveType {
 
   @Override
   public void merge(HiveType other) {
-    if (other instanceof ListType) {
-      ListType otherList = (ListType) other;
+    if (other instanceof ListType otherList) {
       if (elementType.subsumes(otherList.elementType)) {
         elementType.merge(otherList.elementType);
       } else if (otherList.elementType.subsumes(elementType)) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 16 `Pattern Matching for instanceof` (JEP-394) syntax.

### Why are the changes needed?

Since Apache ORC 2.0 supports Java 17+, we can take advantage of this new syntax.

### How was this patch tested?

Pass the CIs.