### PR TITLE
ORC-1602: [C++] limit compression block size

### DIFF
--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -73,6 +73,8 @@ namespace orc {
 
     /**
      * Set the data compression block size.
+     * Should less then 1 << 23 bytes (8M) which is limited by the
+     * 3 bytes size of compression block header (1 bit for isOriginal and 23 bits for length)
      */
     WriterOptions& setCompressionBlockSize(uint64_t size);
 

--- a/c++/src/Writer.cc
+++ b/c++/src/Writer.cc
@@ -110,6 +110,9 @@ namespace orc {
   }
 
   WriterOptions& WriterOptions::setCompressionBlockSize(uint64_t size) {
+    if (size >= (1 << 23)) {
+      throw std::invalid_argument("Compression block size cannot be greater or equal than 8M");
+    }
     privateBits->compressionBlockSize = size;
     return *this;
   }

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -1901,5 +1901,15 @@ namespace orc {
     }
   }
 
+  TEST_P(WriterTest, testValidateOptions) {
+    WriterOptions options;
+    constexpr uint64_t compressionBlockSizeThreshold = (1 << 23) - 1;
+    EXPECT_NO_THROW(options.setCompressionBlockSize(compressionBlockSizeThreshold));
+    EXPECT_THROW(options.setCompressionBlockSize(compressionBlockSizeThreshold + 1),
+                 std::invalid_argument);
+    EXPECT_THROW(options.setCompressionBlockSize(compressionBlockSizeThreshold + 2),
+                 std::invalid_argument);
+  }
+
   INSTANTIATE_TEST_CASE_P(OrcTest, WriterTest, Values(FileVersion::v_0_11(), FileVersion::v_0_12()));
-}
+}  // namespace orc


### PR DESCRIPTION
### What changes were proposed in this pull request?
limit compression block size on c++ side.

### Why are the changes needed?
backport of https://github.com/apache/orc/pull/1774

### How was this patch tested?
UT passed

### Was this patch authored or co-authored using generative AI tooling?
NO
