### PR TITLE
ORC-1699: Fix SparkBenchmark in Parquet format according to SPARK-40918

### DIFF
--- a/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
+++ b/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
@@ -195,6 +195,9 @@ public class SparkBenchmark implements OrcBenchmark {
       case "orc":
         options.add(new Tuple2<>("returning_batch", "true")); // SPARK-40918
         break;
+      case "parquet":
+        options.add(new Tuple2<>("returning_batch", "true")); // SPARK-40918
+        break;
       default:
         break;
     }
@@ -226,6 +229,9 @@ public class SparkBenchmark implements OrcBenchmark {
       case "avro":
         throw new IllegalArgumentException(source.format + " can't handle projection");
       case "orc":
+        options.add(new Tuple2<>("returning_batch", "true")); // SPARK-40918
+        break;
+      case "parquet":
         options.add(new Tuple2<>("returning_batch", "true")); // SPARK-40918
         break;
       default:
@@ -301,6 +307,9 @@ public class SparkBenchmark implements OrcBenchmark {
       case "avro":
         throw new IllegalArgumentException(source.format + " can't handle pushdown");
       case "orc":
+        options.add(new Tuple2<>("returning_batch", "true")); // SPARK-40918
+        break;
+      case "parquet":
         options.add(new Tuple2<>("returning_batch", "true")); // SPARK-40918
         break;
       default:


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix SparkBenchmark in Parquet format according to SPARK-40918.


### Why are the changes needed?
Similar to [ORC-1578](https://issues.apache.org/jira/browse/ORC-1578), there are similar problems when reading parquet format files in SparkBenchmark.




```java
java.lang.IllegalArgumentException: OPTION_RETURNING_BATCH should always be set for ParquetFileFormat. To workaround this issue, set spark.sql.parquet.enableVectorizedReader=false.
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat.$anonfun$buildReaderWithPartitionValues$1(ParquetFileFormat.scala:192)
	at scala.collection.immutable.Map$EmptyMap$.getOrElse(Map.scala:110)
	at org.apache.spark.sql.execution.datasources.parquet.ParquetFileFormat.buildReaderWithPartitionValues(ParquetFileFormat.scala:191)
	at org.apache.orc.bench.spark.SparkBenchmark.pushDown(SparkBenchmark.java:314)
	at org.apache.orc.bench.spark.jmh_generated.SparkBenchmark_pushDown_jmhTest.pushDown_avgt_jmhStub(SparkBenchmark_pushDown_jmhTest.java:219)
```


### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No