### PR TITLE
ORC-1824: Update Python documentation with PyArrow 18.1.0 and Dask 2024.12.1

### DIFF
--- a/site/_docs/dask.md
+++ b/site/_docs/dask.md
@@ -9,7 +9,7 @@ permalink: /docs/dask.html
 [Dask](https://dask.org) also supports Apache ORC.
 
 ```
-pip3 install "dask[dataframe]==2023.8.1"
+pip3 install "dask[dataframe]==2024.12.1"
 pip3 install pandas
 ```
 

--- a/site/_docs/pyarrow.md
+++ b/site/_docs/pyarrow.md
@@ -9,7 +9,7 @@ permalink: /docs/pyarrow.html
 [Apache Arrow](https://arrow.apache.org) project's [PyArrow](https://pypi.org/project/pyarrow/) is the recommended package.
 
 ```
-pip3 install pyarrow==13.0.0
+pip3 install pyarrow==18.1.0
 pip3 install pandas
 ```
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update Python documentation with PyArrow 18.1.0 and Dask 2024.12.1.

### Why are the changes needed?

PyArrow 16.0.0+ uses Apache ORC 2.0+
- https://github.com/apache/arrow/issues/40507

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.