### PR TITLE
ORC-1740: Avoid the dump tool repeatedly parsing ColumnStatistics

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -357,9 +357,10 @@ public final class FileDump {
     for (int n = 0; n < stripeStats.size(); n++) {
       System.out.println("  Stripe " + (n + 1) + ":");
       StripeStatistics ss = stripeStats.get(n);
-      for (int i = 0; i < ss.getColumnStatistics().length; ++i) {
+      ColumnStatistics[] columnStatistics = ss.getColumnStatistics();
+      for (int i = 0; i < columnStatistics.length; ++i) {
         System.out.println("    Column " + i + ": " +
-            ss.getColumnStatistics()[i].toString());
+            columnStatistics[i].toString());
       }
     }
     ColumnStatistics[] stats = reader.getStatistics();

--- a/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/JsonFileDump.java
@@ -112,10 +112,11 @@ public class JsonFileDump {
           writer.name("stripeNumber").value(n + 1);
           StripeStatistics ss = stripeStatistics.get(n);
           writer.name("columnStatistics").beginArray();
-          for (int i = 0; i < ss.getColumnStatistics().length; i++) {
+          ColumnStatistics[] columnStatistics = ss.getColumnStatistics();
+          for (int i = 0; i < columnStatistics.length; i++) {
             writer.beginObject();
             writer.name("columnId").value(i);
-            writeColumnStatistics(writer, ss.getColumnStatistics()[i]);
+            writeColumnStatistics(writer, columnStatistics[i]);
             writer.endObject();
           }
           writer.endArray();


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to avoid the dump tool repeatedly parsing ColumnStatistics.

### Why are the changes needed?
`org.apache.orc.StripeStatistics#getColumnStatistics` always generates statistical information for all columns. When there are many columns, the parsing performance decreases.

https://github.com/apache/orc/blob/c38e20d862ce19395558e092dd42033a000fe22d/java/core/src/java/org/apache/orc/StripeStatistics.java#L57-L66


### How was this patch tested?
local test and exist UT

### Was this patch authored or co-authored using generative AI tooling?
No
