### PR TITLE
ORC-1458: Reduce HDFS NameNode getFileInfo RPC 

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -253,7 +253,7 @@ public enum OrcConf {
       "the ORC row writer writes the batch to the file."
       ),
   FILE_LENGTH_FAST("orc.file.length.fast", "orc.file.length.fast",
-      false, "A boolean flag to enable reduce file length RPC. "
+      true, "A boolean flag to enable reduce file length RPC. "
   )
   ;
 

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -251,7 +251,10 @@ public enum OrcConf {
   ROW_BATCH_CHILD_LIMIT("orc.row.child.limit", "orc.row.child.limit",
       1024 * 32, "The maximum number of child elements to buffer before "+
       "the ORC row writer writes the batch to the file."
-      )
+      ),
+  FILE_LENGTH_FAST("orc.file.length.fast", "orc.file.length.fast",
+      false, "A boolean flag to enable reduce file length RPC. "
+  )
   ;
 
   private final String attribute;

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -253,7 +253,7 @@ public enum OrcConf {
       "the ORC row writer writes the batch to the file."
       ),
   FILE_LENGTH_FAST("orc.file.length.fast", "orc.file.length.fast",
-      true, "A boolean flag to enable reduce file length RPC. "
+      false, "A boolean flag to enable reduce file length RPC. "
   )
   ;
 

--- a/java/core/src/java/org/apache/orc/util/OrcInputStreamUtil.java
+++ b/java/core/src/java/org/apache/orc/util/OrcInputStreamUtil.java
@@ -27,8 +27,6 @@ import java.lang.reflect.Method;
 
 public class OrcInputStreamUtil {
 
-  private static final String DFS_CLASS = "org.apache.hadoop.hdfs.DFSInputStream";
-
   private static Method shortCircuitForbiddenMethod;
 
   static {
@@ -43,9 +41,8 @@ public class OrcInputStreamUtil {
   }
 
   private static void initInt() throws ClassNotFoundException, NoSuchMethodException {
-    Class<?> dfsClass = Class.forName(DFS_CLASS);
     // org.apache.hadoop.hdfs.DFSInputStream.shortCircuitForbidden Method is not public
-    shortCircuitForbiddenMethod = dfsClass.getDeclaredMethod("shortCircuitForbidden");
+    shortCircuitForbiddenMethod = DFSInputStream.class.getDeclaredMethod("shortCircuitForbidden");
     shortCircuitForbiddenMethod.setAccessible(true);
   }
 

--- a/java/core/src/java/org/apache/orc/util/OrcInputStreamUtil.java
+++ b/java/core/src/java/org/apache/orc/util/OrcInputStreamUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.util;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class OrcInputStreamUtil {
+
+  private static final String DFS_CLASS = "org.apache.hadoop.hdfs.DFSInputStream";
+  private static final String DFS_STRIPED_CLASS = "org.apache.hadoop.hdfs.DFSStripedInputStream";
+
+  private static Method shortCircuitForbiddenMethod;
+  private static Method getFileLengthMethod;
+
+  static {
+    init();
+  }
+
+  private static void init() {
+    try {
+      initInt();
+    } catch (ClassNotFoundException | NoSuchMethodException ignored) {
+    }
+  }
+
+  private static void initInt() throws ClassNotFoundException, NoSuchMethodException {
+    Class<?> dfsClass = Class.forName(DFS_CLASS);
+    shortCircuitForbiddenMethod = dfsClass.getDeclaredMethod("shortCircuitForbidden");
+    shortCircuitForbiddenMethod.setAccessible(true);
+    getFileLengthMethod = dfsClass.getMethod("getFileLength");
+  }
+
+  public static long getFileLength(FSDataInputStream file) {
+    try {
+      return getFileLengthInt(file);
+    } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
+      return -1L;
+    }
+  }
+
+  private static long getFileLengthInt(FSDataInputStream file)
+          throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    if (shortCircuitForbiddenMethod == null || getFileLengthMethod == null) {
+      return -1L;
+    }
+    InputStream wrappedStream = file.getWrappedStream();
+    Class<? extends InputStream> wrappedStreamClass = wrappedStream.getClass();
+    String className = wrappedStreamClass.getName();
+    if (!className.equals(DFS_CLASS) && !className.equals(DFS_STRIPED_CLASS)) {
+      return -1L;
+    }
+    boolean isUnderConstruction = (boolean) shortCircuitForbiddenMethod.invoke(wrappedStream);
+    // If file are under construction, we need to get the file length from NameNode.
+    if (!isUnderConstruction) {
+      return (long) getFileLengthMethod.invoke(wrappedStream);
+    }
+    return -1L;
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
If the file in HDFS is in a completed state, avoid calling the HDFS getFileInfo RPC.

Provide `orc.file.length.fast` configuration to enable this behavior.

### Why are the changes needed?
Now reading an ORC file in HDFS will generate at least one `open` and `getFileInfo` RPC. This optimization can remove getFileInfo RPC as much as possible, improve ORC reading efficiency, and reduce the number of HDFS RPCs.

### How was this patch tested?
The production environment has been running stably for several months

### Was this patch authored or co-authored using generative AI tooling?
No
