### PR TITLE
ORC-1782: Upgrade Hadoop to 3.4.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -64,7 +64,7 @@
     <brotli4j.version>1.17.0</brotli4j.version>
     <checkstyle.version>10.18.2</checkstyle.version>
     <example.dir>${project.basedir}/../../examples</example.dir>
-    <hadoop.version>3.4.0</hadoop.version>
+    <hadoop.version>3.4.1</hadoop.version>
     <java.version>17</java.version>
     <javadoc.location>${project.basedir}/../target/javadoc</javadoc.location>
     <junit.version>5.11.2</junit.version>
@@ -304,6 +304,10 @@
       <id>central</id>
       <name>Maven Repository</name>
       <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
+      <id>hadoop</id>
+      <url>https://repository.apache.org/content/repositories/orgapachehadoop-1430</url>
     </repository>
   </repositories>
   <pluginRepositories>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -305,10 +305,6 @@
       <name>Maven Repository</name>
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
-    <repository>
-      <id>hadoop</id>
-      <url>https://repository.apache.org/content/repositories/orgapachehadoop-1430</url>
-    </repository>
   </repositories>
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Hadoop to 3.4.1.

### Why are the changes needed?

To bring the latest bug fixes.

- http://hadoop.apache.org/docs/r3.4.1/index.html
- http://hadoop.apache.org/docs/r3.4.1/hadoop-project-dist/hadoop-common/release/3.4.1/RELEASENOTES.3.4.1.html
- http://hadoop.apache.org/docs/r3.4.1/hadoop-project-dist/hadoop-common/release/3.4.1/CHANGELOG.3.4.1.html 

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.