### PR TITLE
ORC-1388: [C++] Support schema evolution from decimal to timestamp/string group

### DIFF
--- a/c++/src/ConvertColumnReader.cc
+++ b/c++/src/ConvertColumnReader.cc
@@ -593,6 +593,105 @@ namespace orc {
     int32_t toScale;
   };
 
+  template <typename FileTypeBatch>
+  class DecimalToTimestampColumnReader : public ConvertToTimestampColumnReader {
+   public:
+    DecimalToTimestampColumnReader(const Type& _readType, const Type& fileType,
+                                   StripeStreams& stripe, bool _throwOnOverflow)
+        : ConvertToTimestampColumnReader(_readType, fileType, stripe, _throwOnOverflow),
+          precision(static_cast<int32_t>(fileType.getPrecision())),
+          scale(static_cast<int32_t>(fileType.getScale())) {}
+
+    void next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override {
+      ConvertColumnReader::next(rowBatch, numValues, notNull);
+      const auto& srcBatch = *SafeCastBatchTo<const FileTypeBatch*>(data.get());
+      auto& dstBatch = *SafeCastBatchTo<TimestampVectorBatch*>(&rowBatch);
+      for (uint64_t i = 0; i < rowBatch.numElements; ++i) {
+        if (!rowBatch.hasNulls || rowBatch.notNull[i]) {
+          convertDecimalToTimestamp(dstBatch, i, srcBatch);
+        }
+      }
+    }
+
+   private:
+    void convertDecimalToTimestamp(TimestampVectorBatch& dstBatch, uint64_t idx,
+                                   const FileTypeBatch& srcBatch) {
+      constexpr int SecondToNanoFactor = 9;
+      // '-1000000000-01-01T00:00Z'
+      constexpr int64_t MIN_EPOCH_SECONDS = -31557014167219200L;
+      // '1000000000-12-31T23:59:59.999999999Z'
+      constexpr int64_t MAX_EPOCH_SECONDS = 31556889864403199L;
+      // dummy variable, there's no risk of overflow
+
+      Int128 i128(srcBatch.values[idx]);
+      bool overflow = false;
+      Int128 integerPortion = scaleDownInt128ByPowerOfTen(i128, scale);
+      if (integerPortion < MIN_EPOCH_SECONDS || integerPortion > MAX_EPOCH_SECONDS) {
+        handleOverflow<Decimal, int64_t>(dstBatch, idx, throwOnOverflow);
+        return;
+      }
+      i128 -= scaleUpInt128ByPowerOfTen(integerPortion, scale, overflow);
+      Int128 fractionPortion = std::move(i128);
+      if (scale < SecondToNanoFactor) {
+        fractionPortion =
+            scaleUpInt128ByPowerOfTen(fractionPortion, SecondToNanoFactor - scale, overflow);
+      } else {
+        fractionPortion = scaleDownInt128ByPowerOfTen(fractionPortion, scale - SecondToNanoFactor);
+      }
+      if (fractionPortion < 0) {
+        fractionPortion += 1e9;
+        integerPortion -= 1;
+      }
+      dstBatch.data[idx] = integerPortion.toLong();
+      dstBatch.nanoseconds[idx] = fractionPortion.toLong();
+
+      if (needConvertTimezone) {
+        dstBatch.data[idx] = readerTimezone.convertFromUTC(dstBatch.data[idx]);
+      }
+    }
+
+    const int32_t precision;
+    const int32_t scale;
+  };
+
+  template <typename FileTypeBatch>
+  class DecimalToStringVariantColumnReader : public ConvertToStringVariantColumnReader {
+   public:
+    DecimalToStringVariantColumnReader(const Type& _readType, const Type& fileType,
+                                       StripeStreams& stripe, bool _throwOnOverflow)
+        : ConvertToStringVariantColumnReader(_readType, fileType, stripe, _throwOnOverflow),
+          scale(fileType.getScale()) {}
+
+    uint64_t convertToStrBuffer(ColumnVectorBatch& rowBatch, uint64_t numValues) override {
+      uint64_t size = 0;
+      strBuffer.resize(numValues);
+      const auto& srcBatch = *SafeCastBatchTo<const FileTypeBatch*>(data.get());
+      if (readType.getKind() == STRING) {
+        for (uint64_t i = 0; i < rowBatch.numElements; ++i) {
+          if (!rowBatch.hasNulls || rowBatch.notNull[i]) {
+            strBuffer[i] = Int128(srcBatch.values[i]).toDecimalString(scale, true);
+            size += strBuffer[i].size();
+          }
+        }
+      } else {
+        const auto maxLength = readType.getMaximumLength();
+        for (uint64_t i = 0; i < rowBatch.numElements; ++i) {
+          if (!rowBatch.hasNulls || rowBatch.notNull[i]) {
+            strBuffer[i] = Int128(srcBatch.values[i]).toDecimalString(scale, true);
+          }
+          if (strBuffer[i].size() > maxLength) {
+            strBuffer[i].resize(maxLength);
+          }
+          size += strBuffer[i].size();
+        }
+      }
+      return size;
+    }
+
+   private:
+    const int32_t scale;
+  };
+
 #define DEFINE_NUMERIC_CONVERT_READER(FROM, TO, TYPE) \
   using FROM##To##TO##ColumnReader =                  \
       NumericConvertColumnReader<FROM##VectorBatch, TO##VectorBatch, TYPE>;
