### PR TITLE
ORC-1390: [C++] Support schema evolution from string group to decimal/timestamp

### DIFF
--- a/c++/src/ConvertColumnReader.cc
+++ b/c++/src/ConvertColumnReader.cc
@@ -82,7 +82,7 @@ namespace orc {
       dstBatch.hasNulls = true;
     } else {
       std::ostringstream ss;
-      ss << "Failed to parse" << typeName << " from string:" << str;
+      ss << "Failed to parse " << typeName << " from string:" << str;
       throw SchemaEvolutionError(ss.str());
     }
   }

--- a/c++/src/ConvertColumnReader.cc
+++ b/c++/src/ConvertColumnReader.cc
@@ -894,8 +894,7 @@ namespace orc {
         pos += 1;
         size_t subStrLength = timeStr.length() - pos;
         try {
-          const auto& writerTimezone = getTimezoneByName(timeStr.substr(pos, subStrLength));
-          second = writerTimezone.convertFromUTC(second);
+          second = getTimezoneByName(timeStr.substr(pos, subStrLength)).convertFromUTC(second);
         } catch (const TimezoneError&) {
           handleParseFromStringError(dstBatch, idx, throwOnOverflow, "Timestamp_Instant", timeStr);
           return;

--- a/c++/src/SchemaEvolution.cc
+++ b/c++/src/SchemaEvolution.cc
@@ -106,7 +106,8 @@ namespace orc {
         case STRING:
         case CHAR:
         case VARCHAR: {
-          ret.isValid = ret.needConvert = isStringVariant(readType) || isNumeric(readType);
+          ret.isValid = ret.needConvert = isStringVariant(readType) || isNumeric(readType) ||
+                                          isTimestamp(readType) || isDecimal(readType);
           break;
         }
         case TIMESTAMP:

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -980,7 +980,8 @@ namespace orc {
                                        const std::string& zoneName) {
     auto& timezone = getTimezoneByName(zoneName);
     seconds = timezone.convertToUTC(seconds);
-    auto timeinfo = std::gmtime(&seconds);
+    time_t t = static_cast<time_t>(seconds);
+    auto timeinfo = std::gmtime(&t);
     char buffer[100];
     ::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", timeinfo);
     std::string result(buffer);

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -1050,7 +1050,7 @@ namespace orc {
       c1.notNull[1] = false;
       c2.notNull[1] = false;
 
-      raw1.push_back("2024-13-14 00:01:02");
+      raw1.push_back("2024-12-14 00:01:02.-1");
       raw2.push_back("2024-01-02 03:04:05.678");
       c1.data[2] = const_cast<char*>(raw1.back().c_str());
       c1.length[2] = raw1.back().length();

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -1151,6 +1151,7 @@ namespace orc {
     auto& c1 = dynamic_cast<StringVectorBatch&>(*structBatch->fields[0]);
     auto& c2 = dynamic_cast<StringVectorBatch&>(*structBatch->fields[1]);
 
+    // <source_string, failed_to_int64, failed_to_int128, expected_int64, expected_int128>
     std::vector<std::tuple<std::string, bool, bool, int64_t, Int128>> rawDataAndExpected;
 
     rawDataAndExpected = {

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -1070,6 +1070,7 @@ namespace orc {
     rowReaderOptions.setUseTightNumericVector(true);
     rowReaderOptions.setReadType(readType);
     rowReaderOptions.setTimezoneName(readerTimezone);
+    rowReaderOptions.throwOnSchemaEvolutionOverflow(true);
     auto rowReader = reader->createRowReader(rowReaderOptions);
     auto readBatch = rowReader->createRowBatch(TEST_CASES * 2);
     EXPECT_EQ(true, rowReader->next(*readBatch));
@@ -1087,6 +1088,9 @@ namespace orc {
       EXPECT_EQ(readC2.nanoseconds[i], i < TEST_CASES ? 789000000 : 0);
     }
 
+    rowReaderOptions.throwOnSchemaEvolutionOverflow(false);
+    rowReader = reader->createRowReader(rowReaderOptions);
+    EXPECT_EQ(true, rowReader->next(*readBatch));
     EXPECT_EQ(true, rowReader->next(*readBatch));
     EXPECT_EQ(3, readBatch->numElements);
     EXPECT_FALSE(readC1.notNull[0]);


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Support schema evolution from `{stirng, char, varchar}` to `{decimal,timestamp,timestamp_instant}`
2. Fix a bug that cannot convert from `varchar` to `varchar` and `char` to `char`


### Why are the changes needed?
To support Schema evolution at c++ side.


### How was this patch tested?
UT passed

### Was this patch authored or co-authored using generative AI tooling?
NO
