### PR TITLE
 ORC-1635: Try downloading orc-format from dlcdn.apache.org before archive.apache.org

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -72,6 +72,7 @@ endif ()
 # ----------------------------------------------------------------------
 # ORC Format
 ExternalProject_Add (orc-format_ep
+  URL "https://dlcdn.apache.org/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz"
   URL "https://archive.apache.org/dist/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz"
   URL_HASH SHA256=739fae5ff94b1f812b413077280361045bf92e510ef04b34a610e23a945d8cd5
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
### What changes were proposed in this pull request?
Try downloading orc-format from dlcdn.apache.org before archive.apache.org

This replaces https://github.com/apache/orc/pull/1820 which required dlcdn to have the current version.

### Why are the changes needed?
https://archive.apache.org/ discourages heavy use, and its rate limits can cause CI systems building Apache ORC to be banned.

### How was this patch tested?
It builds from a clean repo

### Was this patch authored or co-authored using generative AI tooling?
no