@@ -620,6 +719,14 @@ namespace orc {
       DecimalConvertColumnReader<Decimal64VectorBatch, TO##VectorBatch>; \
   using Decimal128##To##TO##ColumnReader =                               \
       DecimalConvertColumnReader<Decimal128VectorBatch, TO##VectorBatch>;
+
+#define DEFINE_DECIMAL_CONVERT_TO_TIMESTAMP_READER                                               \
+  using Decimal64ToTimestampColumnReader = DecimalToTimestampColumnReader<Decimal64VectorBatch>; \
+  using Decimal128ToTimestampColumnReader = DecimalToTimestampColumnReader<Decimal128VectorBatch>;
+
+#define DEFINE_DECIMAL_CONVERT_TO_STRING_VARINT_READER(TO)                                        \
+  using Decimal64To##TO##ColumnReader = DecimalToStringVariantColumnReader<Decimal64VectorBatch>; \
+  using Decimal128To##TO##ColumnReader = DecimalToStringVariantColumnReader<Decimal128VectorBatch>;
 
   DEFINE_NUMERIC_CONVERT_READER(Boolean, Byte, int8_t)
   DEFINE_NUMERIC_CONVERT_READER(Boolean, Short, int16_t)
@@ -719,6 +826,11 @@ namespace orc {
   // Decimal to Decimal
   DEFINE_DECIMAL_CONVERT_TO_DECIMAL_READER(Decimal64)
   DEFINE_DECIMAL_CONVERT_TO_DECIMAL_READER(Decimal128)
+
+  DEFINE_DECIMAL_CONVERT_TO_TIMESTAMP_READER
+  DEFINE_DECIMAL_CONVERT_TO_STRING_VARINT_READER(String)
+  DEFINE_DECIMAL_CONVERT_TO_STRING_VARINT_READER(Char)
+  DEFINE_DECIMAL_CONVERT_TO_STRING_VARINT_READER(Varchar)
 
 #define CREATE_READER(NAME) \
   return std::make_unique<NAME>(_readType, fileType, stripe, throwOnOverflow);
@@ -935,13 +1047,6 @@ namespace orc {
             CASE_EXCEPTION
         }
       }
-      case STRING:
-      case BINARY:
-      case TIMESTAMP:
-      case LIST:
-      case MAP:
-      case STRUCT:
-      case UNION:
       case DECIMAL: {
         switch (_readType.getKind()) {
           CASE_CREATE_FROM_DECIMAL_READER(BOOLEAN, Boolean)
@@ -951,6 +1056,11 @@ namespace orc {
           CASE_CREATE_FROM_DECIMAL_READER(LONG, Long)
           CASE_CREATE_FROM_DECIMAL_READER(FLOAT, Float)
           CASE_CREATE_FROM_DECIMAL_READER(DOUBLE, Double)
+          CASE_CREATE_FROM_DECIMAL_READER(STRING, String)
+          CASE_CREATE_FROM_DECIMAL_READER(CHAR, Char)
+          CASE_CREATE_FROM_DECIMAL_READER(VARCHAR, Varchar)
+          CASE_CREATE_FROM_DECIMAL_READER(TIMESTAMP, Timestamp)
+          CASE_CREATE_FROM_DECIMAL_READER(TIMESTAMP_INSTANT, Timestamp)
           case DECIMAL: {
             if (isDecimal64(fileType)) {
               if (isDecimal64(_readType)) {
@@ -966,11 +1076,6 @@ namespace orc {
               }
             }
           }
-          case STRING:
-          case CHAR:
-          case VARCHAR:
-          case TIMESTAMP:
-          case TIMESTAMP_INSTANT:
           case BINARY:
           case LIST:
           case MAP:
@@ -980,6 +1085,13 @@ namespace orc {
             CASE_EXCEPTION
         }
       }
+      case STRING:
+      case BINARY:
+      case TIMESTAMP:
+      case LIST:
+      case MAP:
+      case STRUCT:
+      case UNION:
       case DATE:
       case VARCHAR:
       case CHAR:

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -99,7 +99,8 @@ namespace orc {
           break;
         }
         case DECIMAL: {
-          ret.isValid = ret.needConvert = isNumeric(readType);
+          ret.isValid = ret.needConvert =
+              isNumeric(readType) || isStringVariant(readType) || isTimestamp(readType);
           break;
         }
         case STRING:

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -749,7 +749,7 @@ namespace orc {
       EXPECT_TRUE(readC2.notNull[idx]) << i;
       EXPECT_EQ(getTimezoneByName(readerTimezoneName).convertToUTC(readC1.data[i]), ts[0][i]);
       EXPECT_TRUE(readC1.nanoseconds[i] == 123400000);
-      EXPECT_EQ(getTimezoneByName(writerTimezoneName).convertToUTC(readC2.data[i]), ts[1][i]);
+      EXPECT_EQ(readC2.data[i], ts[1][i]);
       if (readC2.data[i] < 0) {
         EXPECT_EQ(readC2.nanoseconds[i], 123456790) << timeStrings[i];
       } else {

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -815,9 +815,9 @@ namespace orc {
       } else if (i >= 10 && i < 100) {
         EXPECT_EQ(std::to_string(i) + ".12", std::string(readC1.data[i], readC1.length[i]));
         EXPECT_EQ(std::to_string(i) + ".45", std::string(readC2.data[i], readC2.length[i]));
-      } else if (i >= 100 && i <= 1000) {
-        EXPECT_EQ(std::to_string(i) + ".12", std::string(readC1.data[i], readC1.length[i]));
-        EXPECT_EQ(std::to_string(i) + ".45", std::string(readC2.data[i], readC2.length[i]));
+      } else if (i >= 100 && i < 1000) {
+        EXPECT_EQ(std::to_string(i) + ".1", std::string(readC1.data[i], readC1.length[i]));
+        EXPECT_EQ(std::to_string(i) + ".4", std::string(readC2.data[i], readC2.length[i]));
       } else {
         EXPECT_EQ(std::to_string(i) + ".", std::string(readC1.data[i], readC1.length[i]));
         EXPECT_EQ(std::to_string(i) + ".", std::string(readC2.data[i], readC2.length[i]));

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 
+#include "Timezone.hh"
 #include "orc/Type.hh"
 #include "wrap/gtest-wrapper.h"
 
@@ -699,16 +700,6 @@ namespace orc {
       return writerTimezone.convertFromUTC(timegm(&timeStruct));
     };
 
-    auto convertToString = [](const Timezone& readerTimezone, int64_t seconds) {
-      time_t gmt = static_cast<time_t>(readerTimezone.convertToUTC(seconds));
-      tm tm;
-      memset(&tm, 0, sizeof(tm));
-      gmtime_r(&gmt, &tm);
-      char buf[30];
-      strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", &tm);
-      return std::string(buf);
-    };
-
     std::vector<std::string> timeStrings;
     for (int i = 0; i < TEST_CASES; i++) {
       int64_t year = 1960 + (i / 12);
@@ -756,11 +747,9 @@ namespace orc {
       size_t idx = static_cast<size_t>(i);
       EXPECT_TRUE(readC1.notNull[idx]) << i;
       EXPECT_TRUE(readC2.notNull[idx]) << i;
-      EXPECT_EQ(convertToString(getTimezoneByName(readerTimezoneName), readC1.data[i]),
-                timeStrings[i]);
+      EXPECT_EQ(getTimezoneByName(readerTimezoneName).convertToUTC(readC1.data[i]), ts[0][i]);
       EXPECT_TRUE(readC1.nanoseconds[i] == 123400000);
-      EXPECT_EQ(convertToString(getTimezoneByName(writerTimezoneName), readC2.data[i]),
-                timeStrings[i]);
+      EXPECT_EQ(getTimezoneByName(writerTimezoneName).convertToUTC(readC2.data[i]), ts[1][i]);
       if (readC2.data[i] < 0) {
         EXPECT_EQ(readC2.nanoseconds[i], 123456790) << timeStrings[i];
       } else {

--- a/c++/test/TestSchemaEvolution.cc
+++ b/c++/test/TestSchemaEvolution.cc
@@ -132,6 +132,22 @@ namespace orc {
       }
     }
 
+    // conversion from decimal to string/char/varchar
+    for (size_t i = 12; i <= 13; i++) {
+      for (size_t j = 7; j <= 11; j++) {
+        canConvert[i][j] = true;
+        needConvert[i][j] = true;
+      }
+    }
+
+    // conversion from decimal to timestamp
+    for (size_t i = 12; i <= 13; i++) {
+      for (size_t j = 14; j <= 15; j++) {
+        canConvert[i][j] = true;
+        needConvert[i][j] = true;
+      }
+    }
+
     for (size_t i = 0; i < typesSize; i++) {
       for (size_t j = 0; j < typesSize; j++) {
         testConvertReader(types[i], types[j], canConvert[i][j], needConvert[i][j]);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support conversion from
{decimal}
to
{string, char, varchar, timestamp, timestamp_instant}

### Why are the changes needed?
Support schema evolution at cpp side.

### How was this patch tested?
UT passed.

### Was this patch authored or co-authored using generative AI tooling?
NO