### PR TITLE
ORC-1640: Upgrade cyclonedx-maven-plugin to 2.7.11

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -737,7 +737,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.6</version>
+        <version>2.7.11</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade cycleonedx-maven-plugin to 2.7.11.

### Why are the changes needed?
Currently ORC uses version 2.7.6

https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.7
https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.8
https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.9
https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.10
https://github.com/CycloneDX/cyclonedx-maven-plugin/releases/tag/cyclonedx-maven-plugin-2.7.11

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No