### PR TITLE
ORC-1852: Add `--enable-native-access=ALL-UNNAMED` to suppress Maven warnings

### DIFF
--- a/java/.mvn/jvm.config
+++ b/java/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--enable-native-access=ALL-UNNAMED

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -431,6 +431,7 @@
               <exclude>.idea/**</exclude>
               <exclude>**/*.iml</exclude>
               <exclude>**/dependency-reduced-pom.xml</exclude>
+              <exclude>.mvn/jvm.config</exclude>
             </excludes>
           </configuration>
           <executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `.mvn/jvm.config` to `java` directory in order to enable `--enable-native-access=ALL-UNNAMED` for Maven.

### Why are the changes needed?

**Java 25-ea**
```
$ java -version
openjdk version "25-ea" 2025-09-16
OpenJDK Runtime Environment (build 25-ea+10-1084)
OpenJDK 64-Bit Server VM (build 25-ea+10-1084, mixed mode, sharing)
```

**BEFORE**
```
$ mvn clean | head -n1
Running `/Users/dongjoon/APACHE/orc-merge/java/mvnw`...
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module (file:/opt/homebrew/Cellar/maven/3.9.9/libexec/lib/jansi-2.4.1.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled

Using `mvn` from path: /opt/homebrew/bin/mvn
WARNING: A restricted method in java.lang.System has been called
WARNING: java.lang.System::load has been called by org.fusesource.jansi.internal.JansiLoader in an unnamed module (file:/opt/homebrew/Cellar/maven/3.9.9/libexec/lib/jansi-2.4.1.jar)
WARNING: Use --enable-native-access=ALL-UNNAMED to avoid a warning for callers in this module
WARNING: Restricted methods will be blocked in a future release unless native access is enabled
...
```

**AFTER**
```
$ mvn clean | head -n1
Running `/Users/dongjoon/APACHE/orc-merge/java/mvnw`...
Using `mvn` from path: /opt/homebrew/bin/mvn
WARNING: A terminally deprecated method in sun.misc.Unsafe has been called
WARNING: sun.misc.Unsafe::objectFieldOffset has been called by com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper (file:/opt/homebrew/Cellar/maven/3.9.9/libexec/lib/guava-33.2.1-jre.jar)
WARNING: Please consider reporting this to the maintainers of class com.google.common.util.concurrent.AbstractFuture$UnsafeAtomicHelper
WARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release
[INFO] Scanning for projects...
...
```

### How was this patch tested?

Pass the CIs and manual testing.

### Was this patch authored or co-authored using generative AI tooling?

No.