### PR TITLE
ORC-1665: Migrate to `importOrder` of `spotless-maven-plugin`

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -38,15 +38,6 @@
       <property name="allowClassImports" value="false"/>
       <property name="allowStaticMemberImports" value="false"/>
     </module>
-    <module name="RedundantImport"/>
-    <!-- https://checkstyle.sourceforge.io/config_imports.html#ImportOrder IntelliJ default example -->
-    <module name="CustomImportOrder">
-      <property name="customImportOrderRules" value="THIRD_PARTY_PACKAGE###SPECIAL_IMPORTS###STANDARD_JAVA_PACKAGE###STATIC"/>
-      <property name="specialImportsRegExp" value="^javax\."/>
-      <property name="standardPackageRegExp" value="^java\."/>
-      <property name="sortImportsInGroupAlphabetically" value="true"/>
-      <property name="separateLineBetweenGroups" value="false"/>
-    </module>
     <module name="ModifierOrder"/>
     <module name="RedundantModifier"/>
     <module name="NoLineWrap"/>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -350,6 +350,15 @@
               </sortPom>
             </pom>
             <java>
+              <includes>
+                <include>src/java/**/*.java</include>
+              </includes>
+              <excludes>
+                <exclude>src/test/**/*.java</exclude>
+              </excludes>
+              <importOrder>
+                <order>,javax|java,\#</order>
+              </importOrder>
               <removeUnusedImports></removeUnusedImports>
             </java>
           </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to enable the `importOrder` function in `spotless-maven-plugin`.

```bash
mvn spotless:apply -Panalyze
```

### Why are the changes needed?
Although there is now checkstyle to limit the order of imports, it cannot be automatically adjusted. `spotless-maven-plugin` can check and automatically adjust.

https://github.com/apache/orc/pull/1859#pullrequestreview-1959266086

### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No