### PR TITLE
read encrypted ORC file

### DIFF
--- a/c++/include/orc/Common.hh
+++ b/c++/include/orc/Common.hh
@@ -224,6 +224,26 @@ namespace orc {
      * Get the writer timezone.
      */
     virtual const std::string& getWriterTimezone() const = 0;
+    /**
+     *Get the list of Localkeys for all columns in the Stripe, with each encrypted column
+     *corresponding to a Localkey.
+     * @return
+     */
+    virtual std::shared_ptr<std::vector<std::vector<unsigned char>>>
+    getEncryptedLocalKeys() const = 0;
+    /**
+     *Get the Localkey for a specific column in this Stripe.
+     * @param col
+     * @return
+     */
+    virtual std::vector<unsigned char>& getEncryptedLocalKeyByVariantId(int col) const = 0;
+    /**
+     * In general, only the first stripe in an ORC file will store the LocalKey.In this case, the
+     * stripeId and originalStripeId are equal. If an ORC file has multiple stripes storing the
+     * LocalKey, the values of stripeId and originalStripeId may not be equal.
+     * @return
+     */
+    virtual long getOriginalStripeId() const = 0;
   };
 
   // Return true if val1 < val2; otherwise return false

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -39,7 +39,7 @@ namespace orc {
   // classes that hold data members so we can maintain binary compatibility
   struct ReaderOptionsPrivate;
   struct RowReaderOptionsPrivate;
-
+  class KeyProvider;
   /**
    * Expose the reader metrics including the latency and
    * number of calls of the decompression/decoding/IO modules.
@@ -138,6 +138,10 @@ namespace orc {
      * Get the reader metrics.
      */
     ReaderMetrics* getReaderMetrics() const;
+
+    ReaderOptions& setKeyProvider(std::shared_ptr<KeyProvider> keyProvider);
+
+    std::shared_ptr<KeyProvider> getKeyProvider() const;
   };
 
   /**

--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -144,7 +144,6 @@ add_custom_command(OUTPUT orc_proto.pb.h orc_proto.pb.cc
         --cpp_out="${CMAKE_CURRENT_BINARY_DIR}"
         ../../orc-format_ep-prefix/src/orc-format_ep/src/main/proto/orc/proto/orc_proto.proto
 )
-
 set(SOURCE_FILES
   "${CMAKE_CURRENT_BINARY_DIR}/Adaptor.hh"
   orc_proto.pb.h
@@ -187,7 +186,10 @@ set(SOURCE_FILES
   Timezone.cc
   TypeImpl.cc
   Vector.cc
-  Writer.cc)
+  Writer.cc
+  security/InMemoryKeystore.cc
+  security/ReaderEncryption.cc
+)
 
 if(BUILD_LIBHDFSPP)
   set(SOURCE_FILES ${SOURCE_FILES} OrcHdfsFile.cc)
@@ -211,6 +213,8 @@ target_link_libraries (orc
     $<BUILD_INTERFACE:orc::lz4>
     $<BUILD_INTERFACE:orc::zstd>
     $<BUILD_INTERFACE:${LIBHDFSPP_LIBRARIES}>
+    ${OPENSSL_CRYPTO_LIBRARY}
+    ${OPENSSL_SSL_LIBRARY}
   )
 
 target_include_directories (orc

--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -1272,7 +1272,13 @@ namespace orc {
         throw NotImplementedYet("compression codec");
     }
   }
-
+  std::unique_ptr<SeekableInputStream> createDecompressorAndDecryption(
+      CompressionKind kind, std::unique_ptr<SeekableInputStream> input, uint64_t blockSize,
+      MemoryPool& pool, ReaderMetrics* metrics,std::vector<unsigned char> key,
+      std::vector<unsigned char> iv,const EVP_CIPHER* cipher){
+    auto dec = std::make_unique<DecryptionInputStream>(std::move(input),key,iv,cipher,pool);
+    return createDecompressor(kind,std::move(dec),blockSize,pool,metrics);
+  }
   std::unique_ptr<SeekableInputStream> createDecompressor(
       CompressionKind kind, std::unique_ptr<SeekableInputStream> input, uint64_t blockSize,
       MemoryPool& pool, ReaderMetrics* metrics) {

--- a/c++/src/Compression.hh
+++ b/c++/src/Compression.hh
@@ -36,6 +36,10 @@ namespace orc {
       CompressionKind kind, std::unique_ptr<SeekableInputStream> input, uint64_t bufferSize,
       MemoryPool& pool, ReaderMetrics* metrics);
 
+  std::unique_ptr<SeekableInputStream> createDecompressorAndDecryption(CompressionKind kind, std::unique_ptr<SeekableInputStream> input, uint64_t blockSize,
+                                                                       MemoryPool& pool, ReaderMetrics* metrics,std::vector<unsigned char> key,
+                                                                       std::vector<unsigned char> iv,const EVP_CIPHER* cipher);
+
   /**
    * Create a compressor for the given compression kind.
    * @param kind the compression type to implement

--- a/c++/src/Options.hh
+++ b/c++/src/Options.hh
@@ -43,6 +43,7 @@ namespace orc {
     MemoryPool* memoryPool;
     std::string serializedTail;
     ReaderMetrics* metrics;
+    std::shared_ptr<KeyProvider> keyProvider;
 
     ReaderOptionsPrivate() {
       tailLocation = std::numeric_limits<uint64_t>::max();
@@ -121,7 +122,14 @@ namespace orc {
   std::ostream* ReaderOptions::getErrorStream() const {
     return privateBits_->errorStream;
   }
+  ReaderOptions& ReaderOptions::setKeyProvider(std::shared_ptr<KeyProvider> keyProvider) {
+    privateBits_->keyProvider = keyProvider;
+    return *this;
+  }
 
+  std::shared_ptr<KeyProvider> ReaderOptions::getKeyProvider() const {
+    return privateBits_->keyProvider;
+  }
   /**
    * RowReaderOptions Implementation
    */

--- a/c++/src/StripeStream.hh
+++ b/c++/src/StripeStream.hh
@@ -26,10 +26,59 @@
 #include "ColumnReader.hh"
 #include "Timezone.hh"
 #include "TypeImpl.hh"
