### PR TITLE
ORC-1556: Add `Rocky Linux 9` Docker Test

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,6 +20,7 @@ jobs:
           - debian10
           - debian11
           - ubuntu18
+          - rocky9
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,6 +3,7 @@
 * CentOS 7
 * Debian 10 and 11
 * Ubuntu 18, 20 and 22
+* Rocky 9
 
 ## Pre-built Images
 

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,3 +4,4 @@ debian11
 ubuntu18
 ubuntu20
 ubuntu22
+rocky9

--- a/docker/rocky9/Dockerfile
+++ b/docker/rocky9/Dockerfile
@@ -1,0 +1,54 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Rocky Linux 9
+#
+
+FROM rockylinux:9
+LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+
+RUN yum check-update || true
+RUN yum install -y \
+  cmake3 \
+  curl-devel \
+  cyrus-sasl-devel \
+  expat-devel \
+  gcc \
+  gcc-c++ \
+  gettext-devel \
+  git \
+  libtool \
+  make \
+  openssl-devel \
+  tar \
+  wget \
+  which \
+  zlib-devel \
+  java-17-openjdk-devel
+
+ENV TZ=America/Los_Angeles
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Rocky Linux 9` Dockerfile.

### Why are the changes needed?

To provide a test coverage for `Oracle 9`-compatible OS environment.

- https://docs.rockylinux.org/release_notes/9_3/
- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/9.3_release_notes/index

### How was this patch tested?

Pass the CIs and check the logs.
- https://github.com/apache/orc/actions/runs/7314447285/job/19927098261?pr=1706

```
...
Status: Downloaded newer image for apache/orc-dev:rocky9
-- The C compiler identification is GNU 11.4.1
-- The CXX compiler identification is GNU 11.4.1
...
Java version: 17.0.9, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-17-openjdk-17.0.9.0.9-2.el9.x86_64
Default locale: en_US, platform encoding: ANSI_X3.4-1968
OS name: "linux", version: "6.2.0-1018-azure", arch: "amd64", family: "unix"
```