### PR TITLE
ORC-1784: Upgrade `Maven` to 3.9.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The subdirectories are:
 ### Building
 
 * Install java 17 or higher
-* Install maven 3.9.6 or higher
+* Install maven 3.9.9 or higher
 * Install cmake 3.12 or higher
 
 To build a release version with debug information:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -73,7 +73,7 @@
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-    <maven.version>3.9.6</maven.version>
+    <maven.version>3.9.9</maven.version>
 
     <mockito.version>5.10.0</mockito.version>
     <orc-format.version>1.0.0</orc-format.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `Maven` to 3.9.9.

### Why are the changes needed?

To bring the latest bug fixed version in addition to align with Apache Spark 4.0.0,
- https://github.com/apache/spark/pull/47827

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.