### PR TITLE
ORC-1688: [C++] Do not access TZDB if there is no timestamp type

### DIFF
--- a/c++/src/Timezone.cc
+++ b/c++/src/Timezone.cc
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <atomic>
 #include <map>
 #include <sstream>
 
@@ -671,6 +672,67 @@ namespace orc {
     return dir;
   }
 
+  static std::vector<unsigned char> loadTZDB(const std::string& filename) {
+    std::vector<unsigned char> buffer;
+    if (!fileExists(filename.c_str())) {
+      std::stringstream ss;
+      ss << "Time zone file " << filename << " does not exist."
+         << " Please install IANA time zone database and set TZDIR env.";
+      throw TimezoneError(ss.str());
+    }
+    try {
+      std::unique_ptr<InputStream> file = readFile(filename);
+      size_t size = static_cast<size_t>(file->getLength());
+      buffer.resize(size);
+      file->read(&buffer[0], size, 0);
+    } catch (ParseError& err) {
+      throw TimezoneError(err.what());
+    }
+    return buffer;
+  }
+
+  class LazyTimezone : public Timezone {
+   private:
+    std::string filename_;
+    mutable std::unique_ptr<TimezoneImpl> impl_;
+    mutable std::atomic<bool> initialized_;
+
+    TimezoneImpl* getImpl() const {
+      if (!initialized_) {
+        std::lock_guard<std::mutex> timezone_lock(timezone_mutex);
+        if (!initialized_) {
+          auto buffer = loadTZDB(filename_);
+          impl_.reset(new TimezoneImpl(filename_, std::move(buffer)));
+        }
+      }
+      return impl_.get();
+    }
+
+   public:
+    LazyTimezone(const std::string& filename) : filename_(filename), initialized_(false) {}
+
+    const TimezoneVariant& getVariant(int64_t clk) const override {
+      return getImpl()->getVariant(clk);
+    }
+    int64_t getEpoch() const override {
+      return getImpl()->getEpoch();
+    }
+    void print(std::ostream& os) const override {
+      return getImpl()->print(os);
+    }
+    uint64_t getVersion() const override {
+      return getImpl()->getVersion();
+    }
+
+    int64_t convertToUTC(int64_t clk) const override {
+      return getImpl()->convertToUTC(clk);
+    }
+
+    int64_t convertFromUTC(int64_t clk) const override {
+      return getImpl()->convertFromUTC(clk);
+    }
+  };
+
   /**
    * Get a timezone by absolute filename.
    * Results are cached.
@@ -682,21 +744,7 @@ namespace orc {
     if (itr != timezoneCache.end()) {
       return *(itr->second).get();
     }
-    if (!fileExists(filename.c_str())) {
-      std::stringstream ss;
-      ss << "Time zone file " << filename << " does not exist."
-         << " Please install IANA time zone database and set TZDIR env.";
-      throw TimezoneError(ss.str());
-    }
-    try {
-      std::unique_ptr<InputStream> file = readFile(filename);
-      size_t size = static_cast<size_t>(file->getLength());
-      std::vector<unsigned char> buffer(size);
-      file->read(&buffer[0], size, 0);
-      timezoneCache[filename] = std::make_shared<TimezoneImpl>(filename, buffer);
-    } catch (ParseError& err) {
-      throw TimezoneError(err.what());
-    }
+    timezoneCache[filename] = std::make_shared<LazyTimezone>(filename);
     return *timezoneCache[filename].get();
   }
 

--- a/c++/test/TestTimezone.cc
+++ b/c++/test/TestTimezone.cc
@@ -431,7 +431,7 @@ namespace orc {
       ASSERT_TRUE(delEnv("TZDIR"));
     }
     ASSERT_TRUE(setEnv("TZDIR", "/path/to/wrong/tzdb"));
-    EXPECT_THAT([]() { getTimezoneByName("America/Los_Angeles"); },
+    EXPECT_THAT([]() { getTimezoneByName("America/Los_Angeles").getVersion(); },
                 testing::ThrowsMessage<TimezoneError>(testing::HasSubstr(
                     "Time zone file /path/to/wrong/tzdb/America/Los_Angeles does not exist."
                     " Please install IANA time zone database and set TZDIR env.")));


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Don't write writer's Time Zone name when there are no timestamp types.
2. Do not access TZDB if there is no timestamp type.


### Why are the changes needed?
This patch could accelerate reading by reducing unnecessary IO.


### How was this patch tested?
All UT passed.

### Was this patch authored or co-authored using generative AI tooling?
NO