### PR TITLE
ORC-1669: [C++] Deprecate HDFS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ option (ANALYZE_JAVA
 
 option (BUILD_LIBHDFSPP
     "Include LIBHDFSPP library in the build process"
-     ON)
+     OFF)
 
 option(BUILD_CPP_TESTS
     "Build the googletest unit tests"

--- a/c++/include/orc/OrcFile.hh
+++ b/c++/include/orc/OrcFile.hh
@@ -127,9 +127,8 @@ namespace orc {
    * @param path the uri of the file in HDFS
    * @param metrics the metrics of the reader
    */
-  [[deprecated("readHdfsFile is deprecated in 2.0.1 and will be removed in 2.1.0")]] std::
-      unique_ptr<InputStream>
-      readHdfsFile(const std::string& path, ReaderMetrics* metrics = nullptr);
+  [[deprecated("readHdfsFile is deprecated in 2.0.1")]] std::unique_ptr<InputStream> readHdfsFile(
+      const std::string& path, ReaderMetrics* metrics = nullptr);
 
   /**
    * Create a reader to read the ORC file.

--- a/c++/include/orc/OrcFile.hh
+++ b/c++/include/orc/OrcFile.hh
@@ -127,8 +127,9 @@ namespace orc {
    * @param path the uri of the file in HDFS
    * @param metrics the metrics of the reader
    */
-  std::unique_ptr<InputStream> readHdfsFile(const std::string& path,
-                                            ReaderMetrics* metrics = nullptr);
+  [[deprecated("readHdfsFile is deprecated in 2.0.1 and will be removed in 2.1.0")]] std::
+      unique_ptr<InputStream>
+      readHdfsFile(const std::string& path, ReaderMetrics* metrics = nullptr);
 
   /**
    * Create a reader to read the ORC file.


### PR DESCRIPTION
### What changes were proposed in this pull request?
Mark readHdfsFile as deprecated.

### Why are the changes needed?
Reading ORC on HDFS was introduced in https://github.com/apache/orc/pull/134 without any test. It has not been updated for 7 years and updating libhdfspp will result in extra dependency like boost library. Staying at an old version of libhdfspp will also prohibit us from updating other libraries like protobuf.

### How was this patch tested?
It does not need test.

### Was this patch authored or co-authored using generative AI tooling?
No.
