### PR TITLE
ORC-1811: Use the recommended `closer.lua` URL to download ORC format

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -138,7 +138,6 @@ endfunction()
 # ORC Format
 ExternalProject_Add (orc-format_ep
   URL "https://www.apache.org/dyn/closer.lua/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz?action=download"
-  URL "https://archive.apache.org/dist/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz"
   URL_HASH SHA256=739fae5ff94b1f812b413077280361045bf92e510ef04b34a610e23a945d8cd5
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -137,7 +137,7 @@ endfunction()
 # ----------------------------------------------------------------------
 # ORC Format
 ExternalProject_Add (orc-format_ep
-  URL "https://dlcdn.apache.org/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz"
+  URL "https://www.apache.org/dyn/closer.lua/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz?action=download"
   URL "https://archive.apache.org/dist/orc/orc-format-${ORC_FORMAT_VERSION}/orc-format-${ORC_FORMAT_VERSION}.tar.gz"
   URL_HASH SHA256=739fae5ff94b1f812b413077280361045bf92e510ef04b34a610e23a945d8cd5
   CONFIGURE_COMMAND ""


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the ASF-recommended `closer.lua` URL instead of the direct `dlcdn` link or `archive` link.
- https://infra.apache.org/release-download-pages.html#download-page

    >  you can generate a direct download link using the following syntax:
    > http://www.apache.org/dyn/closer.lua/bar/foo/foo-5.5.1.zip?action=download

### Why are the changes needed?

To use the recommended download link in order to stabilize CIs.

This is suggested from Arrow community.
- https://github.com/apache/orc/pull/1830#issuecomment-2529406685
- https://github.com/apache/arrow/pull/44977

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.