### PR TITLE
ORC-1655: Add label definition to conan directory

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,6 +30,7 @@ BUILD:
   - "cmake_modules/**/*"
   - "proto/**/*"
   - "**/*pom.xml"
+  - "conan/**/*"
 DOCS:
   - "site/**/*"
   - "**/README.md"


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to add label definition to conan directory.

### Why are the changes needed?
Modifications related to the `conan` directory are not automatically labeled.

### How was this patch tested?

### Was this patch authored or co-authored using generative AI tooling?
No