### PR TITLE
ORC-1725: [C++] Fix BYTE statistics on platforms with unsigned 'char'

### DIFF
--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -592,7 +592,7 @@ namespace orc {
         if (enableBloomFilter) {
           bloomFilter->addLong(data[i]);
         }
-        intStats->update(static_cast<int64_t>(byteData[i]), 1);
+        intStats->update(static_cast<int64_t>(static_cast<signed char>(byteData[i])), 1);
       }
     }
     intStats->increase(count);

--- a/c++/test/TestWriter.cc
+++ b/c++/test/TestWriter.cc
@@ -452,7 +452,7 @@ namespace orc {
     ASSERT_NE(col_stats, nullptr);
     EXPECT_EQ(col_stats->getNumberOfValues(), rowCount);
     EXPECT_FALSE(col_stats->hasNull());
-    auto int_stats = dynamic_cast<const IntegerColumnStatistics *>(col_stats.get());
+    auto int_stats = dynamic_cast<const IntegerColumnStatistics*>(col_stats.get());
     ASSERT_NE(int_stats, nullptr);
     EXPECT_TRUE(int_stats->hasMinimum() && int_stats->hasMaximum());
     EXPECT_EQ(int_stats->getMinimum(), -128);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Calculate min/max statistics for columns of type BYTE using `signed char` instead of `char` type (C++).

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`char` can be signed or unsigned, depending on target platform and compiler flags, but the statistics in the ORC file should always treat numbers as signed. Specifically, it was behaving incorrectly on ARM because `char` is unsigned there.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested as part of ClickHouse here: https://github.com/ClickHouse/ClickHouse/pull/64563 . ~Let me know if I should add a unit test or something (though presumably there are already unit tests for this, they just don't run on ARM in CI?)~ Added a small test in TestWriter.cc reproducing the problem.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No