### PR TITLE
ORC-1593: Set `orc.compression.zstd.level` to 3 by default

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -73,7 +73,7 @@ public enum OrcConf {
           "This changes the compression level of higher level compression\n" +
           "codec (like ZLIB)."),
   COMPRESSION_ZSTD_LEVEL("orc.compression.zstd.level",
-      "hive.exec.orc.compression.zstd.level", 1,
+      "hive.exec.orc.compression.zstd.level", 3,
       "Define the compression level to use with ZStandard codec "
           + "while writing data. The valid range is 1~22"),
   COMPRESSION_ZSTD_WINDOWLOG("orc.compression.zstd.windowlog",

--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -34,7 +34,7 @@ public class ZstdCodec implements CompressionCodec {
   }
 
   public ZstdCodec() {
-    this(1, 0);
+    this(3, 0);
   }
 
   public ZstdOptions getZstdOptions() {
@@ -148,7 +148,7 @@ public class ZstdCodec implements CompressionCodec {
   }
 
   private static final ZstdOptions DEFAULT_OPTIONS =
-      new ZstdOptions(1, 0);
+      new ZstdOptions(3, 0);
 
   @Override
   public Options getDefaultOptions() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `orc.compression.zstd.level` to 3 by default.

### Why are the changes needed?

To prevent a regression from ORC 1.9.x

**ORC 1.9**
```
data/generated//taxi:
total 2196176
drwxr-xr-x  5 dongjoon  staff   160B Jan 17 08:02 .
drwxr-xr-x  5 dongjoon  staff   160B Jan 17 08:07 ..
-rw-r--r--  1 dongjoon  staff   299M Jan 17 08:03 orc.zstd
```

**ORC 2.0**
```
-rw-r--r--  1 dongjoon  staff   334M Jan 17 07:56 orc.zstd (level 1)
-rw-r--r--  1 dongjoon  staff   299M Jan 17 08:16 orc.zstd (level 3)
-rw-r--r--  1 dongjoon  staff   302M Jan 17 08:21 orc.zstd (level 4)
-rw-r--r--  1 dongjoon  staff   300M Jan 17 08:27 orc.zstd (level 5)
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.