### PR TITLE
ORC-1818: Upgrade Spark to 3.5.4 in bench module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,7 +40,7 @@
     <junit.version>5.9.3</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.13.1</parquet.version>
-    <spark.version>3.5.3</spark.version>
+    <spark.version>3.5.4</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to 3.5.4 in `bench` module for Apache ORC 1.9.x

### Why are the changes needed?

Apache Spark 3.5.4 is released.
- https://spark.apache.org/news/spark-3-5-4-released.html

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.