### PR TITLE
ORC-1683: Fix `instanceof` of BinaryStatisticsImpl merge method

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -103,9 +103,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (other instanceof BooleanStatisticsImpl bkt) {
         trueCount += bkt.trueCount;
       } else {
-        if (isStatsExists() && trueCount != 0) {
-          throw new IllegalArgumentException("Incompatible merging of boolean column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of boolean column statistics");
       }
       super.merge(other);
     }
@@ -209,7 +207,6 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     @Override
     public void merge(ColumnStatisticsImpl other) {
       if (other instanceof CollectionColumnStatisticsImpl otherColl) {
-
         if(count == 0) {
           minimum = otherColl.minimum;
           maximum = otherColl.maximum;
@@ -223,9 +220,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         }
         sum += otherColl.sum;
       } else {
-        if (isStatsExists()) {
-          throw new IllegalArgumentException("Incompatible merging of collection column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of collection column statistics");
       }
       super.merge(other);
     }
@@ -398,9 +393,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        if (isStatsExists() && hasMinimum) {
-          throw new IllegalArgumentException("Incompatible merging of integer column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of integer column statistics");
       }
       super.merge(other);
     }
@@ -561,9 +554,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         }
         sum += dbl.sum;
       } else {
-        if (isStatsExists() && hasMinimum) {
-          throw new IllegalArgumentException("Incompatible merging of double column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of double column statistics");
       }
       super.merge(other);
     }
@@ -764,9 +755,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         }
         sum += str.sum;
       } else {
-        if (isStatsExists()) {
-          throw new IllegalArgumentException("Incompatible merging of string column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of string column statistics");
       }
       super.merge(other);
     }
@@ -996,9 +985,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (other instanceof BinaryStatisticsImpl bin) {
         sum += bin.sum;
       } else {
-        if (isStatsExists() && sum != 0) {
-          throw new IllegalArgumentException("Incompatible merging of binary column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of binary column statistics");
       }
       super.merge(other);
     }
@@ -1128,9 +1115,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        if (isStatsExists() && minimum != null) {
-          throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
       }
       super.merge(other);
     }
@@ -1321,9 +1306,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        if (other.getNumberOfValues() != 0) {
-          throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
       }
       super.merge(other);
     }
@@ -1486,9 +1469,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         minimum = Math.min(minimum, dateStats.minimum);
         maximum = Math.max(maximum, dateStats.maximum);
       } else {
-        if (isStatsExists() && count != 0) {
-          throw new IllegalArgumentException("Incompatible merging of date column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of date column statistics");
       }
       super.merge(other);
     }
