### PR TITLE
ORC-1694: Upgrade gson to 2.9.0 for Benchmarks Hive

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,9 @@ updates:
     schedule:
       interval: "weekly"
     ignore:
-      # Pin gson to 2.2.4 because of Hive
+      # Pin gson to 2.9.0 because of Hive
       - dependency-name: "com.google.code.gson:gson"
-        versions: "[2.3,)"
+        versions: "[2.9,1)"
       # Pin jodd-core to 3.5.2
       - dependency-name: "org.jodd:jodd-core"
         versions: "[3.5.3,)"

--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -73,7 +73,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.2.4</version>
+        <version>2.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade gson to 2.9.0 for Benchmarks Hive.

### Why are the changes needed?
ORC-1676 upgraded to Hive4, Hive4 uses gson 2.9.0.

HIVE-26322: Upgrade gson to 2.9.0

https://issues.apache.org/jira/browse/HIVE-26322

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
