### PR TITLE
ORC-1672: Remove test packages `o.a.o.tools.check`

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/TestCheckTool.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestCheckTool.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.orc.tools.check;
+package org.apache.orc.tools;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;

--- a/java/tools/src/test/org/apache/orc/tools/check/TestCheckTool.java
+++ b/java/tools/src/test/org/apache/orc/tools/check/TestCheckTool.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.orc.tools.bloomfilter;
+package org.apache.orc.tools.check;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to remove test packages `o.a.o.tools.check`.

### Why are the changes needed?
ORC-1667 was originally designed for bloom-filter, so the package name has not been modified.

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No