### PR TITLE
ORC-1558: Remove `ubuntu22_jdk=21` and `ubuntu22_jdk=21_cc=clang` test combinations from `docker/os-list.txt`

### DIFF
--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,6 +4,4 @@ ubuntu20
 ubuntu22
 ubuntu24
 fedora37
-ubuntu22_jdk=21
-ubuntu22_jdk=21_cc=clang
 rocky9


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `ubuntu22_jdk=21` and `ubuntu22_jdk=21_cc=clang` test combinations from `docker/os-list.txt`.

### Why are the changes needed?

After the following PR, GitHub Action CI runs all supported OSes and variants (Java 21/clang) at every commit.
- #1696 

### How was this patch tested?

Manual review because this is a removal.