### PR TITLE
ORC-1715: Bump org.objenesis:objenesis to 3.3

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>org.objenesis</groupId>
       <artifactId>objenesis</artifactId>
-      <version>3.2</version>
+      <version>3.3</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -251,7 +251,7 @@
       <dependency>
         <groupId>org.objenesis</groupId>
         <artifactId>objenesis</artifactId>
-        <version>3.2</version>
+        <version>3.3</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade objenesis to 3.3.


### Why are the changes needed?
objenesis 3.3 is used by Spark 3.5.1.

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.

closes #1922 