### PR TITLE
ORC-1556: Add `Rocky Linux 9` Docker Test

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,7 @@
 * Debian 11 and 12
 * Fedora 37
 * Ubuntu 20, 22, 24
+* Rocky 9
 
 ## Pre-built Images
 

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -6,3 +6,4 @@ ubuntu24
 fedora37
 ubuntu22_jdk=21
 ubuntu22_jdk=21_cc=clang
+rocky9

--- a/docker/rocky9/Dockerfile
+++ b/docker/rocky9/Dockerfile
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Rocky Linux 9
+#
+
+FROM rockylinux:9
+LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+
+RUN yum check-update || true
+RUN yum install -y \
+  cmake3 \
+  curl-devel \
+  cyrus-sasl-devel \
+  expat-devel \
+  gcc \
+  gcc-c++ \
+  gettext-devel \
+  git \
+  libtool \
+  make \
+  openssl-devel \
+  tar \
+  wget \
+  which \
+  zlib-devel \
+  java-17-openjdk-devel
+
+ENV TZ=America/Los_Angeles
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Rocky Linux 9` Dockerfile.

### Why are the changes needed?

To provide a test coverage for `Oracle 9`-compatible OS environment.

- https://docs.rockylinux.org/release_notes/9_3/
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.3_release_notes/index

### How was this patch tested?

Manual test.

```
$ ./run-one.sh apache branch-1.9 rocky9
...
Test project /root/orc/build
    Start 1: orc-test
1/8 Test #1: orc-test .........................   Passed    4.92 sec
    Start 2: java-test
2/8 Test #2: java-test ........................   Passed  114.57 sec
    Start 3: java-tools-test
3/8 Test #3: java-tools-test ..................   Passed    0.07 sec
    Start 4: java-bench-gen-test
4/8 Test #4: java-bench-gen-test ..............   Passed    0.75 sec
    Start 5: java-bench-scan-test
5/8 Test #5: java-bench-scan-test .............   Passed    0.71 sec
    Start 6: java-bench-hive-test
6/8 Test #6: java-bench-hive-test .............   Passed   11.45 sec
    Start 7: java-bench-spark-test
7/8 Test #7: java-bench-spark-test ............   Passed    3.26 sec
    Start 8: tool-test
8/8 Test #8: tool-test ........................   Passed    6.70 sec

100% tests passed, 0 tests failed out of 8

Total Test time (real) = 142.44 sec
Built target test-out
Finished rocky9 at Sat Dec 23 23:21:18 PST 2023
```