### PR TITLE
ORC-1641: Remove `sourceFileExcludes ` from `maven-javadoc-plugin`

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -143,9 +143,6 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <sourceFileExcludes>
-            <exclude>**/OrcProto.java</exclude>
-          </sourceFileExcludes>
           <destDir>${project.artifactId}</destDir>
         </configuration>
       </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove exclude `OrcProto.java` in the `maven-javadoc-plugin`.

### Why are the changes needed?
In ORC2.X we use orc-format, so exclude no longer takes effect.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
