### PR TITLE
ORC-1720: [C++] Unified compressor/decompressor exception types

### DIFF
--- a/c++/include/orc/Exceptions.hh
+++ b/c++/include/orc/Exceptions.hh
@@ -67,6 +67,28 @@ namespace orc {
     SchemaEvolutionError(const SchemaEvolutionError&);
     SchemaEvolutionError& operator=(const SchemaEvolutionError&) = delete;
   };
+
+  class CompressionError : public std::runtime_error {
+   public:
+    explicit CompressionError(const std::string& whatArg);
+    explicit CompressionError(const char* whatArg);
+    ~CompressionError() noexcept override;
+    CompressionError(const CompressionError&);
+
+   private:
+    CompressionError& operator=(const CompressionError&);
+  };
+
+  class DecompressionError : public std::runtime_error {
+   public:
+    explicit DecompressionError(const std::string& whatArg);
+    explicit DecompressionError(const char* whatArg);
+    ~DecompressionError() noexcept override;
+    DecompressionError(const DecompressionError&);
+
+   private:
+    DecompressionError& operator=(const DecompressionError&);
+  };
 }  // namespace orc
 
 #endif

--- a/c++/include/orc/Exceptions.hh
+++ b/c++/include/orc/Exceptions.hh
@@ -79,16 +79,6 @@ namespace orc {
     CompressionError& operator=(const CompressionError&);
   };
 
