### PR TITLE
ORC-1802: Enable tag protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,6 +30,9 @@ github:
     - java
     - cpp
     - big-data
+  protected_tags:
+    - "rel/*"
+    - "v*.*.*"
 notifications:
   pullrequests: issues@orc.apache.org
   issues: issues@orc.apache.org


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable tag protection in Apache ORC repository.

### Why are the changes needed?

To protect tags.
- https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-Tagprotection

For example, `rel/*` tags are referenced by Apache ORC website and `v*.*.*` tags are referenced by other ASF projects.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.