### PR TITLE
fix has_null forward compatibility

### DIFF
--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -181,13 +181,13 @@ namespace orc {
 
   ColumnStatisticsImpl::ColumnStatisticsImpl(const proto::ColumnStatistics& pb) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
   }
 
   BinaryColumnStatisticsImpl::BinaryColumnStatisticsImpl(const proto::ColumnStatistics& pb,
                                                          const StatContext& statContext) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (pb.has_binary_statistics() && statContext.correctStats) {
       stats_.setHasTotalLength(pb.binary_statistics().has_sum());
       stats_.setTotalLength(static_cast<uint64_t>(pb.binary_statistics().sum()));
@@ -197,7 +197,7 @@ namespace orc {
   BooleanColumnStatisticsImpl::BooleanColumnStatisticsImpl(const proto::ColumnStatistics& pb,
                                                            const StatContext& statContext) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (pb.has_bucket_statistics() && statContext.correctStats) {
       hasCount_ = true;
       trueCount_ = pb.bucket_statistics().count(0);
@@ -210,7 +210,7 @@ namespace orc {
   DateColumnStatisticsImpl::DateColumnStatisticsImpl(const proto::ColumnStatistics& pb,
                                                      const StatContext& statContext) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (!pb.has_date_statistics() || !statContext.correctStats) {
       // hasMinimum_ is false by default;
       // hasMaximum_ is false by default;
@@ -227,7 +227,7 @@ namespace orc {
   DecimalColumnStatisticsImpl::DecimalColumnStatisticsImpl(const proto::ColumnStatistics& pb,
                                                            const StatContext& statContext) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (pb.has_decimal_statistics() && statContext.correctStats) {
       const proto::DecimalStatistics& stats = pb.decimal_statistics();
       stats_.setHasMinimum(stats.has_minimum());
@@ -242,7 +242,7 @@ namespace orc {
 
   DoubleColumnStatisticsImpl::DoubleColumnStatisticsImpl(const proto::ColumnStatistics& pb) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (!pb.has_double_statistics()) {
       stats_.setMinimum(0);
       stats_.setMaximum(0);
@@ -261,7 +261,7 @@ namespace orc {
 
   IntegerColumnStatisticsImpl::IntegerColumnStatisticsImpl(const proto::ColumnStatistics& pb) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (!pb.has_int_statistics()) {
       stats_.setMinimum(0);
       stats_.setMaximum(0);
@@ -281,7 +281,7 @@ namespace orc {
   StringColumnStatisticsImpl::StringColumnStatisticsImpl(const proto::ColumnStatistics& pb,
                                                          const StatContext& statContext) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (!pb.has_string_statistics() || !statContext.correctStats) {
       stats_.setTotalLength(0);
     } else {
@@ -299,7 +299,7 @@ namespace orc {
   TimestampColumnStatisticsImpl::TimestampColumnStatisticsImpl(const proto::ColumnStatistics& pb,
                                                                const StatContext& statContext) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (!pb.has_timestamp_statistics() || !statContext.correctStats) {
       stats_.setMinimum(0);
       stats_.setMaximum(0);
@@ -365,7 +365,7 @@ namespace orc {
   CollectionColumnStatisticsImpl::CollectionColumnStatisticsImpl(
       const proto::ColumnStatistics& pb) {
     stats_.setNumberOfValues(pb.number_of_values());
-    stats_.setHasNull(pb.has_null());
+    stats_.setHasNull(pb.has_has_null() ? pb.has_null() : false);
     if (!pb.has_collection_statistics()) {
       stats_.setMinimum(0);
       stats_.setMaximum(0);

--- a/c++/src/sargs/PredicateLeaf.cc
+++ b/c++/src/sargs/PredicateLeaf.cc
@@ -390,10 +390,15 @@ namespace orc {
 
   DIAGNOSTIC_POP
 
+  static bool col_has_null_forward_compatible(const proto::ColumnStatistics& stats) {
+    // for foward compatibility, if has_null is not set, assume that the column has nulls
+    return stats.has_has_null() ? stats.has_null() : true;
+  }
+
   static TruthValue evaluateBoolPredicate(const PredicateLeaf::Operator op,
                                           const std::vector<Literal>& literals,
                                           const proto::ColumnStatistics& stats) {
-    bool hasNull = stats.has_null();
+    bool hasNull = col_has_null_forward_compatible(stats);
     if (!stats.has_bucket_statistics() || stats.bucket_statistics().count_size() == 0) {
       // does not have bool stats
       return hasNull ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
@@ -512,8 +517,9 @@ namespace orc {
         if (colStats.has_int_statistics() && colStats.int_statistics().has_minimum() &&
             colStats.int_statistics().has_maximum()) {
           const auto& stats = colStats.int_statistics();
-          result = evaluatePredicateRange(operator_, literal2Long(literals_), stats.minimum(),
-                                          stats.maximum(), colStats.has_null());
+          result =
+              evaluatePredicateRange(operator_, literal2Long(literals_), stats.minimum(),
+                                     stats.maximum(), col_has_null_forward_compatible(colStats));
         }
         break;
       }
@@ -522,10 +528,12 @@ namespace orc {
             colStats.double_statistics().has_maximum()) {
           const auto& stats = colStats.double_statistics();
           if (!std::isfinite(stats.sum())) {
-            result = colStats.has_null() ? TruthValue::YES_NO_NULL : TruthValue::YES_NO;
+            result = col_has_null_forward_compatible(colStats) ? TruthValue::YES_NO_NULL
+                                                               : TruthValue::YES_NO;
           } else {
-            result = evaluatePredicateRange(operator_, literal2Double(literals_), stats.minimum(),
-                                            stats.maximum(), colStats.has_null());
+            result =
+                evaluatePredicateRange(operator_, literal2Double(literals_), stats.minimum(),
+                                       stats.maximum(), col_has_null_forward_compatible(colStats));
           }
         }
         break;
@@ -535,8 +543,9 @@ namespace orc {
         if (colStats.has_string_statistics() && colStats.string_statistics().has_minimum() &&
             colStats.string_statistics().has_maximum()) {
           const auto& stats = colStats.string_statistics();
-          result = evaluatePredicateRange(operator_, literal2String(literals_), stats.minimum(),
-                                          stats.maximum(), colStats.has_null());
+          result =
+              evaluatePredicateRange(operator_, literal2String(literals_), stats.minimum(),
+                                     stats.maximum(), col_has_null_forward_compatible(colStats));
         }
         break;
       }
@@ -544,8 +553,9 @@ namespace orc {
         if (colStats.has_date_statistics() && colStats.date_statistics().has_minimum() &&
             colStats.date_statistics().has_maximum()) {
           const auto& stats = colStats.date_statistics();
-          result = evaluatePredicateRange(operator_, literal2Date(literals_), stats.minimum(),
-                                          stats.maximum(), colStats.has_null());
+          result =
+              evaluatePredicateRange(operator_, literal2Date(literals_), stats.minimum(),
+                                     stats.maximum(), col_has_null_forward_compatible(colStats));
         }
         break;
       }
@@ -567,7 +577,7 @@ namespace orc {
               stats.maximum_utc() / 1000,
               static_cast<int32_t>((stats.maximum_utc() % 1000) * 1000000) + maxNano);
           result = evaluatePredicateRange(operator_, literal2Timestamp(literals_), minTimestamp,
-                                          maxTimestamp, colStats.has_null());
+                                          maxTimestamp, col_has_null_forward_compatible(colStats));
         }
         break;
       }
@@ -577,7 +587,7 @@ namespace orc {
           const auto& stats = colStats.decimal_statistics();
           result = evaluatePredicateRange(operator_, literal2Decimal(literals_),
                                           Decimal(stats.minimum()), Decimal(stats.maximum()),
-                                          colStats.has_null());
+                                          col_has_null_forward_compatible(colStats));
         }
         break;
       }
@@ -592,7 +602,7 @@ namespace orc {
     }
 
     // make sure null literal is respected for IN operator
-    if (operator_ == Operator::IN && colStats.has_null()) {
+    if (operator_ == Operator::IN && col_has_null_forward_compatible(colStats)) {
       for (const auto& literal : literals_) {
         if (literal.isNull()) {
           result = TruthValue::YES_NO_NULL;
@@ -701,16 +711,14 @@ namespace orc {
       }
     }
 
-    // files written by trino may lack of hasnull field.
-    if (!colStats.has_has_null()) return TruthValue::YES_NO_NULL;
-
-    bool allNull = colStats.has_null() && colStats.number_of_values() == 0;
+    bool allNull = col_has_null_forward_compatible(colStats) && colStats.number_of_values() == 0;
     if (operator_ == Operator::IS_NULL ||
         ((operator_ == Operator::EQUALS || operator_ == Operator::NULL_SAFE_EQUALS) &&
          literals_.at(0).isNull())) {
       // IS_NULL operator does not need to check min/max stats and bloom filter
       return allNull ? TruthValue::YES
-                     : (colStats.has_null() ? TruthValue::YES_NO : TruthValue::NO);
+                     : (col_has_null_forward_compatible(colStats) ? TruthValue::YES_NO
+                                                                  : TruthValue::NO);
     } else if (allNull) {
       // if we don't have any value, everything must have been null
       return TruthValue::IS_NULL;
@@ -718,7 +726,7 @@ namespace orc {
 
     TruthValue result = evaluatePredicateMinMax(colStats);
     if (shouldEvaluateBloomFilter(operator_, result, bloomFilter)) {
-      return evaluatePredicateBloomFiter(bloomFilter, colStats.has_null());
+      return evaluatePredicateBloomFiter(bloomFilter, col_has_null_forward_compatible(colStats));
     } else {
       return result;
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->
### What changes were proposed in this pull request?
cose issue: #2079 
relate pr: #2055
Introduce fallback logic in the C++ reader to set hasNull to true when the field is missing, similar to the Java implementation.
The Java implementation includes the following logic:
```java
if (stats.hasHasNull()) {
    hasNull = stats.getHasNull();
} else {
    hasNull = true;
}
```
In contrast, the C++ implementation directly uses the has_null value without any fallback logic:
```c++
ColumnStatisticsImpl::ColumnStatisticsImpl(const proto::ColumnStatistics& pb) {
    stats_.setNumberOfValues(pb.number_of_values());
    stats_.setHasNull(pb.has_null());
}
```
### Why are the changes needed?
We encountered an issue with the C++ implementation of the ORC reader when handling ORC files written with version 0.12. Specifically, files written in this version do not include the hasNull field in the column statistics metadata. While the Java implementation of the ORC reader handles this gracefully by defaulting hasNull to true when the field is absent, the C++ implementation does not handle this scenario correctly.
**This issue prevents predicates like IS NULL from being pushed down to the ORC reader!!! As a result, all rows in the file are filtered out, leading to incorrect query results :(**
### How was this patch tested?
I have tested this using [Doris](https://github.com/apache/doris) external pipeline: 
https://github.com/apache/doris/pull/45104
https://github.com/apache/doris-thirdparty/pull/259

### Was this patch authored or co-authored using generative AI tooling?
No
