### PR TITLE
ORC-1826: [C++][CI] Add ASAN support to CMake

### DIFF
--- a/.github/lsan-suppressions.txt
+++ b/.github/lsan-suppressions.txt
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Add specific leak suppressions here if needed
+# Format:
+# leak:SymbolName
+# leak:source_file.cc

--- a/.github/workflows/asan_test.yml
+++ b/.github/workflows/asan_test.yml
@@ -19,8 +19,9 @@ name: Address Sanitizer Tests
 
 on:
   pull_request:
-    paths:
-    - 'c++/**'
+    paths-ignore:
+    - 'site/**'
+    - 'conan/**'
     branches:
     - main
 

--- a/.github/workflows/asan_test.yml
+++ b/.github/workflows/asan_test.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   asan-test:
     name: "ASAN with ${{ matrix.compiler }} on Ubuntu"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/asan_test.yml
+++ b/.github/workflows/asan_test.yml
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Address Sanitizer Tests
+
+on:
+  pull_request:
+    paths:
+    - 'c++/**'
+    branches:
+    - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  asan-test:
+    name: "ASAN with ${{ matrix.compiler }} on Ubuntu"
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc, clang]
+        include:
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Configure and Build with ASAN
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+      run: |
+        mkdir build && cd build
+        cmake .. -DCMAKE_BUILD_TYPE=Debug -DENABLE_ASAN=ON -DBUILD_JAVA=OFF
+        make
+    - name: Run Tests
+      working-directory: build
+      env:
+        ASAN_OPTIONS: detect_leaks=1:symbolize=1:strict_string_checks=1:halt_on_error=0:detect_container_overflow=0
+        LSAN_OPTIONS: suppressions=${{ github.workspace }}/.github/lsan-suppressions.txt
+      run: |
+        ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,10 @@ option(BUILD_ENABLE_AVX512
     "Enable build with AVX512 at compile time"
     OFF)
 
+option(ENABLE_ASAN
+    "Enable Address Sanitizer"
+    OFF)
+
 option(ORC_PACKAGE_KIND
     "Arbitrary string that identifies the kind of package"
     "")
@@ -152,6 +156,16 @@ elseif (MSVC)
   set (WARN_FLAGS "${WARN_FLAGS} -wd4521") # multiple copy constructors specified
   set (WARN_FLAGS "${WARN_FLAGS} -wd4146") # unary minus operator applied to unsigned type, result still unsigned
 endif ()
+# Configure Address Sanitizer if enabled
+if (ENABLE_ASAN)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
+    message(STATUS "Address Sanitizer enabled")
+  else()
+    message(WARNING "Address Sanitizer is only supported for GCC and Clang compilers")
+  endif()
+endif()
 
 enable_testing()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a CMake option to enable ASan in the C++ build and enable it in the CI.

### Why are the changes needed?

We are able to detect potential memory issues with the help of address sanitizer.

### How was this patch tested?

Pass all CIs (including the new ASan CIs)

### Was this patch authored or co-authored using generative AI tooling?

No.
