### PR TITLE
ORC-1744: Add `ubuntu-24.04` to GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,6 +49,7 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
           - macos-12
           - macos-13
           - macos-14


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `ubuntu-24.04` to GitHub Action.

### Why are the changes needed?

`Ubuntu 24.04` is available as `Beta`.
- https://github.com/actions/runner-images/issues/9848

We can use it to improve the test coverage.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.