### PR TITLE
MINOR: Fix syntax of DOAP

### DIFF
--- a/site/doap_orc.rdf
+++ b/site/doap_orc.rdf
@@ -48,6 +48,8 @@ the values that are required for the current query.</description>
         <created>2022-12-02</created>
         <revision>1.8.1</revision>
       </Version>
+    </release>
+    <release>
       <Version>
         <name>Stable release</name>
         <created>2022-11-17</created>


### PR DESCRIPTION
### What changes were proposed in this pull request?

I'm having some trouble finding an authoritative reference, but it looks like a release (which is a property) may not contain multiple Versions (which is a node) in RDF/XML. The python rdflib at least doesn't support it, and whatever generates https://projects.apache.org/json/projects/orc.json and https://projects.apache.org/project.html?orc also doesn't seem to process it correctly.

### Why are the changes needed?

So infrastructure that uses the information for the DOAP does the right thing.

### How was this patch tested?

n/a

### Was this patch authored or co-authored using generative AI tooling?

no