### PR TITLE
ORC-1855: Add `Amazon Linux 2023` and `Corretto` to docker tests and CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,6 +49,7 @@ jobs:
           - ubuntu24
           - fedora37
           - oraclelinux9
+          - amazonlinux23
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,6 +4,7 @@
 * Fedora 37
 * Ubuntu 22 and 24
 * Oracle Linux 9
+* Amazon Linux 2023
 
 ## Pre-built Images
 

--- a/docker/amazonlinux23/Dockerfile
+++ b/docker/amazonlinux23/Dockerfile
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Amazon Linux 2023
+#
+
+FROM amazonlinux:2023
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Amazon Linux 2023"
+LABEL org.opencontainers.image.version=""
+
+RUN yum check-update || true
+RUN yum install -y \
+  cmake3 \
+  curl-devel \
+  cyrus-sasl-devel \
+  expat-devel \
+  gcc \
+  gcc-c++ \
+  gettext-devel \
+  git \
+  libtool \
+  make \
+  openssl-devel \
+  tar \
+  wget \
+  which \
+  zlib-devel \
+  java-17-amazon-corretto-devel
+
+ENV TZ=America/Los_Angeles
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,3 +4,4 @@ ubuntu22
 ubuntu24
 fedora37
 oraclelinux9
+amazonlinux23


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add the following to Apache ORC 2.1.1.
- `Amazon Linux 2023` Docker Image to docker tests
- `Amazon Corretto Java` test coverage

### Why are the changes needed?

To improve Apache ORC test coverage.

### How was this patch tested?

Check the newly added docker image and `Corretto Java` Version.
```
$ docker run -it --rm apache/orc-dev:amazonlinux23 java --version
openjdk 17.0.14 2025-01-21 LTS
OpenJDK Runtime Environment Corretto-17.0.14.7.1 (build 17.0.14+7-LTS)
OpenJDK 64-Bit Server VM Corretto-17.0.14.7.1 (build 17.0.14+7-LTS, mixed mode, sharing)
```

Pass the CIs with newly added `amazonlinux23` image.

<img width="873" alt="Screenshot 2025-02-22 at 15 23 41" src="https://github.com/user-attachments/assets/7b8c0896-8670-4e18-8fc9-360c0b4d08a2" />


### Was this patch authored or co-authored using generative AI tooling?

No.