### PR TITLE
ORC-1553: Row grouping reads should be skipped when the statistics are written without any values for the SArg column

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -667,6 +667,14 @@ public class RecordReaderImpl implements RecordReader {
                                            TypeDescription type,
                                            boolean writerUsedProlepticGregorian,
                                            boolean useUTCTimestamp) {
+
+    // When statsProto is EMPTY_COLUMN_STATISTICS
+    // this column does not actually provide statistics
+    // we cannot make any assumptions, so we return YES_NO_NULL.
+    if (statsProto == EMPTY_COLUMN_STATISTICS) {
+      return TruthValue.YES_NO_NULL;
+    }
+
     ColumnStatistics cs = ColumnStatisticsImpl.deserialize(
         null, statsProto, writerUsedProlepticGregorian, true);
     ValueRange range = getValueRange(cs, predicate, useUTCTimestamp);
@@ -702,11 +710,6 @@ public class RecordReaderImpl implements RecordReader {
                 predicate.getColumnName());
         return dstas.hasNull() ? TruthValue.YES_NO_NULL : TruthValue.YES_NO;
       }
-    } else if (statsProto == EMPTY_COLUMN_STATISTICS) {
-      // When statsProto is EMPTY_COLUMN_STATISTICS
-      // this column does not actually provide statistics
-      // we cannot make any assumptions, so we return YES_NO_NULL.
-      return TruthValue.YES_NO_NULL;
     }
     return evaluatePredicateRange(predicate, range,
         BloomFilterIO.deserialize(kind, encoding, writerVersion, type.getCategory(),

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -702,6 +702,11 @@ public class RecordReaderImpl implements RecordReader {
                 predicate.getColumnName());
         return dstas.hasNull() ? TruthValue.YES_NO_NULL : TruthValue.YES_NO;
       }
+    } else if (statsProto == EMPTY_COLUMN_STATISTICS) {
+      // When statsProto is EMPTY_COLUMN_STATISTICS
+      // this column does not actually provide statistics
+      // we cannot make any assumptions, so we return YES_NO_NULL.
+      return TruthValue.YES_NO_NULL;
     }
     return evaluatePredicateRange(predicate, range,
         BloomFilterIO.deserialize(kind, encoding, writerVersion, type.getCategory(),
@@ -747,8 +752,10 @@ public class RecordReaderImpl implements RecordReader {
                                            ValueRange range,
                                            BloomFilter bloomFilter,
                                            boolean useUTCTimestamp) {
+    // If range is invalid, that means that no value (including null) is written to this column
+    // we should return TruthValue.NO for any predicate.
     if (!range.isValid()) {
-      return TruthValue.YES_NO_NULL;
+      return TruthValue.NO;
     }
 
     // if we didn't have any values, everything must have been null


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix an issue where the column statistics were incorrectly evaluated in scenarios where no values were written, resulting in the inability to skip row groups.


### Why are the changes needed?
The fix improves the evaluation logic of statistics, enabling the skipping of row groups that don't need to be read, thus enhancing performance.


### How was this patch tested?
Unit tests have been added to validate the changes.





