### PR TITLE
ORC-1676: Use Hive 4.0.0 in benchmark

### DIFF
--- a/java/bench/hive/pom.xml
+++ b/java/bench/hive/pom.xml
@@ -50,7 +50,6 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
-      <classifier>core</classifier>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
@@ -65,6 +64,10 @@
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <avro.version>1.11.3</avro.version>
-    <hive.version>3.1.3</hive.version>
+    <hive.version>4.0.0</hive.version>
     <jmh.version>1.37</jmh.version>
     <junit.version>5.10.2</junit.version>
     <orc.version>${project.version}</orc.version>
@@ -159,7 +159,6 @@
         <groupId>org.apache.hive</groupId>
         <artifactId>hive-exec</artifactId>
         <version>${hive.version}</version>
-        <classifier>core</classifier>
         <exclusions>
           <exclusion>
             <groupId>org.apache.calcite</groupId>
@@ -172,6 +171,10 @@
           <exclusion>
             <groupId>org.apache.calcite.avatica</groupId>
             <artifactId>avatica</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
           </exclusion>
           <exclusion>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Hive 4.0.0 in benchmark.

### Why are the changes needed?

To make Hive benchmark up-to-date.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.