### PR TITLE
ORC-1555: Simplify `fedora37` docker image

### DIFF
--- a/docker/fedora37/Dockerfile
+++ b/docker/fedora37/Dockerfile
@@ -19,7 +19,6 @@
 
 FROM fedora:37
 LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
-ARG jdk=17
 
 RUN yum check-update || true
 RUN yum install -y \
@@ -33,24 +32,12 @@ RUN yum install -y \
   git \
   libtool \
   make \
-  maven \
   openssl-devel \
   tar \
   wget \
   which \
-  zlib-devel && \
-  if [ "${jdk}" = "11" ] ; then \
-    yum install -y \
-    java-11-openjdk \
-    java-11-openjdk-devel \
-    && \
-    update-alternatives --set java  $(readlink -f /usr/lib/jvm/java-11-openjdk/bin/java) && \
-    update-alternatives --set javac $(readlink -f /usr/lib/jvm/java-11-openjdk/bin/javac) \
-  ; elif [ "${jdk}" = "8" ] ; then \
-    yum install -y \
-    java-1.8.0-openjdk \
-    java-1.8.0-openjdk-devel \
-  ; fi
+  zlib-devel \
+  java-17-openjdk-devel
 
 ENV TZ=America/Los_Angeles
 WORKDIR /root


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to simplify `fedora37` docker image for Apache ORC 2.0.
- Explicitly install Java 17
- Remove unused Java8 and Java 11 installation
- Remove unused Maven installation.

### Why are the changes needed?

The docker image is outdated.
- Java 8 and 11-related branches are not used at all.
- The installed Java 17 was due to the transitive dependency of `maven` installation.
- The installed `Maven` is not used because we use `mvnw`.

### How was this patch tested?

Manual tests.
```
$ ./run-one.sh local main fedora37
...
Test project /root/build
    Start 1: orc-test
1/8 Test #1: orc-test .........................   Passed    5.54 sec
    Start 2: java-test
2/8 Test #2: java-test ........................   Passed  118.00 sec
    Start 3: java-tools-test
3/8 Test #3: java-tools-test ..................   Passed    0.09 sec
    Start 4: java-bench-gen-test
4/8 Test #4: java-bench-gen-test ..............   Passed    0.83 sec
    Start 5: java-bench-scan-test
5/8 Test #5: java-bench-scan-test .............   Passed    0.74 sec
    Start 6: java-bench-hive-test
6/8 Test #6: java-bench-hive-test .............   Passed   11.28 sec
    Start 7: java-bench-spark-test
7/8 Test #7: java-bench-spark-test ............   Passed    3.49 sec
    Start 8: tool-test
8/8 Test #8: tool-test ........................   Passed    7.92 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) = 147.89 sec
Built target test-out
Finished fedora37 at Sat Dec 23 19:32:19 PST 2023
```