### PR TITLE
Bump com.google.protobuf:protobuf-java from 3.25.3 to 3.27.4 in /java

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -79,7 +79,7 @@
     <orc-format.version>1.0.0</orc-format.version>
     <!-- Build Properties -->
     <project.build.outputTimestamp>2024-01-08T16:47:56Z</project.build.outputTimestamp>
-    <protobuf.version>3.25.4</protobuf.version>
+    <protobuf.version>3.27.4</protobuf.version>
     <slf4j.version>2.0.16</slf4j.version>
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.0.0-M5</surefire.version>


### PR DESCRIPTION
Similar to https://github.com/apache/orc/pull/1853 but picking up https://github.com/protocolbuffers/protobuf/pull/17934

