### PR TITLE
ORC-1552: Updated Maven version to 3.9.6 to keep documentation in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The subdirectories are:
 ### Building
 
 * Install java 17 or higher
-* Install maven 3.9.4 or higher
+* Install maven 3.9.6 or higher
 * Install cmake 3.12 or higher
 
 To build a release version with debug information:


### PR DESCRIPTION
### What changes were proposed in this pull request?
The PR updates the README.md to reflect upgraded Maven version as part of [ORC-1550](https://issues.apache.org/jira/browse/ORC-1550)

### Why are the changes needed?
The PR is needed to keep Documentation in sync with implementation


### How was this patch tested?
Manually verified, Documentation update only
