### PR TITLE
ORC-1711:[C++] Introduce a memory block size parameter for write option

### DIFF
--- a/c++/include/orc/Writer.hh
+++ b/c++/include/orc/Writer.hh
@@ -266,17 +266,17 @@ namespace orc {
     bool getUseTightNumericVector() const;
 
     /**
-     * Set the initial capacity of output buffer in the class BufferedOutputStream.
+     * Set the initial block size of input buffer in the class CompressionStream.
      * Each column contains one or more BufferOutputStream depending on its type,
      * and these buffers will automatically expand when more memory is required.
      */
-    WriterOptions& setOutputBufferCapacity(uint64_t capacity);
+    WriterOptions& setMemoryBlockSize(uint64_t capacity);
 
     /**
-     * Get the initial capacity of output buffer in the class BufferedOutputStream.
-     * @return if not set, return default value which is 1 MB.
+     * Get the initial block size of input buffer in the class CompressionStream.
+     * @return if not set, return default value which is 64 KB.
      */
-    uint64_t getOutputBufferCapacity() const;
+    uint64_t getMemoryBlockSize() const;
   };
 
   class Writer {

--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -186,16 +186,15 @@ namespace orc {
 
   void ByteRleEncoderImpl::recordPosition(PositionRecorder* recorder) const {
     uint64_t flushedSize = outputStream->getSize();
-    uint64_t unflushedSize = static_cast<uint64_t>(bufferPosition);
+    uint64_t unusedBufferSize = static_cast<uint64_t>(bufferLength - bufferPosition);
     if (outputStream->isCompressed()) {
       // start of the compression chunk in the stream
       recorder->add(flushedSize);
       // number of decompressed bytes that need to be consumed
-      recorder->add(unflushedSize);
+      recorder->add(outputStream->getRawInputBufferSize() - unusedBufferSize);
     } else {
-      flushedSize -= static_cast<uint64_t>(bufferLength);
       // byte offset of the RLE run’s start location
-      recorder->add(flushedSize + unflushedSize);
+      recorder->add(flushedSize - unusedBufferSize);
     }
     recorder->add(static_cast<uint64_t>(numLiterals));
   }

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -50,7 +50,7 @@ namespace orc {
     return createCompressor(options_.getCompression(), outStream_,
                             options_.getCompressionStrategy(),
                             // BufferedOutputStream initial capacity
-                            options_.getOutputBufferCapacity(), options_.getCompressionBlockSize(),
+                            options_.getCompressionBlockSize(), options_.getMemoryBlockSize(),
                             *options_.getMemoryPool(), options_.getWriterMetrics());
   }
 

--- a/c++/src/RLE.cc
+++ b/c++/src/RLE.cc
@@ -108,13 +108,14 @@ namespace orc {
 
   void RleEncoder::recordPosition(PositionRecorder* recorder) const {
     uint64_t flushedSize = outputStream->getSize();
-    uint64_t unflushedSize = static_cast<uint64_t>(bufferPosition);
+    uint64_t unusedBufferSize =
+        static_cast<uint64_t>(bufferLength - bufferPosition);
     if (outputStream->isCompressed()) {
       recorder->add(flushedSize);
-      recorder->add(unflushedSize);
+      // number of decompressed bytes that need to be consumed
+      recorder->add(outputStream->getRawInputBufferSize() - unusedBufferSize);
     } else {
-      flushedSize -= static_cast<uint64_t>(bufferLength);
-      recorder->add(flushedSize + unflushedSize);
+      recorder->add(flushedSize - unusedBufferSize);
     }
     recorder->add(static_cast<uint64_t>(numLiterals));
   }

--- a/c++/src/io/OutputStream.cc
+++ b/c++/src/io/OutputStream.cc
@@ -98,6 +98,12 @@ namespace orc {
     dataBuffer_->resize(0);
   }
 
+  uint64_t BufferedOutputStream::getRawInputBufferSize() const {
+    // we're unable to determine the size of the raw input buffer
+    // simply return 0
+    return 0;
+  }
+
   void AppendOnlyBufferedStream::write(const char* data, size_t size) {
     size_t dataOffset = 0;
     while (size > 0) {
@@ -128,16 +134,15 @@ namespace orc {
 
   void AppendOnlyBufferedStream::recordPosition(PositionRecorder* recorder) const {
     uint64_t flushedSize = outStream_->getSize();
-    uint64_t unflushedSize = static_cast<uint64_t>(bufferOffset_);
+    uint64_t unusedBufferSize = static_cast<uint64_t>(bufferLength_ - bufferOffset_);
     if (outStream_->isCompressed()) {
       // start of the compression chunk in the stream
       recorder->add(flushedSize);
       // number of decompressed bytes that need to be consumed
-      recorder->add(unflushedSize);
+      recorder->add(outStream_->getRawInputBufferSize() - unusedBufferSize);
     } else {
-      flushedSize -= static_cast<uint64_t>(bufferLength_);
       // byte offset of the start location
-      recorder->add(flushedSize + unflushedSize);
+      recorder->add(flushedSize - unusedBufferSize);
     }
   }
 

--- a/c++/src/io/OutputStream.hh
+++ b/c++/src/io/OutputStream.hh
@@ -69,6 +69,7 @@ namespace orc {
     virtual uint64_t getSize() const;
     virtual uint64_t flush();
     virtual void suppress();
+    virtual uint64_t getRawInputBufferSize() const;
 
     virtual bool isCompressed() const {
       return false;

--- a/c++/test/TestDictionaryEncoding.cc
+++ b/c++/test/TestDictionaryEncoding.cc
@@ -53,7 +53,7 @@ namespace orc {
 
     WriterOptions options;
     options.setStripeSize(1024);
-    options.setCompressionBlockSize(1024);
+    options.setMemoryBlockSize(1024);
     options.setCompression(CompressionKind_ZLIB);
     options.setMemoryPool(pool);
     options.setDictionaryKeySizeThreshold(threshold);
@@ -109,7 +109,7 @@ namespace orc {
 
     WriterOptions options;
     options.setStripeSize(1024);
-    options.setCompressionBlockSize(1024);
+    options.setMemoryBlockSize(1024);
     options.setCompression(CompressionKind_ZLIB);
     options.setMemoryPool(pool);
     options.setDictionaryKeySizeThreshold(threshold);
@@ -170,7 +170,7 @@ namespace orc {
 
     WriterOptions options;
     options.setStripeSize(1024);
-    options.setCompressionBlockSize(1024);
+    options.setMemoryBlockSize(1024);
     options.setCompression(CompressionKind_ZLIB);
     options.setMemoryPool(pool);
     options.setDictionaryKeySizeThreshold(threshold);
@@ -233,7 +233,7 @@ namespace orc {
 
     WriterOptions options;
     options.setStripeSize(1024);
-    options.setCompressionBlockSize(1024);
+    options.setMemoryBlockSize(1024);
     options.setCompression(CompressionKind_ZLIB);
     options.setMemoryPool(pool);
     options.setDictionaryKeySizeThreshold(threshold);
@@ -302,7 +302,8 @@ namespace orc {
 
     WriterOptions options;
     options.setStripeSize(1);
-    options.setCompressionBlockSize(1024);
+    options.setMemoryBlockSize(1024);
+    options.setCompressionBlockSize(2 * 1024);
     options.setCompression(CompressionKind_ZLIB);
     options.setMemoryPool(pool);
     options.setDictionaryKeySizeThreshold(threshold);

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -41,7 +41,8 @@ namespace orc {
 
   const int DEFAULT_MEM_STREAM_SIZE = 100 * 1024 * 1024;  // 100M
 
-  std::unique_ptr<Writer> createWriter(uint64_t stripeSize, uint64_t compresionblockSize,
+  std::unique_ptr<Writer> createWriter(uint64_t stripeSize, uint64_t memoryBlockSize,
+                                       uint64_t compresionblockSize,
                                        CompressionKind compression, const Type& type,
                                        MemoryPool* memoryPool, OutputStream* stream,
                                        FileVersion version, uint64_t stride = 0,
@@ -56,6 +57,7 @@ namespace orc {
     options.setFileVersion(version);
     options.setTimezoneName(timezone);
     options.setUseTightNumericVector(useTightNumericVector);
+    options.setMemoryBlockSize(memoryBlockSize);
     return createWriter(type, stream, options);
   }
 
@@ -107,9 +109,10 @@ namespace orc {
 
     uint64_t stripeSize = 16 * 1024;       // 16K
     uint64_t compressionBlockSize = 1024;  // 1k
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     writer->close();
 
@@ -135,9 +138,10 @@ namespace orc {
 
     uint64_t stripeSize = 16 * 1024;       // 16K
     uint64_t compressionBlockSize = 1024;  // 1k
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(1024);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -195,9 +199,10 @@ namespace orc {
 
     uint64_t stripeSize = 1024;            // 1K
     uint64_t compressionBlockSize = 1024;  // 1k
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(65535);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -241,12 +246,13 @@ namespace orc {
 
     uint64_t stripeSize = 1024;            // 1K
     uint64_t compressionBlockSize = 1024;  // 1k
+    uint64_t memoryBlockSize = 64;
 
     char dataBuffer[327675];
     uint64_t offset = 0;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(65535);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -301,6 +307,7 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 655350;
+    uint64_t memoryBlockSize = 64;
 
     std::vector<double> data(rowCount);
     for (uint64_t i = 0; i < rowCount; ++i) {
@@ -308,7 +315,7 @@ namespace orc {
     }
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -356,9 +363,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 65535;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -406,9 +414,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 65535;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -446,9 +455,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 65535;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -486,9 +496,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 1024;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
 
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
@@ -527,9 +538,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 102400;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -568,7 +580,7 @@ namespace orc {
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
     MemoryPool* pool = getDefaultPool();
     std::unique_ptr<Type> type(Type::buildTypeFromString("struct<a:timestamp>"));
-    auto writer = createWriter(16 * 1024 * 1024, 64 * 1024, CompressionKind_ZLIB, *type, pool,
+    auto writer = createWriter(16 * 1024 * 1024, 64 * 1024, 256 * 1024, CompressionKind_ZLIB, *type, pool,
                                &memStream, fileVersion);
     uint64_t batchCount = 5;
     auto batch = writer->createRowBatch(batchCount * 2);
@@ -638,9 +650,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 1;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion, 0, writerTimezone);
     auto batch = writer->createRowBatch(rowCount);
     auto& structBatch = dynamic_cast<StructVectorBatch&>(*batch);
@@ -734,9 +747,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 102400;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -779,12 +793,13 @@ namespace orc {
     uint64_t stripeSize = 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 65535;
+    uint64_t memoryBlockSize = 64;
 
     char dataBuffer[327675];
     uint64_t offset = 0;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
 
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
@@ -858,9 +873,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;       // 16K
     uint64_t compressionBlockSize = 1024;  // 1k
     uint64_t rowCount = 1024;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -934,9 +950,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 1024;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -1022,9 +1039,10 @@ namespace orc {
     uint64_t rowCount = 1024;
     uint64_t maxListLength = 10;
     uint64_t offset = 0;
+    uint64_t memoryBlockSize = 8 * 1024;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount * maxListLength);
 
@@ -1081,9 +1099,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 1024, maxListLength = 10, offset = 0;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount * maxListLength);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -1162,9 +1181,10 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 3333;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -1257,8 +1277,9 @@ namespace orc {
     uint64_t stripeSize = 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 3;
+    uint64_t memoryBlockSize = 64;
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -1326,9 +1347,10 @@ namespace orc {
 
     uint64_t stripeSize = 1024;
     uint64_t compressionBlockSize = 1024;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
 
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(4);
@@ -1407,9 +1429,10 @@ namespace orc {
 
     uint64_t stripeSize = 1024;
     uint64_t compressionBlockSize = 1024;
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
 
     // test data looks like below -
@@ -1485,11 +1508,12 @@ namespace orc {
 
     uint64_t stripeSize = 1024;
     uint64_t compressionBlockSize = 1024;
+    uint64_t memoryBlockSize = 64;
 
     // 10000 rows with every 1000 row as an RG
     // Each RG has 100 null rows except that the 5th RG is all null
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion, 1000);
 
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(10000);
@@ -1622,12 +1646,13 @@ namespace orc {
   TEST_P(WriterTest, testBloomFilter) {
     WriterOptions options;
     options.setStripeSize(1024)
-        .setCompressionBlockSize(64)
+        .setCompressionBlockSize(1024)
         .setCompression(CompressionKind_ZSTD)
         .setMemoryPool(getDefaultPool())
         .setRowIndexStride(10000)
         .setFileVersion(fileVersion)
-        .setColumnsUseBloomFilter({1, 2, 3});
+        .setColumnsUseBloomFilter({1, 2, 3})
+        .setMemoryBlockSize(64);
 
     // write 65535 rows of data
     MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
@@ -1716,7 +1741,7 @@ namespace orc {
       auto type = std::unique_ptr<Type>(Type::buildTypeFromString("struct<col1:int,col2:int>"));
       WriterOptions options;
       options.setStripeSize(1024 * 1024)
-          .setCompressionBlockSize(1024)
+          .setMemoryBlockSize(1024)
           .setCompression(CompressionKind_NONE)
           .setMemoryPool(pool)
           .setRowIndexStride(1000);
@@ -1809,7 +1834,7 @@ namespace orc {
     uint64_t rowCount = 5000000;
     auto type = std::unique_ptr<Type>(Type::buildTypeFromString("struct<c0:int>"));
     WriterOptions options;
-    options.setStripeSize(1024).setCompressionBlockSize(1024).setCompression(kind).setMemoryPool(
+    options.setStripeSize(1024).setMemoryBlockSize(1024).setCompression(kind).setMemoryPool(
         pool);
 
     auto writer = createWriter(*type, &memStream, options);
@@ -1852,11 +1877,11 @@ namespace orc {
       auto type = std::unique_ptr<Type>(Type::buildTypeFromString("struct<col1:int,col2:int>"));
       WriterOptions options;
       options.setStripeSize(1024 * 1024)
-          .setCompressionBlockSize(64 * 1024)
+          .setMemoryBlockSize(64 * 1024)
           .setCompression(CompressionKind_NONE)
           .setMemoryPool(pool)
           .setRowIndexStride(1000)
-          .setOutputBufferCapacity(capacity);
+          .setCompressionBlockSize(capacity);
 
       auto writer = createWriter(*type, &memStream, options);
       auto batch = writer->createRowBatch(rowCount);
@@ -1913,6 +1938,7 @@ namespace orc {
     uint64_t stripeSize = 16 * 1024;
     uint64_t compressionBlockSize = 1024;
     uint64_t rowCount = 65530;
+    uint64_t memoryBlockSize = 64;
 
     std::vector<double> data(rowCount);
     for (uint64_t i = 0; i < rowCount; ++i) {
@@ -1920,7 +1946,7 @@ namespace orc {
     }
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion, 0, "GMT", true);
     // start from here/
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(rowCount / 2);
@@ -2010,9 +2036,10 @@ namespace orc {
 
     uint64_t stripeSize = 1024;            // 1K
     uint64_t compressionBlockSize = 1024;  // 1k
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(65535);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -2065,9 +2092,10 @@ namespace orc {
 
     uint64_t stripeSize = 1024;            // 1K
     uint64_t compressionBlockSize = 1024;  // 1k
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion);
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(65535);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());
@@ -2130,7 +2158,7 @@ namespace orc {
       auto type = std::unique_ptr<Type>(Type::buildTypeFromString("struct<col1:int>"));
       WriterOptions options;
       options.setStripeSize(16 * 1024)
-          .setCompressionBlockSize(1024)
+          .setMemoryBlockSize(1024)
           .setCompression(CompressionKind_NONE)
           .setMemoryPool(pool)
           .setRowIndexStride(1000);
@@ -2208,9 +2236,10 @@ namespace orc {
 
     uint64_t stripeSize = 1024;            // 1K
     uint64_t compressionBlockSize = 1024;  // 1k
+    uint64_t memoryBlockSize = 64;
 
     std::unique_ptr<Writer> writer =
-        createWriter(stripeSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
+        createWriter(stripeSize, memoryBlockSize, compressionBlockSize, CompressionKind_ZLIB, *type, pool,
                      &memStream, fileVersion, 0, "/ERROR/TIMEZONE");
     std::unique_ptr<ColumnVectorBatch> batch = writer->createRowBatch(10);
     StructVectorBatch* structBatch = dynamic_cast<StructVectorBatch*>(batch.get());


### PR DESCRIPTION
What changes were proposed in this pull request?
1.  Add the memory block size parameter to the writer option, which initializing the compressed input buffer block size
2. The compressed stream will retain the input buffer until the input buffer size reaches the compression block size, allowing the compressed stream to start with a minimal initial memory footprint.

Why are the changes needed?
This code segment distinguishes between the compression block size and the input buffer size to solve the [issue](https://issues.apache.org/jira/browse/ORC-1711).

How was this patch tested?
The UTs in TestCompression.cc and TestWriter.cc can cover this patch.