### PR TITLE
ORC-1588: Fix incorrect `Decimal` assert in `LeafFilterFactory`

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/filter/leaf/LeafFilterFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/filter/leaf/LeafFilterFactory.java
@@ -159,7 +159,7 @@ public class LeafFilterFactory {
       case DECIMAL:
         HiveDecimalWritable dLow = (HiveDecimalWritable) low;
         HiveDecimalWritable dHigh = (HiveDecimalWritable) high;
-        assert dLow.scale() <= colType.getScale() && dLow.scale() <= colType.getScale();
+        assert dLow.scale() <= colType.getScale() && dHigh.getScale() <= colType.getScale();
         if (isDecimalAsLong(version, colType.getPrecision())) {
           return new LongFilters.LongBetween(colName, dLow.serialize64(colType.getScale()),
                                              dHigh.serialize64(colType.getScale()), negated);

--- a/java/core/src/test/org/apache/orc/impl/filter/TestConvFilter.java
+++ b/java/core/src/test/org/apache/orc/impl/filter/TestConvFilter.java
@@ -34,6 +34,8 @@ import java.sql.Date;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class TestConvFilter {
   private final int scale = 4;
   private final TypeDescription schema = TypeDescription.createStruct()
@@ -152,6 +154,16 @@ public class TestConvFilter {
 
     FilterUtils.createVectorFilter(sArg, schema).accept(fc);
     ATestFilter.validateSelected(fc, 1, 2, 3);
+
+    SearchArgument sArg2 = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .between("f3", PredicateLeaf.Type.DECIMAL, decimal(0),
+         new HiveDecimalWritable(HiveDecimal.create(Long.MAX_VALUE / 18, scale + scale)))
+      .end()
+      .build();
+    assertThrows(AssertionError.class, () -> {
+      FilterUtils.createVectorFilter(sArg2, schema).accept(fc);
+    });
   }
 
   protected void setBatch(Boolean[] f1Values, Date[] f2Values, HiveDecimalWritable[] f3Values) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix incorrect Decimal assert in LeafFilterFactory.

### Why are the changes needed?

Due to the wrong assertion, `ArrayIndexOutOfBoundsException` happens.
```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -2 out of bounds for length 19
	at org.apache.hadoop.hive.common.type.FastHiveDecimalImpl.fastSerialize64(FastHiveDecimalImpl.java:2205)
	at org.apache.hadoop.hive.common.type.FastHiveDecimal.fastSerialize64(FastHiveDecimal.java:290)
	at org.apache.hadoop.hive.serde2.io.HiveDecimalWritable.serialize64(HiveDecimalWritable.java:537)
	at org.apache.orc.impl.filter.leaf.LeafFilterFactory.createBetweenFilter(LeafFilterFactory.java:165)
```

### How was this patch tested?

UT & GA 

### Was this patch authored or co-authored using generative AI tooling?
No