@@ -1698,9 +1679,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        if (isStatsExists() && count != 0) {
-          throw new IllegalArgumentException("Incompatible merging of timestamp column statistics");
-        }
+        throw new IllegalArgumentException("Incompatible merging of timestamp column statistics");
       }
       super.merge(other);
     }

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -993,8 +993,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
 
     @Override
     public void merge(ColumnStatisticsImpl other) {
-      if (other instanceof BinaryColumnStatistics) {
-        BinaryStatisticsImpl bin = (BinaryStatisticsImpl) other;
+      if (other instanceof BinaryStatisticsImpl bin) {
         sum += bin.sum;
       } else {
         if (isStatsExists() && sum != 0) {

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -102,6 +102,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     public void merge(ColumnStatisticsImpl other) {
       if (other instanceof BooleanStatisticsImpl bkt) {
         trueCount += bkt.trueCount;
+      } else if (!(other instanceof BooleanColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of boolean column statistics");
       } else {
         if (isStatsExists() && trueCount != 0) {
           throw new IllegalArgumentException("Incompatible merging of boolean column statistics");
@@ -222,6 +224,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
         sum += otherColl.sum;
+      } else if (!(other instanceof CollectionColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of collection column statistics");
       } else {
         if (isStatsExists()) {
           throw new IllegalArgumentException("Incompatible merging of collection column statistics");
@@ -397,6 +401,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
             overflow = true;
           }
         }
+      } else if (!(other instanceof IntegerColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of integer column statistics");
       } else {
         if (isStatsExists() && hasMinimum) {
           throw new IllegalArgumentException("Incompatible merging of integer column statistics");
@@ -560,6 +566,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
         sum += dbl.sum;
+      } else if (!(other instanceof DoubleColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of double column statistics");
       } else {
         if (isStatsExists() && hasMinimum) {
           throw new IllegalArgumentException("Incompatible merging of double column statistics");
@@ -763,6 +771,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
         sum += str.sum;
+      } else if (!(other instanceof StringColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of string column statistics");
       } else {
         if (isStatsExists()) {
           throw new IllegalArgumentException("Incompatible merging of string column statistics");
@@ -995,6 +1005,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     public void merge(ColumnStatisticsImpl other) {
       if (other instanceof BinaryStatisticsImpl bin) {
         sum += bin.sum;
+      } else if (!(other instanceof BinaryColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of binary column statistics");
       } else {
         if (isStatsExists() && sum != 0) {
           throw new IllegalArgumentException("Incompatible merging of binary column statistics");
@@ -1127,6 +1139,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
             sum.mutateAdd(dec.sum);
           }
         }
+      } else if (!(other instanceof DecimalColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
       } else {
         if (isStatsExists() && minimum != null) {
           throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
@@ -1320,6 +1334,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
             hasSum = false;
           }
         }
+      } else if (!(other instanceof DecimalColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
       } else {
         if (other.getNumberOfValues() != 0) {
           throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
@@ -1485,6 +1501,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (other instanceof DateStatisticsImpl dateStats) {
         minimum = Math.min(minimum, dateStats.minimum);
         maximum = Math.max(maximum, dateStats.maximum);
+      } else if (!(other instanceof DateColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of date column statistics");
       } else {
         if (isStatsExists() && count != 0) {
           throw new IllegalArgumentException("Incompatible merging of date column statistics");
@@ -1697,6 +1715,8 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
             maximum = timestampStats.maximum;
           }
         }
+      } else if (!(other instanceof TimestampColumnStatistics)) {
+        throw new IllegalArgumentException("Incompatible merging of timestamp column statistics");
       } else {
         if (isStatsExists() && count != 0) {
           throw new IllegalArgumentException("Incompatible merging of timestamp column statistics");

--- a/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ColumnStatisticsImpl.java
@@ -103,7 +103,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (other instanceof BooleanStatisticsImpl bkt) {
         trueCount += bkt.trueCount;
       } else {
-        throw new IllegalArgumentException("Incompatible merging of boolean column statistics");
+        if (isStatsExists() && trueCount != 0) {
+          throw new IllegalArgumentException("Incompatible merging of boolean column statistics");
+        }
       }
       super.merge(other);
     }
@@ -207,6 +209,7 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
     @Override
     public void merge(ColumnStatisticsImpl other) {
       if (other instanceof CollectionColumnStatisticsImpl otherColl) {
+
         if(count == 0) {
           minimum = otherColl.minimum;
           maximum = otherColl.maximum;
@@ -220,7 +223,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         }
         sum += otherColl.sum;
       } else {
-        throw new IllegalArgumentException("Incompatible merging of collection column statistics");
+        if (isStatsExists()) {
+          throw new IllegalArgumentException("Incompatible merging of collection column statistics");
+        }
       }
       super.merge(other);
     }
@@ -393,7 +398,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        throw new IllegalArgumentException("Incompatible merging of integer column statistics");
+        if (isStatsExists() && hasMinimum) {
+          throw new IllegalArgumentException("Incompatible merging of integer column statistics");
+        }
       }
       super.merge(other);
     }
@@ -554,7 +561,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         }
         sum += dbl.sum;
       } else {
-        throw new IllegalArgumentException("Incompatible merging of double column statistics");
+        if (isStatsExists() && hasMinimum) {
+          throw new IllegalArgumentException("Incompatible merging of double column statistics");
+        }
       }
       super.merge(other);
     }
@@ -755,7 +764,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         }
         sum += str.sum;
       } else {
-        throw new IllegalArgumentException("Incompatible merging of string column statistics");
+        if (isStatsExists()) {
+          throw new IllegalArgumentException("Incompatible merging of string column statistics");
+        }
       }
       super.merge(other);
     }
@@ -985,7 +996,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
       if (other instanceof BinaryStatisticsImpl bin) {
         sum += bin.sum;
       } else {
-        throw new IllegalArgumentException("Incompatible merging of binary column statistics");
+        if (isStatsExists() && sum != 0) {
+          throw new IllegalArgumentException("Incompatible merging of binary column statistics");
+        }
       }
       super.merge(other);
     }
@@ -1115,7 +1128,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
+        if (isStatsExists() && minimum != null) {
+          throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
+        }
       }
       super.merge(other);
     }
@@ -1306,7 +1321,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
+        if (other.getNumberOfValues() != 0) {
+          throw new IllegalArgumentException("Incompatible merging of decimal column statistics");
+        }
       }
       super.merge(other);
     }
@@ -1469,7 +1486,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
         minimum = Math.min(minimum, dateStats.minimum);
         maximum = Math.max(maximum, dateStats.maximum);
       } else {
-        throw new IllegalArgumentException("Incompatible merging of date column statistics");
+        if (isStatsExists() && count != 0) {
+          throw new IllegalArgumentException("Incompatible merging of date column statistics");
+        }
       }
       super.merge(other);
     }
@@ -1679,7 +1698,9 @@ public class ColumnStatisticsImpl implements ColumnStatistics {
           }
         }
       } else {
-        throw new IllegalArgumentException("Incompatible merging of timestamp column statistics");
+        if (isStatsExists() && count != 0) {
+          throw new IllegalArgumentException("Incompatible merging of timestamp column statistics");
+        }
       }
       super.merge(other);
     }

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -45,7 +45,6 @@ import java.util.TimeZone;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -723,25 +722,6 @@ public class TestColumnStatistics {
     assertEquals(25, ((BinaryColumnStatistics) stats1).getSum());
   }
 
-  @Test
-  public void testMergeIncompatible() {
-    TypeDescription stringSchema = TypeDescription.createString();
-    ColumnStatisticsImpl stringStats = ColumnStatisticsImpl.create(stringSchema);
-
-    TypeDescription doubleSchema = TypeDescription.createDouble();
-    ColumnStatisticsImpl doubleStats = ColumnStatisticsImpl.create(doubleSchema);
-
-    stringStats.increment(3);
-    stringStats.updateString(new Text("bob"));
-    stringStats.updateString(new Text("david"));
-    stringStats.updateString(new Text("charles"));
-
-    assertThrows(IllegalArgumentException.class, () -> {
-      doubleStats.merge(stringStats);
-    });
-
-    assertEquals(0, ((DoubleColumnStatistics) doubleStats).getNumberOfValues());
-  }
 
   Path workDir = new Path(System.getProperty("test.tmp.dir",
       "target" + File.separator + "test" + File.separator + "tmp"));

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.io.DateWritable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.orc.impl.ColumnStatisticsImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -697,6 +698,28 @@ public class TestColumnStatistics {
         "Incorrect maximum value");
     assertEquals(new BigDecimal("-88888.88"), statistics.getMaximum().bigDecimalValue(),
         "Incorrect minimum value");
+  }
+
+  @Test
+  public void testBinaryMerge() {
+    TypeDescription schema = TypeDescription.createBinary();
+
+    ColumnStatisticsImpl stats1 = ColumnStatisticsImpl.create(schema);
+    ColumnStatisticsImpl stats2 = ColumnStatisticsImpl.create(schema);
+    stats1.increment(3);
+    stats1.updateBinary(new BytesWritable("bob".getBytes(StandardCharsets.UTF_8)));
+    stats1.updateBinary(new BytesWritable("david".getBytes(StandardCharsets.UTF_8)));
+    stats1.updateBinary(new BytesWritable("charles".getBytes(StandardCharsets.UTF_8)));
+    stats2.increment(2);
+    stats2.updateBinary(new BytesWritable("anne".getBytes(StandardCharsets.UTF_8)));
+    stats2.updateBinary(new BytesWritable("abcdef".getBytes(StandardCharsets.UTF_8)));
+
+    assertEquals(15, ((BinaryColumnStatistics) stats1).getSum());
+    assertEquals(10, ((BinaryColumnStatistics) stats2).getSum());
+
+    stats1.merge(stats2);
+
+    assertEquals(25, ((BinaryColumnStatistics) stats1).getSum());
   }
 
 

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -45,6 +45,7 @@ import java.util.TimeZone;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -722,6 +723,25 @@ public class TestColumnStatistics {
     assertEquals(25, ((BinaryColumnStatistics) stats1).getSum());
   }
 
