### PR TITLE
ORC-1618: Disable building tests for snappy

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -99,7 +99,7 @@ else ()
 
   ExternalProject_Add (snappy_ep
     URL "https://github.com/google/snappy/archive/${SNAPPY_VERSION}.tar.gz"
-    CMAKE_ARGS ${SNAPPY_CMAKE_ARGS}
+    CMAKE_ARGS ${SNAPPY_CMAKE_ARGS} -DSNAPPY_BUILD_TESTS=OFF
     ${THIRDPARTY_LOG_OPTIONS}
     BUILD_BYPRODUCTS "${SNAPPY_STATIC_LIB}")
 


### PR DESCRIPTION
Disabling the building of tests is a workaround for issue #1791 and is probably not an issue since snappy tests are not executed as part of the build process of orc c++ libs.

Note that snappy 1.1.9 and 1.1.10 cannot be used as is because source assets on snappy's gh page are not buildable out of the box, so stick to 1.1.8 for now.

### What changes were proposed in this pull request?
Disable  building snappy tests as a workaround for issue #1791.

### Why are the changes needed?
compilation broken in some situations otherwise (see issue)

### How was this patch tested?
compile & unit tests

### Was this patch authored or co-authored using generative AI tooling?
no
