### PR TITLE
ORC-1684: [C++] Find tzdb without TZDIR when in conda-environments

### DIFF
--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -659,7 +659,15 @@ namespace orc {
   const char* getTimezoneDirectory() {
     const char* dir = getenv("TZDIR");
     if (!dir) {
-      dir = DEFAULT_TZDIR;
+      // this is present if we're in an activated conda environment
+      const char* conda_prefix = getenv("CONDA_PREFIX");
+      if (conda_prefix) {
+        std::string conda_dir(conda_prefix);
+        conda_dir += "/share/zoneinfo";
+        dir = conda_dir.c_str();
+      } else {
+        dir = DEFAULT_TZDIR;
+      }
     }
     return dir;
   }

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -656,7 +656,7 @@ namespace orc {
     epoch_ = utcEpoch - getVariant(utcEpoch).gmtOffset;
   }
 
-  const char* getTimezoneDirectory() {
+  std::string getTimezoneDirectory() {
     const char* dir = getenv("TZDIR");
     if (!dir) {
       // this is present if we're in an activated conda environment
@@ -664,12 +664,13 @@ namespace orc {
       if (condaPrefix) {
         std::string condaDir(condaPrefix);
         condaDir += "/share/zoneinfo";
-        dir = condaDir.c_str();
+        return condaDir;
       } else {
         dir = DEFAULT_TZDIR;
       }
     }
-    return dir;
+    std::string tzDir(dir);
+    return tzDir;
   }
 
   /**

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -669,8 +669,7 @@ namespace orc {
         dir = DEFAULT_TZDIR;
       }
     }
-    std::string tzDir(dir);
-    return tzDir;
+    return dir;
   }
 
   /**

--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -660,11 +660,11 @@ namespace orc {
     const char* dir = getenv("TZDIR");
     if (!dir) {
       // this is present if we're in an activated conda environment
-      const char* conda_prefix = getenv("CONDA_PREFIX");
-      if (conda_prefix) {
-        std::string conda_dir(conda_prefix);
-        conda_dir += "/share/zoneinfo";
-        dir = conda_dir.c_str();
+      const char* condaPrefix = getenv("CONDA_PREFIX");
+      if (condaPrefix) {
+        std::string condaDir(condaPrefix);
+        condaDir += "/share/zoneinfo";
+        dir = condaDir.c_str();
       } else {
         dir = DEFAULT_TZDIR;
       }

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -476,13 +476,13 @@ namespace orc {
       // CONDA_PREFIX contains backslashes on windows; test that this doesn't blow up
       std::replace(condaPrefix.begin(), condaPrefix.end(), '/', '\\');
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
-      const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
-      const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
-      EXPECT_EQ(la1, la2);
-      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-01-06 09:59:59"));
-      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-01-06 10:00:00"));
-      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-10-27 08:59:59"));
-      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-10-27 09:00:00"));
+      const Timezone* la3 = &getTimezoneByName("America/Los_Angeles");
+      const Timezone* la4 = &getTimezoneByName("America/Los_Angeles");
+      EXPECT_EQ(la3, la4);
+      EXPECT_EQ("PST", getVariantFromZone(*la3, "1974-01-06 09:59:59"));
+      EXPECT_EQ("PDT", getVariantFromZone(*la3, "1974-01-06 10:00:00"));
+      EXPECT_EQ("PDT", getVariantFromZone(*la3, "1974-10-27 08:59:59"));
+      EXPECT_EQ("PST", getVariantFromZone(*la3, "1974-10-27 09:00:00"));
 
       ASSERT_TRUE(delEnv("CONDA_PREFIX"));
       ASSERT_TRUE(setEnv("TZDIR", tzDirBackup));

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -466,7 +466,7 @@ namespace orc {
       std::replace(condaPrefix.begin(), condaPrefix.end(), '/', '\\');
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
-      // as above
+      // as above, but different timezone to avoid hitting cache
       const Timezone* syd = &getTimezoneByName("Australia/Sydney");
       EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-04-06 15:59:59"));
       EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-04-06 16:00:00"));

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -421,21 +421,13 @@ namespace orc {
 #endif
   }
 
-  char* deepcopy(const char* name) {
-    // this allocates a new buffer that must be freed after use
-#ifdef _MSC_VER
-    return _strdup(name);
-#else
-    return strdup(name);
-#endif
-  }
-
   TEST(TestTimezone, testMissingTZDB) {
     const char* tzDir = std::getenv("TZDIR");
-    char* tzDirBackup = nullptr;
+    std::string tzDirBackup = nullptr;
     if (tzDir != nullptr) {
-      // avoid that unsetting environment variable wrecks pointer to tzDir
-      tzDirBackup = deepcopy(tzDir);
+      // std::string creates a deepcopy of buffer, which avoids that
+      // unsetting environment variable wrecks pointer to tzDir
+      tzDirBackup = tzDir;
       ASSERT_TRUE(delEnv("TZDIR"));
     }
     ASSERT_TRUE(setEnv("TZDIR", "/path/to/wrong/tzdb"));
@@ -444,8 +436,7 @@ namespace orc {
                     "Time zone file /path/to/wrong/tzdb/America/Los_Angeles does not exist."
                     " Please install IANA time zone database and set TZDIR env.")));
     if (tzDirBackup != nullptr) {
-      ASSERT_TRUE(setEnv("TZDIR", tzDirBackup));
-      free(tzDirBackup);
+      ASSERT_TRUE(setEnv("TZDIR", tzDirBackup.c_str()));
     } else {
       ASSERT_TRUE(delEnv("TZDIR"));
     }
@@ -455,7 +446,7 @@ namespace orc {
     const char* tzDir = std::getenv("TZDIR");
     // test only makes sense if TZDIR exists
     if (tzDir != nullptr) {
-      char* tzDirBackup = deepcopy(tzDir);
+      std::string tzDirBackup = tzDir;
       ASSERT_TRUE(delEnv("TZDIR"));
 
       // remove "/share/zoneinfo" from TZDIR (as set through TZDATA_DIR in CI) to
@@ -488,8 +479,7 @@ namespace orc {
 
       // restore state of environment variables
       ASSERT_TRUE(delEnv("CONDA_PREFIX"));
-      ASSERT_TRUE(setEnv("TZDIR", tzDirBackup));
-      free(tzDirBackup);
+      ASSERT_TRUE(setEnv("TZDIR", tzDirBackup.c_str()));
     }
   }
 

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -21,8 +21,8 @@
 #include "wrap/gmock.h"
 #include "wrap/gtest-wrapper.h"
 
-#include <cstdlib>
 #include <algorithm>
+#include <cstdlib>
 #include <iostream>
 #include <vector>
 
@@ -458,13 +458,13 @@ namespace orc {
       char* tzDirBackup = deepcopy(tzDir);
       ASSERT_TRUE(delEnv("TZDIR"));
 
-      // remove "/share/zoneinfo" from TZDIR (as set through TZDATA_DIR) to get
-      // the equivalent of CONDA_PREFIX, relative to the location of the tzdb
+      // remove "/share/zoneinfo" from TZDIR (as set through TZDATA_DIR in CI) to
+      // get the equivalent of CONDA_PREFIX, relative to the location of the tzdb
       std::string condaPrefix(tzDirBackup);
       condaPrefix += "/../..";
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
-      // small sample to ensure tzbd loads correctly with CONDA_PREFIX, even without TZDIR
+      // small test sample to ensure tzbd loads with CONDA_PREFIX, even without TZDIR
       const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
       const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
       EXPECT_EQ(la1, la2);
@@ -476,6 +476,8 @@ namespace orc {
       // CONDA_PREFIX contains backslashes on windows; test that this doesn't blow up
       std::replace(condaPrefix.begin(), condaPrefix.end(), '/', '\\');
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
+
+      // as above
       const Timezone* la3 = &getTimezoneByName("America/Los_Angeles");
       const Timezone* la4 = &getTimezoneByName("America/Los_Angeles");
       EXPECT_EQ(la3, la4);
@@ -484,6 +486,7 @@ namespace orc {
       EXPECT_EQ("PDT", getVariantFromZone(*la3, "1974-10-27 08:59:59"));
       EXPECT_EQ("PST", getVariantFromZone(*la3, "1974-10-27 09:00:00"));
 
+      // restore state of environment variables
       ASSERT_TRUE(delEnv("CONDA_PREFIX"));
       ASSERT_TRUE(setEnv("TZDIR", tzDirBackup));
       free(tzDirBackup);

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -22,6 +22,7 @@
 #include "wrap/gtest-wrapper.h"
 
 #include <cstdlib>
+#include <algorithm>
 #include <iostream>
 #include <vector>
 
@@ -464,6 +465,17 @@ namespace orc {
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
       // small sample to ensure tzbd loads correctly with CONDA_PREFIX, even without TZDIR
+      const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
+      const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
+      EXPECT_EQ(la1, la2);
+      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-01-06 09:59:59"));
+      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-01-06 10:00:00"));
+      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-10-27 08:59:59"));
+      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-10-27 09:00:00"));
+
+      // CONDA_PREFIX contains backslashes on windows; test that this doesn't blow up
+      std::replace(condaPrefix.begin(), condaPrefix.end(), '/', '\\');
+      ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
       const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
       const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
       EXPECT_EQ(la1, la2);

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -441,14 +441,14 @@ namespace orc {
     const char* tzDirBackup = std::getenv("TZDIR");
     // test only makes sense if TZDIR exists
     if (tzDirBackup != nullptr) {
-      ASSERT_TRUE(delEnv("TZDIR"));
-
-      // remove "/share/zoneinfo" from TZDIR to get (equivalent of) CONDA_PREFIX
+      // remove "/share/zoneinfo" from TZDIR (as set through TZDATA_DIR) to get
+      // the equivalent of CONDA_PREFIX, relative to the location of the tzdb
       std::string condaPrefix(tzDirBackup);
       condaPrefix += "/../..";
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
       // small sample to ensure tzbd loads correctly with CONDA_PREFIX, even without TZDIR
+      ASSERT_TRUE(delEnv("TZDIR"));
       const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
       const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
       EXPECT_EQ(la1, la2);

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -454,6 +454,8 @@ namespace orc {
     // test only makes sense if TZDIR exists
     if (tzDir != nullptr) {
       char* tzDirBackup = deepcopy(tzDir);
+      ASSERT_TRUE(delEnv("TZDIR"));
+
       // remove "/share/zoneinfo" from TZDIR (as set through TZDATA_DIR) to get
       // the equivalent of CONDA_PREFIX, relative to the location of the tzdb
       std::string condaPrefix(tzDirBackup);
@@ -461,7 +463,6 @@ namespace orc {
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
       // small sample to ensure tzbd loads correctly with CONDA_PREFIX, even without TZDIR
-      ASSERT_TRUE(delEnv("TZDIR"));
       const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
       const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
       EXPECT_EQ(la1, la2);

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -437,4 +437,29 @@ namespace orc {
     }
   }
 
+  TEST(TestTimezone, testTzdbFromCondaEnv) {
+    const char* tzDirBackup = std::getenv("TZDIR");
+    // test only makes sense if TZDIR exists
+    if (tzDirBackup != nullptr) {
+      ASSERT_TRUE(delEnv("TZDIR"));
+
+      // remove "/share/zoneinfo" from TZDIR to get (equivalent of) CONDA_PREFIX
+      std::string condaPrefix(tzDirBackup)
+      condaPrefix += "/../.."
+      ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
+
+      // small sample to ensure tzbd loads correctly with CONDA_PREFIX, even without TZDIR
+      const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
+      const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
+      EXPECT_EQ(la1, la2);
+      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-01-06 09:59:59"));
+      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-01-06 10:00:00"));
+      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-10-27 08:59:59"));
+      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-10-27 09:00:00"));
+
+      ASSERT_TRUE(delEnv("CONDA_PREFIX"));
+      ASSERT_TRUE(setEnv("TZDIR", tzDirBackup));
+    }
+  }
+
 }  // namespace orc

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -457,10 +457,10 @@ namespace orc {
 
       // small test sample to ensure tzbd loads with CONDA_PREFIX, even without TZDIR
       const Timezone* zrh = &getTimezoneByName("Europe/Zurich");
-      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-03-31 01:59:59"));
-      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-03-31 02:00:00"));
-      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-10-27 00:59:59"));
-      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-10-27 01:00:00"));
+      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-03-31 00:59:59"));
+      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-03-31 01:00:00"));
+      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-10-26 23:59:59"));
+      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-10-27 00:00:00"));
 
       // CONDA_PREFIX contains backslashes on windows; test that this doesn't blow up
       std::replace(condaPrefix.begin(), condaPrefix.end(), '/', '\\');
@@ -468,10 +468,10 @@ namespace orc {
 
       // as above
       const Timezone* syd = &getTimezoneByName("Australia/Sydney");
-      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-04-06 15:59:59"));
-      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-04-06 16:00:00"));
-      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-10-05 16:59:59"));
-      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-10-05 17:00:00"));
+      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-04-06 14:59:59"));
+      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-04-06 15:00:00"));
+      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-10-05 15:59:59"));
+      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-10-05 16:00:00"));
 
       // restore state of environment variables
       ASSERT_TRUE(delEnv("CONDA_PREFIX"));

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -423,7 +423,7 @@ namespace orc {
 
   TEST(TestTimezone, testMissingTZDB) {
     const char* tzDir = std::getenv("TZDIR");
-    std::string tzDirBackup = nullptr;
+    std::string tzDirBackup;
     if (tzDir != nullptr) {
       // std::string creates a deepcopy of buffer, which avoids that
       // unsetting environment variable wrecks pointer to tzDir
@@ -435,7 +435,7 @@ namespace orc {
                 testing::ThrowsMessage<TimezoneError>(testing::HasSubstr(
                     "Time zone file /path/to/wrong/tzdb/America/Los_Angeles does not exist."
                     " Please install IANA time zone database and set TZDIR env.")));
-    if (tzDirBackup != nullptr) {
+    if (!tzDirBackup.empty()) {
       ASSERT_TRUE(setEnv("TZDIR", tzDirBackup.c_str()));
     } else {
       ASSERT_TRUE(delEnv("TZDIR"));

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -460,7 +460,7 @@ namespace orc {
       EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-03-31 00:59:59"));
       EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-03-31 01:00:00"));
       EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-10-26 23:59:59"));
-      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-10-27 00:00:00"));
+      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-10-27 01:00:00"));
 
       // CONDA_PREFIX contains backslashes on windows; test that this doesn't blow up
       std::replace(condaPrefix.begin(), condaPrefix.end(), '/', '\\');
@@ -469,7 +469,7 @@ namespace orc {
       // as above
       const Timezone* syd = &getTimezoneByName("Australia/Sydney");
       EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-04-06 14:59:59"));
-      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-04-06 15:00:00"));
+      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-04-06 16:00:00"));
       EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-10-05 15:59:59"));
       EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-10-05 16:00:00"));
 

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -459,7 +459,7 @@ namespace orc {
       const Timezone* zrh = &getTimezoneByName("Europe/Zurich");
       EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-03-31 00:59:59"));
       EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-03-31 01:00:00"));
-      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-10-26 23:59:59"));
+      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-10-27 00:59:59"));
       EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-10-27 01:00:00"));
 
       // CONDA_PREFIX contains backslashes on windows; test that this doesn't blow up
@@ -468,7 +468,7 @@ namespace orc {
 
       // as above
       const Timezone* syd = &getTimezoneByName("Australia/Sydney");
-      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-04-06 14:59:59"));
+      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-04-06 15:59:59"));
       EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-04-06 16:00:00"));
       EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-10-05 15:59:59"));
       EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-10-05 16:00:00"));

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -433,6 +433,7 @@ namespace orc {
     const char* tzDir = std::getenv("TZDIR");
     char* tzDirBackup = nullptr;
     if (tzDir != nullptr) {
+      // avoid that unsetting environment variable wrecks pointer to tzDir
       tzDirBackup = deepcopy(tzDir);
       ASSERT_TRUE(delEnv("TZDIR"));
     }

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -420,7 +420,7 @@ namespace orc {
 #endif
   }
 
-  char * deepcopy(const char* name) {
+  char* deepcopy(const char* name) {
     // this allocates a new buffer that must be freed after use
 #ifdef _MSC_VER
     return _strdup(name);

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -444,8 +444,8 @@ namespace orc {
       ASSERT_TRUE(delEnv("TZDIR"));
 
       // remove "/share/zoneinfo" from TZDIR to get (equivalent of) CONDA_PREFIX
-      std::string condaPrefix(tzDirBackup)
-      condaPrefix += "/../.."
+      std::string condaPrefix(tzDirBackup);
+      condaPrefix += "/../..";
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
       // small sample to ensure tzbd loads correctly with CONDA_PREFIX, even without TZDIR

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -456,26 +456,22 @@ namespace orc {
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
       // small test sample to ensure tzbd loads with CONDA_PREFIX, even without TZDIR
-      const Timezone* la1 = &getTimezoneByName("America/Los_Angeles");
-      const Timezone* la2 = &getTimezoneByName("America/Los_Angeles");
-      EXPECT_EQ(la1, la2);
-      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-01-06 09:59:59"));
-      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-01-06 10:00:00"));
-      EXPECT_EQ("PDT", getVariantFromZone(*la1, "1974-10-27 08:59:59"));
-      EXPECT_EQ("PST", getVariantFromZone(*la1, "1974-10-27 09:00:00"));
+      const Timezone* zrh = &getTimezoneByName("Europe/Zurich");
+      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-03-31 01:59:59"));
+      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-03-31 02:00:00"));
+      EXPECT_EQ("CEST", getVariantFromZone(*zrh, "2024-10-27 00:59:59"));
+      EXPECT_EQ("CET", getVariantFromZone(*zrh, "2024-10-27 01:00:00"));
 
       // CONDA_PREFIX contains backslashes on windows; test that this doesn't blow up
       std::replace(condaPrefix.begin(), condaPrefix.end(), '/', '\\');
       ASSERT_TRUE(setEnv("CONDA_PREFIX", condaPrefix.c_str()));
 
       // as above
-      const Timezone* la3 = &getTimezoneByName("America/Los_Angeles");
-      const Timezone* la4 = &getTimezoneByName("America/Los_Angeles");
-      EXPECT_EQ(la3, la4);
-      EXPECT_EQ("PST", getVariantFromZone(*la3, "1974-01-06 09:59:59"));
-      EXPECT_EQ("PDT", getVariantFromZone(*la3, "1974-01-06 10:00:00"));
-      EXPECT_EQ("PDT", getVariantFromZone(*la3, "1974-10-27 08:59:59"));
-      EXPECT_EQ("PST", getVariantFromZone(*la3, "1974-10-27 09:00:00"));
+      const Timezone* syd = &getTimezoneByName("Australia/Sydney");
+      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-04-06 15:59:59"));
+      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-04-06 16:00:00"));
+      EXPECT_EQ("AEST", getVariantFromZone(*syd, "2024-10-05 16:59:59"));
+      EXPECT_EQ("AEDT", getVariantFromZone(*syd, "2024-10-05 17:00:00"));
 
       // restore state of environment variables
       ASSERT_TRUE(delEnv("CONDA_PREFIX"));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->

Find tzdb without having to set `TZDIR` when in a conda-environment (where `tzdata` [has](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fnoarch%2Ftzdata-2024a-h0c530f3_0.conda) a uniform location of `$CONDA_PREFIX/share/zoneinfo` across all platforms).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


This is due to issues in arrow (see https://github.com/apache/arrow/issues/36026) that cannot really be fixed there, as it assumes that orc >=2.0 knows how to find the tzdb. Having to set `TZDIR` in all user environments is an intrusive change that should be avoided, and since the cost here is checking a single environment variable, it's hopefully not too onerous for consideration.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
CI here


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No


CC @wgtmac

See also: #1587