### PR TITLE
ORC-1619: Add `MacOS 14` to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,6 +49,7 @@ jobs:
           - ubuntu-22.04
           - macos-12
           - macos-13
+          - macos-14
         java:
           - 17
           - 21


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `MacOS 14` to GitHub Action.

### Why are the changes needed?

As of now, the latest MacOS is `14.3.1`.
```
$ sw_vers
ProductName:		macOS
ProductVersion:		14.3.1
BuildVersion:		23D60
```

```
$ g++ --version
Apple clang version 15.0.0 (clang-1500.1.0.2.5)
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.