### PR TITLE
ORC-1624: Upgrade Spark to 3.5.1

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -39,7 +39,7 @@
     <junit.version>5.10.2</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.13.1</parquet.version>
-    <spark.version>3.5.0</spark.version>
+    <spark.version>3.5.1</spark.version>
   </properties>
 
   <dependencyManagement>
@@ -364,6 +364,13 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <repositories>
+    <repository>
+      <id>staging</id>
+      <url>https://repository.apache.org/content/repositories/orgapachespark-1452/</url>
+    </repository>
+  </repositories>
 
   <build>
     <pluginManagement>

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -365,13 +365,6 @@
     </dependencies>
   </dependencyManagement>
 
-  <repositories>
-    <repository>
-      <id>staging</id>
-      <url>https://repository.apache.org/content/repositories/orgapachespark-1452/</url>
-    </repository>
-  </repositories>
-
   <build>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade the benchmark module to use Spark 3.5.1.


### Why are the changes needed?


### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
