### PR TITLE
ORC-1389: [C++] Support schema evolution from string group to numeric/string group

### DIFF
--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -24,6 +24,7 @@
 #include "RLE.hh"
 #include "Statistics.hh"
 #include "Timezone.hh"
+#include "Utils.hh"
 
 namespace orc {
   StreamsFactory::~StreamsFactory() {
@@ -1355,75 +1356,6 @@ namespace orc {
 
     deleteDictStreams();
   }
-
-  struct Utf8Utils {
-    /**
-     * Counts how many utf-8 chars of the input data
-     */
-    static uint64_t charLength(const char* data, uint64_t length) {
-      uint64_t chars = 0;
-      for (uint64_t i = 0; i < length; i++) {
-        if (isUtfStartByte(data[i])) {
-          chars++;
-        }
-      }
-      return chars;
-    }
-
-    /**
-     * Return the number of bytes required to read at most maxCharLength
-     * characters in full from a utf-8 encoded byte array provided
-     * by data. This does not validate utf-8 data, but
-     * operates correctly on already valid utf-8 data.
-     *
-     * @param maxCharLength number of characters required
-     * @param data the bytes of UTF-8
-     * @param length the length of data to truncate
-     */
-    static uint64_t truncateBytesTo(uint64_t maxCharLength, const char* data, uint64_t length) {
-      uint64_t chars = 0;
-      if (length <= maxCharLength) {
-        return length;
-      }
-      for (uint64_t i = 0; i < length; i++) {
-        if (isUtfStartByte(data[i])) {
-          chars++;
-        }
-        if (chars > maxCharLength) {
-          return i;
-        }
-      }
-      // everything fits
-      return length;
-    }
-
-    /**
-     * Checks if b is the first byte of a UTF-8 character.
-     */
-    inline static bool isUtfStartByte(char b) {
-      return (b & 0xC0) != 0x80;
-    }
-
-    /**
-     * Find the start of the last character that ends in the current string.
-     * @param text the bytes of the utf-8
-     * @param from the first byte location
-     * @param until the last byte location
-     * @return the index of the last character
-     */
-    static uint64_t findLastCharacter(const char* text, uint64_t from, uint64_t until) {
-      uint64_t posn = until;
-      /* we don't expect characters more than 5 bytes */
-      while (posn >= from) {
-        if (isUtfStartByte(text[posn])) {
-          return posn;
-        }
-        posn -= 1;
-      }
-      /* beginning of a valid char not found */
-      throw std::logic_error("Could not truncate string, beginning of a valid char not found");
-    }
-  };
 
   class CharColumnWriter : public StringColumnWriter {
    public:

--- a/c++/src/ConvertColumnReader.cc
+++ b/c++/src/ConvertColumnReader.cc
@@ -722,17 +722,12 @@ namespace orc {
     void convertToInteger(ReadTypeBatch& dstBatch, const StringVectorBatch& srcBatch,
                           uint64_t idx) {
       int64_t longValue = 0;
-      if (throwOnOverflow) {
+      try {
         longValue = std::stoll(std::string(srcBatch.data[idx], srcBatch.length[idx]));
-      } else {
-        try {
-          longValue = std::stoll(std::string(srcBatch.data[idx], srcBatch.length[idx]));
-        } catch (...) {
-          handleOverflow<std::string, ReadType>(dstBatch, idx, throwOnOverflow);
-          return;
-        }
+      } catch (...) {
+        handleOverflow<std::string, ReadType>(dstBatch, idx, throwOnOverflow);
+        return;
       }
-
       if constexpr (std::is_same_v<ReadType, bool>) {
         dstBatch.data[idx] = longValue == 0 ? 0 : 1;
       } else {
@@ -743,22 +738,14 @@ namespace orc {
     }
 
     void convertToDouble(ReadTypeBatch& dstBatch, const StringVectorBatch& srcBatch, uint64_t idx) {
-      if (throwOnOverflow) {
+      try {
         if constexpr (std::is_same_v<ReadType, float>) {
           dstBatch.data[idx] = std::stof(std::string(srcBatch.data[idx], srcBatch.length[idx]));
         } else {
           dstBatch.data[idx] = std::stod(std::string(srcBatch.data[idx], srcBatch.length[idx]));
         }
-      } else {
-        try {
-          if constexpr (std::is_same_v<ReadType, float>) {
-            dstBatch.data[idx] = std::stof(std::string(srcBatch.data[idx], srcBatch.length[idx]));
-          } else {
-            dstBatch.data[idx] = std::stod(std::string(srcBatch.data[idx], srcBatch.length[idx]));
-          }
-        } catch (...) {
-          handleOverflow<std::string, ReadType>(dstBatch, idx, throwOnOverflow);
-        }
+      } catch (...) {
+        handleOverflow<std::string, ReadType>(dstBatch, idx, throwOnOverflow);
       }
     }
   };

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -80,7 +80,7 @@ namespace orc {
     if (readType.getKind() == fileType.getKind()) {
       ret.isValid = true;
       if (fileType.getKind() == CHAR || fileType.getKind() == VARCHAR) {
-        ret.isValid = readType.getMaximumLength() == fileType.getMaximumLength();
+        ret.needConvert = readType.getMaximumLength() != fileType.getMaximumLength();
       } else if (fileType.getKind() == DECIMAL) {
         ret.needConvert = readType.getPrecision() != fileType.getPrecision() ||
                           readType.getScale() != fileType.getScale();
@@ -105,7 +105,10 @@ namespace orc {
         }
         case STRING:
         case CHAR:
-        case VARCHAR:
+        case VARCHAR: {
+          ret.isValid = ret.needConvert = isStringVariant(readType) || isNumeric(readType);
+          break;
+        }
         case TIMESTAMP:
         case TIMESTAMP_INSTANT:
         case DATE:

--- a/c++/src/Utils.hh
+++ b/c++/src/Utils.hh
@@ -21,6 +21,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <stdexcept>
 
 namespace orc {
 
@@ -69,6 +70,75 @@ namespace orc {
 #define SCOPED_STOPWATCH(METRICS_PTR, LATENCY_VAR, COUNT_VAR)
 #define SCOPED_MINUS_STOPWATCH(METRICS_PTR, LATENCY_VAR)
 #endif
+
+  struct Utf8Utils {
+    /**
+     * Counts how many utf-8 chars of the input data
+     */
+    static uint64_t charLength(const char* data, uint64_t length) {
+      uint64_t chars = 0;
+      for (uint64_t i = 0; i < length; i++) {
+        if (isUtfStartByte(data[i])) {
+          chars++;
+        }
+      }
+      return chars;
+    }
+
+    /**
+     * Return the number of bytes required to read at most maxCharLength
+     * characters in full from a utf-8 encoded byte array provided
+     * by data. This does not validate utf-8 data, but
+     * operates correctly on already valid utf-8 data.
+     *
+     * @param maxCharLength number of characters required
+     * @param data the bytes of UTF-8
+     * @param length the length of data to truncate
+     */
+    static uint64_t truncateBytesTo(uint64_t maxCharLength, const char* data, uint64_t length) {
+      uint64_t chars = 0;
+      if (length <= maxCharLength) {
+        return length;
+      }
+      for (uint64_t i = 0; i < length; i++) {
+        if (isUtfStartByte(data[i])) {
+          chars++;
+        }
+        if (chars > maxCharLength) {
+          return i;
+        }
+      }
+      // everything fits
+      return length;
+    }
+
+    /**
+     * Checks if b is the first byte of a UTF-8 character.
+     */
+    inline static bool isUtfStartByte(char b) {
+      return (b & 0xC0) != 0x80;
+    }
+
+    /**
+     * Find the start of the last character that ends in the current string.
+     * @param text the bytes of the utf-8
+     * @param from the first byte location
+     * @param until the last byte location
+     * @return the index of the last character
+     */
+    static uint64_t findLastCharacter(const char* text, uint64_t from, uint64_t until) {
+      uint64_t posn = until;
+      /* we don't expect characters more than 5 bytes */
+      while (posn >= from) {
+        if (isUtfStartByte(text[posn])) {
+          return posn;
+        }
+        posn -= 1;
+      }
+      /* beginning of a valid char not found */
+      throw std::logic_error("Could not truncate string, beginning of a valid char not found");
+    }
+  };
 
 }  // namespace orc
 

--- a/c++/test/TestSchemaEvolution.cc
+++ b/c++/test/TestSchemaEvolution.cc
@@ -148,6 +148,22 @@ namespace orc {
       }
     }
 
+    // conversion from string variant to numeric
+    for (size_t i = 7; i <= 11; i++) {
+      for (size_t j = 0; j <= 6; j++) {
+        canConvert[i][j] = true;
+        needConvert[i][j] = true;
+      }
+    }
+
+    // conversion from string variant to string variant
+    for (size_t i = 7; i <= 11; i++) {
+      for (size_t j = 7; j <= 11; j++) {
+        canConvert[i][j] = true;
+        needConvert[i][j] = (i != j);
+      }
+    }
+
     for (size_t i = 0; i < typesSize; i++) {
       for (size_t j = 0; j < typesSize; j++) {
         testConvertReader(types[i], types[j], canConvert[i][j], needConvert[i][j]);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support conversion from

{string, char, varchar}
to
{boolean, byte, short, int, long, float, double, string, char, varchar}

### Why are the changes needed?
To support schema evolution on c++ side.

### How was this patch tested?
UT passed

### Was this patch authored or co-authored using generative AI tooling?
NO
