### PR TITLE
ORC-1664: Migrate to `removeUnusedImports` of `spotless-maven-plugin`

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -38,7 +38,6 @@
       <property name="allowClassImports" value="false"/>
       <property name="allowStaticMemberImports" value="false"/>
     </module>
-    <module name="UnusedImports"/>
     <module name="RedundantImport"/>
     <!-- https://checkstyle.sourceforge.io/config_imports.html#ImportOrder IntelliJ default example -->
     <module name="CustomImportOrder">

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -349,6 +349,9 @@
                 <sortProperties>true</sortProperties>
               </sortPom>
             </pom>
+            <java>
+              <removeUnusedImports></removeUnusedImports>
+            </java>
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to enable the `removeUnusedImports` function in `spotless-maven-plugin`.

Now we can use the following command to automatically remove unused imports.
```bash
mvn spotless:apply -Panalyze
```

### Why are the changes needed?
We now checkstyle configured `<module name="UnusedImports"/>`, but it will only check and will not automatically fix the problem.

`spotless-maven-plugin` provides a useful function to automatically remove unused imports, which can provide the efficiency of java developers.



### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No
