### PR TITLE
ORC-1627: Unpin `scala-library`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,9 +23,6 @@ updates:
       # Pin gson to 2.2.4 because of Hive
       - dependency-name: "com.google.code.gson:gson"
         versions: "[2.3,)"
-      # Pin scala-library to 2.12.15
-      - dependency-name: "org.scala-lang:scala-library"
-        versions: "[2.12.16,)"
       # Pin jodd-core to 3.5.2
       - dependency-name: "org.jodd:jodd-core"
         versions: "[3.5.3,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to unpin `scala-library`.

### Why are the changes needed?

ORC-1505 upgraded it to 2.12.18 already to match Spark 3.5.0.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.