### PR TITLE
ORC-1600: Reduce getStaticMemoryManager sync block in OrcFile

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -1044,11 +1044,15 @@ public class OrcFile {
     return new WriterOptions(tableProperties, conf);
   }
 
-  private static MemoryManager memoryManager = null;
+  private static volatile MemoryManager memoryManager = null;
 
-  private static synchronized MemoryManager getStaticMemoryManager(Configuration conf) {
+  private static MemoryManager getStaticMemoryManager(Configuration conf) {
     if (memoryManager == null) {
-      memoryManager = new MemoryManagerImpl(conf);
+      synchronized (OrcFile.class) {
+        if (memoryManager == null) {
+          memoryManager = new MemoryManagerImpl(conf);
+        }
+      }
     }
     return memoryManager;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Improve calling efficiency of `org.apache.orc.OrcFile#getStaticMemoryManager`.

### Why are the changes needed?
`org.apache.orc.OrcFile#getStaticMemoryManager` is a static method with synchronized. It needs to be locked every time it is called. This is unnecessary.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
