### PR TITLE
ORC-1663: [C++] Enable TestTimezone.testMissingTZDB on Windows

### DIFF
--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -428,15 +428,18 @@ namespace orc {
 
   TEST(TestTimezone, testMissingTZDB) {
     const char* tzDirBackup = std::getenv("TZDIR");
-    setEnv("TZDIR", "/path/to/wrong/tzdb");
+    if (tzDirBackup != nullptr) {
+      ASSERT_TRUE(delEnv("TZDIR"));
+    }
+    ASSERT_TRUE(setEnv("TZDIR", "/path/to/wrong/tzdb"));
     EXPECT_THAT([]() { getTimezoneByName("America/Los_Angeles"); },
                 testing::ThrowsMessage<TimezoneError>(testing::HasSubstr(
                     "Time zone file /path/to/wrong/tzdb/America/Los_Angeles does not exist."
                     " Please install IANA time zone database and set TZDIR env.")));
     if (tzDirBackup != nullptr) {
-      setEnv("TZDIR", tzDirBackup);
+      ASSERT_TRUE(setEnv("TZDIR", tzDirBackup));
     } else {
-      delEnv("TZDIR");
+      ASSERT_TRUE(delEnv("TZDIR"));
     }
   }
 

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -22,7 +22,10 @@
 #include "wrap/gtest-wrapper.h"
 
 #ifdef _MSC_VER
+// clang-format off
+#include "windows.h"
 #include "processenv.h"
+// clang-format on
 #endif
 
 #include <iostream>
@@ -417,7 +420,7 @@ namespace orc {
 
   bool delEnv(const char* name) {
 #ifdef _MSC_VER
-  return SetEnvironmentVariableA(name, nullptr));
+    return SetEnvironmentVariableA(name, nullptr);
 #else
     return unsetenv(name) == 0;
 #endif

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -21,13 +21,7 @@
 #include "wrap/gmock.h"
 #include "wrap/gtest-wrapper.h"
 
-#ifdef _MSC_VER
-// clang-format off
-#include "windows.h"
-#include "processenv.h"
-// clang-format on
-#endif
-
+#include <cstdlib>
 #include <iostream>
 #include <vector>
 

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -403,7 +403,6 @@ namespace orc {
     EXPECT_EQ(1699164000 + 8 * 3600, la->convertFromUTC(1699164000));
   }
 
-#ifndef _MSC_VER
   TEST(TestTimezone, testMissingTZDB) {
     const char* tzDirBackup = std::getenv("TZDIR");
     setenv("TZDIR", "/path/to/wrong/tzdb", 1);
@@ -417,6 +416,5 @@ namespace orc {
       unsetenv("TZDIR");
     }
   }
-#endif
 
 }  // namespace orc

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -412,7 +412,7 @@ namespace orc {
 
   bool setEnv(const char* name, const char* value) {
 #ifdef _MSC_VER
-    return SetEnvironmentVariableA(name, value);
+    return _putenv_s(name, value) == 0;
 #else
     return setenv(name, value, 1) == 0;
 #endif
@@ -420,7 +420,7 @@ namespace orc {
 
   bool delEnv(const char* name) {
 #ifdef _MSC_VER
-    return SetEnvironmentVariableA(name, nullptr);
+    return _putenv_s(name, "") == 0;
 #else
     return unsetenv(name) == 0;
 #endif


### PR DESCRIPTION
### What changes were proposed in this pull request?

Enable TestTimezone.testMissingTZDB unit test to run on Windows.

### Why are the changes needed?

When /usr/share/zoneinfo is unavailable and TZDIR env is unset, creating C++ ORC reader will crash on Windows. We need to better deal with this case. See context from the Apache Arrow community: https://github.com/apache/arrow/issues/36026 and https://github.com/apache/arrow/issues/40633


### How was this patch tested?

Make sure the test passes on Windows.

### Was this patch authored or co-authored using generative AI tooling?

No.
