### PR TITLE
ORC-1559: Remove Java11 and clang variants from `docker/os-list.txt`

### DIFF
--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -5,7 +5,4 @@ debian12
 ubuntu20
 ubuntu22
 fedora37
-debian11_jdk=11
-ubuntu22_jdk=11
-ubuntu22_jdk=11_cc=clang
 rocky9


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove Java11 and clang variants from `docker/os-list.txt` in `branch-1.9`.

### Why are the changes needed?

After the following PR, `GitHub Action CI` runs all supported OSes and variants (Java 11/clang) at every commit.
- #1696 

### How was this patch tested?

Manual review because this is a removal.