### PR TITLE
ORC-1853: Rename class `TesScanData` to `TestScanData`

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/TestScanData.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestScanData.java
@@ -36,7 +36,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TesScanData {
+public class TestScanData {
   private Path workDir = new Path(System.getProperty("test.tmp.dir"));
   private Configuration conf;
   private FileSystem fs;

--- a/java/tools/src/test/org/apache/orc/tools/TestScanData.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestScanData.java
@@ -47,7 +47,7 @@ public class TestScanData {
     conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     fs.setWorkingDirectory(workDir);
-    testFilePath = new Path("TesScanData.testScan.orc");
+    testFilePath = new Path("TestScanData.testScan.orc");
     fs.delete(testFilePath, false);
   }
 
@@ -86,6 +86,6 @@ public class TestScanData {
     assertTrue(output.contains("{\"category\": \"struct\", \"id\": 0, \"max\": 2, \"fields\": [\n" +
         "{  \"x\": {\"category\": \"int\", \"id\": 1, \"max\": 1}},\n" +
         "{  \"y\": {\"category\": \"string\", \"id\": 2, \"max\": 2}}]}"));
-    assertTrue(output.contains("File: TesScanData.testScan.orc, bad batches: 0, rows: 10000/10000"));
+    assertTrue(output.contains("File: TestScanData.testScan.orc, bad batches: 0, rows: 10000/10000"));
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to rename class `TesScanData` to `TestScanData`.

### Why are the changes needed?

This is a typo when we added this class.
- #1833

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.