+#include "security/ReaderEncryption.hh"
 
 namespace orc {
 
   class RowReaderImpl;
+  /**
+   * StreamInformation Implementation
+  */
+  class StreamInformationImpl : public StreamInformation {
+   private:
+    StreamKind kind;
+    uint64_t column;
+    uint64_t offset;
+    uint64_t length;
+    proto::Stream_Kind originalKind;
+
+   public:
+    StreamInformationImpl(uint64_t _offset, const proto::Stream& stream)
+        : kind(static_cast<StreamKind>(stream.kind())),
+          column(stream.column()),
+          offset(_offset),
+          length(stream.length()) {
+      // PASS
+    }
+    StreamInformationImpl(proto::Stream_Kind originalKind, uint64_t column, uint64_t _offset,
+                          uint64_t length)
+        : kind(static_cast<StreamKind>(originalKind)),
+          column(column),
+          offset(_offset),
+          length(length),
+          originalKind(originalKind) {
+      // PASS
+    }
+    ~StreamInformationImpl() override;
+
+    StreamKind getKind() const override {
+      return kind;
+    }
+
+    uint64_t getColumnId() const override {
+      return column;
+    }
+
+    uint64_t getOffset() const override {
+      return offset;
+    }
+
+    uint64_t getLength() const override {
+      return length;
+    }
+  };
+
+  enum class Area { DATA, INDEX, FOOTER };
 
   /**
    * StripeStream Implementation
@@ -41,13 +90,39 @@ namespace orc {
     const proto::StripeInformation& stripeInfo_;
     const proto::StripeFooter& footer_;
     const uint64_t stripeIndex_;
+    long originalStripeId = 0;
     const uint64_t stripeStart_;
     InputStream& input_;
     const Timezone& writerTimezone_;
     const Timezone& readerTimezone_;
-
+    mutable std::map<std::string, std::shared_ptr<StreamInformation>> streamMap;
+    std::vector<std::shared_ptr<StreamInformation>> streams;
+    static long handleStream(long offset, const proto::Stream& stream, Area area,
+                                   ReaderEncryptionVariant* variant, ReaderEncryption* encryption,
+                                   std::vector<std::shared_ptr<StreamInformation>>& streams) {
+      int column = stream.column();
+      if (stream.has_kind()) {
+        proto::Stream_Kind kind = stream.kind();
+        // If there are no encrypted columns
+        /*            if (encryption->getKeys().empty()) {
+                        StreamInformationImpl* info = new StreamInformationImpl(kind, column, offset, stream.length());
+                        streams.push_back(std::shared_ptr<StreamInformation>(info));
+                        return stream.length();
+                    }*/
+        if (getArea(kind) != area || kind == proto::Stream_Kind::Stream_Kind_ENCRYPTED_INDEX ||
+            kind == proto::Stream_Kind::Stream_Kind_ENCRYPTED_DATA) {
+          //Ignore the placeholder that should not be included in the offset calculation.
+          return 0;
+        }
+        if (encryption->getVariant(column) == variant) {
+          StreamInformationImpl* info = new StreamInformationImpl(kind, column, offset, stream.length());
+          streams.push_back(std::shared_ptr<StreamInformation>(info));
+        }
+      }
+      return stream.length();
+    }
    public:
