### PR TITLE
ORC-1626: Upgrade `Mockito` to 5.10 and `byte-buddy` to `1.14.11`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,3 @@ updates:
       # Pin annotations to 17.0.0
       - dependency-name: "org.jetbrains.annotations"
         versions: "[17.0.1,)"
-      # Pin mockito to 4.x
-      - dependency-name: "org.mockito"
-        versions: "[5.0.0,)"
-      # Pin byte-buddy to 1.12.x aline with mockito
-      - dependency-name: "net.bytebuddy"
-        versions: "[1.13.0,)"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,7 +74,7 @@
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
     <maven.version>3.9.6</maven.version>
 
-    <mockito.version>4.11.0</mockito.version>
+    <mockito.version>5.10.0</mockito.version>
     <orc-format.version>1.0.0</orc-format.version>
     <!-- Build Properties -->
     <project.build.outputTimestamp>2024-01-08T16:47:56Z</project.build.outputTimestamp>
@@ -256,13 +256,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.12.23</version>
+        <version>1.14.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.12.23</version>
+        <version>1.14.11</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to unpin and upgrade
- Mockito from 4.11.0 to 5.10.0
- byte-buddy from 1.12.23 to 1.14.11

### Why are the changes needed?

To bring the latest bug fixes and improvement in test framework for Apache ORC 2.0.0.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.