### PR TITLE
ORC-1776: Remove `MacOS 12` from GitHub Action CI and docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,6 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-12
           - macos-13
           - macos-14
         java:
@@ -193,7 +192,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [12, 13, 14]
+        version: [13, 14]
     runs-on: macos-${{ matrix.version }}
     steps:
     - name: Checkout repository

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -11,7 +11,7 @@ The C++ library is supported on the following operating systems:
 
 * CentOS 7
 * Debian 10 to 12
-* MacOS 12 to 14
+* MacOS 13 to 14
 * Ubuntu 22.04 to 24.04
 
 You'll want to install the usual set of developer tools, but at least:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `MacOS 12` from GitHub Action CI and docs.

### Why are the changes needed?

- MacOS 12 started to release on October 25, 2021 .
- Apache ORC has 3-year support policy. We had better focus on MacOS 13+ from Apache ORC 2.1.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.