### PR TITLE
ORC-1793: Upgrade Spark to 3.4.4

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,7 +40,7 @@
     <junit.version>5.8.2</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.13.0</parquet.version>
-    <spark.version>3.4.0</spark.version>
+    <spark.version>3.4.4</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to 3.4.4 in branch-1.8 bench module.

### Why are the changes needed?

Apache Spark 3.4 reached the end of support and 3.4.4 is the last release. We can use this last release until Apache ORC 1.8.x reaches our end of support.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.