### PR TITLE
ORC-1575: Use ASF Archive URL instead Download URL for `orc-format`

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -72,7 +72,7 @@ endif ()
 # ----------------------------------------------------------------------
 # ORC Format
 ExternalProject_Add (orc-format_ep
-  URL "https://downloads.apache.org/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz"
+  URL "https://archive.apache.org/dist/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz"
   URL_HASH SHA256=739fae5ff94b1f812b413077280361045bf92e510ef04b34a610e23a945d8cd5
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update ORC Format download link to `ASF Archive` from `ASF Download`.

### Why are the changes needed?

Since ASF Download keeps only the latest live releases, the links on Download are improper for old release branches.

### How was this patch tested?

Pass the CIs.