### PR TITLE
ORC-1612: Document available encodings at `orc.compress`

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -54,7 +54,7 @@ public enum OrcConf {
       "Define whether stripes should be padded to the HDFS block boundaries."),
   COMPRESS("orc.compress", "hive.exec.orc.default.compress", "ZSTD",
       "Define the default compression codec for ORC file. " +
-              "It can be NONE, ZLIB, SNAPPY, LZO, LZ4, ZSTD, BROTLI."),
+          "It can be NONE, ZLIB, SNAPPY, LZO, LZ4, ZSTD, BROTLI."),
   WRITE_FORMAT("orc.write.format", "hive.exec.orc.write.format", "0.12",
       "Define the version of the file to write. Possible values are 0.11 and\n"+
           " 0.12. If this parameter is not defined, ORC will use the run\n" +

--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -53,7 +53,8 @@ public enum OrcConf {
       true,
       "Define whether stripes should be padded to the HDFS block boundaries."),
   COMPRESS("orc.compress", "hive.exec.orc.default.compress", "ZSTD",
-      "Define the default compression codec for ORC file"),
+      "Define the default compression codec for ORC file. " +
+              "It can be NONE, ZLIB, SNAPPY, LZO, LZ4, ZSTD, BROTLI."),
   WRITE_FORMAT("orc.write.format", "hive.exec.orc.write.format", "0.12",
       "Define the version of the file to write. Possible values are 0.11 and\n"+
           " 0.12. If this parameter is not defined, ORC will use the run\n" +

--- a/site/_docs/core-java-config.md
+++ b/site/_docs/core-java-config.md
@@ -71,7 +71,7 @@ permalink: /docs/core-java-config.html
   <td><code>orc.compress</code></td>
   <td>ZSTD</td>
   <td>
-    Define the default compression codec for ORC file
+    Define the default compression codec for ORC file. It can be NONE, ZLIB, SNAPPY, LZO, LZ4, ZSTD, BROTLI.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added documentation about optional compression encoding enum values ​​for `orc.compress`.

### Why are the changes needed?
Currently ORC has a wealth of optional encoders, but they are not documented in the documentation.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No