### PR TITLE
ORC-1850: Upgrade `maven-surefire-plugin` to 3.5.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -82,7 +82,7 @@
     <protobuf.version>3.25.5</protobuf.version>
     <slf4j.version>2.0.16</slf4j.version>
     <storage-api.version>2.8.1</storage-api.version>
-    <surefire.version>3.0.0-M5</surefire.version>
+    <surefire.version>3.5.2</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
     <zstd-jni.version>1.5.6-9</zstd-jni.version>
   </properties>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `maven-surefire-plugin` to 3.5.2.

### Why are the changes needed?

To use the latest version.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.