### PR TITLE
ORC-1566: Make Brotli dependency as optional

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -207,6 +207,7 @@
         <groupId>com.aayushatharva.brotli4j</groupId>
         <artifactId>brotli4j</artifactId>
         <version>${brotli4j.version}</version>
+        <optional>true</optional>
       </dependency>
 
       <!-- test inter-project -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to make the Brotli dependency as optional.

### Why are the changes needed?
Brotli is not required when Brotli codec is not used. 

### How was this patch tested?
Pass the CIs.