### PR TITLE
ORC-1681: Remove redundant import statement in tests to fix checkstyle failures

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/TestCheckTool.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestCheckTool.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.apache.orc.tools.CheckTool;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/java/tools/src/test/org/apache/orc/tools/TestColumnSizes.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestColumnSizes.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.apache.orc.tools.ColumnSizes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/java/tools/src/test/org/apache/orc/tools/TestMergeFiles.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestMergeFiles.java
@@ -29,7 +29,6 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.apache.orc.tools.MergeFiles;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/java/tools/src/test/org/apache/orc/tools/TestRowCount.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestRowCount.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.apache.orc.tools.RowCount;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a kind of follow-up of the following to remove redundant `import` statement in tests to fix checkstyle failure.
- https://github.com/apache/orc/pull/1871
- https://github.com/apache/orc/pull/1870

### Why are the changes needed?

To recover CIs.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.