### PR TITLE
ORC-1792: Upgrade Spark to 3.5.3

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,7 +40,7 @@
     <junit.version>5.9.3</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.13.1</parquet.version>
-    <spark.version>3.5.0</spark.version>
+    <spark.version>3.5.3</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Spark dependency to 3.5.3 in `branch-1.9` bench module.

### Why are the changes needed?

To run the benchmark with the latest Spark 3.5.3.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.