### PR TITLE
ORC-1837: Remove `commons-csv` from parent `pom.xml`

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -163,11 +163,6 @@
         <version>${zstd-jni.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-csv</artifactId>
-        <version>1.12.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-client-api</artifactId>
         <version>${hadoop.version}</version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `commons-csv` from parent `pom.xml`.

### Why are the changes needed?

We can remove `commons-csv` from the parent pom file.

- `commons-cvs` is used in `bench` module only and it's defined in `pom.xml` of `bench` module already.
- `opencsv` is used in `tools`

```
$ git grep csv | grep import
bench/core/src/java/org/apache/orc/bench/core/convert/GenerateVariants.java:import org.apache.orc.bench.core.convert.csv.CsvReader;
bench/core/src/java/org/apache/orc/bench/core/convert/csv/CsvReader.java:import org.apache.commons.csv.CSVFormat;
bench/core/src/java/org/apache/orc/bench/core/convert/csv/CsvReader.java:import org.apache.commons.csv.CSVParser;
bench/core/src/java/org/apache/orc/bench/core/convert/csv/CsvReader.java:import org.apache.commons.csv.CSVRecord;
tools/src/java/org/apache/orc/tools/convert/CsvReader.java:import com.opencsv.CSVParser;
tools/src/java/org/apache/orc/tools/convert/CsvReader.java:import com.opencsv.CSVParserBuilder;
tools/src/java/org/apache/orc/tools/convert/CsvReader.java:import com.opencsv.CSVReader;
tools/src/java/org/apache/orc/tools/convert/CsvReader.java:import com.opencsv.CSVReaderBuilder;
tools/src/java/org/apache/orc/tools/convert/CsvReader.java:import com.opencsv.exceptions.CsvValidationException;
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.