### PR TITLE
Add a copyright messaging to the BpackingAvx512.hh

### DIFF
--- a/c++/src/BpackingAvx512.hh
+++ b/c++/src/BpackingAvx512.hh
@@ -16,6 +16,46 @@
  * limitations under the License.
  */
 
+/*******************************************************************************
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+/**
+ * @brief Contains implementation of functions for unpacking 1..32-bit data to bytes
+ *
+ * @details Function list:
+ *          - @ref vectorUnpack1
+ *          - @ref vectorUnpack2
+ *          - @ref vectorUnpack3
+ *          - @ref vectorUnpack4
+ *          - @ref vectorUnpack5
+ *          - @ref vectorUnpack6
+ *          - @ref vectorUnpack7
+ *          - @ref vectorUnpack9
+ *          - @ref vectorUnpack10
+ *          - @ref vectorUnpack11
+ *          - @ref vectorUnpack12
+ *          - @ref vectorUnpack13
+ *          - @ref vectorUnpack14
+ *          - @ref vectorUnpack15
+ *          - @ref vectorUnpack16
+ *          - @ref vectorUnpack17
+ *          - @ref vectorUnpack18
+ *          - @ref vectorUnpack19
+ *          - @ref vectorUnpack20
+ *          - @ref vectorUnpack21
+ *          - @ref vectorUnpack22
+ *          - @ref vectorUnpack23
+ *          - @ref vectorUnpack24
+ *          - @ref vectorUnpack26
+ *          - @ref vectorUnpack28
+ *          - @ref vectorUnpack30
+ *          - @ref vectorUnpack32
+ *
+ */
+
 #ifndef ORC_BPACKINGAVX512_HH
 #define ORC_BPACKINGAVX512_HH
 


### PR DESCRIPTION

###  What changes were proposed in this pull request?
 Add copyright messaging to BpackingAvx512.hh

### Why are the changes needed?
The vector unpacking functions  in this PR[ https://github.com/apache/orc/pull/1375]() is derived from Intel's QPL library,  hence,  Maybe copyright messaging should be added.

QPL Link: [https://github.com/intel/qpl]()


### How was this patch tested?
N/A
