### PR TITLE
ORC-1614: Use `directOut.put(out)` instead of `directOut.put(out.array())` in `TestBrotli` test

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestBrotli.java
+++ b/java/core/src/test/org/apache/orc/impl/TestBrotli.java
@@ -136,10 +136,12 @@ public class TestBrotli {
       // write bytes to heap buffer.
       assertTrue(brotliCodec.compress(in, out, null,
           brotliCodec.getDefaultOptions()));
+      int position = out.position();
       out.flip();
       // copy heap buffer to direct buffer.
       directOut.put(out.array());
       directOut.flip();
+      directOut.limit(position);
 
       brotliCodec.decompress(directOut, directResult);
 

--- a/java/core/src/test/org/apache/orc/impl/TestBrotli.java
+++ b/java/core/src/test/org/apache/orc/impl/TestBrotli.java
@@ -136,12 +136,10 @@ public class TestBrotli {
       // write bytes to heap buffer.
       assertTrue(brotliCodec.compress(in, out, null,
           brotliCodec.getDefaultOptions()));
-      int position = out.position();
       out.flip();
       // copy heap buffer to direct buffer.
-      directOut.put(out.array());
+      directOut.put(out);
       directOut.flip();
-      directOut.limit(position);
 
       brotliCodec.decompress(directOut, directResult);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set ByteBuffer limit in `TestBrotli` test

### Why are the changes needed?
`TestBrotli#testDirectDecompress` attempts to put the compressed result in direct ByteBuffer.
When calling `decompress`, we will find that the input buffer length is still `10000` not `217` since we put the array without `limit` on the length.

```java
      directOut.put(out.array());
      directOut.flip();
```

This PR is aimed to use `directOut.put(out)` instead of `directOut.put(out.array())`


### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No