### PR TITLE
ORC-1584: Remove `proto` from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The subdirectories are:
 * docker - docker scripts to build and test on various linuxes
 * examples - various ORC example files that are used to test compatibility
 * java - the java reader and writer
-* proto - the protocol buffer definition for the ORC metadata
 * site - the website and documentation
 * tools - the c++ tools for reading and inspecting ORC files
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Delete proto subdirectory description.

### Why are the changes needed?
We have moved to [orc-format](https://github.com/apache/orc-format) project.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No