### PR TITLE
ORC-1570: Add `supportVectoredIO` API to `HadoopShimsCurrent` and use it

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -48,6 +48,7 @@ import java.util.function.Supplier;
  */
 public class RecordReaderUtils {
   private static final HadoopShims SHIMS = HadoopShimsFactory.get();
+  private static final boolean supportVectoredIO = SHIMS.supportVectoredIO();
   private static final Logger LOG = LoggerFactory.getLogger(RecordReaderUtils.class);
 
   private static class DefaultDataReader implements DataReader {
@@ -107,7 +108,7 @@ public class RecordReaderUtils {
     public BufferChunkList readFileData(BufferChunkList range,
                                         boolean doForceDirect
                                         ) throws IOException {
-      if (zcr == null) {
+      if (supportVectoredIO && zcr == null) {
         RecordReaderUtils.readDiskRangesVectored(file, range, doForceDirect);
       } else {
         RecordReaderUtils.readDiskRanges(file, zcr, range, doForceDirect,

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -20,6 +20,7 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.util.VersionInfo;
 import org.apache.orc.EncryptionAlgorithm;
 
 import java.io.Closeable;
@@ -130,6 +131,15 @@ public interface HadoopShims {
    * @return was a variable length block created?
    */
   boolean endVariableLengthBlock(OutputStream output) throws IOException;
+
+  default boolean supportVectoredIO() {
+    // HADOOP-18103 is available since Apache Hadoop 3.3.5+
+    String[] versionParts = VersionInfo.getVersion().split("[.]");
+    int major = Integer.parseInt(versionParts[0]);
+    int minor = Integer.parseInt(versionParts[1]);
+    int patch = Integer.parseInt(versionParts[2]);
+    return major == 3 && (minor > 3 || (minor == 3 && patch > 4));
+  }
 
   /**
    * The known KeyProviders for column encryption.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `HadoopShimsCurrent` by adding `supportVectoredIO`.

### Why are the changes needed?

Hadoop Vectored IO exists at Apache Hadoop 3.3.5+ via HADOOP-18103.

### How was this patch tested?

Pass the CIs.