### PR TITLE
ORC-1752: Fix NumberFormatException when reading json timestamp type in benchmark

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/convert/json/JsonReader.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/convert/json/JsonReader.java
@@ -172,7 +172,12 @@ public class JsonReader implements BatchReader {
         vect.isNull[row] = true;
       } else {
         TimestampColumnVector vector = (TimestampColumnVector) vect;
-        vector.set(row, new Timestamp(value.getAsLong()));
+        try {
+          vector.set(row, new Timestamp(value.getAsLong()));
+        } catch (NumberFormatException e) {
+          vector.set(row, Timestamp.valueOf(value.getAsString()
+              .replaceAll("[TZ]", " ")));
+        }
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix NumberFormatException when reading json timestamp type in benchmark.

### Why are the changes needed?
Because the source data of the benchmark has two timestamp formats, we need to be compatible with both Long and String timestamp formats.

```java
Exception in thread "main" java.lang.NumberFormatException: For input string: "2015-11-04T12:00:00Z"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Long.parseLong(Long.java:711)
	at java.base/java.lang.Long.parseLong(Long.java:836)
	at com.google.gson.JsonPrimitive.getAsLong(JsonPrimitive.java:206)
	at org.apache.orc.bench.core.convert.json.JsonReader$TimestampColumnConverter.convert(JsonReader.java:175)
	at org.apache.orc.bench.core.convert.json.JsonReader.nextBatch(JsonReader.java:86)
	at org.apache.orc.bench.core.convert.GenerateVariants$RecursiveReader.nextBatch(GenerateVariants.java:195)
	at org.apache.orc.bench.core.convert.GenerateVariants.run(GenerateVariants.java:154)
	at org.apache.orc.bench.core.Driver.main(Driver.java:64)
```

### How was this patch tested?
```bash
java -jar core/target/orc-benchmarks-core-*-uber.jar generate data
java -jar core/target/orc-benchmarks-core-*-uber.jar scan data
```

### Was this patch authored or co-authored using generative AI tooling?
No
