### PR TITLE
ORC-1724: JsonFileDump utility should print user metadata

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
@@ -49,6 +49,8 @@ import org.apache.orc.util.BloomFilterIO;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -221,6 +223,17 @@ public class JsonFileDump {
           writer.name("numInserts").value(acidStats.inserts);
           writer.name("numDeletes").value(acidStats.deletes);
           writer.name("numUpdates").value(acidStats.updates);
+        }
+        List<String> keys = reader.getMetadataKeys();
+        keys.remove(OrcAcidUtils.ACID_STATS);
+        if (!keys.isEmpty()) {
+          writer.name("userMetadata").beginObject();
+          for (String key : keys) {
+            writer.name(key);
+            ByteBuffer byteBuffer = reader.getMetadataValue(key);
+            writer.value(String.valueOf(StandardCharsets.UTF_8.decode(byteBuffer)));
+          }
+          writer.endObject();
         }
         writer.name("status").value("OK");
         rows.close();

--- a/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
@@ -117,6 +117,10 @@ public class TestJsonFileDump {
       writer.addRowBatch(batch);
     }
 
+    writer.addUserMetadata("hive.acid.key.index",
+        StandardCharsets.UTF_8.encode("1,1,1;2,3,5;"));
+    writer.addUserMetadata("some.user.property",
+        StandardCharsets.UTF_8.encode("foo#bar$baz&"));
     writer.close();
     PrintStream origOut = System.out;
     String outputFilename = "orc-file-dump.json";

--- a/java/tools/src/test/resources/orc-file-dump.json
+++ b/java/tools/src/test/resources/orc-file-dump.json
@@ -1380,5 +1380,9 @@
   "rawDataSize": 2144730,
   "paddingLength": 0,
   "paddingRatio": 0.0,
+  "userMetadata": {
+    "hive.acid.key.index": "1,1,1;2,3,5;",
+    "some.user.property": "foo#bar$baz&"
+  },
   "status": "OK"
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to implement JsonFileDump to output user metadata.

### Why are the changes needed?
ORC-223 implements the output of user metadata in non-json format, but the json format does not output user metadata.

### How was this patch tested?
add UT

### Was this patch authored or co-authored using generative AI tooling?
No