-    StripeStreamsImpl(const RowReaderImpl& reader, uint64_t index,
+    StripeStreamsImpl(const RowReaderImpl& reader, uint64_t index, long originalStripeId,
                       const proto::StripeInformation& stripeInfo, const proto::StripeFooter& footer,
                       uint64_t stripeStart, InputStream& input, const Timezone& writerTimezone,
                       const Timezone& readerTimezone);
@@ -79,44 +154,42 @@ namespace orc {
     int32_t getForcedScaleOnHive11Decimal() const override;
 
     const SchemaEvolution* getSchemaEvolution() const override;
-  };
-
-  /**
-   * StreamInformation Implementation
-   */
-
-  class StreamInformationImpl : public StreamInformation {
-   private:
-    StreamKind kind_;
-    uint64_t column_;
-    uint64_t offset_;
-    uint64_t length_;
-
-   public:
-    StreamInformationImpl(uint64_t offset, const proto::Stream& stream)
-        : kind_(static_cast<StreamKind>(stream.kind())),
-          column_(stream.column()),
-          offset_(offset),
-          length_(stream.length()) {
-      // PASS
+    //
+    static Area getArea(proto::Stream_Kind kind) {
+      switch (kind) {
+        case proto::Stream_Kind::Stream_Kind_FILE_STATISTICS:
+        case proto::Stream_Kind::Stream_Kind_STRIPE_STATISTICS:
+          return Area::FOOTER;
+        case proto::Stream_Kind::Stream_Kind_ROW_INDEX:
+        case proto::Stream_Kind::Stream_Kind_DICTIONARY_COUNT:
+        case proto::Stream_Kind::Stream_Kind_BLOOM_FILTER:
+        case proto::Stream_Kind::Stream_Kind_BLOOM_FILTER_UTF8:
+        case proto::Stream_Kind::Stream_Kind_ENCRYPTED_INDEX:
+          return Area::INDEX;
+        default:
+          return Area::DATA;
+      }
     }
-
-    ~StreamInformationImpl() override;
-
-    StreamKind getKind() const override {
-      return kind_;
-    }
-
-    uint64_t getColumnId() const override {
-      return column_;
-    }
-
-    uint64_t getOffset() const override {
-      return offset_;
-    }
-
-    uint64_t getLength() const override {
-      return length_;
+    static long findStreamsByArea(proto::StripeFooter& footer, long currentOffset, Area area,
+                                  ReaderEncryption* encryption,
+                                  std::vector<std::shared_ptr<StreamInformation>>& streams) {
+      // Look for the unencrypted stream.
+      for (const proto::Stream& stream : footer.streams()) {
+        currentOffset += handleStream(currentOffset, stream, area, nullptr, encryption, streams);
+      }
+      //If there are encrypted columns
+      if (!encryption->getKeys().empty()) {
+        std::vector<std::shared_ptr<ReaderEncryptionVariant>>& vList = encryption->getVariants();
+        for (std::vector<orc::ReaderEncryptionVariant*>::size_type i = 0; i < vList.size(); i++) {
+          ReaderEncryptionVariant* variant = vList.at(i).get();
+          int variantId = variant->getVariantId();
+          const proto::StripeEncryptionVariant& stripeVariant = footer.encryption(variantId);
+          for (const proto::Stream& stream : stripeVariant.streams()) {
+            currentOffset += handleStream(currentOffset, stream, area, variant, encryption, streams);
+          }
+        }
+      }
+      return currentOffset;
     }
   };
 
@@ -137,6 +210,9 @@ namespace orc {
     mutable std::unique_ptr<proto::StripeFooter> stripeFooter_;
     ReaderMetrics* metrics_;
     void ensureStripeFooterLoaded() const;
+    std::shared_ptr<std::vector<std::vector<unsigned char>>> encryptedKeys;
+    long originalStripeId = 0;
+    ReaderEncryption* encryption;
 
    public:
     StripeInformationImpl(uint64_t offset, uint64_t indexLength, uint64_t dataLength,
@@ -155,7 +231,42 @@ namespace orc {
           metrics_(metrics) {
       // PASS
     }
-
+    StripeInformationImpl(proto::StripeInformation* stripeInfo, ReaderEncryption* encryption,
+                          long previousOriginalStripeId,
+                          std::shared_ptr<std::vector<std::vector<unsigned char>>> previousKeys, InputStream* _stream,
+                          MemoryPool& _memory, CompressionKind _compression, uint64_t _blockSize,
+                          ReaderMetrics* _metrics)
+        : offset_(stripeInfo->offset()),
+          indexLength_(stripeInfo->index_length()),
+          dataLength_(stripeInfo->data_length()),
+          footerLength_(stripeInfo->footer_length()),
+          numRows_(stripeInfo->number_of_rows()),
+          stream_(_stream),
+          memory_(_memory),
+          compression_(_compression),
+          blockSize_(_blockSize),
+          metrics_(_metrics),
+          encryption(encryption) {
+      // It is usually the first strip that has this value.
+      if (stripeInfo->has_encrypt_stripe_id()) {
+        originalStripeId = stripeInfo->encrypt_stripe_id();
+      } else {
+        originalStripeId = previousOriginalStripeId + 1;
+      }
+      // The value is generally present in the first strip.
+      // Each encrypted column corresponds to a key.
+      if (stripeInfo->encrypted_local_keys_size() != 0) {
+        encryptedKeys = std::shared_ptr<std::vector<std::vector<unsigned char>>>(
+            new std::vector<std::vector<unsigned char>>());
+        for (int i = 0; i < static_cast<int>(stripeInfo->encrypted_local_keys_size()); i++) {
+          std::string str = stripeInfo->encrypted_local_keys(i);
+          std::vector<unsigned char> chars(str.begin(), str.end());
+          encryptedKeys->push_back(chars);
+        }
+      } else {
+        encryptedKeys = std::shared_ptr<std::vector<std::vector<unsigned char>>>(previousKeys);
+      }
+    }
     virtual ~StripeInformationImpl() override {
       // PASS
     }
@@ -192,20 +303,39 @@ namespace orc {
 
     ColumnEncodingKind getColumnEncoding(uint64_t colId) const override {
       ensureStripeFooterLoaded();
-      return static_cast<ColumnEncodingKind>(
-          stripeFooter_->columns(static_cast<int>(colId)).kind());
+      ReaderEncryptionVariant* variant = this->encryption->getVariant(colId);
+      if (variant != nullptr) {
+        int subColumn = colId - variant->getRoot()->getColumnId();
+        return static_cast<ColumnEncodingKind>(
+            stripeFooter_->encryption().Get(variant->getVariantId()).encoding(subColumn).kind());
+      } else {
+        return static_cast<ColumnEncodingKind>(stripeFooter_->columns(static_cast<int>(colId)).kind());
+      }
     }
 
     uint64_t getDictionarySize(uint64_t colId) const override {
       ensureStripeFooterLoaded();
-      return static_cast<ColumnEncodingKind>(
-          stripeFooter_->columns(static_cast<int>(colId)).dictionary_size());
+      ReaderEncryptionVariant* variant = this->encryption->getVariant(colId);
+      if (variant != nullptr) {
+        int subColumn = colId - variant->getRoot()->getColumnId();
+        return static_cast<ColumnEncodingKind>(
+            stripeFooter_->encryption().Get(variant->getVariantId()).encoding(subColumn).dictionary_size());
+      } else {
+        return static_cast<ColumnEncodingKind>(stripeFooter_->columns(static_cast<int>(colId)).dictionary_size());
+      }
     }
 
     const std::string& getWriterTimezone() const override {
       ensureStripeFooterLoaded();
       return stripeFooter_->writer_timezone();
     }
+    std::shared_ptr<std::vector<std::vector<unsigned char>>> getEncryptedLocalKeys() const override {
+      return this->encryptedKeys;
+    }
+    std::vector<unsigned char>& getEncryptedLocalKeyByVariantId(int col) const override {
+      return getEncryptedLocalKeys()->at(col);
+    }
+    long getOriginalStripeId() const override { return originalStripeId; }
   };
 
 }  // namespace orc

--- a/c++/src/TypeImpl.cc
+++ b/c++/src/TypeImpl.cc
@@ -837,5 +837,4 @@ namespace orc {
     }
     return nullptr;
   }
-
 }  // namespace orc

--- a/c++/src/io/InputStream.cc
+++ b/c++/src/io/InputStream.cc
@@ -209,5 +209,99 @@ namespace orc {
     result << input_->getName() << " from " << start_ << " for " << length_;
     return result.str();
   }
+  DecryptionInputStream::DecryptionInputStream(std::unique_ptr<SeekableInputStream> input,
+                                               std::vector<unsigned char> key,
+                                               std::vector<unsigned char> iv,
+                                               const EVP_CIPHER* cipher,MemoryPool& pool)
+      : input_(std::move(input)),
+        key_(key),
+        iv_(iv),
+        cipher(cipher),
+        pool(pool){
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (ctx == nullptr) {
+      throw std::runtime_error("Failed to create EVP cipher context");
+    }
+    int ret = EVP_DecryptInit_ex(ctx, cipher, NULL, key_.data(), iv_.data());
+    if (ret != 1) {
+      EVP_CIPHER_CTX_free(ctx);
+      EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+      throw std::runtime_error("Failed to initialize EVP cipher context");
+    }
+    ctx_ = ctx;
+    outputBuffer_.reset(new DataBuffer<unsigned char>(pool));
+    inputBuffer_.reset(new DataBuffer<unsigned char>(pool));
+  }
 
-}  // namespace orc
+  DecryptionInputStream::~DecryptionInputStream() {
+    EVP_CIPHER_CTX_free(ctx_);
+    EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+  }
+
+  bool DecryptionInputStream::Next(const void** data, int* size) {
+    int bytesRead = 0;
+    //const void* ptr;
+    const void* inptr = static_cast<void*>(inputBuffer_->data());
+    input_->Next(&inptr, &bytesRead);
+    if (bytesRead == 0) {
+      return false;
+    }
+    // decrypt data
+    const unsigned char* result = static_cast<const unsigned char*>(inptr);
+    int outlen = 0;
+    //int blockSize = EVP_CIPHER_block_size(this->cipher);
+    outputBuffer_->resize(bytesRead);
+    int ret = EVP_DecryptUpdate(ctx_, outputBuffer_->data(), &outlen, result, bytesRead);
+    if (ret != 1) {
+      throw std::runtime_error("Failed to decrypt data");
+    }
+    outputBuffer_->resize(outlen);
+    *data = outputBuffer_->data();
+    *size = outputBuffer_->size();
+    return true;
+  }
+  void DecryptionInputStream::BackUp(int count) {
+    this->input_->BackUp(count);
+  }
+
+  bool DecryptionInputStream::Skip(int count) {
+    return this->input_->Skip(count);
+  }
+
+  google::protobuf::int64 DecryptionInputStream::ByteCount() const {
+    return input_->ByteCount();
+  }
+
+  void DecryptionInputStream::seek(PositionProvider& position) {
+    //std::cout<<"PPP:DecryptionInputStream::seek:"<<position.current()<<std::endl;
+    changeIv(position.current());
+    input_->seek(position);
+  }
+  void DecryptionInputStream::changeIv(long offset) {
+    int blockSize = EVP_CIPHER_key_length(cipher);
+    long encryptionBlocks = offset / blockSize;
+    long extra = offset % blockSize;
+    std::fill(iv_.end() - 8, iv_.end(), 0);
+    if (encryptionBlocks != 0) {
+      // Add the encryption blocks into the initial iv, to compensate for
+      // skipping over decrypting those bytes.
+      int posn = iv_.size() - 1;
+      while (encryptionBlocks > 0) {
+        long sum = (iv_[posn] & 0xff) + encryptionBlocks;
+        iv_[posn--] = (unsigned char) sum;
+        encryptionBlocks = sum / 0x100;
+      }
+    }
+    EVP_DecryptInit_ex(ctx_, cipher, NULL, key_.data(), iv_.data());
+    // If the range starts at an offset that doesn't match the encryption
+    // block, we need to advance some bytes within an encryption block.
+    if (extra > 0) {
+      std::vector<unsigned char> decrypted(extra);
+      int decrypted_len;
+      EVP_DecryptUpdate(ctx_, decrypted.data(), &decrypted_len, decrypted.data(), extra);
+    }
+  }
+  std::string DecryptionInputStream::getName() const {
+    return "DecryptionInputStream("+input_->getName()+")";
+  }
+}// namespace orc

--- a/c++/src/security/InMemoryKeystore.cc
+++ b/c++/src/security/InMemoryKeystore.cc
@@ -1,0 +1,247 @@
+// Copyright 2010-present vivo, Inc. All rights reserved.
+//
+//Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "InMemoryKeystore.hh"
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+namespace orc {
+  InMemoryKeystore::InMemoryKeystore() : random(rd()) {}
+
+  InMemoryKeystore::~InMemoryKeystore() {
+    keys.clear();
+    currentVersion.clear();
+  }
+
+  InMemoryKeystore* InMemoryKeystore::addKey(std::string name, EncryptionAlgorithm* algorithm,
+                                             std::string material) {
+    return addKey(name, 0, algorithm, material);
+  }
+  InMemoryKeystore* InMemoryKeystore::addKey(std::string keyName, int version,
+                                             EncryptionAlgorithm* algorithm,
+                                             std::string password) {
+    std::vector<unsigned char> material = std::vector<unsigned char>(password.begin(), password.end());
+    return  addKey(keyName,version,algorithm,material);
+  }
+  InMemoryKeystore* InMemoryKeystore::addKey(std::string keyName, int version,
+                                             EncryptionAlgorithm* algorithm,
+                                             std::vector<unsigned char> material) {
+    // Test whether platform supports the algorithm
+    if (!testSupportsAes256() && (algorithm != EncryptionAlgorithm::AES_CTR_128)) {
+      algorithm = EncryptionAlgorithm::AES_CTR_128;
+    }
+    int masterKeyLength = material.size();
+    int algorithmLength = algorithm->getKeyLength();
+    std::vector<unsigned char> buffer(algorithmLength, 0);
+    // std::vector<unsigned char>* buffer = new std::vector<unsigned char>(algorithmLength);
+    int dataLen = algorithmLength > masterKeyLength ? masterKeyLength : algorithmLength;
+    std::copy(material.begin(), material.begin() + dataLen, buffer.begin());
+
+    std::unique_ptr<SecurityKey> key = std::make_unique<SecurityKey>(keyName, version, algorithm, buffer);
+
+    // Check whether the key is already present and has a smaller version
+    if (currentVersion.find(keyName) != currentVersion.end()) {
+      int oldV = currentVersion[keyName];
+      if (oldV >= version) {
+        throw std::runtime_error("Key " + key->toString() + " with equal or higher version " +
+                                 std::to_string(version) + " already exists");
+      }
+    }
+    //std::pair<std::string, std::unique_ptr<SecurityKey>> keyPair(buildVersionName(keyName, version), std::move(key));
+    //keys[](keyPair);
+    keys.emplace(buildVersionName(keyName, version),std::move(key));
+    currentVersion[keyName] = version;
+
+    return this;
+  }
+  bool InMemoryKeystore::testSupportsAes256() {
+    const EVP_CIPHER * cipher = EVP_aes_256_cbc();
+    int maxKeyLength = EVP_CIPHER_key_length(cipher);
+    EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+    return maxKeyLength >= 256 / 8;
+  }
+
+  std::string InMemoryKeystore::buildVersionName(const std::string& name, int version) {
+    return name + "@" + std::to_string(version);
+  }
+
+  std::vector<std::string> InMemoryKeystore::getKeyNames() {
+    std::vector<std::string> names;
+    for (const auto& kv : currentVersion) {
+      names.push_back(kv.first);
+    }
+    return names;
+  }
+
+  std::unique_ptr<SecurityKey>& InMemoryKeystore::getCurrentKeyVersion(std::string keyName) {
+    int version = currentVersion[keyName];
+    const std::string keyVersionName = buildVersionName(keyName, version);
+    return keys[keyVersionName];
+  }
+
+  LocalKey* InMemoryKeystore::createLocalKey(KeyMetadata* key) {
+    const std::string keyVersion = buildVersionName(key->getKeyName(), key->getVersion());
+    if (keys.count(keyVersion) == 0) {
+      throw std::invalid_argument("Unknown key " + keyVersion);
+    }
+    SecurityKey* secret = keys[keyVersion].get();
+    EncryptionAlgorithm* algorithm = secret->getAlgorithm();
+    std::vector<unsigned char> encryptedKey(algorithm->getKeyLength());
+        //new std::vector<unsigned char>(algorithm->getKeyLength());
+    RAND_bytes(encryptedKey.data(), encryptedKey.size());
+
+    std::vector<unsigned char> iv(algorithm->getIvLength());
+    std::copy(encryptedKey.begin(), encryptedKey.begin() + algorithm->getIvLength(), iv.begin());
+
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (ctx == nullptr) {
+      throw std::runtime_error("EVP_CIPHER_CTX_new() failed");
+    }
+    const EVP_CIPHER* cipher = algorithm->createCipher();
+    if (EVP_DecryptInit_ex(ctx, cipher, nullptr, secret->getMaterial().data(),
+                           iv.data()) != 1) {
+      EVP_CIPHER_CTX_free(ctx);
+      EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+      throw std::runtime_error("EVP_DecryptInit_ex() failed");
+    }
+    int blockSize = EVP_CIPHER_block_size(cipher);
+    std::vector<unsigned char> decryptedKey(encryptedKey.size() + blockSize);
+       // new std::vector<unsigned char>(encryptedKey->size() + blockSize);
+    int outlen = 0;
+    if (EVP_DecryptUpdate(ctx, decryptedKey.data(), &outlen, encryptedKey.data(),
+                          encryptedKey.size()) != 1) {
+      EVP_CIPHER_CTX_free(ctx);
+      EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+      throw std::runtime_error("EVP_DecryptUpdate() failed");
+    }
+    int plaintext_len = outlen;
+    if (EVP_DecryptFinal_ex(ctx, decryptedKey.data() + outlen, &outlen) != 1) {
+      EVP_CIPHER_CTX_free(ctx);
+      EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+      throw std::runtime_error("EVP_DecryptFinal_ex() failed");
+    }
+    plaintext_len += outlen;
+    decryptedKey.resize(plaintext_len);
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+    LocalKey* localKey = new LocalKey(algorithm->getAlgorithm(), decryptedKey, encryptedKey);
+    return localKey;
+  }
+
+  std::shared_ptr<SecretKeySpec> InMemoryKeystore::decryptLocalKey(
+      KeyMetadata* key, std::vector<unsigned char> encryptedKey) {
+    const std::string keyVersion = buildVersionName(key->getKeyName(), key->getVersion());
+    if (keys.count(keyVersion) == 0) {
+      throw std::invalid_argument("Unknown key " + keyVersion);
+    }
+    SecurityKey* secret = keys[keyVersion].get();
+    EncryptionAlgorithm* algorithm = secret->getAlgorithm();
+
+    std::vector<unsigned char> iv(algorithm->getIvLength());
+    std::copy(encryptedKey.begin(), encryptedKey.begin() + algorithm->getIvLength(), iv.begin());
+
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (ctx == nullptr) {
+      throw std::runtime_error("EVP_CIPHER_CTX_new() failed");
+    }
+    const evp_cipher_st* cipher = algorithm->createCipher();
+    if (EVP_DecryptInit_ex(ctx, cipher, nullptr, secret->getMaterial().data(),
+                           iv.data()) != 1) {
+      EVP_CIPHER_CTX_free(ctx);
+      EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+      throw std::runtime_error("EVP_DecryptInit_ex() failed");
+    }
+    int blockSize = EVP_CIPHER_block_size(cipher);
+    std::vector<unsigned char> decryptedKey((encryptedKey.size() + blockSize));
+        //new std::vector<unsigned char>(encryptedKey->size() + blockSize);
+    int outlen = 0;
+    if (EVP_DecryptUpdate(ctx, decryptedKey.data(), &outlen, encryptedKey.data(),
+                          encryptedKey.size()) != 1) {
+      EVP_CIPHER_CTX_free(ctx);
+      EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+      throw std::runtime_error("EVP_DecryptUpdate() failed");
+    }
+    int plaintext_len = outlen;
+    if (EVP_DecryptFinal_ex(ctx, decryptedKey.data() + outlen, &outlen) != 1) {
+      EVP_CIPHER_CTX_free(ctx);
+      EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+      throw std::runtime_error("EVP_DecryptFinal_ex() failed");
+    }
+    plaintext_len += outlen;
+    decryptedKey.resize(plaintext_len);
+    EVP_CIPHER_CTX_free(ctx);
+    EVP_CIPHER_free(const_cast<evp_cipher_st*>(cipher));
+    return std::make_unique<SecretKeySpec>(decryptedKey, algorithm->getAlgorithm());
+  }
+  LocalKey::LocalKey(std::string algorithm, std::vector<unsigned char> decryptedKey,
+                     std::vector<unsigned char> encryptedKey):encryptedKey(encryptedKey) {
+    if (!decryptedKey.empty()) {
+      setDecryptedKey(algorithm, decryptedKey);
+    }
+  }
+
+  void LocalKey::setDecryptedKey(std::string algorithm, std::vector<unsigned char> decrypt) {
+    this->decryptedKey = std::make_unique<SecretKeySpec>(decrypt, algorithm);
+  }
+  void LocalKey::setDecryptedKey(std::shared_ptr<SecretKeySpec> secretKeySpec) {
+    this->decryptedKey = secretKeySpec;
+  }
+
+  std::shared_ptr<SecretKeySpec> LocalKey::getDecryptedKey() {
+    return decryptedKey;
+  }
+
+  std::vector<unsigned char> LocalKey::getEncryptedKey() {
+    return encryptedKey;
+  }
+  EncryptionAlgorithm::EncryptionAlgorithm(const std::string& algorithm, const std::string& mode,
+                                           int keyLength)
+      : algorithm(algorithm), mode(mode), keyLength(keyLength) {}
+  EncryptionAlgorithm* EncryptionAlgorithm::AES_CTR_128 =
+      new EncryptionAlgorithm("AES", "CTR/NoPadding", 16);
+  EncryptionAlgorithm* EncryptionAlgorithm::AES_CTR_256 =
+      new EncryptionAlgorithm("AES", "CTR/NoPadding", 32);
+  int EncryptionAlgorithm::getIvLength() {
+    return 16;
+  }
+
+  int EncryptionAlgorithm::getKeyLength() {
+    return this->keyLength;
+  }
+  const std::string EncryptionAlgorithm::getAlgorithm() {
+    return this->algorithm;
+  }
+
+  const std::string EncryptionAlgorithm::toString() {
+    return algorithm + std::to_string(keyLength * 8);
+  }
+  const EVP_CIPHER* EncryptionAlgorithm::createCipher() {
+    if (algorithm == "AES" && mode == "CTR/NoPadding" && keyLength == 16){
+      return EVP_aes_128_ctr();
+    }else if (algorithm == "AES" && mode == "CTR/NoPadding" && keyLength == 32)
+      return EVP_aes_256_ctr();
+    else {
+      throw std::invalid_argument("Bad algorithm or padding");
+    }
+    return NULL;
+  }
+}  // namespace orc

--- a/c++/src/security/InMemoryKeystore.hh
+++ b/c++/src/security/InMemoryKeystore.hh
@@ -1,0 +1,182 @@
+// Copyright 2010-present vivo, Inc. All rights reserved.
+//
+//Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CPPDEMO_INMEMORYKEYSTORE_H
+#define CPPDEMO_INMEMORYKEYSTORE_H
+
+#include <openssl/evp.h>
+#include <openssl/rand.h>
+#include <iostream>
+#include <map>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+#include <memory>
+namespace orc {
+  class EncryptionAlgorithm {
+   public:
+    EncryptionAlgorithm(const std::string& algorithm, const std::string& mode, int keyLength);
+    //Get the EVP_CIPHER and use it for every decryption
+    const EVP_CIPHER* createCipher();
+    int getIvLength();
+    //algorithm name like AES
+    const std::string getAlgorithm();
+    const std::string toString();
+    static EncryptionAlgorithm* AES_CTR_128;
+    static EncryptionAlgorithm* AES_CTR_256;
+    //The length of the algorithm key
+    int getKeyLength();
+
+   private:
+    std::string algorithm;
+    std::string mode;
+    int keyLength;
+  };
+  //describing the KeyProvider key
+  class KeyMetadata {
+   private:
+    std::string keyName;
+    int version;
+    EncryptionAlgorithm* algorithm;
+
+   public:
+    KeyMetadata(std::string key, int version, EncryptionAlgorithm* algorithm)
+        : keyName(key), version(version), algorithm(algorithm) {}
+
+    std::string getKeyName() const {
+      return keyName;
+    }
+
+    EncryptionAlgorithm* getAlgorithm() {
+      return algorithm;
+    }
+
+    int getVersion() const {
+      return version;
+    }
+
+    std::string toString() {
+      return keyName + "@" + std::to_string(version) + " " + algorithm->toString();
+    }
+  };
+  //The key used for decrypting data
+  class SecurityKey : public KeyMetadata {
+   private:
+    std::vector<unsigned char> material;
+   public:
+    SecurityKey(std::string keyName, int version, EncryptionAlgorithm* algorithm,
+               std::vector<unsigned char>& material)
+        : KeyMetadata(keyName, version, algorithm), material(material) {}
+    std::vector<unsigned char> getMaterial() {
+      return material;
+    }
+  };
+
+  //Use the SecurityKey to encrypt the encryptedKey and obtain the reuslt
+  class SecretKeySpec {
+   private:
+    std::vector<unsigned char> key;
+    std::string algorithm;
+
+   public:
+    SecretKeySpec(std::vector<unsigned char> var1, const std::string& var2) {
+      if (!var1.empty() && !var2.empty()) {
+        key = std::vector<unsigned char>(var1);
+        algorithm = var2;
+      } else {
+        throw std::invalid_argument("Missing argument");
+      }
+    }
+    std::string getAlgorithm() const {
+      return algorithm;
+    }
+
+    std::vector<unsigned char> getEncoded() const {
+      return key;
+    }
+  };
+
+  //Use the SecurityKey to encrypt the encryptedKey with the algorithm and obtain the decryptedKey
+  class LocalKey {
+   public:
+    LocalKey(std::string algorithm, std::vector<unsigned char> decryptedKey ,
+             std::vector<unsigned char> encryptedKey);
+
+    void setDecryptedKey(std::string algorithm, std::vector<unsigned char> key);
+    void setDecryptedKey(std::shared_ptr<SecretKeySpec> secretKeySpec);
+
+
+    std::shared_ptr<SecretKeySpec> getDecryptedKey();
+
+    std::vector<unsigned char> getEncryptedKey();
+
+   private:
+    std::vector<unsigned char> encryptedKey;
+    std::shared_ptr<SecretKeySpec> decryptedKey = nullptr;
+  };
+
+  class KeyProvider {
+   public:
+    //virtual ~KeyProvider() = 0;
+    virtual std::vector<std::string> getKeyNames() = 0;
+    //obtain the master key based on the keyName for decrypting the localKey
+    virtual std::unique_ptr<SecurityKey>& getCurrentKeyVersion(std::string keyName) = 0;
+    //decrypt the random number using the master key to generate the local key
+    virtual  LocalKey* createLocalKey(KeyMetadata* key) = 0;
+    //Use the key to find the master key in the KeyProvider, then decrypt the encryptedKey and return the plaintext
+    virtual  std::shared_ptr<SecretKeySpec> decryptLocalKey(KeyMetadata* key, std::vector<unsigned char> encryptedKey) = 0;
+  };
+  //Used for storing the master key and generating multiple local keys when writing data
+  class InMemoryKeystore : public KeyProvider{
+   private:
+    //Used for generating  local keys
+    std::random_device rd;
+    std::mt19937 random;
+    //the master key stored in this keys
+    std::map<std::string, std::unique_ptr<SecurityKey>> keys;
+    // The latest version of the master key used for storage
+    std::map<std::string, int> currentVersion;
+
+   public:
+    InMemoryKeystore();
+    ~InMemoryKeystore();
+    //get the names of all master keys
+    std::vector<std::string> getKeyNames() override;
+    //add master key
+    InMemoryKeystore* addKey(std::string name, EncryptionAlgorithm* algorithm,
+                             std::string password);
+    // add master key with version
+    InMemoryKeystore* addKey(std::string keyName, int version, EncryptionAlgorithm* algorithm,
+                             std::string password);
+    InMemoryKeystore* addKey(std::string keyName, int version,
+                             EncryptionAlgorithm* algorithm,
+                             std::vector<unsigned char> material);
+
+    std::unique_ptr<SecurityKey>& getCurrentKeyVersion(std::string keyName)  override;
+
+    LocalKey* createLocalKey(KeyMetadata* key)  override;
+
+    std::shared_ptr<SecretKeySpec> decryptLocalKey(KeyMetadata* key, std::vector<unsigned char> encryptedKey)  override;
+    //Check if Aes256 encryption and decryption is supported
+    bool testSupportsAes256();
+    std::string buildVersionName(const std::string& name, int version);
+  };
+
+}
+#endif //CPPDEMO_INMEMORYKEYSTORE_H

--- a/c++/src/security/ReaderEncryption.cc
+++ b/c++/src/security/ReaderEncryption.cc
@@ -1,0 +1,278 @@
+// Copyright 2010-present vivo, Inc. All rights reserved.
+//
+//Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ReaderEncryption.hh"
+#include "../Reader.hh"
+namespace orc {
+  EncryptionAlgorithm* fromSerialization(orc::proto::EncryptionAlgorithm& serialization) {
+    switch (serialization) {
+      case orc::proto::EncryptionAlgorithm::AES_CTR_128:
+        return EncryptionAlgorithm::AES_CTR_128;
+      case orc::proto::EncryptionAlgorithm::AES_CTR_256:
+        return EncryptionAlgorithm::AES_CTR_256;
+      default:
+        throw std::invalid_argument("Unknown code in encryption algorithm");
+    }
+  }
+  ReaderEncryption::ReaderEncryption(){};
+
+  ReaderEncryption::ReaderEncryption(std::shared_ptr<FileContents> contents,
+                                     long stripeStatisticsOffset,
+                                     std::shared_ptr<KeyProvider> provider) {
+    if (nullptr != contents->footer || contents->footer->has_encryption()) {
+      keyProvider = provider;
+      const proto::Encryption& encrypt = contents->footer->encryption();
+      //Initialize keys.
+      int keysSize = encrypt.key_size();
+      for (int k = 0; k < keysSize; ++k) {
+        keys.push_back(std::make_unique<ReaderEncryptionKey>(encrypt.key(k)));
+      }
+      //Initialize variants
+      int variantsSize = encrypt.variants_size();
+      //The offset of the stripe statistics information for the column that is encrypted.
+      uint64_t offset = stripeStatisticsOffset;
+      for (int v = 0; v < variantsSize; ++v) {
+        const proto::EncryptionVariant& variant = encrypt.variants(v);
+        std::unique_ptr<ReaderEncryptionKey>& k = keys[static_cast<int>(variant.key())];
+        ReaderEncryptionVariant* readerEncryptionVariant =
+            new ReaderEncryptionVariant(variant,k.get(), v, contents, offset, provider);
+        variants.push_back(std::unique_ptr<ReaderEncryptionVariant>(readerEncryptionVariant));
+        offset += variants[v]->getStripeStatisticsLength();
+      }
+      //ColumnVariants's size is columnSize +1, and for unencrypted columns, its value is null.
+      int columnVariantsSize = contents->schema->getMaximumColumnId() + 1;
+      columnVariants.resize(columnVariantsSize);
+      for (auto it = variants.begin(); it != variants.end(); ++it) {
+        std::shared_ptr<ReaderEncryptionVariant> variant = *it;
+        Type* root = variant->getRoot();
+        //If nested columns are encrypted, they share the same variant object with their parent and sibling columns.
+        for (int c = root->getColumnId(); c <= static_cast<int>(root->getMaximumColumnId()); ++c) {
+          // set the variant if it is the first one that we've found
+          if (columnVariants[c] == nullptr) {
+            columnVariants[c] = std::shared_ptr<ReaderEncryptionVariant>(variant);
+          }
+        }
+      }
+    }
+  }
+  ReaderEncryptionVariant* ReaderEncryption::getVariant(int column) {
+    if (columnVariants.size() == 0) {
+      return nullptr;
+    } else {
+      //If a given variant cannot obtain the decrypted footer key, then look for a variant object that can be decrypted for that column.
+      //Look for a variant object that can be decrypted within its subcolumns.
+      while (columnVariants[column] != nullptr &&
+             !columnVariants[column]->getKeyDescription()->isAvailable()) {
+        if (keyProvider != nullptr) {
+          columnVariants[column].reset(findNextVariant(column, columnVariants[column]->getVariantId()));
+        }
+      }
+      return columnVariants[column].get();
+    }
+  }
+
+  ReaderEncryptionVariant* ReaderEncryption::findNextVariant(int column, int lastVariant) {
+    for (int v = lastVariant + 1; v < static_cast<int>(this->variants.size()); ++v) {
+      Type* root = variants[v]->getRoot();
+      if (static_cast<int>(root->getColumnId()) <= column &&
+          column <= static_cast<int>(root->getMaximumColumnId())) {
+        return variants[v].get();
+      }
+    }
+    return nullptr;
+  }
+  std::vector<std::unique_ptr<ReaderEncryptionKey>>& ReaderEncryption::getKeys() {
+    return keys;
+  }
+  std::vector<std::shared_ptr<ReaderEncryptionVariant>>& ReaderEncryption::getVariants() {
+    return variants;
+  }
+
+  ReaderEncryptionKey::ReaderEncryptionKey(const orc::proto::EncryptionKey& key)
+      : name(key.key_name()), version(key.key_version()), state(State::UNTRIED) {
+    orc::proto::EncryptionAlgorithm al = key.algorithm();
+    algorithm = orc::fromSerialization(al);
+  }
+  std::string ReaderEncryptionKey::getKeyName() const {
+    return name;
+  }
+
+  int ReaderEncryptionKey::getKeyVersion() {
+    return version;
+  }
+
+  orc::EncryptionAlgorithm* ReaderEncryptionKey::getAlgorithm() {
+    return algorithm;
+  }
+
+  std::vector<ReaderEncryptionVariant*>& ReaderEncryptionKey::getEncryptionRoots() {
+    return roots;
+  }
+
+  std::unique_ptr<orc::KeyMetadata> ReaderEncryptionKey::getMetadata() {
+    return std::make_unique<KeyMetadata>(name, version, algorithm);
+  }
+
+  ReaderEncryptionKey::State& ReaderEncryptionKey::getState() {
+    return this->state;
+  }
+
+  void ReaderEncryptionKey::setFailure() {
+    this->state = State::SUCCESS;
+  }
+
+  void ReaderEncryptionKey::setSuccess() {
+    this->state = State::SUCCESS;
+  }
+
+  void ReaderEncryptionKey::addVariant(ReaderEncryptionVariant* newVariant) {
+    roots.push_back(newVariant);
+  }
+  bool ReaderEncryptionKey::isAvailable() {
+    if (getState() == ReaderEncryptionKey::State::SUCCESS) {
+      return true;
+    } else if (getState() == ReaderEncryptionKey::State::UNTRIED && !getEncryptionRoots().empty()) {
+      // Check to see if we can decrypt the footer key of the first variant.
+      try {
+        return getEncryptionRoots()[0]->getFileFooterKey() != nullptr;
+      } catch (const std::exception& e) {
+        setFailure();
+      }
+    }
+    return false;
+  }
+  ReaderEncryptionVariant::ReaderEncryptionVariant(
+      const proto::EncryptionVariant& proto,
+      ReaderEncryptionKey* key,
+      int variantId,
+      std::shared_ptr<FileContents> contents,
+      uint64_t stripeStatsOffset,
+      std::shared_ptr<KeyProvider> provider)
+      : proto(proto),
+        key(key),
+        variantId(variantId),
+        stripeStatsOffset(stripeStatsOffset),
+        provider(provider){
+    if (proto.has_root()) {
+      column = contents->schema->getTypeByColumnId(proto.root());
+    } else {
+      column = contents->schema.get();
+    }
+    // Each strip in this column has its own key.
+    size_t stripeCount = contents->stripeList.size();
+    if (proto.has_encrypted_key()) {
+      std::string algorithm = key->getAlgorithm()->getAlgorithm();
+      for (size_t s = 0; s < stripeCount; ++s) {
+        StripeInformation* stripe = contents->stripeList.at(s).get();
+        std::vector<unsigned char> colKey = stripe->getEncryptedLocalKeyByVariantId(variantId);
+        std::vector<unsigned char> deKey;
+        LocalKey* localKey = new LocalKey(algorithm,deKey, colKey);
+        localKeys.push_back(std::shared_ptr<LocalKey>(localKey));
+      }
+      // The FileStat and StripStat information for decrypting this column.
+      std::string footerKeyStr = proto.encrypted_key();
+      std::vector<unsigned char> enKey(footerKeyStr.begin(), footerKeyStr.end());
+      std::vector<unsigned char> deKey;
+      footerKey =std::shared_ptr<LocalKey>(new LocalKey(algorithm, deKey,enKey));
+      key->addVariant(this);
+    } else {
+      footerKey = nullptr;
+    }
+  }
+  ReaderEncryptionKey* ReaderEncryptionVariant::getKeyDescription() {
+    return this->key;
+  }
+  Type* ReaderEncryptionVariant::getRoot() {
+    return const_cast<Type*>(this->column);
+  }
+
+  int ReaderEncryptionVariant::getVariantId() {
+    return this->variantId;
+  }
+
+  std::shared_ptr<SecretKeySpec> ReaderEncryptionVariant::getFileFooterKey() {
+    if (this->key != nullptr && this->provider != nullptr) {
+      return  getDecryptedKey(footerKey.get());;
+    } else {
+      return nullptr;
+    }
+  }
+  long ReaderEncryptionVariant::getStripeStatisticsLength() {
+    long result = 0;
+    // proto.stripestatistics()
+    for (int i = 0; i < proto.stripe_statistics_size(); i++) {
+      result +=  proto.stripe_statistics(i).length();
+    }
+    return result;
+  }
+  uint64_t ReaderEncryptionVariant::getStripeStatsOffset(){
+      return stripeStatsOffset;
+  }
+  orc::proto::ColumnarStripeStatistics* ReaderEncryptionVariant::getAllEncryptStripeStatistics(){
+    return allEncryptionStripeStatistics.get();
+  }
+  void ReaderEncryptionVariant::setAllEncryptStripeStatistics(orc::proto::ColumnarStripeStatistics* tmp){
+    allEncryptionStripeStatistics = std::unique_ptr<orc::proto::ColumnarStripeStatistics>(tmp);
+  }
+  void ReaderEncryptionVariant::setFileStatistics(orc::proto::FileStatistics* tmp){
+    fileStatistics = std::unique_ptr<orc::proto::FileStatistics>(tmp);
+  }
+  orc::proto::FileStatistics* ReaderEncryptionVariant::getFileStatistics(){
+    return fileStatistics.get();
+  }
+  const proto::EncryptionVariant& ReaderEncryptionVariant::getEncryptionVariantProto(){
+      return this->proto;
+  }
+  std::shared_ptr<SecretKeySpec> ReaderEncryptionVariant::getStripeKey(long stripe) {
+    if (key == nullptr || provider == nullptr) return nullptr;
+    return getDecryptedKey(localKeys[stripe].get());
+  }
+
+  std::shared_ptr<SecretKeySpec> ReaderEncryptionVariant::getDecryptedKey(LocalKey* localKey) const {
+    std::shared_ptr<SecretKeySpec> result = localKey->getDecryptedKey();
+    //Check if localkey has been decrypted.
+    if (result == nullptr) {
+      switch (key->getState()) {
+        case ReaderEncryptionKey::State::UNTRIED:
+          try {
+            result = provider->decryptLocalKey(key->getMetadata().get(), localKey->getEncryptedKey());
+          } catch (const std::exception& e) {
+            std::cout << "Can't decrypt using key " << key->getKeyName() << std::endl;
+          }
+          if (result != nullptr) {
+            localKey->setDecryptedKey(result);
+            key->setSuccess();
+          } else {
+            key->setFailure();
+          }
+          break;
+        case ReaderEncryptionKey::State::SUCCESS:
+          result = provider->decryptLocalKey(key->getMetadata().get(), localKey->getEncryptedKey());
+          if (result == nullptr) {
+            throw std::runtime_error("Can't decrypt local key " + key->getKeyName());
+          }
+          localKey->setDecryptedKey(result);
+          break;
+        case ReaderEncryptionKey::State::FAILURE:
+          return nullptr;
+      }
+    }
+    return result;
+  };
+
+}  // namespace orc

--- a/c++/src/security/ReaderEncryption.hh
+++ b/c++/src/security/ReaderEncryption.hh
@@ -1,0 +1,215 @@
+// Copyright 2010-present vivo, Inc. All rights reserved.
+//
+//Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ORC_READERENCRYPTION_H
+#define ORC_READERENCRYPTION_H
+
+#include <memory>
+#include "InMemoryKeystore.hh"
+#include "orc/Common.hh"
+#include "orc/Statistics.hh"
+#include "orc/Type.hh"
+#include "orc_proto.pb.h"
+namespace orc {
+  class ReaderEncryptionKey;
+  struct FileContents;
+  class EncryptionVariant {
+   public:
+    std::shared_ptr<ReaderEncryptionKey> getKeyDescription();
+
+    Type* getRoot();
+
+    int getVariantId();
+
+    std::shared_ptr<SecretKeySpec> getFileFooterKey();
+
+    std::shared_ptr<SecretKeySpec> getStripeKey(long stripe);
+  };
+
+  // 加密变体，每个列一个
+  // 每个strip 都有个StripeKey,用于解密数据的
+  // 每个列都有一个FileFooterKey，用于解密FileStat，StripStat
+  class ReaderEncryptionVariant : public EncryptionVariant {
+   public:
+    ReaderEncryptionVariant(const proto::EncryptionVariant& proto,
+                            ReaderEncryptionKey* key,
+                            int variantId,
+                            std::shared_ptr<FileContents> contents,
+                            uint64_t stripeStatsOffset,
+                            std::shared_ptr<KeyProvider> provider);
+    //Type* getColumn();
+    long getStripeStatisticsLength();
+    ReaderEncryptionKey* getKeyDescription();
+    Type* getRoot();
+    int getVariantId();
+    /**
+     * Get the footer key of this column and decrypt it.
+     * @return
+     */
+    std::shared_ptr<SecretKeySpec> getFileFooterKey();
+    /**
+     * Get the local key of a specific stripe in this column and decrypt it.
+     * @param stripe
+     * @return
+     */
+    std::shared_ptr<SecretKeySpec> getStripeKey(long stripe);
+    /**
+     * Get the length of the statistical information of the column
+     * @return
+     */
+    uint64_t getStripeStatsOffset();
+    /**
+     * All the statistical information of this column after stripping is stored here for caching,
+     * avoiding multiple readings and affecting performance.
+     * @return
+     */
+    orc::proto::ColumnarStripeStatistics* getAllEncryptStripeStatistics();
+    /**
+     * All the statistical information of this column after stripping is stored here for caching,
+     * avoiding multiple readings and affecting performance.
+     * @return
+     */
+    void setAllEncryptStripeStatistics(orc::proto::ColumnarStripeStatistics* tmp);
+    void setFileStatistics(orc::proto::FileStatistics* tmp);
+    orc::proto::FileStatistics* getFileStatistics();
+    const proto::EncryptionVariant& getEncryptionVariantProto();
+   private:
+    const proto::EncryptionVariant& proto;
+    ReaderEncryptionKey* key;
+    const Type* column;
+    //The indexes of all encrypted columns.
+    int variantId;
+    //Each stripe in this column has a local key.
+    std::vector<std::shared_ptr<LocalKey>> localKeys;
+    //All stripes in this column have a footer key.
+    std::shared_ptr<LocalKey> footerKey;
+    //
+    uint64_t stripeStatsOffset;
+    std::shared_ptr<KeyProvider> provider;
+    // All the statistical information of this column after stripping is stored here for caching,
+    // avoiding multiple readings and affecting performance.
+    std::unique_ptr<orc::proto::ColumnarStripeStatistics> allEncryptionStripeStatistics = nullptr;
+    std::unique_ptr<orc::proto::FileStatistics> fileStatistics = nullptr;
+    /**
+     * Decrypt local key,
+     * @param pKey
+     * @return
+     */
+    std::shared_ptr<SecretKeySpec> getDecryptedKey(LocalKey* pKey) const;
+  };
+  // 定义 加密key的信息，不存储密钥
+  class ReaderEncryptionKey {
+   public:
+    enum class State { UNTRIED, FAILURE, SUCCESS };
+    ReaderEncryptionKey();
+    ReaderEncryptionKey(const proto::EncryptionKey& key);
+    std::string getKeyName() const;
+    int getKeyVersion();
+    //Check if the footerkey can be decrypted.
+    bool isAvailable();
+    EncryptionAlgorithm* getAlgorithm();
+    std::vector<ReaderEncryptionVariant*>& getEncryptionRoots();
+    std::unique_ptr<KeyMetadata> getMetadata();
+    ReaderEncryptionKey::State& getState();
+    void setFailure();
+    void setSuccess();
+    void addVariant(ReaderEncryptionVariant* newVariant);
+    bool operator==(const ReaderEncryptionKey& other) const {
+      return (name == other.name) && (version == other.version) && (algorithm == other.algorithm);
+    }
+
+    bool operator!=(const ReaderEncryptionKey& other) const {
+      return !(*this == other);
+    }
+
+   private:
+    std::string name;
+    int version;
+    EncryptionAlgorithm* algorithm;
+    std::vector<ReaderEncryptionVariant*> roots;
+    State state;
+  };
+  class ReaderEncryption {
+   public:
+    ReaderEncryption(std::shared_ptr<FileContents> contents,
+                     long stripeStatisticsOffset,
+                     std::shared_ptr<KeyProvider> provider);
+    ReaderEncryption();
+    std::vector<std::unique_ptr<ReaderEncryptionKey>>& getKeys();
+    ReaderEncryptionVariant* getVariant(int column);
+    std::vector<std::shared_ptr<ReaderEncryptionVariant>>& getVariants();
+
+   private:
+    std::shared_ptr<KeyProvider> keyProvider;
+    std::vector<std::unique_ptr<ReaderEncryptionKey>> keys;
+    std::vector<std::shared_ptr<ReaderEncryptionVariant>> variants;
+    //ColumnVariants's size is columnSize +1, and for unencrypted columns, its value is null.
+    std::vector<std::shared_ptr<ReaderEncryptionVariant>> columnVariants;
+    ReaderEncryptionVariant* findNextVariant(int column, int lastVariant);
+  };
+  class CryptoUtil {
+   private:
+    static const int COLUMN_ID_LENGTH = 3;
+    static const int KIND_LENGTH = 2;
+    static const int STRIPE_ID_LENGTH = 3;
+    static const int MIN_COUNT_BYTES = 8;
+
+    static const int MAX_COLUMN = 0xffffff;
+    static const int MAX_KIND = 0xffff;
+    static const int MAX_STRIPE = 0xffffff;
+
+   public:
+    static unsigned char* modifyIvForStream(int columnId, proto::Stream_Kind kind, long stripeId,
+                                            unsigned char* iv, int ivLength) {
+      if (columnId < 0 || columnId > MAX_COLUMN) {
+        throw std::invalid_argument("ORC encryption is limited to " + std::to_string(MAX_COLUMN) +
+                                    " columns. Value = " + std::to_string(columnId));
+      }
+      int k = kind;
+      if (k < 0 || k > MAX_KIND) {
+        throw std::invalid_argument("ORC encryption is limited to " + std::to_string(MAX_KIND) +
+                                    " stream kinds. Value = " + std::to_string(k));
+      }
+      if (ivLength - (COLUMN_ID_LENGTH + KIND_LENGTH + STRIPE_ID_LENGTH) < MIN_COUNT_BYTES) {
+        throw std::invalid_argument("Not enough space in the iv for the count");
+      }
+      iv[0] = static_cast<char>(columnId >> 16);
+      iv[1] = static_cast<char>(columnId >> 8);
+      iv[2] = static_cast<char>(columnId);
+      iv[COLUMN_ID_LENGTH] = static_cast<char>(k >> 8);
+      iv[COLUMN_ID_LENGTH + 1] = static_cast<char>(k);
+      modifyIvForStripe(stripeId, iv, ivLength);
+      return iv;
+    }
+
+    static unsigned char* modifyIvForStripe(long stripeId, unsigned char* iv, int ivLength) {
+      if (stripeId < 1 || stripeId > MAX_STRIPE) {
+        throw std::invalid_argument("ORC encryption is limited to " + std::to_string(MAX_STRIPE) +
+                                    " stripes. Value = " + std::to_string(stripeId));
+      }
+      iv[COLUMN_ID_LENGTH + KIND_LENGTH] = static_cast<char>(stripeId >> 16);
+      iv[COLUMN_ID_LENGTH + KIND_LENGTH + 1] = static_cast<char>(stripeId >> 8);
+      iv[COLUMN_ID_LENGTH + KIND_LENGTH + 2] = static_cast<char>(stripeId);
+      for (int i = COLUMN_ID_LENGTH + KIND_LENGTH + STRIPE_ID_LENGTH; i < ivLength; ++i) {
+        iv[i] = 0;
+      }
+      return iv;
+    }
+  };
+}  // namespace orc
+#endif  // ORC_READERENCRYPTION_H


### PR DESCRIPTION
### What changes were proposed in this pull request?
you can use C++ version code to read encrypted ORC files


### Why are the changes needed?
The C++ version is not yet able to read encrypted ORC files now


### How was this patch tested?
    orc::RowReaderOptions rowReaderOptions;
    orc::ReaderOptions readerOpts;
    std::shared_ptr<orc::InMemoryKeystore> keyStore = std::make_shared<orc::InMemoryKeystore>();
    std::string passKey ="secret123";
    keyStore->addKey("pii", 0, orc::EncryptionAlgorithm::AES_CTR_128,passKey);
    readerOpts.setKeyProvider(keyStore);
    printContents("/root/starrocks/encryption.orc",readerOpts, rowReaderOptions);


