### PR TITLE
ORC-1707: Fix `sun.util.calendar` IllegalAccessException when SparkBenchmark runs on JDK17

### DIFF
--- a/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
+++ b/java/bench/spark/src/java/org/apache/orc/bench/spark/SparkBenchmark.java
@@ -74,7 +74,8 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @AutoService(OrcBenchmark.class)
-@Fork(jvmArgsAppend = "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED")
+@Fork(jvmArgsAppend = {"--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED"})
 public class SparkBenchmark implements OrcBenchmark {
 
   private static final Path root = Utilities.getBenchmarkRoot();


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix `sun.util.calendar` IllegalAccessException when SparkBenchmark runs on JDK17.

### Why are the changes needed?
https://github.com/apache/orc/pull/1909#discussion_r1585891308

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No