### PR TITLE
MINOR: Add ffacs in collaborators list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,6 +24,8 @@ github:
     merge: false
     squash: true
     rebase: true
+  collaborators:
+    - ffacs
   labels:
     - apache
     - orc


### PR DESCRIPTION
### Why are the changes needed?
Recently I am active on maintaining C++ codes. The contributions can be seembelow:
https://github.com/apache/orc/pulls?q=is%3Apr+author%3Affacs+is%3Aclosed

I want to add myself as collaborators.

### How was this patch tested?

No tests

### Was this patch authored or co-authored using generative AI tooling?

No
