### PR TITLE
ORC-1561: Remove Java11 and clang variants from `docker/os-list.txt` in `branch-1.7`

### DIFF
--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,6 +4,3 @@ debian11
 ubuntu18
 ubuntu20
 ubuntu22
-debian10_jdk=11
-ubuntu20_jdk=11
-ubuntu20_jdk=11_cc=clang


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove Java11 and clang variants from `docker/os-list.txt` in `branch-1.7`.

### Why are the changes needed?

After the following PR, `GitHub Action CI` runs all supported OSes and variants (Java 11/clang) at every commit.
- #1700 

### How was this patch tested?

Manual review because this is a removal.