### PR TITLE
ORC-1747: Upgrade `zstd-jni` to 1.5.6-4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -84,7 +84,7 @@
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.0.0-M5</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
-    <zstd-jni.version>1.5.6-3</zstd-jni.version>
+    <zstd-jni.version>1.5.6-4</zstd-jni.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade `zstd-jni` to 1.5.6-4.

### Why are the changes needed?
https://github.com/luben/zstd-jni/compare/v1.5.6-3...v1.5.6-4

### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No

Closes #1987 