### PR TITLE
ORC-1778: Upgrade Spark to 4.0.0-preview2

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -41,7 +41,7 @@
     <parquet.version>1.14.2</parquet.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scala.version>2.13.14</scala.version>
-    <spark.version>4.0.0-preview1</spark.version>
+    <spark.version>4.0.0-preview2</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade the benchmark module to use Spark 4.0.0-preview2.

### Why are the changes needed?


### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
