### PR TITLE
ORC-1545: [JAVA] Use `orc-format` 1.0.0-SNAPSHOT

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -33,6 +33,10 @@
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-shims</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-format</artifactId>
+    </dependency>
 
     <!-- inter-project -->
     <dependency>
@@ -123,10 +127,6 @@
       </testResource>
     </testResources>
     <plugins>
-      <plugin>
-        <groupId>com.github.os72</groupId>
-        <artifactId>protoc-jar-maven-plugin</artifactId>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,11 +74,11 @@
     <maven.version>3.9.4</maven.version>
 
     <mockito.version>4.11.0</mockito.version>
+    <orc-format.version>1.0.0-SNAPSHOT</orc-format.version>
     <!-- Build Properties -->
     <project.build.outputTimestamp>2023-05-15T16:29:49Z</project.build.outputTimestamp>
     <protobuf.version>3.25.1</protobuf.version>
     <slf4j.version>2.0.9</slf4j.version>
-    <orc-format.version>1.0.0-SNAPSHOT</orc-format.version>
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -77,8 +77,8 @@
     <!-- Build Properties -->
     <project.build.outputTimestamp>2023-05-15T16:29:49Z</project.build.outputTimestamp>
     <protobuf.version>3.25.1</protobuf.version>
-    <protoc.version>3.17.3</protoc.version>
     <slf4j.version>2.0.9</slf4j.version>
+    <orc-format.version>1.0.0-SNAPSHOT</orc-format.version>
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
@@ -87,6 +87,11 @@
   <dependencyManagement>
     <dependencies>
       <!-- intra-project dependencies -->
+      <dependency>
+        <groupId>org.apache.orc</groupId>
+        <artifactId>orc-format</artifactId>
+        <version>${orc-format.version}</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.orc</groupId>
         <artifactId>orc-shims</artifactId>
@@ -476,30 +481,6 @@
                 <sources>
                   <source>${project.build.directory}/generated-sources</source>
                 </sources>
-              </configuration>
-            </execution>
-          </executions>
-        </plugin>
-        <plugin>
-          <groupId>com.github.os72</groupId>
-          <artifactId>protoc-jar-maven-plugin</artifactId>
-          <version>3.11.4</version>
-          <executions>
-            <execution>
-              <goals>
-                <goal>run</goal>
-              </goals>
-              <phase>generate-sources</phase>
-              <configuration>
-                <protocVersion>${protoc.version}</protocVersion>
-                <protocArtifact>com.google.protobuf:protoc:${protoc.version}</protocArtifact>
-                <addSources>none</addSources>
-                <includeDirectories>
-                  <include>../../proto</include>
-                </includeDirectories>
-                <inputDirectories>
-                  <include>../../proto</include>
-                </inputDirectories>
               </configuration>
             </execution>
           </executions>

--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -29,6 +29,10 @@
     <!-- intra-project -->
     <dependency>
       <groupId>org.apache.orc</groupId>
+      <artifactId>orc-format</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.orc</groupId>
       <artifactId>orc-shims</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `orc-format` 1.0.0-SNAPSHOT in `Java` as an interim stage.

1. We need to change C++ separately later.
2. After (1), we can delete `proto/orc_proto.proto`.
3. After releasing `orc-format` 1.0.0, we need to use it instead of SNAPSHOT.

### Why are the changes needed?

To verify `orc-format` repository and snapshot.

### How was this patch tested?

Pass the CIs.