### PR TITLE
ORC-1819: [FOLLOWUP] Fix baseurl parameter and more links

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,7 +60,7 @@ jobs:
           gem install bundler -n /usr/local/bin
           bundle install --retry=100
           git clone https://github.com/apache/orc.git -b asf-site target
-          bundle exec jekyll build -b https://apache.github.io/orc
+          bundle exec jekyll build -b /orc
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/site/_includes/docs_ul.html
+++ b/site/_includes/docs_ul.html
@@ -12,7 +12,7 @@
 
   {% for p in site.docs %}
     {% if p.url == item_url %}
-      <li class="{{ c }}"><a href="{{ p.url }}">{{ p.title }}</a></li>
+      <li class="{{ c }}"><a href="{{ site.baseurl }}{{ p.url }}">{{ p.title }}</a></li>
       {% break %}
     {% endif %}
   {% endfor %}

--- a/site/_includes/header.html
+++ b/site/_includes/header.html
@@ -5,7 +5,7 @@
   <div class="grid">
     <div class="unit one-quarter center-on-mobiles">
       <h1>
-        <a href="/">
+        <a href="{{ site.baseurl }}/">
           <span class="sr-only">Apache ORC</span>
           <img src="{{ site.baseurl }}/img/logo.png" width="249" height="101" alt="ORC Logo">
         </a>

--- a/site/_includes/news_contents.html
+++ b/site/_includes/news_contents.html
@@ -12,7 +12,7 @@
     <ul>
       {% for post in site.categories.release limit:5 %}
       <li class="{% if page.title == post.title %}current{% endif %}">
-        <a href="{{ post.url }}">Version {{ post.version }}</a>
+        <a href="{{ site.baseurl }}{{ post.url }}">Version {{ post.version }}</a>
       </li>
       {% endfor %}
     </ul>
@@ -21,7 +21,7 @@
         {% for post in site.posts %}
         {% unless post.categories contains 'release' %}
         <li class="{% if page.title == post.title %}current{% endif %}">
-          <a href="{{ post.url }}">{{ post.title }}</a>
+          <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
         </li>
         {% endunless %}
         {% endfor %}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a follow-up to fix `baseurl` parameter and more links.
- #2095

### Why are the changes needed?

`baseurl` option is defined like the following.
- https://jekyllrb.com/docs/configuration/options/
> Base URL: Serve the website from the given base URL (the path between web-server or domain root and your landing page).

This only updates https://apache.github.io/orc/ while keeping https://orc.apache.org unchanged.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.