### PR TITLE
ORC-1854: Remove `ubuntu20` from `os-list.txt`

### DIFF
--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -1,6 +1,5 @@
 debian11
 debian12
-ubuntu20
 ubuntu22
 ubuntu24
 fedora37


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `ubuntu20` from `os-list.txt` at Apache ORC 2.1.1.

### Why are the changes needed?

When we remove `Ubuntu 20.04 Support` at ORC 2.1.0, we missed this.

- https://github.com/apache/orc/pull/1983

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.