### PR TITLE
ORC-1670: Upgrade `zstd-jni` to 1.5.6-1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -84,7 +84,7 @@
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
-    <zstd-jni.version>1.5.5-11</zstd-jni.version>
+    <zstd-jni.version>1.5.6-1</zstd-jni.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.6-1.

### Why are the changes needed?

This release has the following memory-leak bug fix.

- https://github.com/luben/zstd-jni/releases/tag/v1.5.6-1
  - https://github.com/luben/zstd-jni/pull/303

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.