### PR TITLE
ORC-1840: Add `Matomo` script to support `https://analytics.apache.org`

### DIFF
--- a/site/_includes/top.html
+++ b/site/_includes/top.html
@@ -12,4 +12,21 @@
   <script src="{{ site.baseurl }}/js/html5shiv.min.js"></script>
   <script src="{{ site.baseurl }}/js/respond.min.js"></script>
   <![endif]-->
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    _paq.push(["setDoNotTrack", true]);
+    _paq.push(["disableCookies"]);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '68']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
 </head>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Matomo` script to support ASF web traffic analytics.
- https://analytics.apache.org

### Why are the changes needed?

To collect statistics.

### How was this patch tested?

Manually build the website and check headers.

### Was this patch authored or co-authored using generative AI tooling?

No.