### PR TITLE
ORC-1695: Upgrade gson to 2.10.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -135,7 +135,7 @@
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
-        <version>2.9.0</version>
+        <version>2.10.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.protobuf</groupId>

--- a/java/tools/src/test/resources/orc-file-dump.json
+++ b/java/tools/src/test/resources/orc-file-dump.json
@@ -2,7 +2,7 @@
   "fileName": "TestFileDump.testDump.orc",
   "fileVersion": "0.12",
   "writerVersion": "ORC_14",
-  "softwareVersion": "ORC Java 1.9.0-SNAPSHOT",
+  "softwareVersion": "ORC Java 2.1.0-SNAPSHOT",
   "numberOfRows": 21000,
   "compression": "ZLIB",
   "compressionBufferSize": 4096,
@@ -461,48 +461,48 @@
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 1,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 2,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 3,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 4,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             }
           ],
           "stripeLevelBloomFilter": {
             "numHashFunctions": 7,
             "bitCount": 9600,
             "popCount": 238,
-            "loadFactor": 0.024791667237877846,
-            "expectedFpp": 5.756256582500896E-12
+            "loadFactor": 0.024791667,
+            "expectedFpp": 5.7562566E-12
           }
         }
       ]
@@ -704,48 +704,48 @@
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 1,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 2,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 3,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 4,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             }
           ],
           "stripeLevelBloomFilter": {
             "numHashFunctions": 7,
             "bitCount": 9600,
             "popCount": 238,
-            "loadFactor": 0.024791667237877846,
-            "expectedFpp": 5.756256582500896E-12
+            "loadFactor": 0.024791667,
+            "expectedFpp": 5.7562566E-12
           }
         }
       ]
@@ -947,48 +947,48 @@
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 1,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 2,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 3,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 4,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             }
           ],
           "stripeLevelBloomFilter": {
             "numHashFunctions": 7,
             "bitCount": 9600,
             "popCount": 238,
-            "loadFactor": 0.024791667237877846,
-            "expectedFpp": 5.756256582500896E-12
+            "loadFactor": 0.024791667,
+            "expectedFpp": 5.7562566E-12
           }
         }
       ]
@@ -1190,48 +1190,48 @@
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 1,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 2,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 3,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             },
             {
               "entryId": 4,
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             }
           ],
           "stripeLevelBloomFilter": {
             "numHashFunctions": 7,
             "bitCount": 9600,
             "popCount": 238,
-            "loadFactor": 0.024791667237877846,
-            "expectedFpp": 5.756256582500896E-12
+            "loadFactor": 0.024791667,
+            "expectedFpp": 5.7562566E-12
           }
         }
       ]
@@ -1361,16 +1361,16 @@
               "numHashFunctions": 7,
               "bitCount": 9600,
               "popCount": 238,
-              "loadFactor": 0.024791667237877846,
-              "expectedFpp": 5.756256582500896E-12
+              "loadFactor": 0.024791667,
+              "expectedFpp": 5.7562566E-12
             }
           ],
           "stripeLevelBloomFilter": {
             "numHashFunctions": 7,
             "bitCount": 9600,
             "popCount": 238,
-            "loadFactor": 0.024791667237877846,
-            "expectedFpp": 5.756256582500896E-12
+            "loadFactor": 0.024791667,
+            "expectedFpp": 5.7562566E-12
           }
         }
       ]


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade `Gson` to `2.10.1`.

### Why are the changes needed?
Jan 7, 2023

https://github.com/google/gson/releases/tag/gson-parent-2.10.1

Oct 25, 2022

https://github.com/google/gson/releases/tag/gson-parent-2.10

Aug 1, 2022

https://github.com/google/gson/releases/tag/gson-parent-2.9.1

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
