### PR TITLE
ORC-1596: Remove redundant `Zstd.isError` JNI usage

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -189,9 +189,6 @@ public class ZstdCodec implements CompressionCodec {
 
       int outBytes = zstdCompressCtx.compressByteArray(compressed, 0, compressed.length,
               in.array(), in.arrayOffset() + in.position(), inBytes);
-      if (Zstd.isError(outBytes)) {
-        throw new IOException(String.format("Error code %s!", outBytes));
-      }
       if (outBytes < inBytes) {
         int remaining = out.remaining();
         if (remaining >= outBytes) {
@@ -225,9 +222,6 @@ public class ZstdCodec implements CompressionCodec {
     long decompressOut =
         Zstd.decompressByteArray(out.array(), dstOffset, dstSize, in.array(),
             srcOffset, srcSize);
-    if (Zstd.isError(decompressOut)) {
-      throw new IOException(String.format("Error code %s!", decompressOut));
-    }
     in.position(in.limit());
     out.position(dstOffset + (int) decompressOut);
     out.flip();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove `Zstd.isError` JNI call inZstdCodec.

### Why are the changes needed?
`compressByteArray` and `decompressByteArray` API will call `Zstd.isError` after compression and decompression, and will throw an exception if there is a problem.

https://github.com/luben/zstd-jni/blob/20014d19a91a1b04e4e198ac1cb85b5acb1c1142/src/main/java/com/github/luben/zstd/ZstdCompressCtx.java#L562-L570

https://github.com/luben/zstd-jni/blob/20014d19a91a1b04e4e198ac1cb85b5acb1c1142/src/main/java/com/github/luben/zstd/ZstdDecompressCtx.java#L198-L206


### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No