### PR TITLE
ORC-1592: Suppress `KeyProvider` missing log

### DIFF
--- a/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShimsCurrent.java
@@ -96,7 +96,7 @@ public class HadoopShimsCurrent implements HadoopShims {
     List<org.apache.hadoop.crypto.key.KeyProvider> result =
         KeyProviderFactory.getProviders(conf);
     if (result.size() == 0) {
-      LOG.info("Can't get KeyProvider for ORC encryption from" +
+      LOG.debug("Can't get KeyProvider for ORC encryption from" +
           " hadoop.security.key.provider.path.");
       return new NullKeyProvider();
     } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to suppress `KeyProvider` missing log by lowering the log level to DEBUG.

### Why are the changes needed?

To reduce the verbose log message in the normal usage.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.