### PR TITLE
ORC-1629: Make VectoredIO configurable

### DIFF
--- a/java/core/src/java/org/apache/orc/OrcConf.java
+++ b/java/core/src/java/org/apache/orc/OrcConf.java
@@ -252,7 +252,9 @@ public enum OrcConf {
   ROW_BATCH_CHILD_LIMIT("orc.row.child.limit", "orc.row.child.limit",
       1024 * 32, "The maximum number of child elements to buffer before "+
       "the ORC row writer writes the batch to the file."
-      )
+      ),
+  USE_VECTOREDIO("orc.use.vectoredio", "orc.use.vectoredio", true,
+      "Use VectoredIO reads with ORC. (This requires Hadoop 3.3.5 or later.)"),
   ;
 
   private final String attribute;

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -240,6 +240,7 @@ public interface Reader extends Closeable {
     private double minSeekSizeTolerance = (double) OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE
         .getDefaultValue();
     private int rowBatchSize = (int) OrcConf.ROW_BATCH_SIZE.getDefaultValue();
+    private Boolean useVectoredIO = (boolean) OrcConf.USE_VECTOREDIO.getDefaultValue();
 
     /**
      * @since 1.1.0
@@ -266,6 +267,7 @@ public interface Reader extends Closeable {
       minSeekSize = OrcConf.ORC_MIN_DISK_SEEK_SIZE.getInt(conf);
       minSeekSizeTolerance = OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE.getDouble(conf);
       rowBatchSize = OrcConf.ROW_BATCH_SIZE.getInt(conf);
+      useVectoredIO = OrcConf.USE_VECTOREDIO.getBoolean(conf);
     }
 
     /**
@@ -710,6 +712,21 @@ public interface Reader extends Closeable {
      */
     public Options rowBatchSize(int value) {
       this.rowBatchSize = value;
+      return this;
+    }
+
+    /**
+     * @since 2.0.0
+     */
+    public Boolean getUseVectoredIO() {
+      return useVectoredIO;
+    }
+
+    /**
+     * @since 2.0.0
+     */
+    public Options useVectoredIO(boolean value) {
+      this.useVectoredIO = value;
       return this;
     }
   }

--- a/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
+++ b/java/core/src/java/org/apache/orc/impl/DataReaderProperties.java
@@ -34,6 +34,7 @@ public final class DataReaderProperties {
   private final int maxDiskRangeChunkLimit;
   private final int minSeekSize;
   private final double minSeekSizeTolerance;
+  private final boolean vectoredIO;
 
   private DataReaderProperties(Builder builder) {
     this.fileSystemSupplier = builder.fileSystemSupplier;
@@ -44,6 +45,7 @@ public final class DataReaderProperties {
     this.maxDiskRangeChunkLimit = builder.maxDiskRangeChunkLimit;
     this.minSeekSize = builder.minSeekSize;
     this.minSeekSizeTolerance = builder.minSeekSizeTolerance;
+    this.vectoredIO = builder.vectoredIO;
   }
 
   public Supplier<FileSystem> getFileSystemSupplier() {
@@ -82,6 +84,10 @@ public final class DataReaderProperties {
     return minSeekSizeTolerance;
   }
 
+  public boolean getVectoredIO() {
+    return vectoredIO;
+  }
+
   public static class Builder {
 
     private Supplier<FileSystem> fileSystemSupplier;
@@ -94,6 +100,7 @@ public final class DataReaderProperties {
     private int minSeekSize = (int) OrcConf.ORC_MIN_DISK_SEEK_SIZE.getDefaultValue();
     private double minSeekSizeTolerance = (double) OrcConf.ORC_MIN_DISK_SEEK_SIZE_TOLERANCE
         .getDefaultValue();
+    private boolean vectoredIO = (boolean) OrcConf.USE_VECTOREDIO.getDefaultValue();
 
     private Builder() {
 
@@ -141,6 +148,11 @@ public final class DataReaderProperties {
 
     public Builder withMinSeekSizeTolerance(double value) {
       minSeekSizeTolerance = value;
+      return this;
+    }
+
+    public Builder withVectoredIO(boolean vectoredIO) {
+      this.vectoredIO = vectoredIO;
       return this;
     }
 

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -268,6 +268,10 @@ public class RecordReaderImpl implements RecordReader {
     if (zeroCopy == null) {
       zeroCopy = OrcConf.USE_ZEROCOPY.getBoolean(fileReader.conf);
     }
+    Boolean vectoredIO = options.getUseVectoredIO();
+    if (vectoredIO == null) {
+      vectoredIO = OrcConf.USE_VECTOREDIO.getBoolean(fileReader.conf);
+    }
     if (options.getDataReader() != null) {
       this.dataReader = options.getDataReader().clone();
     } else {
@@ -283,7 +287,8 @@ public class RecordReaderImpl implements RecordReader {
               .withMaxDiskRangeChunkLimit(maxDiskRangeChunkLimit)
               .withZeroCopy(zeroCopy)
               .withMinSeekSize(options.minSeekSize())
-              .withMinSeekSizeTolerance(options.minSeekSizeTolerance());
+              .withMinSeekSizeTolerance(options.minSeekSizeTolerance())
+              .withVectoredIO(vectoredIO);
       FSDataInputStream file = fileReader.takeFile();
       if (file != null) {
         builder.withFile(file);

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -60,6 +60,7 @@ public class RecordReaderUtils {
     private final boolean useZeroCopy;
     private final int minSeekSize;
     private final double minSeekSizeTolerance;
+    private final boolean useVectoredIO;
     private InStream.StreamOptions options;
     private boolean isOpen = false;
 
@@ -71,6 +72,7 @@ public class RecordReaderUtils {
       this.options = properties.getCompression();
       this.minSeekSize = properties.getMinSeekSize();
       this.minSeekSizeTolerance = properties.getMinSeekSizeTolerance();
+      this.useVectoredIO = properties.getVectoredIO();
     }
 
     @Override
@@ -108,7 +110,7 @@ public class RecordReaderUtils {
     public BufferChunkList readFileData(BufferChunkList range,
                                         boolean doForceDirect
                                         ) throws IOException {
-      if (supportVectoredIO && zcr == null) {
+      if (useVectoredIO && supportVectoredIO && zcr == null) {
         RecordReaderUtils.readDiskRangesVectored(file, range, doForceDirect);
       } else {
         RecordReaderUtils.readDiskRanges(file, zcr, range, doForceDirect,

--- a/site/_docs/core-java-config.md
+++ b/site/_docs/core-java-config.md
@@ -410,4 +410,11 @@ permalink: /docs/core-java-config.html
     The maximum number of child elements to buffer before the ORC row writer writes the batch to the file.
   </td>
 </tr>
+<tr>
+  <td><code>orc.use.vectoredio</code></td>
+  <td>true</td>
+  <td>
+    Use VectoredIO reads with ORC. (This requires Hadoop 3.3.5 or later.)
+  </td>
+</tr>
 </table>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Provide configuration item `orc.use.vectoredio` to decide whether to enable Hadoop's VectoredIO reading.

### Why are the changes needed?
Conveniently verify the performance difference between turning on and not turning on VectoredIO.

### How was this patch tested?
add UT

### Was this patch authored or co-authored using generative AI tooling?
No
