### PR TITLE
ORC-1597: [C++] Set bloom filter fpp to 1%

### DIFF
--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -58,7 +58,7 @@ namespace orc {
       errorStream = &std::cerr;
       dictionaryKeySizeThreshold = 0.0;
       enableIndex = true;
-      bloomFilterFalsePositiveProb = 0.05;
+      bloomFilterFalsePositiveProb = 0.01;
       bloomFilterVersion = UTF8;
       // Writer timezone uses "GMT" by default to get rid of potential issues
       // introduced by moving timestamps between different timezones.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set the bloom filter fpp to 1% in C++ Writer.

### Why are the changes needed?
Java Writer changed `orc.bloom.filter.fpp` to 0.01 in ORC-1338, C++ Writer is still 0.05.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No