### PR TITLE
ORC-1623: Use `directOut.put(out)` instead of `directOut.put(out.array())` in `TestZstd` test

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestZstd.java
+++ b/java/core/src/test/org/apache/orc/impl/TestZstd.java
@@ -136,12 +136,10 @@ public class TestZstd {
       // write bytes to heap buffer.
       assertTrue(zstdCodec.compress(in, out, null,
               zstdCodec.getDefaultOptions()));
-      int position = out.position();
       out.flip();
       // copy heap buffer to direct buffer.
-      directOut.put(out.array());
+      directOut.put(out);
       directOut.flip();
-      directOut.limit(position);
 
       zstdCodec.decompress(directOut, directResult);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to use `directOut.put(out)` instead of `directOut.put(out.array())` in `TestZstd` test.

### Why are the changes needed?
Improve the readability of test code.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No