### PR TITLE
ORC-1849: Upgrade `byte-buddy` to 1.17.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -252,13 +252,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.11</version>
+        <version>1.17.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.11</version>
+        <version>1.17.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `byte-buddy` to 1.17.0.

### Why are the changes needed?

**Release Note**
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.0

**Support Matrix of ByteBuddy**
| ByteBuddy Version | Java Version |
| - | - |
| 1.17.0 | 25+ |
| 1.15.4 | 24 |
| 1.14.12 | 23 |
| 1.14.8 | 22 |
| 1.14.3 | 21 |
| 1.12.18 | 20 |
| 1.12.9 | 19 |
| 1.11.6 | 18 |
| 1.10.19 | 17 |

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.