### PR TITLE
ORC-1819: Publish snapshot website through GitHub Pages

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,6 +24,8 @@ github:
     merge: false
     squash: true
     rebase: true
+  ghp_branch: main
+  ghp_path: /site
   labels:
     - apache
     - orc

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: GitHub Pages deployment
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: 'docs preview'
+  cancel-in-progress: false
+
+jobs:
+  docs:
+    name: Build and deploy documentation
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      pages: write
+    environment:
+      name: github-pages # https://github.com/actions/deploy-pages/issues/271
+    if: github.repository == 'apache/orc'
+    steps:
+      - name: Checkout ORC repository
+        uses: actions/checkout@v4
+        with:
+          repository: apache/orc
+          ref: 'main'
+      - name: Install Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 17
+      - name: Install Ruby for documentation generation
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - name: Run documentation build
+        run: |
+          cd site
+          gem install bundler -n /usr/local/bin
+          bundle install --retry=100
+          git clone https://github.com/apache/orc.git -b asf-site target
+          bundle exec jekyll build -b https://apache.github.io/orc
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'site/target'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/_docs/index.md
+++ b/site/_docs/index.md
@@ -37,4 +37,4 @@ are separated from each other so the reader can read just the columns
 that are required.
 
 For details on the specifics of the ORC format, please see the [ORC
-format specification](/specification/).
+format specification]({{ site.baseurl }}/specification/).

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -7,7 +7,7 @@
       <h1>
         <a href="/">
           <span class="sr-only">Apache ORC</span>
-          <img src="/img/logo.png" width="249" height="101" alt="ORC Logo">
+          <img src="{{ site.baseurl }}/img/logo.png" width="249" height="101" alt="ORC Logo">
         </a>
       </h1>
     </div>

--- a/site/_includes/news_contents.html
+++ b/site/_includes/news_contents.html
@@ -2,10 +2,10 @@
   <aside>
     <ul>
       <li class="{% if page.title == 'News' %}current{% endif %}">
-        <a href="/news/">All News</a>
+        <a href="{{ site.baseurl }}/news/">All News</a>
       </li>
       <li class="{% if page.title == 'Releases' %}current{% endif %}">
-        <a href="/news/releases/">ORC Releases</a>
+        <a href="{{ site.baseurl }}/news/releases/">ORC Releases</a>
       </li>
     </ul>
     <h4>Recent Releases</h4>

--- a/site/_includes/news_contents_mobile.html
+++ b/site/_includes/news_contents_mobile.html
@@ -1,7 +1,7 @@
 <div class="docs-nav-mobile unit whole show-on-mobiles">
   <select onchange="if (this.value) window.location.href=this.value">
     <option value="">Navigate the blog…</option>
-    <option value="/news/">Home</option>
+    <option value="{{ site.baseurl }}/news/">Home</option>
     <optgroup label="v1.x">
       {% for post in site.posts %}
       <option value="{{ post.url }}">{{ post.title }}</option>

--- a/site/_includes/primary-nav-items.html
+++ b/site/_includes/primary-nav-items.html
@@ -1,27 +1,27 @@
 <ul>
   <li class="{% if page.overview %}current{% endif %}">
-    <a href="/">Home</a>
+    <a href="{{ site.baseurl }}/">Home</a>
   </li>
   <li class="{% if page.url == '/releases/' %}current{% endif %}">
-    <a href="/releases/"><span class="show-on-mobiles">Rel</span>
+    <a href="{{ site.baseurl }}/releases/"><span class="show-on-mobiles">Rel</span>
                          <span class="hide-on-mobiles">Releases</span></a>
   </li>
   <li class="{% if page.url contains '/docs/' %}current{% endif %}">
-    <a href="/docs/"><span class="show-on-mobiles">Doc</span>
+    <a href="{{ site.baseurl }}/docs/"><span class="show-on-mobiles">Doc</span>
                      <span class="hide-on-mobiles">Documentation</span></a>
   </li>
   <li class="{% if page.url contains '/talks/' %}current{% endif %}">
-    <a href="/talks/"><span class="show-on-mobiles">Talk</span>
+    <a href="{{ site.baseurl }}/talks/"><span class="show-on-mobiles">Talk</span>
                       <span class="hide-on-mobiles">Talks</span></a>
   </li>
   <li class="{% if page.url contains '/news/' %}current{% endif %}">
-    <a href="/news/">News</a>
+    <a href="{{ site.baseurl }}/news/">News</a>
   </li>
   <li class="{% if page.url contains '/develop/' %}current{% endif %}">
-    <a href="/develop/"><span class="show-on-mobiles">Dev</span>
+    <a href="{{ site.baseurl }}/develop/"><span class="show-on-mobiles">Dev</span>
                         <span class="hide-on-mobiles">Develop</span></a>
   </li>
   <li class="{% if page.url contains '/help/' %}current{% endif %}">
