### PR TITLE
ORC-1647: Tips for supporting ORC in the `convert` command

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -86,7 +86,7 @@ public class Driver {
           " [--define X=Y] <command> <args>");
       System.err.println();
       System.err.println("Commands:");
-      System.err.println("   convert - convert CSV and JSON files to ORC");
+      System.err.println("   convert - convert CSV/JSON/ORC files to ORC");
       System.err.println("   count - recursively find *.orc and print the number of rows");
       System.err.println("   data - print the data from the ORC file");
       System.err.println("   json-schema - scan JSON files to determine their schema");

--- a/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
+++ b/java/tools/src/java/org/apache/orc/tools/convert/ConvertTool.java
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 /**
- * A conversion tool to convert CSV or JSON files into ORC files.
+ * A conversion tool to convert CSV, JSON OR ORC files into ORC files.
  */
 public class ConvertTool {
   static final String DEFAULT_TIMESTAMP_FORMAT =

--- a/site/_docs/java-tools.md
+++ b/site/_docs/java-tools.md
@@ -11,7 +11,7 @@ supports both the local file system and HDFS.
 
 The subcommands for the tools are:
 
-  * convert (since ORC 1.4) - convert JSON/CSV files to ORC
+  * convert (since ORC 1.4) - convert CSV/JSON/ORC files to ORC
   * count (since ORC 1.6) - recursively find *.orc and print the number of rows
   * data - print the data of an ORC file
   * json-schema (since ORC 1.4) - determine the schema of JSON documents
@@ -29,7 +29,7 @@ The command line looks like:
 
 ## Java Convert
 
-The convert command reads several JSON/CSV files and converts them into a
+The convert command reads several CSV/JSON/ORC files and converts them into a
 single ORC file.
 
 `-b,--bloomFilterColumns <columns>`


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add tips for supporting ORC in the `convert` command.

### Why are the changes needed?
In the convert command, the source file format is supported to contain ORC, but this is not mentioned in the tools and documentation.

### How was this patch tested?
local test

```bash
java -jar orc-tools-2.1.0-SNAPSHOT-uber.jar -h
```

Output
```
ORC Java Tools

usage: java -jar orc-tools-*.jar [--help] [--define X=Y] <command> <args>

Commands:
   convert - convert CSV/JSON/ORC files to ORC
   count - recursively find *.orc and print the number of rows
   data - print the data from the ORC file
   json-schema - scan JSON files to determine their schema
   key - print information about the keys
   meta - print the metadata about the ORC file
   scan - scan the ORC file
   sizes - list size on disk of each column
   version - print the version of this ORC tool

To get more help, provide -h to the command
```

### Was this patch authored or co-authored using generative AI tooling?
No