-  class DecompressionError : public std::runtime_error {
-   public:
-    explicit DecompressionError(const std::string& whatArg);
-    explicit DecompressionError(const char* whatArg);
-    ~DecompressionError() noexcept override;
-    DecompressionError(const DecompressionError&);
-
-   private:
-    DecompressionError& operator=(const DecompressionError&);
-  };
 }  // namespace orc
 
 #endif

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -128,12 +128,12 @@ namespace orc {
     while (offset < size) {
       if (outputPosition == outputSize) {
         if (!BufferedOutputStream::Next(reinterpret_cast<void**>(&outputBuffer), &outputSize)) {
-          throw std::runtime_error("Failed to get next output buffer from output stream.");
+          throw CompressionError("Failed to get next output buffer from output stream.");
         }
         outputPosition = 0;
       } else if (outputPosition > outputSize) {
         // for safety this will unlikely happen
-        throw std::logic_error("Write to an out-of-bound place during compression!");
+        throw CompressionError("Write to an out-of-bound place during compression!");
       }
       int currentSize = std::min(outputSize - outputPosition, size - offset);
       memcpy(outputBuffer + outputPosition, data + offset, static_cast<size_t>(currentSize));
@@ -147,7 +147,7 @@ namespace orc {
     for (uint32_t i = 0; i < HEADER_SIZE; ++i) {
       if (outputPosition >= outputSize) {
         if (!BufferedOutputStream::Next(reinterpret_cast<void**>(&outputBuffer), &outputSize)) {
-          throw std::runtime_error("Failed to get next output buffer from output stream.");
+          throw CompressionError("Failed to get next output buffer from output stream.");
         }
         outputPosition = 0;
       }
@@ -188,7 +188,7 @@ namespace orc {
     uint64_t backup = static_cast<uint64_t>(count);
     uint64_t currSize = rawInputBuffer.size();
     if (backup > currSize) {
-      throw std::logic_error("Can't backup that much!");
+      throw CompressionError("Can't backup that much!");
     }
     rawInputBuffer.resize(currSize - backup);
   }
@@ -250,7 +250,7 @@ namespace orc {
       std::stringstream ss;
       ss << "uncompressed data size " << rawInputBuffer.size()
          << " is larger than compression block size " << compressionBlockSize;
-      throw std::logic_error(ss.str());
+      throw CompressionError(ss.str());
     }
 
     // compress data in the rawInputBuffer when it is full
@@ -297,7 +297,7 @@ namespace orc {
 
   uint64_t ZlibCompressionStream::doStreamingCompression() {
     if (deflateReset(&strm_) != Z_OK) {
-      throw std::runtime_error("Failed to reset inflate.");
+      throw CompressionError("Failed to reset inflate.");
     }
 
     // iterate through all blocks
@@ -318,7 +318,7 @@ namespace orc {
       do {
         if (outputPosition >= outputSize) {
           if (!BufferedOutputStream::Next(reinterpret_cast<void**>(&outputBuffer), &outputSize)) {
-            throw std::runtime_error("Failed to get next output buffer from output stream.");
+            throw CompressionError("Failed to get next output buffer from output stream.");
           }
           outputPosition = 0;
         }
@@ -333,7 +333,7 @@ namespace orc {
         } else if (ret == Z_OK) {
           // needs more buffer so will continue the loop
         } else {
-          throw std::runtime_error("Failed to deflate input data.");
+          throw CompressionError("Failed to deflate input data.");
         }
       } while (strm_.avail_out == 0);
     } while (!finish);
@@ -357,7 +357,7 @@ namespace orc {
     strm_.next_in = nullptr;
 
     if (deflateInit2(&strm_, level, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) != Z_OK) {
-      throw std::runtime_error("Error while calling deflateInit2() for zlib.");
+      throw CompressionError("Error while calling deflateInit2() for zlib.");
     }
   }
 
@@ -557,7 +557,7 @@ namespace orc {
     } else if (state == DECOMPRESS_START) {
       NextDecompress(data, size, availableSize);
     } else {
-      throw std::logic_error(
+      throw DecompressionError(
           "Unknown compression state in "
           "DecompressionStream::Next");
     }
@@ -571,7 +571,7 @@ namespace orc {
 
   void DecompressionStream::BackUp(int count) {
     if (outputBuffer == nullptr || outputBufferLength != 0) {
-      throw std::logic_error("Backup without previous Next in " + getName());
+      throw DecompressionError("Backup without previous Next in " + getName());
     }
     outputBuffer -= static_cast<size_t>(count);
     outputBufferLength = static_cast<size_t>(count);
@@ -699,13 +699,17 @@ namespace orc {
       case Z_OK:
         break;
       case Z_MEM_ERROR:
-        throw std::logic_error("Memory error from inflateInit2");
+        throw DecompressionError(
+            "Memory error from ZlibDecompressionStream::ZlibDecompressionStream");
       case Z_VERSION_ERROR:
-        throw std::logic_error("Version error from inflateInit2");
+        throw DecompressionError(
+            "Version error from ZlibDecompressionStream::ZlibDecompressionStream");
       case Z_STREAM_ERROR:
-        throw std::logic_error("Stream error from inflateInit2");
+        throw DecompressionError(
+            "Stream error from ZlibDecompressionStream::ZlibDecompressionStream");
       default:
-        throw std::logic_error("Unknown error from inflateInit2");
+        throw DecompressionError(
+            "Unknown error from  ZlibDecompressionStream::ZlibDecompressionStream");
     }
   }
 
@@ -726,7 +730,7 @@ namespace orc {
     zstream_.next_out = reinterpret_cast<Bytef*>(const_cast<char*>(outputBuffer));
     zstream_.avail_out = static_cast<uInt>(outputDataBuffer.capacity());
     if (inflateReset(&zstream_) != Z_OK) {
-      throw std::logic_error(
+      throw DecompressionError(
           "Bad inflateReset in "
           "ZlibDecompressionStream::NextDecompress");
     }
@@ -746,19 +750,19 @@ namespace orc {
         case Z_STREAM_END:
           break;
         case Z_BUF_ERROR:
-          throw std::logic_error(
+          throw DecompressionError(
               "Buffer error in "
               "ZlibDecompressionStream::NextDecompress");
         case Z_DATA_ERROR:
-          throw std::logic_error(
+          throw DecompressionError(
               "Data error in "
               "ZlibDecompressionStream::NextDecompress");
         case Z_STREAM_ERROR:
-          throw std::logic_error(
+          throw DecompressionError(
               "Stream error in "
               "ZlibDecompressionStream::NextDecompress");
         default:
-          throw std::logic_error(
+          throw DecompressionError(
               "Unknown error in "
               "ZlibDecompressionStream::NextDecompress");
       }
@@ -864,7 +868,7 @@ namespace orc {
     }
 
     if (outLength > maxOutputLength) {
-      throw std::logic_error("Snappy length exceeds block size");
+      throw DecompressionError("Snappy length exceeds block size");
     }
 
     if (!snappy::RawUncompress(input, length, output)) {
@@ -966,7 +970,7 @@ namespace orc {
 
   void BlockCompressionStream::BackUp(int count) {
     if (count > bufferSize) {
-      throw std::logic_error("Can't backup that much!");
+      throw DecompressionError("Can't backup that much!");
     }
     bufferSize -= count;
   }
@@ -975,7 +979,7 @@ namespace orc {
     void* data;
     int size;
     if (!Next(&data, &size)) {
-      throw std::runtime_error("Failed to flush compression buffer.");
+      throw CompressionError("Failed to flush compression buffer.");
     }
     BufferedOutputStream::BackUp(outputSize - outputPosition);
     bufferSize = outputSize = outputPosition = 0;
@@ -1058,7 +1062,7 @@ namespace orc {
         reinterpret_cast<char*>(compressorBuffer.data()), bufferSize,
         static_cast<int>(compressorBuffer.size()), level);
     if (result == 0) {
-      throw std::runtime_error("Error during block compression using lz4.");
+      throw CompressionError("Error during block compression using lz4.");
     }
     return static_cast<uint64_t>(result);
   }
@@ -1066,7 +1070,7 @@ namespace orc {
   void Lz4CompressionSteam::init() {
     state_ = LZ4_createStream();
     if (!state_) {
-      throw std::runtime_error("Error while allocating state for lz4.");
+      throw CompressionError("Error while allocating state for lz4.");
     }
   }
 
@@ -1154,7 +1158,7 @@ namespace orc {
   void ZSTDCompressionStream::init() {
     cctx_ = ZSTD_createCCtx();
     if (!cctx_) {
-      throw std::runtime_error("Error while calling ZSTD_createCCtx() for zstd.");
+      throw CompressionError("Error while calling ZSTD_createCCtx() for zstd.");
     }
   }
 
@@ -1211,7 +1215,7 @@ namespace orc {
   void ZSTDDecompressionStream::init() {
     dctx_ = ZSTD_createDCtx();
     if (!dctx_) {
-      throw std::runtime_error("Error while calling ZSTD_createDCtx() for zstd.");
+      throw DecompressionError("Error while calling ZSTD_createDCtx() for zstd.");
     }
   }
 

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -700,16 +700,16 @@ namespace orc {
         break;
       case Z_MEM_ERROR:
         throw DecompressionError(
-            "Memory error from ZlibDecompressionStream::ZlibDecompressionStream");
+            "Memory error from ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
       case Z_VERSION_ERROR:
         throw DecompressionError(
-            "Version error from ZlibDecompressionStream::ZlibDecompressionStream");
+            "Version error from ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
       case Z_STREAM_ERROR:
         throw DecompressionError(
-            "Stream error from ZlibDecompressionStream::ZlibDecompressionStream");
+            "Stream error from ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
       default:
         throw DecompressionError(
-            "Unknown error from  ZlibDecompressionStream::ZlibDecompressionStream");
+            "Unknown error from  ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
     }
   }
 

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -557,7 +557,7 @@ namespace orc {
     } else if (state == DECOMPRESS_START) {
       NextDecompress(data, size, availableSize);
     } else {
-      throw DecompressionError(
+      throw CompressionError(
           "Unknown compression state in "
           "DecompressionStream::Next");
     }
@@ -571,7 +571,7 @@ namespace orc {
 
   void DecompressionStream::BackUp(int count) {
     if (outputBuffer == nullptr || outputBufferLength != 0) {
-      throw DecompressionError("Backup without previous Next in " + getName());
+      throw CompressionError("Backup without previous Next in " + getName());
     }
     outputBuffer -= static_cast<size_t>(count);
     outputBufferLength = static_cast<size_t>(count);
@@ -699,16 +699,16 @@ namespace orc {
       case Z_OK:
         break;
       case Z_MEM_ERROR:
-        throw DecompressionError(
+        throw CompressionError(
             "Memory error from ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
       case Z_VERSION_ERROR:
-        throw DecompressionError(
+        throw CompressionError(
             "Version error from ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
       case Z_STREAM_ERROR:
-        throw DecompressionError(
+        throw CompressionError(
             "Stream error from ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
       default:
-        throw DecompressionError(
+        throw CompressionError(
             "Unknown error from  ZlibDecompressionStream::ZlibDecompressionStream inflateInit2");
     }
   }
@@ -730,7 +730,7 @@ namespace orc {
     zstream_.next_out = reinterpret_cast<Bytef*>(const_cast<char*>(outputBuffer));
     zstream_.avail_out = static_cast<uInt>(outputDataBuffer.capacity());
     if (inflateReset(&zstream_) != Z_OK) {
-      throw DecompressionError(
+      throw CompressionError(
           "Bad inflateReset in "
           "ZlibDecompressionStream::NextDecompress");
     }
@@ -750,19 +750,19 @@ namespace orc {
         case Z_STREAM_END:
           break;
         case Z_BUF_ERROR:
-          throw DecompressionError(
+          throw CompressionError(
               "Buffer error in "
               "ZlibDecompressionStream::NextDecompress");
         case Z_DATA_ERROR:
-          throw DecompressionError(
+          throw CompressionError(
               "Data error in "
               "ZlibDecompressionStream::NextDecompress");
         case Z_STREAM_ERROR:
-          throw DecompressionError(
+          throw CompressionError(
               "Stream error in "
               "ZlibDecompressionStream::NextDecompress");
         default:
-          throw DecompressionError(
+          throw CompressionError(
               "Unknown error in "
               "ZlibDecompressionStream::NextDecompress");
       }
@@ -868,7 +868,7 @@ namespace orc {
     }
 
     if (outLength > maxOutputLength) {
-      throw DecompressionError("Snappy length exceeds block size");
+      throw CompressionError("Snappy length exceeds block size");
     }
 
     if (!snappy::RawUncompress(input, length, output)) {
@@ -970,7 +970,7 @@ namespace orc {
 
   void BlockCompressionStream::BackUp(int count) {
     if (count > bufferSize) {
-      throw DecompressionError("Can't backup that much!");
+      throw CompressionError("Can't backup that much!");
     }
     bufferSize -= count;
   }
@@ -1215,7 +1215,7 @@ namespace orc {
   void ZSTDDecompressionStream::init() {
     dctx_ = ZSTD_createDCtx();
     if (!dctx_) {
-      throw DecompressionError("Error while calling ZSTD_createDCtx() for zstd.");
+      throw CompressionError("Error while calling ZSTD_createDCtx() for zstd.");
     }
   }
 

--- a/c++/src/Exceptions.cc
+++ b/c++/src/Exceptions.cc
@@ -100,20 +100,4 @@ namespace orc {
   CompressionError::~CompressionError() noexcept {
     // PASS
   }
-
-  DecompressionError::DecompressionError(const std::string& whatArg) : runtime_error(whatArg) {
-    // PASS
-  }
-
-  DecompressionError::DecompressionError(const char* whatArg) : runtime_error(whatArg) {
-    // PASS
-  }
-
-  DecompressionError::DecompressionError(const DecompressionError& error) : runtime_error(error) {
-    // PASS
-  }
-
-  DecompressionError::~DecompressionError() noexcept {
-    // PASS
-  }
 }  // namespace orc

--- a/c++/src/Exceptions.cc
+++ b/c++/src/Exceptions.cc
@@ -84,4 +84,36 @@ namespace orc {
   SchemaEvolutionError::~SchemaEvolutionError() noexcept {
     // PASS
   }
+
+  CompressionError::CompressionError(const std::string& whatArg) : runtime_error(whatArg) {
+    // PASS
+  }
+
+  CompressionError::CompressionError(const char* whatArg) : runtime_error(whatArg) {
+    // PASS
+  }
+
+  CompressionError::CompressionError(const CompressionError& error) : runtime_error(error) {
+    // PASS
+  }
+
+  CompressionError::~CompressionError() noexcept {
+    // PASS
+  }
+
+  DecompressionError::DecompressionError(const std::string& whatArg) : runtime_error(whatArg) {
+    // PASS
+  }
+
+  DecompressionError::DecompressionError(const char* whatArg) : runtime_error(whatArg) {
+    // PASS
+  }
+
+  DecompressionError::DecompressionError(const DecompressionError& error) : runtime_error(error) {
+    // PASS
+  }
+
+  DecompressionError::~DecompressionError() noexcept {
+    // PASS
+  }
 }  // namespace orc

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -93,20 +93,31 @@ namespace orc {
     }
     printBuffer(str, buffer.data(), 300);
     std::ostringstream expected;
-    expected
-        << "0000000 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10" << " 11 12 13 14 15 16 17\n"
-        << "0000018 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28" << " 29 2a 2b 2c 2d 2e 2f\n"
-        << "0000030 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40" << " 41 42 43 44 45 46 47\n"
-        << "0000048 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58" << " 59 5a 5b 5c 5d 5e 5f\n"
-        << "0000060 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70" << " 71 72 73 74 75 76 77\n"
-        << "0000078 78 79 7a 7b 7c 7d 7e 7f 80 81 82 83 84 85 86 87 88" << " 89 8a 8b 8c 8d 8e 8f\n"
-        << "0000090 90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f a0" << " a1 a2 a3 a4 a5 a6 a7\n"
-        << "00000a8 a8 a9 aa ab ac ad ae af b0 b1 b2 b3 b4 b5 b6 b7 b8" << " b9 ba bb bc bd be bf\n"
-        << "00000c0 c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf d0" << " d1 d2 d3 d4 d5 d6 d7\n"
-        << "00000d8 d8 d9 da db dc dd de df e0 e1 e2 e3 e4 e5 e6 e7 e8" << " e9 ea eb ec ed ee ef\n"
-        << "00000f0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff 00" << " 01 02 03 04 05 06 07\n"
-        << "0000108 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18" << " 19 1a 1b 1c 1d 1e 1f\n"
-        << "0000120 20 21 22 23 24 25 26 27 28 29 2a 2b\n";
+    expected << "0000000 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10"
+             << " 11 12 13 14 15 16 17\n"
+             << "0000018 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28"
+             << " 29 2a 2b 2c 2d 2e 2f\n"
+             << "0000030 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40"
+             << " 41 42 43 44 45 46 47\n"
+             << "0000048 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58"
+             << " 59 5a 5b 5c 5d 5e 5f\n"
+             << "0000060 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70"
+             << " 71 72 73 74 75 76 77\n"
+             << "0000078 78 79 7a 7b 7c 7d 7e 7f 80 81 82 83 84 85 86 87 88"
+             << " 89 8a 8b 8c 8d 8e 8f\n"
+             << "0000090 90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f a0"
+             << " a1 a2 a3 a4 a5 a6 a7\n"
+             << "00000a8 a8 a9 aa ab ac ad ae af b0 b1 b2 b3 b4 b5 b6 b7 b8"
+             << " b9 ba bb bc bd be bf\n"
+             << "00000c0 c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf d0"
+             << " d1 d2 d3 d4 d5 d6 d7\n"
+             << "00000d8 d8 d9 da db dc dd de df e0 e1 e2 e3 e4 e5 e6 e7 e8"
+             << " e9 ea eb ec ed ee ef\n"
+             << "00000f0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff 00"
+             << " 01 02 03 04 05 06 07\n"
+             << "0000108 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18"
+             << " 19 1a 1b 1c 1d 1e 1f\n"
+             << "0000120 20 21 22 23 24 25 26 27 28 29 2a 2b\n";
     EXPECT_EQ(expected.str(), str.str());
   }
 

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -545,7 +545,7 @@ namespace orc {
         *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
-    ASSERT_THROW(result->BackUp(20), DecompressionError);
+    ASSERT_THROW(result->BackUp(20), CompressionError);
     ASSERT_EQ(true, result->Next(&ptr, &length));
     ASSERT_EQ(30, length);
     for (int i = 0; i < 10; ++i) {
@@ -554,7 +554,7 @@ namespace orc {
       }
     }
     result->BackUp(10);
-    ASSERT_THROW(result->BackUp(2), DecompressionError);
+    ASSERT_THROW(result->BackUp(2), CompressionError);
     ASSERT_EQ(true, result->Next(&ptr, &length));
     ASSERT_EQ(10, length);
     for (int i = 0; i < 10; ++i) {

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -93,31 +93,20 @@ namespace orc {
     }
     printBuffer(str, buffer.data(), 300);
     std::ostringstream expected;
-    expected << "0000000 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10"
-             << " 11 12 13 14 15 16 17\n"
-             << "0000018 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28"
-             << " 29 2a 2b 2c 2d 2e 2f\n"
-             << "0000030 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40"
-             << " 41 42 43 44 45 46 47\n"
-             << "0000048 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58"
-             << " 59 5a 5b 5c 5d 5e 5f\n"
-             << "0000060 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70"
-             << " 71 72 73 74 75 76 77\n"
-             << "0000078 78 79 7a 7b 7c 7d 7e 7f 80 81 82 83 84 85 86 87 88"
-             << " 89 8a 8b 8c 8d 8e 8f\n"
-             << "0000090 90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f a0"
-             << " a1 a2 a3 a4 a5 a6 a7\n"
-             << "00000a8 a8 a9 aa ab ac ad ae af b0 b1 b2 b3 b4 b5 b6 b7 b8"
-             << " b9 ba bb bc bd be bf\n"
-             << "00000c0 c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf d0"
-             << " d1 d2 d3 d4 d5 d6 d7\n"
-             << "00000d8 d8 d9 da db dc dd de df e0 e1 e2 e3 e4 e5 e6 e7 e8"
-             << " e9 ea eb ec ed ee ef\n"
-             << "00000f0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff 00"
-             << " 01 02 03 04 05 06 07\n"
-             << "0000108 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18"
-             << " 19 1a 1b 1c 1d 1e 1f\n"
-             << "0000120 20 21 22 23 24 25 26 27 28 29 2a 2b\n";
+    expected
+        << "0000000 00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10" << " 11 12 13 14 15 16 17\n"
+        << "0000018 18 19 1a 1b 1c 1d 1e 1f 20 21 22 23 24 25 26 27 28" << " 29 2a 2b 2c 2d 2e 2f\n"
+        << "0000030 30 31 32 33 34 35 36 37 38 39 3a 3b 3c 3d 3e 3f 40" << " 41 42 43 44 45 46 47\n"
+        << "0000048 48 49 4a 4b 4c 4d 4e 4f 50 51 52 53 54 55 56 57 58" << " 59 5a 5b 5c 5d 5e 5f\n"
+        << "0000060 60 61 62 63 64 65 66 67 68 69 6a 6b 6c 6d 6e 6f 70" << " 71 72 73 74 75 76 77\n"
+        << "0000078 78 79 7a 7b 7c 7d 7e 7f 80 81 82 83 84 85 86 87 88" << " 89 8a 8b 8c 8d 8e 8f\n"
+        << "0000090 90 91 92 93 94 95 96 97 98 99 9a 9b 9c 9d 9e 9f a0" << " a1 a2 a3 a4 a5 a6 a7\n"
+        << "00000a8 a8 a9 aa ab ac ad ae af b0 b1 b2 b3 b4 b5 b6 b7 b8" << " b9 ba bb bc bd be bf\n"
+        << "00000c0 c0 c1 c2 c3 c4 c5 c6 c7 c8 c9 ca cb cc cd ce cf d0" << " d1 d2 d3 d4 d5 d6 d7\n"
+        << "00000d8 d8 d9 da db dc dd de df e0 e1 e2 e3 e4 e5 e6 e7 e8" << " e9 ea eb ec ed ee ef\n"
+        << "00000f0 f0 f1 f2 f3 f4 f5 f6 f7 f8 f9 fa fb fc fd fe ff 00" << " 01 02 03 04 05 06 07\n"
+        << "0000108 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18" << " 19 1a 1b 1c 1d 1e 1f\n"
+        << "0000120 20 21 22 23 24 25 26 27 28 29 2a 2b\n";
     EXPECT_EQ(expected.str(), str.str());
   }
 
@@ -545,7 +534,7 @@ namespace orc {
         *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
-    ASSERT_THROW(result->BackUp(20), std::logic_error);
+    ASSERT_THROW(result->BackUp(20), DecompressionError);
     ASSERT_EQ(true, result->Next(&ptr, &length));
     ASSERT_EQ(30, length);
     for (int i = 0; i < 10; ++i) {
@@ -554,7 +543,7 @@ namespace orc {
       }
     }
     result->BackUp(10);
-    ASSERT_THROW(result->BackUp(2), std::logic_error);
+    ASSERT_THROW(result->BackUp(2), DecompressionError);
     ASSERT_EQ(true, result->Next(&ptr, &length));
     ASSERT_EQ(10, length);
     for (int i = 0; i < 10; ++i) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new exception types to the decompressor/compressor.


### Why are the changes needed?
The current implementation of the compressor/decompressor uses a variety of std::exception types, which can perplex users. We can enhance users' debugging efficiency by adopting a unified exception class.

### How was this patch tested?
The tests in TestWriter.cc can cover this patch.

### Was this patch authored or co-authored using generative AI tooling?
NO