-    <a href="/help/">Help</a>
+    <a href="{{ site.baseurl }}/help/">Help</a>
   </li>
 </ul>

--- a/site/_includes/top.html
+++ b/site/_includes/top.html
@@ -6,10 +6,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <meta name="generator" content="Jekyll v{{ jekyll.version }}">
   <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Lato:300,300italic,400,400italic,700,700italic,900">
-  <link rel="stylesheet" href="/css/screen.css">
-  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="stylesheet" href="{{ site.baseurl }}/css/screen.css">
+  <link rel="icon" type="image/x-icon" href="{{ site.baseurl }}/favicon.ico">
   <!--[if lt IE 9]>
-  <script src="/js/html5shiv.min.js"></script>
-  <script src="/js/respond.min.js"></script>
+  <script src="{{ site.baseurl }}/js/html5shiv.min.js"></script>
+  <script src="{{ site.baseurl }}/js/respond.min.js"></script>
   <![endif]-->
 </head>

--- a/site/_layouts/news_item.html
+++ b/site/_layouts/news_item.html
@@ -5,7 +5,7 @@ layout: news
 <article>
   <h2>
     {{ page.title }}
-    <a href="{{ page.url }}" class="permalink" title="Permalink">∞</a>
+    <a href="{{ page.url | relative_url }}" class="permalink" title="Permalink">∞</a>
   </h2>
   <span class="post-category">
     <span class="label">

--- a/site/develop/index.md
+++ b/site/develop/index.md
@@ -6,7 +6,7 @@ title: Developing
 Information about the ORC project that is most important for
 developers working on the project.
 
-The [ORC format specification](/specification) defines the format
+The [ORC format specification]({{ site.baseurl }}/specification) defines the format
 to promote compatibility between implementations.
 
 ## Development community
@@ -83,11 +83,11 @@ We've added several shortcuts to various relevant pages:
 
 From our website, you can use:
 
