### PR TITLE
ORC-1567: Support `-ignoreExtension` option at `sizes` and `count` commands of orc-tools

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
+++ b/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Given a set of paths, finds all of the orc files under them and
+ * Given a set of paths, finds all of the "*.orc" files under them and
  * prints the sizes of each column, both as a percentage and the number of
  * bytes per a row.
  */
@@ -163,7 +163,7 @@ public class ColumnSizes {
       FileSystem fs = rootPath.getFileSystem(conf);
       for(RemoteIterator<LocatedFileStatus> itr = fs.listFiles(rootPath, true); itr.hasNext(); ) {
         LocatedFileStatus status = itr.next();
-        if (status.isFile()) {
+        if (status.isFile() && status.getPath().getName().endsWith(".orc")) {
           try {
             if (result == null) {
               result = new ColumnSizes(conf, status);

--- a/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
+++ b/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Given a set of paths, finds all of the "*.orc" files under them and
+ * Given a set of paths, finds all of the orc files under them and
  * prints the sizes of each column, both as a percentage and the number of
  * bytes per a row.
  */
@@ -163,7 +163,7 @@ public class ColumnSizes {
       FileSystem fs = rootPath.getFileSystem(conf);
       for(RemoteIterator<LocatedFileStatus> itr = fs.listFiles(rootPath, true); itr.hasNext(); ) {
         LocatedFileStatus status = itr.next();
-        if (status.isFile() && status.getPath().getName().endsWith(".orc")) {
+        if (status.isFile()) {
           try {
             if (result == null) {
               result = new ColumnSizes(conf, status);

--- a/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
+++ b/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
@@ -212,15 +212,15 @@ public class ColumnSizes {
   private static Options createOptions() {
     Options result = new Options();
 
-    result.addOption(Option.builder()
-            .longOpt("ignoreExtension")
-            .desc("Ignore ORC file extension")
-            .build());
+    result.addOption(Option.builder("i")
+        .longOpt("ignoreExtension")
+        .desc("Ignore ORC file extension")
+        .build());
 
     result.addOption(Option.builder("h")
-            .longOpt("help")
-            .desc("Print help message")
-            .build());
+        .longOpt("help")
+        .desc("Print help message")
+        .build());
     return result;
   }
 }

--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -87,7 +87,7 @@ public class Driver {
       System.err.println();
       System.err.println("Commands:");
       System.err.println("   convert - convert CSV and JSON files to ORC");
-      System.err.println("   count - recursively find orc file and print the number of rows");
+      System.err.println("   count - recursively find *.orc and print the number of rows");
       System.err.println("   data - print the data from the ORC file");
       System.err.println("   json-schema - scan JSON files to determine their schema");
       System.err.println("   key - print information about the keys");

--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -87,7 +87,7 @@ public class Driver {
       System.err.println();
       System.err.println("Commands:");
       System.err.println("   convert - convert CSV and JSON files to ORC");
-      System.err.println("   count - recursively find *.orc and print the number of rows");
+      System.err.println("   count - recursively find orc file and print the number of rows");
       System.err.println("   data - print the data from the ORC file");
       System.err.println("   json-schema - scan JSON files to determine their schema");
       System.err.println("   key - print information about the keys");

--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -29,7 +29,7 @@ import org.apache.orc.Reader;
 import java.io.IOException;
 
 /**
- * Given a set of paths, finds all of the "*.orc" files under them and prints the number of rows in each file.
+ * Given a set of paths, finds all of the orc files under them and prints the number of rows in each file.
  */
 public class RowCount {
   public static void main(Configuration conf, String[] args) throws IOException {
@@ -39,7 +39,7 @@ public class RowCount {
       FileSystem fs = rootPath.getFileSystem(conf);
       for(RemoteIterator<LocatedFileStatus> itr = fs.listFiles(rootPath, true); itr.hasNext(); ) {
         LocatedFileStatus status = itr.next();
-        if (status.isFile() && status.getPath().getName().endsWith(".orc")) {
+        if (status.isFile()) {
           Path filename = status.getPath();
           try (Reader reader = OrcFile.createReader(filename, OrcFile.readerOptions(conf))) {
             System.out.println(String.format("%s %d",

--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -29,7 +29,7 @@ import org.apache.orc.Reader;
 import java.io.IOException;
 
 /**
- * Given a set of paths, finds all of the orc files under them and prints the number of rows in each file.
+ * Given a set of paths, finds all of the "*.orc" files under them and prints the number of rows in each file.
  */
 public class RowCount {
   public static void main(Configuration conf, String[] args) throws IOException {
@@ -39,7 +39,7 @@ public class RowCount {
       FileSystem fs = rootPath.getFileSystem(conf);
       for(RemoteIterator<LocatedFileStatus> itr = fs.listFiles(rootPath, true); itr.hasNext(); ) {
         LocatedFileStatus status = itr.next();
-        if (status.isFile()) {
+        if (status.isFile() && status.getPath().getName().endsWith(".orc")) {
           Path filename = status.getPath();
           try (Reader reader = OrcFile.createReader(filename, OrcFile.readerOptions(conf))) {
             System.out.println(String.format("%s %d",

--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -76,15 +76,15 @@ public class RowCount {
   private static Options createOptions() {
     Options result = new Options();
 
-    result.addOption(Option.builder()
-            .longOpt("ignoreExtension")
-            .desc("Ignore ORC file extension")
-            .build());
+    result.addOption(Option.builder("i")
+        .longOpt("ignoreExtension")
+        .desc("Ignore ORC file extension")
+        .build());
 
     result.addOption(Option.builder("h")
-            .longOpt("help")
-            .desc("Print help message")
-            .build());
+        .longOpt("help")
+        .desc("Print help message")
+        .build());
     return result;
   }
 }

--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -18,6 +18,11 @@
 
 package org.apache.orc.tools;
 
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -32,14 +37,24 @@ import java.io.IOException;
  * Given a set of paths, finds all of the "*.orc" files under them and prints the number of rows in each file.
  */
 public class RowCount {
-  public static void main(Configuration conf, String[] args) throws IOException {
+  public static void main(Configuration conf, String[] args) throws Exception {
+    Options opts = createOptions();
+    CommandLine cli = new DefaultParser().parse(opts, args);
+    if (cli.hasOption('h')) {
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp("count", opts);
+      return;
+    }
+    boolean ignoreExtension = cli.hasOption("ignoreExtension");
+    String[] files = cli.getArgs();
+
     int bad = 0;
-    for(String root: args) {
+    for(String root: files) {
       Path rootPath = new Path(root);
       FileSystem fs = rootPath.getFileSystem(conf);
       for(RemoteIterator<LocatedFileStatus> itr = fs.listFiles(rootPath, true); itr.hasNext(); ) {
         LocatedFileStatus status = itr.next();
-        if (status.isFile() && status.getPath().getName().endsWith(".orc")) {
+        if (status.isFile() && (ignoreExtension || status.getPath().getName().endsWith(".orc"))) {
           Path filename = status.getPath();
           try (Reader reader = OrcFile.createReader(filename, OrcFile.readerOptions(conf))) {
             System.out.println(String.format("%s %d",
@@ -54,7 +69,22 @@ public class RowCount {
     System.exit(bad == 0 ? 0 : 1);
   }
 
-  public static void main(String[] args) throws IOException {
+  public static void main(String[] args) throws Exception {
     main(new Configuration(), args);
+  }
+
+  private static Options createOptions() {
+    Options result = new Options();
+
+    result.addOption(Option.builder()
+            .longOpt("ignoreExtension")
+            .desc("Ignore ORC file extension")
+            .build());
+
+    result.addOption(Option.builder("h")
+            .longOpt("help")
+            .desc("Print help message")
+            .build());
+    return result;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add the `--ignoreExtension` option.

```bash
java -jar orc-tools-2.0.0-SNAPSHOT-uber.jar sizes --ignoreExtension path
java -jar orc-tools-2.0.0-SNAPSHOT-uber.jar count --ignoreExtension path

```



### Why are the changes needed?
The `count` and `sizes` commands provided by `orc-tools` now require that the file must have an orc suffix.
However, files in orc format do not necessarily have the orc suffix, which is inconvenient to use.

### How was this patch tested?
