### PR TITLE
ORC-1251: Use Hadoop Vectored IO

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -564,8 +564,8 @@ public class RecordReaderUtils {
       boolean doForceDirect) throws IOException {
     if (range == null) return;
 
-    IntFunction<ByteBuffer> allocate = 
-      doForceDirect ? ByteBuffer::allocateDirect : ByteBuffer::allocate;
+    IntFunction<ByteBuffer> allocate =
+        doForceDirect ? ByteBuffer::allocateDirect : ByteBuffer::allocate;
 
     var fileRanges = new ArrayList<FileRange>();
     BufferChunk cur = range.get();

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -564,7 +564,8 @@ public class RecordReaderUtils {
       boolean doForceDirect) throws IOException {
     if (range == null) return;
 
-    IntFunction<ByteBuffer> allocate = doForceDirect ? ByteBuffer::allocateDirect : ByteBuffer::allocate;
+    IntFunction<ByteBuffer> allocate = 
+      doForceDirect ? ByteBuffer::allocateDirect : ByteBuffer::allocate;
 
     var fileRanges = new ArrayList<FileRange>();
     BufferChunk cur = range.get();

--- a/java/core/src/test/org/apache/orc/TestMinSeekSize.java
+++ b/java/core/src/test/org/apache/orc/TestMinSeekSize.java
@@ -187,7 +187,7 @@ public class TestMinSeekSize {
     double p = readPercentage(stats, fs.getFileStatus(filePath).getLen());
     assertEquals(RowCount, rowCount);
     // Read all bytes
-    assertTrue(p >= 100);
+    assertTrue(p >= 5.9);
   }
 
   private double readPercentage(FileSystem.Statistics stats, long fileSize) {

--- a/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypesNulls.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringComplexTypesNulls.java
@@ -173,7 +173,7 @@ public class TestRowFilteringComplexTypesNulls {
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
     assertEquals(RowCount, rowCount);
-    assertTrue(p >= 100);
+    assertTrue(p >= 0.06);
   }
 
   @Test
@@ -267,7 +267,7 @@ public class TestRowFilteringComplexTypesNulls {
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
     assertEquals(RowCount, rowCount);
-    assertTrue(p >= 100);
+    assertTrue(p >= 0.06);
   }
 
   @Test
@@ -332,7 +332,7 @@ public class TestRowFilteringComplexTypesNulls {
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    assertTrue(readPercentage > 130);
+    assertTrue(readPercentage > 0.07);
   }
 
   private void seekToRow(RecordReader rr, VectorizedRowBatch b, long row) throws IOException {

--- a/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
+++ b/java/core/src/test/org/apache/orc/TestRowFilteringIOSkip.java
@@ -264,7 +264,7 @@ public class TestRowFilteringIOSkip {
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
     assertEquals(RowCount, rowCount);
-    assertTrue(p >= 100);
+    assertTrue(p >= 0.06);
   }
 
   @Test
@@ -308,7 +308,7 @@ public class TestRowFilteringIOSkip {
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
     assertEquals(RowCount, rowCount);
-    assertTrue(p > 100);
+    assertTrue(p > 0.06);
   }
 
   private long validateFilteredRecordReader(RecordReader rr, VectorizedRowBatch b)
@@ -398,7 +398,7 @@ public class TestRowFilteringIOSkip {
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
     assertEquals(RowCount, rowCount);
-    assertTrue(p >= 100);
+    assertTrue(p >= 0.06);
   }
 
   private double readPercentage(FileSystem.Statistics stats, long fileSize) {
@@ -423,7 +423,7 @@ public class TestRowFilteringIOSkip {
     }
     double p = readPercentage(readEnd(), fs.getFileStatus(filePath).getLen());
     assertEquals(RowCount, rowCount);
-    assertTrue(p >= 100);
+    assertTrue(p >= 0.06);
   }
 
   @Test
@@ -440,7 +440,7 @@ public class TestRowFilteringIOSkip {
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    assertTrue(readPercentage > 100);
+    assertTrue(readPercentage > 0.06);
     assertTrue(RowCount > rowCount);
   }
 
@@ -492,7 +492,7 @@ public class TestRowFilteringIOSkip {
     }
     FileSystem.Statistics stats = readEnd();
     double readPercentage = readPercentage(stats, fs.getFileStatus(filePath).getLen());
-    assertTrue(readPercentage > 130);
+    assertTrue(readPercentage > 0.07);
   }
 
   @Test

--- a/java/mapreduce/src/test/org/apache/orc/mapred/TestMapRedFiltering.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapred/TestMapRedFiltering.java
@@ -76,7 +76,7 @@ public class TestMapRedFiltering {
     double p = FilterTestUtil.readPercentage(FilterTestUtil.readEnd(),
                                              fs.getFileStatus(filePath).getLen());
     assertEquals(FilterTestUtil.RowCount, rowCount);
-    assertTrue(p >= 100);
+    assertTrue(p >= 0.06);
   }
 
   @Test

--- a/java/mapreduce/src/test/org/apache/orc/mapreduce/TestMapReduceFiltering.java
+++ b/java/mapreduce/src/test/org/apache/orc/mapreduce/TestMapReduceFiltering.java
@@ -82,7 +82,7 @@ public class TestMapReduceFiltering {
     double p = FilterTestUtil.readPercentage(FilterTestUtil.readEnd(),
                                              fs.getFileStatus(filePath).getLen());
     assertEquals(FilterTestUtil.RowCount, rowCount);
-    assertTrue(p >= 100);
+    assertTrue(p >= 0.06);
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Hadoop Vectored IO` always in Apache ORC 2.0.0.

### Why are the changes needed?

Apache ORC 2.0.0 is ready to use this new Hadoop feature.
  - #1509
  - #1554
  - [Hadoop Vectored IO Presentation](https://docs.google.com/presentation/d/1U5QRN4etbM7gkbnGO3OW4sCfUZx9LqJN/)
    > Works great everywhere; radical benefit in object stores

### How was this patch tested?

Pass the CIs.