+  @Test
+  public void testMergeIncompatible() {
+    TypeDescription stringSchema = TypeDescription.createString();
+    ColumnStatisticsImpl stringStats = ColumnStatisticsImpl.create(stringSchema);
+
+    TypeDescription doubleSchema = TypeDescription.createDouble();
+    ColumnStatisticsImpl doubleStats = ColumnStatisticsImpl.create(doubleSchema);
+
+    stringStats.increment(3);
+    stringStats.updateString(new Text("bob"));
+    stringStats.updateString(new Text("david"));
+    stringStats.updateString(new Text("charles"));
+
+    assertThrows(IllegalArgumentException.class, () -> {
+      doubleStats.merge(stringStats);
+    });
+
+    assertEquals(0, ((DoubleColumnStatistics) doubleStats).getNumberOfValues());
+  }
 
   Path workDir = new Path(System.getProperty("test.tmp.dir",
       "target" + File.separator + "test" + File.separator + "tmp"));


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix `instanceof` of `BinaryStatisticsImpl` merge method.

### Why are the changes needed?
In [ORC-1542](https://issues.apache.org/jira/browse/ORC-1542), we modified part of instanceof, but `BinaryStatisticsImpl` was not modified because the merge method was written differently.


However, the current code is instanceof `BinaryColumnStatistics` and then explicitly cast `BinaryStatisticsImpl`, so it should be replaced by the new instanceof writing method (`Pattern Matching for instanceof`).

```java
if (other instanceof BinaryColumnStatistics) {
        BinaryStatisticsImpl bin = (BinaryStatisticsImpl) other;
```


### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
