### PR TITLE
ORC-1696: Fix ClassCastException when reading avro decimal type in bechmark

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/avro/AvroReader.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/avro/AvroReader.java
@@ -191,8 +191,10 @@ public class AvroReader implements BatchReader {
 
   private static class DecimalConverter implements AvroConverter {
     final int scale;
+    final double multiplier;
     DecimalConverter(int scale) {
       this.scale = scale;
+      this.multiplier = Math.pow(10.0, this.scale);
     }
     public void convert(ColumnVector cv, int row, Object value) {
       if (value == null) {
@@ -200,7 +202,11 @@ public class AvroReader implements BatchReader {
         cv.isNull[row] = true;
       } else {
         DecimalColumnVector tc = (DecimalColumnVector) cv;
-        tc.vector[row].set(getHiveDecimalFromByteBuffer((ByteBuffer) value, scale));
+        if (value instanceof ByteBuffer) {
+          tc.vector[row].set(getHiveDecimalFromByteBuffer((ByteBuffer) value, scale));
+        } else {
+          tc.vector[row].set(HiveDecimal.create(Math.round((double) value * multiplier)));
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix `ClassCastException` when reading avro decimal type in bechmark.

### Why are the changes needed?
ORC-1191 Forcing `object` to `double`, but object type is `ByteBuffer`, which causes scan to fail.

```bash
 java -jar core/target/orc-benchmarks-core-*-uber.jar scan data
```

```java
Exception in thread "main" java.lang.ClassCastException: class java.nio.HeapByteBuffer cannot be cast to class java.lang.Double (java.nio.HeapByteBuffer and java.lang.Double are in module java.base of loader 'bootstrap')
	at org.apache.orc.bench.core.convert.avro.AvroReader$DecimalConverter.convert(AvroReader.java:204)
	at org.apache.orc.bench.core.convert.avro.AvroReader.nextBatch(AvroReader.java:69)
	at org.apache.orc.bench.core.convert.ScanVariants.run(ScanVariants.java:92)
	at org.apache.orc.bench.core.Driver.main(Driver.java:64)
```


### How was this patch tested?
local test
```bash
 java -jar core/target/orc-benchmarks-core-*-uber.jar scan data
```
output
```
data/generated/taxi/avro.snappy rows: 22758236 batches: 22225
```

### Was this patch authored or co-authored using generative AI tooling?
No
