### PR TITLE
ORC-1599: Add zstd compression level and windowlog in Java configuration documentation

### DIFF
--- a/site/_docs/core-java-config.md
+++ b/site/_docs/core-java-config.md
@@ -103,6 +103,20 @@ permalink: /docs/core-java-config.html
   </td>
 </tr>
 <tr>
+  <td><code>orc.compression.zstd.level</code></td>
+  <td>3</td>
+  <td>
+    Define the compression level to use with ZStandard codec while writing data. The valid range is 1~22.
+  </td>
+</tr>
+<tr>
+  <td><code>orc.compression.zstd.windowlog</code></td>
+  <td>0</td>
+  <td>
+    Set the maximum allowed back-reference distance for ZStandard codec, expressed as power of 2.
+  </td>
+</tr>
+<tr>
   <td><code>orc.block.padding.tolerance</code></td>
   <td>0.05</td>
   <td>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added documentation about `orc.compression.zstd.level` `orc.compression.zstd.windowlog` configuration.
(ORC-817, ORC-1088 2.0.0)

### Why are the changes needed?


### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No