### PR TITLE
ORC-1730: [C++] Add finishEncode support for the encoder

### DIFF
--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -63,9 +63,6 @@ namespace orc {
 
     virtual void suppress() override;
 
-    /**
-     * Finish encoding the stream.
-     */
     virtual void finishEncode() override;
 
     /**

--- a/c++/src/ByteRLE.cc
+++ b/c++/src/ByteRLE.cc
@@ -64,6 +64,11 @@ namespace orc {
     virtual void suppress() override;
 
     /**
+     * Finish encoding the stream.
+     */
+    virtual void finishEncode() override;
+
+    /**
      * Reset to initial state
      */
     void reset();
@@ -214,6 +219,13 @@ namespace orc {
     // written data can be just ignored because they are only flushed in memory
     outputStream->suppress();
     reset();
+  }
+
+  void ByteRleEncoderImpl::finishEncode() {
+    writeValues();
+    outputStream->BackUp(bufferLength - bufferPosition);
+    outputStream->finishStream();
+    bufferLength = bufferPosition = 0;
   }
 
   std::unique_ptr<ByteRleEncoder> createByteRleEncoder(

--- a/c++/src/ByteRLE.hh
+++ b/c++/src/ByteRLE.hh
@@ -61,7 +61,9 @@ namespace orc {
     virtual void suppress() = 0;
 
     /**
-     * finish current encoding
+     * Finalize the encoding process. This function should be called after all data required for
+     * encoding has been added. It ensures that any remaining data is processed and the final state
+     * of the encoder is set.
      */
     virtual void finishEncode() = 0;
   };

--- a/c++/src/ByteRLE.hh
+++ b/c++/src/ByteRLE.hh
@@ -59,6 +59,11 @@ namespace orc {
      * suppress the data and reset to initial state
      */
     virtual void suppress() = 0;
+
+    /**
+     * finish current encoding
+     */
+    virtual void finishEncode() = 0;
   };
 
   class ByteRleDecoder {

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -67,6 +67,7 @@ namespace orc {
     }
     virtual uint64_t getSize() const override;
     virtual uint64_t getRawInputBufferSize() const override = 0;
+    virtual void finishStream() override = 0;
 
    protected:
     void writeData(const unsigned char* data, int size);
@@ -172,6 +173,9 @@ namespace orc {
     virtual uint64_t flush() override;
     uint64_t getRawInputBufferSize() const override {
       return rawInputBuffer.size();
+    }
+    virtual void finishStream() override {
+      compressInternal();
     }
 
    protected:
@@ -953,6 +957,8 @@ namespace orc {
       return rawInputBuffer.size();
     }
 
+    virtual void finishStream() override;
+
    protected:
     // compresses a block and returns the compressed size
     virtual uint64_t doBlockCompression() = 0;
@@ -1022,6 +1028,10 @@ namespace orc {
     outputBuffer = nullptr;
     bufferSize = outputPosition = outputSize = 0;
     BufferedOutputStream::suppress();
+  }
+
+  void BlockCompressionStream::finishStream() {
+    doBlockCompression();
   }
 
   /**

--- a/c++/src/RLE.cc
+++ b/c++/src/RLE.cc
@@ -121,4 +121,10 @@ namespace orc {
     recorder->add(static_cast<uint64_t>(numLiterals));
   }
 
+  void RleEncoder::finishEncode() {
+    outputStream->BackUp(static_cast<int>(bufferLength - bufferPosition));
+    outputStream->finishStream();
+    bufferLength = bufferPosition = 0;
+  }
+
 }  // namespace orc

--- a/c++/src/RLE.hh
+++ b/c++/src/RLE.hh
@@ -84,6 +84,8 @@ namespace orc {
 
     virtual void write(int64_t val) = 0;
 
+    virtual void finishEncode();
+
    protected:
     std::unique_ptr<BufferedOutputStream> outputStream;
     size_t bufferPosition;

--- a/c++/src/RLE.hh
+++ b/c++/src/RLE.hh
@@ -84,6 +84,11 @@ namespace orc {
 
     virtual void write(int64_t val) = 0;
 
+    /**
+     * Finalize the encoding process. This function should be called after all data required for
+     * encoding has been added. It ensures that any remaining data is processed and the final state
+     * of the encoder is set.
+     */
     virtual void finishEncode();
 
    protected:

--- a/c++/src/RLEv1.cc
+++ b/c++/src/RLEv1.cc
@@ -74,10 +74,8 @@ namespace orc {
   }
 
   uint64_t RleEncoderV1::flush() {
-    writeValues();
-    outputStream->BackUp(static_cast<int>(bufferLength - bufferPosition));
+    finishEncode();
     uint64_t dataSize = outputStream->flush();
-    bufferLength = bufferPosition = 0;
     return dataSize;
   }
 

--- a/c++/src/RLEv1.cc
+++ b/c++/src/RLEv1.cc
@@ -135,6 +135,11 @@ namespace orc {
     }
   }
 
+  void RleEncoderV1::finishEncode() {
+    writeValues();
+    RleEncoder::finishEncode();
+  }
+
   signed char RleDecoderV1::readByte() {
     SCOPED_MINUS_STOPWATCH(metrics, DecodingLatencyUs);
     if (bufferStart_ == bufferEnd_) {

--- a/c++/src/RLEv1.hh
+++ b/c++/src/RLEv1.hh
@@ -38,6 +38,8 @@ namespace orc {
 
     void write(int64_t val) override;
 
+    void finishEncode() override;
+
    private:
     int64_t delta_;
     bool repeat_;

--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -108,6 +108,8 @@ namespace orc {
 
     void write(int64_t val) override;
 
+    void finishEncode() override;
+
    private:
     const bool alignedBitPacking_;
     uint32_t fixedRunLength_;

--- a/c++/src/io/OutputStream.cc
+++ b/c++/src/io/OutputStream.cc
@@ -61,6 +61,10 @@ namespace orc {
     }
   }
 
+  void BufferedOutputStream::finishStream() {
+    // PASS
+  }
+
   google::protobuf::int64 BufferedOutputStream::ByteCount() const {
     return static_cast<google::protobuf::int64>(dataBuffer_->size());
   }

--- a/c++/src/io/OutputStream.hh
+++ b/c++/src/io/OutputStream.hh
@@ -74,6 +74,7 @@ namespace orc {
     virtual bool isCompressed() const {
       return false;
     }
+    virtual void finishStream();
   };
   DIAGNOSTIC_POP
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add finishEncode() to the RLE encoder and implement finishStream()  in BufferedOutputStream / compressionStream.

### Why are the changes needed?
We expect to finish encoding when the compression block is aligned with the row group boundary.

### How was this patch tested?
Uts in testRleEncode() can cover this patch.

### Was this patch authored or co-authored using generative AI tooling?
No
