### PR TITLE
ORC-1753: Use Avro 1.12.0 in `bench` module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -33,7 +33,7 @@
   </modules>
 
   <properties>
-    <avro.version>1.11.3</avro.version>
+    <avro.version>1.12.0</avro.version>
     <hive.version>4.0.0</hive.version>
     <jmh.version>1.37</jmh.version>
     <junit.version>5.10.3</junit.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Avro 1.12.0 in `bench` module.

### Why are the changes needed?

Apache Avro 1.12.0 is the latest feature release.

Since we are fixing this area recently, we had better keep it up-to-date in order to avoid re-validation in the future.
- https://github.com/apache/orc/pull/1930
- https://github.com/apache/orc/pull/1995

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.