### PR TITLE
ORC-1595: Add a short-cut to skip tiny inputs for `ZstdCodec.compress`

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -171,6 +171,12 @@ public class ZstdCodec implements CompressionCodec {
   public boolean compress(ByteBuffer in, ByteBuffer out,
       ByteBuffer overflow,
       Options options) throws IOException {
+    int inBytes = in.remaining();
+    // Skip with minimum ZStandard format size:
+    // https://datatracker.ietf.org/doc/html/rfc8878#name-zstandard-frames
+    // Magic Number (4 bytes) + Frame Header (2 bytes) + Data Block Header (3 bytes)
+    if (inBytes < 10) return false;
+
     ZstdOptions zso = (ZstdOptions) options;
 
     zstdCompressCtx = new ZstdCompressCtx();
@@ -179,7 +185,6 @@ public class ZstdCodec implements CompressionCodec {
     zstdCompressCtx.setChecksum(false);
 
     try {
-      int inBytes = in.remaining();
       byte[] compressed = getBuffer((int) Zstd.compressBound(inBytes));
 
       int outBytes = zstdCompressCtx.compressByteArray(compressed, 0, compressed.length,


### PR DESCRIPTION
### What changes were proposed in this pull request?

For `ZstdCodec.compress`, this PR aims to add a short-cut to skip tiny inputs which is smaller than the minimum ZStandard format.

### Why are the changes needed?

To reduce the number of JNI call.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.