### PR TITLE
ORC-1621: Switch to `oraclelinux9` from `rocky9`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,7 +29,7 @@ jobs:
           - debian12
           - ubuntu24
           - fedora37
-          - rocky9
+          - oraclelinux9
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/docker/oraclelinux9/Dockerfile
+++ b/docker/oraclelinux9/Dockerfile
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ORC compile for Rocky Linux 9
+# ORC compile for Oracle Linux 9
 #
 
-FROM rockylinux:9
+FROM oraclelinux:9
 LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
 
 RUN yum check-update || true

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,4 +4,4 @@ ubuntu20
 ubuntu22
 ubuntu24
 fedora37
-rocky9
+oraclelinux9


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to switch to `oraclelinux9` from `rocky9`.

### Why are the changes needed?

Now, the official OracleLinux 9 image is available.

- https://hub.docker.com/_/oraclelinux

### How was this patch tested?

Pass the CIs. The GitHub Action CI has the replaced `oraclelinux9` job.

### Was this patch authored or co-authored using generative AI tooling?

No.