### PR TITLE
ORC-1746: Bump `netty-all` to 4.1.110.Final in `bench` module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -92,7 +92,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.96.Final</version>
+        <version>4.1.110.Final</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to bump `netty-all` to 4.1.110.Final.

### Why are the changes needed?
1. Align the netty version with Spark 4.0.0-preview1 version
2. Avoid potential netty CVE https://github.com/advisories/GHSA-5jpm-x58v-624v

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
