### PR TITLE
ORC-1815: Remove broken `people.apache.org` links

### DIFF
--- a/site/_includes/news_item.html
+++ b/site/_includes/news_item.html
@@ -13,12 +13,9 @@
     <span class="post-date">
       {{ post.date | date_to_string }}
     </span>
-    <a href="https://people.apache.org/~{{ post.author }}" class="post-author">
-      <img src="https://people.apache.org/~{{ post.author }}//{{ post.author }}.png"
-           class="avatar" alt="{{ post.author }} avatar"
-           width="24" height="24">
+    <span class="post-author">
       {{ post.author }}
-    </a>
+    </span>
   </div>
   <div class="post-content">
     {{ post.content }}

--- a/site/_layouts/news_item.html
+++ b/site/_layouts/news_item.html
@@ -16,12 +16,9 @@ layout: news
     <span class="post-date">
       {{ page.date | date_to_string }}
     </span>
-    <a href="https://people.apache.org/~{{ page.author }}" class="post-author">
-      <img src="https://people.apache.org/~{{ page.author }}/{{ page.author }}.png"
-           class="avatar" alt="{{ page.author }} avatar"
-           width="24" height="24">
+    <span class="post-author">
       {{ page.author }}
-    </a>
+    </span>
   </div>
   <div class="post-content">
     {{ content }}

--- a/site/security/index.md
+++ b/site/security/index.md
@@ -27,7 +27,7 @@ are subscribed.
 
 Please note that we do not use a team GnuPG key. If you wish to
 encrypt your e-mail to security@orc.apache.org then please use the GnuPG
-keys from [ORC GPG keys](https://people.apache.org/keys/group/orc.asc) for
+keys from [ORC GPG keys](https://dist.apache.org/repos/dist/release/orc/KEYS) for
 the members of the
 [ORC PMC](https://people.apache.org/phonebook.html?ctte=orc).
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove broken `people.apache.org` links from Apache ORC websites.

- `https://people.apache.org/~`
- `https://people.apache.org/keys/group/orc.asc`

Please note we have six lines but Phonebook service is still alive, `https://people.apache.org/phonebook.html?ctte=orc`.
```
$ git grep people.apache.org
site/_includes/news_item.html:    <a href="https://people.apache.org/~{{ post.author }}" class="post-author">
site/_includes/news_item.html:      <img src="https://people.apache.org/~{{ post.author }}//{{ post.author }}.png"
site/_layouts/news_item.html:    <a href="https://people.apache.org/~{{ page.author }}" class="post-author">
site/_layouts/news_item.html:      <img src="https://people.apache.org/~{{ page.author }}/{{ page.author }}.png"
site/security/index.md:keys from [ORC GPG keys](https://people.apache.org/keys/group/orc.asc) for
site/security/index.md:[ORC PMC](https://people.apache.org/phonebook.html?ctte=orc).
```

### Why are the changes needed?

Apache Infra turned off `home` service on 2024-09-12.

- https://infra.apache.org/blog/end_of_home.html

> Today, there are so many options to host content that it no longer makes sense for the Foundation to perform that function, and we will be turning "home" off around Thursday, September 12, 2024. We ask that anyone with content on the service to log in via sftp and download the data they want to preserve.

The links and avatar images are broken currently.
- https://orc.apache.org/news/

<img width="386" alt="Screenshot 2024-12-12 at 08 27 24" src="https://github.com/user-attachments/assets/60485ea8-bd96-41de-ba99-6f6a002578cc" />

### How was this patch tested?
Manual review.

```
$ cd site
$ docker run -d --name orc-container -p 4000:4000 -v $PWD:/home/orc/site apache/orc-dev:site
```

**AFTER THIS PR**
<img width="380" alt="Screenshot 2024-12-12 at 08 28 42" src="https://github.com/user-attachments/assets/2d6a43a6-2ca2-4b65-be88-caa299cdf51f" />


### Was this patch authored or co-authored using generative AI tooling?

No.