### PR TITLE
ORC-1638: Avoid `System.exit(0)` in `count` command

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -66,7 +66,9 @@ public class RowCount {
         }
       }
     }
-    System.exit(bad == 0 ? 0 : 1);
+    if (bad > 0) {
+      System.exit(1);
+    }
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to avoid `System.exit(0)` in `count` command.

### Why are the changes needed?
https://github.com/apache/orc/pull/1817#discussion_r1503572991

`System.exit(0)` is not conducive to testing, especially in Java17 and above. Without `System.exit(0)`, the program can exit normally.


### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No
