### PR TITLE
ORC-1585: [C++] Add orc-format_ep as a dependency of orc

### DIFF
--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -217,4 +217,6 @@ target_link_libraries (orc
   ${LIBHDFSPP_LIBRARIES}
   )
 
+add_dependencies(orc orc-format_ep)
+
 install(TARGETS orc DESTINATION lib)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Makes orc-format_ep a dependency of orc

### Why are the changes needed?
Building breaks if `make orc-format_ep` or `make` have not been run.


### How was this patch tested?
`mkdir build && cd build && cmake .. -DBUILD_JAVA=OFF && make orc-scan -j 100` success

### Was this patch authored or co-authored using generative AI tooling?
No
