### PR TITLE
ORC-1758: Use `OpenContainers` Annotations in docker images

### DIFF
--- a/docker/debian11/Dockerfile
+++ b/docker/debian11/Dockerfile
@@ -20,6 +20,8 @@
 FROM debian:bullseye
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Debian 11"
+LABEL org.opencontainers.image.version=""
 ARG jdk=17
 
 RUN apt-get update

--- a/docker/debian11/Dockerfile
+++ b/docker/debian11/Dockerfile
@@ -18,7 +18,8 @@
 #
 
 FROM debian:bullseye
-LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 ARG jdk=17
 
 RUN apt-get update

--- a/docker/debian12/Dockerfile
+++ b/docker/debian12/Dockerfile
@@ -20,6 +20,8 @@
 FROM debian:bookworm
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Debian 12"
+LABEL org.opencontainers.image.version=""
 ARG jdk=17
 
 RUN apt-get update

--- a/docker/debian12/Dockerfile
+++ b/docker/debian12/Dockerfile
@@ -18,7 +18,8 @@
 #
 
 FROM debian:bookworm
-LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 ARG jdk=17
 
 RUN apt-get update

--- a/docker/fedora37/Dockerfile
+++ b/docker/fedora37/Dockerfile
@@ -14,12 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ORC compile for CentOS 7
+# ORC compile for Fedora Linux 37
 #
 
 FROM fedora:37
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Fedora Linux 37"
+LABEL org.opencontainers.image.version=""
 
 RUN yum check-update || true
 RUN yum install -y \

--- a/docker/fedora37/Dockerfile
+++ b/docker/fedora37/Dockerfile
@@ -18,7 +18,8 @@
 #
 
 FROM fedora:37
-LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 RUN yum check-update || true
 RUN yum install -y \

--- a/docker/oraclelinux9/Dockerfile
+++ b/docker/oraclelinux9/Dockerfile
@@ -18,7 +18,8 @@
 #
 
 FROM oraclelinux:9
-LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 RUN yum check-update || true
 RUN yum install -y \

--- a/docker/ubuntu22/Dockerfile
+++ b/docker/ubuntu22/Dockerfile
@@ -18,7 +18,8 @@
 #
 
 FROM ubuntu:22.04
-LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 ARG jdk=17
 ARG cc=gcc
 

--- a/docker/ubuntu22/Dockerfile
+++ b/docker/ubuntu22/Dockerfile
@@ -20,6 +20,8 @@
 FROM ubuntu:22.04
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Ubuntu 22"
+LABEL org.opencontainers.image.version=""
 ARG jdk=17
 ARG cc=gcc
 

--- a/docker/ubuntu24/Dockerfile
+++ b/docker/ubuntu24/Dockerfile
@@ -18,7 +18,8 @@
 #
 
 FROM ubuntu:24.04
-LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 ARG jdk=21
 ARG cc=gcc
 

--- a/docker/ubuntu24/Dockerfile
+++ b/docker/ubuntu24/Dockerfile
@@ -20,6 +20,8 @@
 FROM ubuntu:24.04
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Ubuntu 24"
+LABEL org.opencontainers.image.version=""
 ARG jdk=21
 ARG cc=gcc
 

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -20,6 +20,8 @@
 FROM ubuntu:20.04
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC site builder"
+LABEL org.opencontainers.image.version=""
 
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -18,7 +18,8 @@
 #
 
 FROM ubuntu:20.04
-LABEL maintainer="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
 RUN apt-get update


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `OpenContainers` Annotations to docker image.

- https://specs.opencontainers.org/image-spec/annotations/

### Why are the changes needed?

**AFTER**
```
$ docker inspect apache/orc-dev:ubuntu24 | jq '.[0].Config.Labels'
{
  "org.opencontainers.image.authors": "Apache ORC project <dev@orc.apache.org>",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.ref.name": "Apache ORC on Ubuntu 24",
  "org.opencontainers.image.version": ""
}
```

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.