### PR TITLE
ORC-1662: [C++] Upgrade protobuf to 3.21.12

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -20,7 +20,7 @@ set(LZ4_VERSION "1.9.3")
 set(SNAPPY_VERSION "1.1.7")
 set(ZLIB_VERSION "1.2.11")
 set(GTEST_VERSION "1.12.1")
-set(PROTOBUF_VERSION "3.5.1")
+set(PROTOBUF_VERSION "3.21.12")
 set(ZSTD_VERSION "1.5.5")
 
 option(ORC_PREFER_STATIC_PROTOBUF "Prefer static protobuf library, if available" ON)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade protobuf to 3.21.12

### Why are the changes needed?
To fix compilation failure on vs2022


### How was this patch tested?
UT passed

### Was this patch authored or co-authored using generative AI tooling?
NO
