### PR TITLE
ORC-1642: Avoid `System.exit(0)` in `scan` command

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/ScanData.java
+++ b/java/tools/src/java/org/apache/orc/tools/ScanData.java
@@ -215,7 +215,10 @@ public class ScanData {
           }
         }
       }
-      System.exit(badFiles.size());
+      if (!badFiles.isEmpty()) {
+        System.err.println(badFiles + " bad ORC files found.");
+        System.exit(1);
+      }
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to avoid `System.exit(0)` in `scan` command.

### Why are the changes needed?
`System.exit(0)` is not conducive to testing, especially in Java17 and above. Without `System.exit(0)`, the program can exit normally.

### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No
