### PR TITLE
ORC-1646: Close the reader when reading the schema with the `convert` command

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
@@ -79,6 +79,7 @@ public class ConvertTool {
         Reader reader = OrcFile.createReader(file.path,
             OrcFile.readerOptions(conf)
                 .filesystem(file.filesystem));
+        reader.close();
         if (files.size() == 1) {
           return reader.getSchema();
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to close the reader when reading the schema with the `convert` command.

### Why are the changes needed?
When using the `convert` command, when the input file format is ORC, the ORC schema is read, but not the close ORC reader.

### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No
