### PR TITLE
ORC-1749: Fix `supportVectoredIO` for hadoop version string with optional patch labels

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.FileRange;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
+import org.apache.hadoop.util.VersionInfo;
 import org.apache.orc.CompressionCodec;
 import org.apache.orc.DataReader;
 import org.apache.orc.OrcProto;
@@ -48,7 +49,8 @@ import java.util.function.Supplier;
  */
 public class RecordReaderUtils {
   private static final HadoopShims SHIMS = HadoopShimsFactory.get();
-  private static final boolean supportVectoredIO = SHIMS.supportVectoredIO();
+  private static final boolean supportVectoredIO =
+      SHIMS.supportVectoredIO(VersionInfo.getVersion());
   private static final Logger LOG = LoggerFactory.getLogger(RecordReaderUtils.class);
 
   private static class DefaultDataReader implements DataReader {

--- a/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
+++ b/java/shims/src/java/org/apache/orc/impl/HadoopShims.java
@@ -20,7 +20,6 @@ package org.apache.orc.impl;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.util.VersionInfo;
 import org.apache.orc.EncryptionAlgorithm;
 
 import java.io.Closeable;
@@ -132,9 +131,9 @@ public interface HadoopShims {
    */
   boolean endVariableLengthBlock(OutputStream output) throws IOException;
 
-  default boolean supportVectoredIO() {
+  default boolean supportVectoredIO(String version) {
     // HADOOP-18103 is available since Apache Hadoop 3.3.5+
-    String[] versionParts = VersionInfo.getVersion().split("[.]");
+    String[] versionParts = version.split("[.-]");
     int major = Integer.parseInt(versionParts[0]);
     int minor = Integer.parseInt(versionParts[1]);
     int patch = Integer.parseInt(versionParts[2]);

--- a/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPost3_3_4.java
+++ b/java/shims/src/test/org/apache/orc/impl/TestHadoopShimsPost3_3_4.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TestHadoopShimsPost3_3_4 {
+
+  @Test
+  public void testOlderVersionForSupportVectoredIO() {
+    assertFalse(new HadoopShimsCurrent().supportVectoredIO("3.3.4"));
+  }
+
+  @Test
+  public void testSupportedVersionForSupportVectoredIO() {
+    assertTrue(new HadoopShimsCurrent().supportVectoredIO("3.3.5"));
+  }
+
+  @Test
+  public void testExtendedSemanticVersionForSupportVectoredIO() {
+    assertTrue(new HadoopShimsCurrent().supportVectoredIO("3.3.6-co-3"));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
Parse correctly semantic versioning when there is the optional labels in the patch are present.

### Why are the changes needed?
There are cases where the hadoop version info may not be respecting the semantic versioning. It is the case for the hadoop version provided in some of the AWS managed services. This causes a ExceptionInInitializerError while trying to instantiate and ORC file reader.

### How was this patch tested?
Included unit tests. It required a small refactor to be able to test it in an easier way

### Was this patch authored or co-authored using generative AI tooling?
No
