### PR TITLE
ORC-1738: [C++] Fix wrong Int128 maximum value

### DIFF
--- a/c++/src/Int128.cc
+++ b/c++/src/Int128.cc
@@ -27,7 +27,7 @@
 namespace orc {
 
   Int128 Int128::maximumValue() {
-    return Int128(0x7fffffffffffffff, 0xfffffffffffffff);
+    return Int128(0x7fffffffffffffff, 0xffffffffffffffff);
   }
 
   Int128 Int128::minimumValue() {

--- a/c++/test/TestInt128.cc
+++ b/c++/test/TestInt128.cc
@@ -555,6 +555,11 @@ namespace orc {
 
     num = Int128("-12345678901122334455667788990011122233");
     EXPECT_EQ("-12345678901122334455667788990011122233", num.toString());
+
+    num = Int128::maximumValue();
+    EXPECT_EQ("170141183460469231731687303715884105727", num.toString());
+    num = Int128::minimumValue();
+    EXPECT_EQ("-170141183460469231731687303715884105728", num.toString());
   }
 
   TEST(Int128, testToDecimalString) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The low part of Int128::maximumValue is wrong. In hex format, it should be 0xffffffffffffffff rather than 0xfffffffffffffff, in which one f is dropped by mistake. 


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

I have added the relevant unit tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.
