### PR TITLE
ORC-1602: [C++] limit compression block size

### DIFF
--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -77,6 +77,8 @@ namespace orc {
 
     /**
      * Set the data compression block size.
+     * Should less then 1 << 23 bytes (8M) which is limited by the
+     * 3 bytes size of compression block header (1 bit for isOriginal and 23 bits for length)
      */
     WriterOptions& setCompressionBlockSize(uint64_t size);
 

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -338,6 +338,12 @@ namespace orc {
 
   const WriterId WriterImpl::writerId = WriterId::ORC_CPP_WRITER;
 
+  static void validateOptions(const WriterOptions& opts) {
+    if (opts.getCompressionBlockSize() >= (1 << 23)) {
+      throw std::invalid_argument("Compression block size cannot be greater or equal than 8M");
+    }
+  }
+
   WriterImpl::WriterImpl(const Type& t, OutputStream* stream, const WriterOptions& opts)
       : outStream(stream), options(opts), type(t) {
     streamsFactory = createStreamsFactory(options, outStream);
@@ -346,6 +352,8 @@ namespace orc {
     currentOffset = 0;
     stripesAtLastFlush = 0;
     lastFlushOffset = 0;
+
+    validateOptions(opts);
 
     useTightNumericVector = opts.getUseTightNumericVector();
 

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -114,6 +114,9 @@ namespace orc {
   }
 
   WriterOptions& WriterOptions::setCompressionBlockSize(uint64_t size) {
+    if (size >= (1 << 23)) {
+      throw std::invalid_argument("Compression block size cannot be greater or equal than 8M");
+    }
     privateBits->compressionBlockSize = size;
     return *this;
   }
@@ -338,12 +341,6 @@ namespace orc {
 
   const WriterId WriterImpl::writerId = WriterId::ORC_CPP_WRITER;
 
-  static void validateOptions(const WriterOptions& opts) {
-    if (opts.getCompressionBlockSize() >= (1 << 23)) {
-      throw std::invalid_argument("Compression block size cannot be greater or equal than 8M");
-    }
-  }
-
   WriterImpl::WriterImpl(const Type& t, OutputStream* stream, const WriterOptions& opts)
       : outStream(stream), options(opts), type(t) {
     streamsFactory = createStreamsFactory(options, outStream);
@@ -352,8 +349,6 @@ namespace orc {
     currentOffset = 0;
     stripesAtLastFlush = 0;
     lastFlushOffset = 0;
-
-    validateOptions(opts);
 
     useTightNumericVector = opts.getUseTightNumericVector();
 

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 
-#include <_types/_uint64_t.h>
-#include "gtest/gtest.h"
 #include "orc/ColumnPrinter.hh"
 #include "orc/OrcFile.hh"
 
@@ -25,14 +23,12 @@
 #include "MemoryOutputStream.hh"
 #include "Reader.hh"
 
-#include "orc/Writer.hh"
 #include "wrap/gmock.h"
 #include "wrap/gtest-wrapper.h"
 
 #include <cmath>
 #include <ctime>
 #include <sstream>
-#include <stdexcept>
 
 #ifdef __clang__
 DIAGNOSTIC_IGNORE("-Wmissing-variable-declarations")


### PR DESCRIPTION
### What changes were proposed in this pull request?
limit compression block size on c++ side.


### Why are the changes needed?
to fix https://github.com/apache/orc/issues/1727

### How was this patch tested?
UT passed

### Was this patch authored or co-authored using generative AI tooling?
NO
