### PR TITLE
ORC-1003: Recover `java-examples-test` in `java` module

### DIFF
--- a/java/CMakeLists.txt
+++ b/java/CMakeLists.txt
@@ -70,11 +70,10 @@ add_test(
            -Dbuild.dir=${CMAKE_CURRENT_BINARY_DIR} test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-# TOOD(ORC-1003)
-# add_test(
-#   NAME java-examples-test
-#   COMMAND java -jar examples/orc-examples-${ORC_VERSION}-uber.jar write
-#   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(
+  NAME java-examples-test
+  COMMAND java -jar examples/orc-examples-${ORC_VERSION}-uber.jar write
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_test(
   NAME java-tools-test


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to recover `java-examples-test` at `CMakefile` of `java` module.

### Why are the changes needed?

To restore the test coverage.

### How was this patch tested?

Pass the CIs.