### PR TITLE
ORC-1649:[C++][Conan] Add 2.0.0 to conan recipe and update release guide

### DIFF
--- a/conan/all/conandata.yml
+++ b/conan/all/conandata.yml
@@ -16,6 +16,9 @@
 # under the License.
 
 sources:
+  "2.0.0":
+    url: "https://dlcdn.apache.org/orc/orc-2.0.0/orc-2.0.0.tar.gz"
+    sha256: "9107730919c29eb39efaff1b9e36166634d1d4d9477e5fee76bfd6a8fec317df"
   "1.9.2":
     url: "https://dlcdn.apache.org/orc/orc-1.9.2/orc-1.9.2.tar.gz"
     sha256: "7f46f2c184ecefd6791f1a53fb062286818bd8710c3f08b94dd3cac365e240ee"

--- a/conan/config.yml
+++ b/conan/config.yml
@@ -16,6 +16,8 @@
 # under the License.
 
 versions:
+  "2.0.0":
+    folder: all
   "1.9.2":
     folder: all
   "1.8.6":

--- a/site/develop/make-release.md
+++ b/site/develop/make-release.md
@@ -235,4 +235,28 @@ This is an [example](https://github.com/microsoft/vcpkg/pull/36098/files) of upd
 
 > Note: You will not immediately find the merged PR version on the official website of vcpkg. check [vcpkg release](https://github.com/microsoft/vcpkg/releases) to know the latest release progress.
 
+## To release ORC in Conan.
 
+We could release the latest ORC version in [conan](https://conan.io/center/recipes/orc).
+
+1.Install conan
+
+Install your conan with the help of the official guide: [Install](https://docs.conan.io/2/installation.html)
+
+2.Download the source code of conan-center-index:
+~~~
+% git clone git@github.com:conan-io/conan-center-index.git
+~~~
+
+3.Update ORC version
+
+Add the new version to [config.yml](https://github.com/conan-io/conan-center-index/blob/master/recipes/orc/config.yml) and [conandata.yml](https://github.com/conan-io/conan-center-index/blob/master/recipes/orc/all/conandata.yml) locally in your conan-center-index. Run the following command in the conan-center-index/recipes/orc/all directory to build ORC of version X.Y.Z:
+```
+% conan create . --version=X.Y.Z
+```
+
+4.Commit current changes
+
+If everything is ok, commit the local change and open a pull request to [conan-center-index repo](https://github.com/conan-io/conan-center-index).
+
+This is an [example](https://github.com/conan-io/conan-center-index/pull/23046) of adding ORC 2.0.0 to it.


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Sync the conan recipe from upstream.
- Update the release guide for steps to release in conan center.

### Why are the changes needed?
Upstream has added ORC 2.0.0: https://github.com/conan-io/conan-center-index/pull/23046


### How was this patch tested?
Tested it locally.

### Was this patch authored or co-authored using generative AI tooling?
No.
