### PR TITLE
ORC-1814: Use Ubuntu 24.04/Jekyll 4.3/Rouge 4.5 to generate website

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -17,7 +17,7 @@
 # ORC site builder
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache ORC site builder"
@@ -40,8 +40,8 @@ RUN gem install \
   liquid \
   listen \
   rouge
-RUN gem install jekyll -v 3.8.6
-RUN gem install github-pages
+RUN gem install jekyll
+RUN gem install -f github-pages
 
 RUN useradd -ms /bin/bash orc
 COPY . /home/orc/site

--- a/site/Gemfile
+++ b/site/Gemfile
@@ -1,3 +1,2 @@
 source 'https://rubygems.org'
-gem 'rouge'
-gem 'jekyll', "~> 3.8.3"
+gem 'jekyll', "~> 4.3"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update website doc generation softwares.

| SW  | BEFORE | AFTER |
| - | - | - |
| Ubuntu | 20.04 | 24.04 |
| Ruby | 2 | 3 |
| Jekyll | 3 | 4 |
| Rouge | 3 | 4 |

New image is published like the following.
```
$ docker images
REPOSITORY       TAG       IMAGE ID       CREATED         SIZE
apache/orc-dev   site      8616e418af07   4 minutes ago   671MB
```

### Why are the changes needed?

To use the latest versions and avoid the deprecated or end-of-support SWs.

### How was this patch tested?

Manual verification.

```
$ cd site
$ docker run -d --name orc-container -p 4000:4000 -v $PWD:/home/orc/site apache/orc-dev:site
# wait a few minutes until the web server starts
$ open http://localhost:4000/
```

### Was this patch authored or co-authored using generative AI tooling?

No.