### PR TITLE
ORC-1830: Fix release table hyperlink to use baseurl

### DIFF
--- a/site/_includes/release_table.html
+++ b/site/_includes/release_table.html
@@ -19,7 +19,7 @@ This include generates the table of releases.
         <td style="text-align: center">{{ release[1]["date"] }}</td>
         <td style="text-align: center">{{ release[1]["state"] }}</td>
         <td style="text-align: center">
-          <a href="/news/{{ datestr }}/ORC-{{ release[0] }}/">
+          <a href="{{ site.baseurl }}/news/{{ datestr }}/ORC-{{ release[0] }}/">
           ORC-{{ release[0] }}</a></td>
       </tr>
     {% endfor %}


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix the release table hyperlink to use baseurl.


### Why are the changes needed?
The release table hyperlinks are currently broken on the snapshot website.
- https://apache.github.io/orc/releases/

### How was this patch tested?
Manually.

### Was this patch authored or co-authored using generative AI tooling?
No.
