### PR TITLE
ORC-1673: Remove test packages `o.a.o.tools.[count|merge|sizes]`

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/TestColumnSizes.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestColumnSizes.java
@@ -16,17 +16,18 @@
  * limitations under the License.
  */
 
-package org.apache.orc.tools.count;
+package org.apache.orc.tools;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.apache.orc.tools.RowCount;
+import org.apache.orc.tools.ColumnSizes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,9 +40,9 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestRowCount {
+public class TestColumnSizes {
   private Path workDir = new Path(
-      Paths.get(System.getProperty("test.tmp.dir"), "orc-test-count").toString());
+      Paths.get(System.getProperty("test.tmp.dir"), "orc-test-sizes").toString());
   private Configuration conf;
   private FileSystem fs;
 
@@ -55,20 +56,23 @@ public class TestRowCount {
   }
 
   @Test
-  public void testCount() throws Exception {
-    TypeDescription schema = TypeDescription.fromString("struct<x:int>");
+  public void testSizes() throws Exception {
+    TypeDescription schema = TypeDescription.fromString("struct<x:int,y:string>");
     Map<String, Integer> fileToRowCountMap = new LinkedHashMap<>();
-    fileToRowCountMap.put("test-count-1.orc", 10000);
-    fileToRowCountMap.put("test-count-2.orc", 20000);
+    fileToRowCountMap.put("test-sizes-1.orc", 10000);
+    fileToRowCountMap.put("test-sizes-2.orc", 20000);
     for (Map.Entry<String, Integer> fileToRowCount : fileToRowCountMap.entrySet()) {
       Writer writer = OrcFile.createWriter(new Path(fileToRowCount.getKey()),
           OrcFile.writerOptions(conf)
               .setSchema(schema));
       VectorizedRowBatch batch = schema.createRowBatch();
       LongColumnVector x = (LongColumnVector) batch.cols[0];
+      BytesColumnVector y = (BytesColumnVector) batch.cols[1];
       for (int r = 0; r < fileToRowCount.getValue(); ++r) {
         int row = batch.size++;
         x.vector[row] = r;
+        byte[] buffer = ("byte-" + r).getBytes();
+        y.setRef(row, buffer, 0, buffer.length);
         if (batch.size == batch.getMaxSize()) {
           writer.addRowBatch(batch);
           batch.reset();
@@ -84,11 +88,13 @@ public class TestRowCount {
     ByteArrayOutputStream myOut = new ByteArrayOutputStream();
     // replace stdout and run command
     System.setOut(new PrintStream(myOut, false, StandardCharsets.UTF_8));
-    RowCount.main(conf, new String[]{workDir.toString()});
+    ColumnSizes.main(conf, new String[]{"--summary", workDir.toString()});
     System.out.flush();
     System.setOut(origOut);
     String output = myOut.toString(StandardCharsets.UTF_8);
-    assertTrue(output.contains(" 10000"));
-    assertTrue(output.contains(" 20000"));
+    assertTrue(output.contains("Total Files: 2"));
+    assertTrue(output.contains("Total Rows: 30000"));
+    assertTrue(output.contains("Percent  Bytes/Row  Name"));
+    assertTrue(output.contains("_stripe_footer"));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove test packages, `o.a.o.tools.[count|merge|sizes]`, and move the test class to the parent directory.

### Why are the changes needed?

Those test packages have no corresponding source package. In other words, the main code is implemented in `o.a.o.tools` package.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.