### PR TITLE
ORC-1550: Upgrade `Maven` to 3.9.6

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -71,7 +71,7 @@
     <maven-shade-plugin.version>3.5.1</maven-shade-plugin.version>
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-    <maven.version>3.9.4</maven.version>
+    <maven.version>3.9.6</maven.version>
 
     <mockito.version>4.11.0</mockito.version>
     <orc-format.version>1.0.0-SNAPSHOT</orc-format.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Apache Maven` to 3.9.6.

### Why are the changes needed?

Apache Maven 3.9.6 has MNG-7913 to improve Java supports. Although it's only for up to Java 19, this is better than the previous condition (up to Java 14).
- https://github.com/apache/maven/pull/1286

> To version that supports gleaning JSR330 component classes up to Java 19. The reasoning of this change is only to allow 3rd party Maven plugins/Maven extensions/other JSR330 components (managed by Maven embedded Sisu) to use bytecode newer that Java 14 (Sisu 0.3.5).

In addition, Maven 3.9.4 hits IOError like the following on Ubuntu 24.04.
```
root@479e66773188:/orc/java# ./mvnw --version
Exception in thread "main" java.io.IOError: java.io.IOException: Broken pipe
	at org.fusesource.jansi.AnsiConsole.systemUninstall(AnsiConsole.java:544)
	at org.apache.maven.shared.utils.logging.MessageUtils.doSystemUninstall(MessageUtils.java:101)
	at org.apache.maven.shared.utils.logging.MessageUtils.systemUninstall(MessageUtils.java:80)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:197)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:283)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:226)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:407)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:348)
Caused by: java.io.IOException: Broken pipe
	at java.base/java.io.FileOutputStream.writeBytes(Native Method)
	at java.base/java.io.FileOutputStream.write(FileOutputStream.java:367)
	at org.fusesource.jansi.io.FastBufferedOutputStream.flushBuffer(FastBufferedOutputStream.java:58)
	at org.fusesource.jansi.io.FastBufferedOutputStream.flush(FastBufferedOutputStream.java:65)
	at java.base/java.io.FilterOutputStream.flush(FilterOutputStream.java:155)
	at org.fusesource.jansi.io.AnsiOutputStream.uninstall(AnsiOutputStream.java:338)
	at org.fusesource.jansi.AnsiPrintStream.uninstall(AnsiPrintStream.java:82)
	at org.fusesource.jansi.AnsiConsole.systemUninstall(AnsiConsole.java:541)
	... 9 more
Using `mvn` from path: /orc/java/build/apache-maven-3.9.4/bin/mvn
```
This is fixed at Maven 3.9.5+.
```
root@479e66773188:/orc/java# ./mvnw --version
exec: curl --silent --show-error -L https://www.apache.org/dyn/closer.lua?action=download&filename=/maven/maven-3/3.9.5/binaries/apache-maven-3.9.5-bin.tar.gz
Using `mvn` from path: /orc/java/build/apache-maven-3.9.5/bin/mvn
Apache Maven 3.9.5 (57804ffe001d7215b5e7bcb531cf83df38f93546)
Maven home: /orc/java/build/apache-maven-3.9.5
Java version: 21.0.1, vendor: Private Build, runtime: /usr/lib/jvm/java-21-openjdk-arm64
Default locale: en_US, platform encoding: UTF-8
OS name: "linux", version: "6.4.16-linuxkit", arch: "aarch64", family: "unix"
```

### How was this patch tested?

Pass the CIs.