### PR TITLE
ORC-870: Unpin and upgrade `jmh` to 1.37

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,6 @@ updates:
       # Pin gson to 2.2.4 because of Hive
       - dependency-name: "com.google.code.gson:gson"
         versions: "[2.3,)"
-      # Pin jmh to 1.20
-      - dependency-name: "org.openjdk.jmh:jmh-core"
-        versions: "[1.21,)"
       # Pin scala-library to 2.12.15
       - dependency-name: "org.scala-lang:scala-library"
         versions: "[2.12.16,)"
@@ -38,6 +35,6 @@ updates:
       # Pin mockito to 4.x
       - dependency-name: "org.mockito"
         versions: "[5.0.0,)"
-      # Pin byte-buddy to 1.12.x aline with mockito
+      # Pin byte-buddy to 1.12.x align with mockito
       - dependency-name: "net.bytebuddy"
         versions: "[1.13.0,)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,6 @@ updates:
       # Pin mockito to 4.x
       - dependency-name: "org.mockito"
         versions: "[5.0.0,)"
-      # Pin byte-buddy to 1.12.x align with mockito
+      # Pin byte-buddy to 1.12.x aline with mockito
       - dependency-name: "net.bytebuddy"
         versions: "[1.13.0,)"

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/BooleanRowFilterBenchmark.java
@@ -91,10 +91,14 @@ public class BooleanRowFilterBenchmark extends org.openjdk.jmh.Main {
    * Run this test:
    *  java -cp hive/target/orc-benchmarks-hive-*-uber.jar org.apache.orc.bench.hive.rowfilter.BooleanRowFilterBenchmark
    */
-  public static void main(String[] args) throws RunnerException {
-    new Runner(new OptionsBuilder()
-        .include(BooleanRowFilterBenchmark.class.getSimpleName())
-        .forks(1)
-        .build()).run();
+  public static void main(String[] args) {
+    try {
+      new Runner(new OptionsBuilder()
+          .include(BooleanRowFilterBenchmark.class.getSimpleName())
+          .forks(1)
+          .build()).run();
+    } catch (RunnerException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DecimalRowFilterBenchmark.java
@@ -92,10 +92,14 @@ public class DecimalRowFilterBenchmark extends org.openjdk.jmh.Main {
    * Run this test:
    *  java -cp hive/target/orc-benchmarks-hive-*-uber.jar org.apache.orc.bench.hive.rowfilter.DecimalRowFilterBenchmark
    */
-  public static void main(String[] args) throws RunnerException {
-    new Runner(new OptionsBuilder()
-        .include(DecimalRowFilterBenchmark.class.getSimpleName())
-        .forks(1)
-        .build()).run();
+  public static void main(String[] args) {
+    try {
+      new Runner(new OptionsBuilder()
+          .include(DecimalRowFilterBenchmark.class.getSimpleName())
+          .forks(1)
+          .build()).run();
+    } catch (RunnerException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/DoubleRowFilterBenchmark.java
@@ -92,10 +92,14 @@ public class DoubleRowFilterBenchmark extends org.openjdk.jmh.Main {
    * Run this test:
    *  java -cp hive/target/orc-benchmarks-hive-*-uber.jar org.apache.orc.bench.hive.rowfilter.DoubleRowFilterBenchmark
    */
-  public static void main(String[] args) throws RunnerException {
-    new Runner(new OptionsBuilder()
-        .include(DoubleRowFilterBenchmark.class.getSimpleName())
-        .forks(1)
-        .build()).run();
+  public static void main(String[] args) {
+    try {
+      new Runner(new OptionsBuilder()
+          .include(DoubleRowFilterBenchmark.class.getSimpleName())
+          .forks(1)
+          .build()).run();
+    } catch (RunnerException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/StringRowFilterBenchmark.java
@@ -91,10 +91,14 @@ public class StringRowFilterBenchmark extends org.openjdk.jmh.Main {
    * Run this test:
    *  java -cp hive/target/orc-benchmarks-hive-*-uber.jar org.apache.orc.bench.hive.rowfilter.StringRowFilterBenchmark
    */
-  public static void main(String[] args) throws RunnerException {
-    new Runner(new OptionsBuilder()
-        .include(StringRowFilterBenchmark.class.getSimpleName())
-        .forks(1)
-        .build()).run();
+  public static void main(String[] args) {
+    try {
+      new Runner(new OptionsBuilder()
+          .include(StringRowFilterBenchmark.class.getSimpleName())
+          .forks(1)
+          .build()).run();
+    } catch (RunnerException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/TimestampRowFilterBenchmark.java
@@ -95,10 +95,14 @@ public class TimestampRowFilterBenchmark extends org.openjdk.jmh.Main {
    *  java -cp hive/target/orc-benchmarks-hive-*-uber.jar \
    *    org.apache.orc.bench.hive.rowfilter.TimestampRowFilterBenchmark
    */
-  public static void main(String[] args) throws RunnerException {
-    new Runner(new OptionsBuilder()
-        .include(TimestampRowFilterBenchmark.class.getSimpleName())
-        .forks(1)
-        .build()).run();
+  public static void main(String[] args) {
+    try {
+      new Runner(new OptionsBuilder()
+          .include(TimestampRowFilterBenchmark.class.getSimpleName())
+          .forks(1)
+          .build()).run();
+    } catch (RunnerException e) {
+      throw new RuntimeException(e);
+    }
   }
 }

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -35,7 +35,7 @@
   <properties>
     <avro.version>1.11.3</avro.version>
     <hive.version>3.1.3</hive.version>
-    <jmh.version>1.20</jmh.version>
+    <jmh.version>1.37</jmh.version>
     <junit.version>5.10.1</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.13.1</parquet.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to unpin and upgrade `jmh` to 1.37.

### Why are the changes needed?

To use the latest bug fixed version.

### How was this patch tested?
```
cd java
./mvnw clean package -Pbenchmark -DskipTests
```

### Was this patch authored or co-authored using generative AI tooling?
No
