### PR TITLE
ORC-1656: Skip build and test on conan updates

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -4,11 +4,13 @@ on:
   push:
     paths-ignore:
     - 'site/**'
+    - 'conan/**'
     branches:
     - main
   pull_request:
     paths-ignore:
     - 'site/**'
+    - 'conan/**'
     branches:
     - main
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to skip build and test on conan updates

### Why are the changes needed?
To save community resources from running tests on irrelevant changes.

https://github.com/apache/orc/pull/1846#pullrequestreview-1938239894

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No