### PR TITLE
ORC-642: update PatchedBase doc with patch ceiling in spec

### DIFF
--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -824,14 +824,31 @@ the index values and the additional value bits.
   bit is set, the entire value is negated.
 * Data values (W * L bits padded to the byte) - A sequence of W bit positive
   values that are added to the base value.
-* Patch list (PLL * (PGW + PW) bytes) - A list of patches for values
+* Patch list (PLL * ceil(PGW + PW) bits) - A list of patches for values
   that didn't fit within W bits. Each entry in the list consists of a
   gap, which is the number of elements skipped from the previous
   patch, and a patch value. Patches are applied by logically or'ing
   the data values with the relevant patch shifted W bits left. If a
   patch is 0, it was introduced to skip over more than 255 items. The
   combined length of each patch (PGW + PW) must be less or equal to
-  64.
+  64. (PGW + PW) is padded to the nearest fixed bit size according to the
+  below table before being encoded in the patch list.
+
+(PGW + PW)    | ceil(PGW + PW)
+:------------ | :-------------
+1 <= x <= 24  | x
+25            | 26
+26            | 26
+27            | 28
+28            | 28
+29            | 30
+30            | 30
+31            | 32
+32            | 32
+33 <= x <= 40 | 40
+41 <= x <= 48 | 48
+49 <= x <= 56 | 56
+57 <= x <= 64 | 64
 
 The unsigned sequence of [2030, 2000, 2020, 1000000, 2040, 2050, 2060, 2070,
 2080, 2090, 2100, 2110, 2120, 2130, 2140, 2150, 2160, 2170, 2180, 2190]

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -824,17 +824,17 @@ the index values and the additional value bits.
   bit is set, the entire value is negated.
 * Data values (W * L bits padded to the byte) - A sequence of W bit positive
   values that are added to the base value.
-* Patch list (PLL * ceil(PGW + PW) bits) - A list of patches for values
-  that didn't fit within W bits. Each entry in the list consists of a
+* Patch list (PLL * closestFixedBits(PGW + PW) bits) - A list of patches for
+  values that didn't fit within W bits. Each entry in the list consists of a
   gap, which is the number of elements skipped from the previous
   patch, and a patch value. Patches are applied by logically or'ing
   the data values with the relevant patch shifted W bits left. If a
   patch is 0, it was introduced to skip over more than 255 items. The
   combined length of each patch (PGW + PW) must be less or equal to
-  64. (PGW + PW) is padded to the nearest fixed bit size according to the
+  64. (PGW + PW) is padded to the closest fixed bit size according to the
   below table before being encoded in the patch list.
 
-(PGW + PW)    | ceil(PGW + PW)
+(PGW + PW)    | closestFixedBits(PGW + PW)
 :------------ | :-------------
 1 <= x <= 24  | x
 25            | 26

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -843,14 +843,31 @@ the index values and the additional value bits.
   bit is set, the entire value is negated.
 * Data values (W * L bits padded to the byte) - A sequence of W bit positive
   values that are added to the base value.
-* Patch list (PLL * (PGW + PW) bytes) - A list of patches for values
-  that didn't fit within W bits. Each entry in the list consists of a
+* Patch list (PLL * closestFixedBits(PGW + PW) bits) - A list of patches for
+  values that didn't fit within W bits. Each entry in the list consists of a
   gap, which is the number of elements skipped from the previous
   patch, and a patch value. Patches are applied by logically or'ing
   the data values with the relevant patch shifted W bits left. If a
   patch is 0, it was introduced to skip over more than 255 items. The
   combined length of each patch (PGW + PW) must be less or equal to
-  64.
+  64. (PGW + PW) is padded to the closest fixed bit size according to the
+  below table before being encoded in the patch list.
+
+(PGW + PW)    | closestFixedBits(PGW + PW)
+:------------ | :-------------
+1 <= x <= 24  | x
+25            | 26
+26            | 26
+27            | 28
+28            | 28
+29            | 30
+30            | 30
+31            | 32
+32            | 32
+33 <= x <= 40 | 40
+41 <= x <= 48 | 48
+49 <= x <= 56 | 56
+57 <= x <= 64 | 64
 
 The unsigned sequence of [2030, 2000, 2020, 1000000, 2040, 2050, 2060, 2070,
 2080, 2090, 2100, 2110, 2120, 2130, 2140, 2150, 2160, 2170, 2180, 2190]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->

Update PatchedBase specification doc to include details about the behaviour of padding the patch gap + patch width bits to nearest fixed btis.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Ensure spec is accurate to implementation details


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No