### PR TITLE
ORC-1636: Pin `scala-library` to 2.12.18

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,9 @@ updates:
       # Pin gson to 2.2.4 because of Hive
       - dependency-name: "com.google.code.gson:gson"
         versions: "[2.3,)"
+      # Pin scala-library to 2.12.18 because of Spark
+      - dependency-name: "org.scala-lang:scala-library"
+        versions: "[2.12.19,)"
       # Pin jodd-core to 3.5.2
       - dependency-name: "org.jodd:jodd-core"
         versions: "[3.5.3,)"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to pin `scala-library` to 2.12.18.

### Why are the changes needed?
Apache Spark 3.5 uses 2.12.18.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
