### PR TITLE
ORC-1576: Upgrade `spark.jackson.version` to 2.15.2 in `bench` module

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -32,7 +32,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Spark Jackson version may not be same as ORC -->
-    <spark.jackson.version>2.14.2</spark.jackson.version>
+    <spark.jackson.version>2.15.2</spark.jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spark.jackson.version` to 2.15.2 in `bench` module.

### Why are the changes needed?

Apache Spark 3.5.0 uses 2.15.2 via [SPARK-43904](https://issues.apache.org/jira/browse/SPARK-43904)

### How was this patch tested?

Pass the CIs.