### PR TITLE
ORC-1625: Switch to oraclelinux9 from rocky9 in `README`

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@
 * Debian 11 and 12
 * Fedora 37
 * Ubuntu 20, 22, 24
-* Rocky 9
+* Oracle Linux 9
 
 ## Pre-built Images
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to switch to oraclelinux9 from rocky9 in `README`.

### Why are the changes needed?
[ORC-1621](https://issues.apache.org/jira/browse/ORC-1621) Switch to `oraclelinux9` from `rocky9`.
Document description is out of date.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