-* [/bugs](/bugs) to jump to our bug database
-* [/downloads](/downloads) to jump to our downloads page
-* [/releases](/releases) to jump to our releases page
-* [/src](/src) to jump to our source code
-* [/web-src](/web-src) to jump to our site source code
+* [/bugs](https://orc.apache.org/bugs) to jump to our bug database
+* [/downloads](https://orc.apache.org/downloads) to jump to our downloads page
+* [/releases](https://orc.apache.org/releases) to jump to our releases page
+* [/src](https://orc.apache.org/src) to jump to our source code
+* [/web-src](https://orc.apache.org/web-src) to jump to our site source code
 
 ## Reviews
 

--- a/site/index.html
+++ b/site/index.html
@@ -18,19 +18,19 @@ overview: true
       <h2>ACID Support</h2>
       <p>Includes support for ACID transactions and snapshot
          isolation</p>
-      <a href="/docs/acid.html">ACID support &rarr;</a>
+      <a href="docs/acid.html">ACID support &rarr;</a>
     </div>
     <div class="unit one-third">
       <h2>Built-in Indexes</h2>
       <p>Jump to the right row with indexes including minimum, maximum,
 	 and bloom filters for each column.</p>
-      <a href="/docs/indexes.html">ORC's indexes &rarr;</a>
+      <a href="docs/indexes.html">ORC's indexes &rarr;</a>
     </div>
     <div class="unit one-third">
       <h2>Complex Types</h2>
       <p>Supports all of Hive's types including the compound types:
          structs, lists, maps, and unions</p>
-      <a href="/docs/types.html">ORC's types &rarr;</a>
+      <a href="docs/types.html">ORC's types &rarr;</a>
     </div>
     <div class="clear"></div>
   </div>
@@ -61,7 +61,7 @@ overview: true
       <div class="grid pane">
         <div class="unit whole center-on-mobiles">
           <a href="https://www.apache.org">
-             <img src="img/asf_logo.png" width="429" height="175"
+             <img src="./img/asf_logo.png" width="429" height="175"
                   alt="Apache Software Foundation"></a>
           <div class="pane-content">
             <h2 class="center-on-mobiles">ORC is an <strong>Apache</strong>

--- a/site/specification/ORCv0.md
+++ b/site/specification/ORCv0.md
@@ -27,7 +27,7 @@ include the minimum and maximum values for each column in each set of
 file reader can skip entire sets of rows that aren't important for
 this query.
 
-![ORC file structure](/img/OrcFileLayout.png)
+![ORC file structure]({{ site.baseurl }}/img/OrcFileLayout.png)
 
 # File Tail
 
@@ -381,7 +381,7 @@ for a chunk that compressed to 100,000 bytes would be [0x40, 0x0d,
 that as long as a decompressor starts at the top of a header, it can
 start decompressing without the previous bytes.
 
-![compression streams](/img/CompressionStream.png)
+![compression streams]({{ site.baseurl }}/img/CompressionStream.png)
 
 The default compression chunk size is 256K, but writers can choose
 their own value. Larger chunks lead to better compression, but require

--- a/site/specification/ORCv1.md
+++ b/site/specification/ORCv1.md
@@ -27,7 +27,7 @@ include the minimum and maximum values for each column in each set of
 file reader can skip entire sets of rows that aren't important for
 this query.
 
-![ORC file structure](/img/OrcFileLayout.png)
+![ORC file structure]({{ site.baseurl }}/img/OrcFileLayout.png)
 
 # File Tail
 
@@ -201,7 +201,7 @@ All of the rows in an ORC file must have the same schema. Logically
 the schema is expressed as a tree as in the figure below, where
 the compound types have subcolumns under them.
 
-![ORC column structure](/img/TreeWriters.png)
+![ORC column structure]({{ site.baseurl }}/img/TreeWriters.png)
 
 The equivalent Hive DDL would be:
 
@@ -620,7 +620,7 @@ for a chunk that compressed to 100,000 bytes would be [0x40, 0x0d,
 that as long as a decompressor starts at the top of a header, it can
 start decompressing without the previous bytes.
 
-![compression streams](/img/CompressionStream.png)
+![compression streams]({{ site.baseurl }}/img/CompressionStream.png)
 
 The default compression chunk size is 256K, but writers can choose
 their own value. Larger chunks lead to better compression, but require
@@ -797,7 +797,7 @@ length of 4 (3) as [0x5e, 0x03, 0x5c, 0xa1, 0xab, 0x1e, 0xde, 0xad,
 > Note: the run length(4) is one-off. We can get 4 by adding 1 to 3
 (See [Hive-4123](https://github.com/apache/hive/commit/69deabeaac020ba60b0f2156579f53e9fe46157a#diff-c00fea1863eaf0d6f047535e874274199020ffed3eb00deb897f513aa86f6b59R232-R236))
 
-![Direct](/img/Direct.png)
+![Direct]({{ site.baseurl }}/img/Direct.png)
 
 ### Patched Base
 
@@ -1352,4 +1352,4 @@ Bloom filter streams are interlaced with row group indexes. This placement
 makes it convenient to read the bloom filter stream and row index stream
 together in single read operation.
 
-![bloom filter](/img/BloomFilter.png)
+![bloom filter]({{ site.baseurl }}/img/BloomFilter.png)

--- a/site/specification/ORCv2.md
+++ b/site/specification/ORCv2.md
@@ -47,7 +47,7 @@ include the minimum and maximum values for each column in each set of
 file reader can skip entire sets of rows that aren't important for
 this query.
 
-![ORC file structure](/img/OrcFileLayout.png)
+![ORC file structure]({{ site.baseurl }}/img/OrcFileLayout.png)
 
 # File Tail
 
@@ -221,7 +221,7 @@ All of the rows in an ORC file must have the same schema. Logically
 the schema is expressed as a tree as in the figure below, where
 the compound types have subcolumns under them.
 
-![ORC column structure](/img/TreeWriters.png)
+![ORC column structure]({{ site.baseurl }}/img/TreeWriters.png)
 
 The equivalent Hive DDL would be:
 
@@ -639,7 +639,7 @@ for a chunk that compressed to 100,000 bytes would be [0x40, 0x0d,
 that as long as a decompressor starts at the top of a header, it can
 start decompressing without the previous bytes.
 
-![compression streams](/img/CompressionStream.png)
+![compression streams]({{ site.baseurl }}/img/CompressionStream.png)
 
 The default compression chunk size is 256K, but writers can choose
 their own value. Larger chunks lead to better compression, but require
@@ -816,7 +816,7 @@ length of 4 (3) as [0x5e, 0x03, 0x5c, 0xa1, 0xab, 0x1e, 0xde, 0xad,
 > Note: the run length(4) is one-off. We can get 4 by adding 1 to 3
 (See [Hive-4123](https://github.com/apache/hive/commit/69deabeaac020ba60b0f2156579f53e9fe46157a#diff-c00fea1863eaf0d6f047535e874274199020ffed3eb00deb897f513aa86f6b59R232-R236))
 
-![Direct](/img/Direct.png)
+![Direct]({{ site.baseurl }}/img/Direct.png)
 
 ### Patched Base
 
@@ -1368,4 +1368,4 @@ Bloom filter streams are interlaced with row group indexes. This placement
 makes it convenient to read the bloom filter stream and row index stream
 together in single read operation.
 
-![bloom filter](/img/BloomFilter.png)
+![bloom filter]({{ site.baseurl }}/img/BloomFilter.png)


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to publish the Apache ORC snapshot website through GitHub Pages.


### Why are the changes needed?
To provide users with the most recent updates on the website in between releases.


### How was this patch tested?
Manually.

### Was this patch authored or co-authored using generative AI tooling?
No.