### PR TITLE
ORC-1544: Unpin and upgrade `protobuf-java` to 3.25.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,9 +29,6 @@ updates:
       # Pin scala-library to 2.12.15
       - dependency-name: "org.scala-lang:scala-library"
         versions: "[2.12.16,)"
-      # Pin protobuf-java to 3.22.3
-      - dependency-name: "com.google.protobuf:protobuf-java"
-        versions: "[3.22.4,)"
       # Pin jodd-core to 3.5.2
       - dependency-name: "org.jodd:jodd-core"
         versions: "[3.5.3,)"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,6 +76,7 @@
     <mockito.version>4.11.0</mockito.version>
     <!-- Build Properties -->
     <project.build.outputTimestamp>2023-05-15T16:29:49Z</project.build.outputTimestamp>
+    <protobuf.version>3.25.1</protobuf.version>
     <protoc.version>3.17.3</protoc.version>
     <slf4j.version>2.0.9</slf4j.version>
     <storage-api.version>2.8.1</storage-api.version>
@@ -131,7 +132,7 @@
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>3.22.3</version>
+        <version>${protobuf.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to unpin and upgrade `protobuf-java` to 3.25.1

### Why are the changes needed?

To match with Apache Spark 4.0.0, [SPARK-45991](https://issues.apache.org/jira/browse/SPARK-45991).

### How was this patch tested?

Pass the CIs.