### PR TITLE
ORC-1631: Support `summary` output in `sizes` command

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
+++ b/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
@@ -154,8 +154,8 @@ public class ColumnSizes {
     sizes.sort((x, y) -> x.size != y.size ?
         Long.compare(y.size, x.size) : x.name.compareTo(y.name));
     if (summary) {
-      out.printf("Total Sizes: %d\n", totalSize);
-      out.printf("Total Rows: %d\n", rows);
+      out.printf("Total Sizes: %d%n", totalSize);
+      out.printf("Total Rows: %d%n", rows);
     }
     out.println("Percent  Bytes/Row  Name");
     for (StringLongPair item: sizes) {
@@ -205,7 +205,7 @@ public class ColumnSizes {
       System.err.println("No files found");
     } else {
       if (summary) {
-        System.out.printf("Total Files: %d\n", totalFiles);
+        System.out.printf("Total Files: %d%n", totalFiles);
       }
       result.printResults(System.out, summary);
     }
@@ -229,7 +229,7 @@ public class ColumnSizes {
 
     result.addOption(Option.builder("s")
         .longOpt("summary")
-        .desc("Summarize the number of files, file size, and number of file lines")
+        .desc("Summarize the number of files, file sizes, and file rows")
         .build());
 
     result.addOption(Option.builder("h")


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add support for summarizing the number of files, file sizes and file lines in the sizes command.

### Why are the changes needed?
When we count the size of each field, we only know the percentage and the average size of each row, but we do not know the overall value.

### How was this patch tested?
local test

```bash
java -jar orc-tools-2.1.0-SNAPSHOT-uber.jar sizes -h
usage: sizes
 -h,--help              Print help message
 -i,--ignoreExtension   Ignore ORC file extension
 -s,--summary           Summarize the number of files, file sizes, and
                        file rows
```

```
java -jar orc-tools-2.1.0-SNAPSHOT-uber.jar sizes -s
```

```
Total Files: 5
Total Sizes: 4803687270
Total Rows: 39820045
Percent  Bytes/Row  Name
  26.41  31.86
```

### Was this patch authored or co-authored using generative AI tooling?
No