### PR TITLE
ORC-1858: [C++] Add support to get StripeStatistics without row index

### DIFF
--- a/c++/build-support/README.md
+++ b/c++/build-support/README.md
@@ -11,7 +11,7 @@ To use `run_clang_format.py` you could act like below:
 ```shell
 mkdir build
 cd build
-cmake .. -DBUILD_JAVA=OFF -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+cmake .. -DBUILD_JAVA=OFF -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DORC_ENABLE_CLANG_TOOLS=1
 make check-format # Do checks only
 make format # This would apply suggested changes, take care!
 ```
@@ -23,7 +23,7 @@ To use `run_clang_tidy.py` you could act like below:
 ```shell
 mkdir build
 cd build
-cmake .. -DBUILD_JAVA=OFF -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+cmake .. -DBUILD_JAVA=OFF -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DORC_ENABLE_CLANG_TOOLS=1
 make -j`nproc` # Important
 make check-clang-tidy # Do checks only
 make fix-clang-tidy # This would apply suggested changes, take care!

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -496,9 +496,16 @@ namespace orc {
     virtual uint64_t getNumberOfStripeStatistics() const = 0;
 
     /**
+     * Get the statistics about a stripe .
+     * @param stripeIndex the index of the stripe (0 to N-1) to get statistics about
+     * @return the statistics about that stripe without reading row group index statistics
+     */
+    virtual std::unique_ptr<Statistics> getStripeStatisticsOnly(uint64_t stripeIndex) const = 0;
+
+    /**
      * Get the statistics about a stripe.
      * @param stripeIndex the index of the stripe (0 to N-1) to get statistics about
-     * @return the statistics about that stripe
+     * @return the statistics about that stripe and row group index statistics
      */
     virtual std::unique_ptr<StripeStatistics> getStripeStatistics(uint64_t stripeIndex) const = 0;
 

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -496,18 +496,13 @@ namespace orc {
     virtual uint64_t getNumberOfStripeStatistics() const = 0;
 
     /**
-     * Get the statistics about a stripe .
-     * @param stripeIndex the index of the stripe (0 to N-1) to get statistics about
-     * @return the statistics about that stripe without reading row group index statistics
-     */
-    virtual std::unique_ptr<Statistics> getStripeStatisticsOnly(uint64_t stripeIndex) const = 0;
-
-    /**
      * Get the statistics about a stripe.
      * @param stripeIndex the index of the stripe (0 to N-1) to get statistics about
+     * @param includeRowIndex whether the row index of the stripe is included
      * @return the statistics about that stripe and row group index statistics
      */
-    virtual std::unique_ptr<StripeStatistics> getStripeStatistics(uint64_t stripeIndex) const = 0;
+    virtual std::unique_ptr<StripeStatistics> getStripeStatistics(
+        uint64_t stripeIndex, bool includeRowIndex = true) const = 0;
 
     /**
      * Get the length of the data stripes in the file.

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -761,7 +761,7 @@ namespace orc {
     }
     StatContext statContext(hasCorrectStatistics());
     return std::unique_ptr<Statistics>(new StatisticsImpl(
-        contents_->metadata->stripestats(static_cast<int>(stripeIndex)),
+        contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)),
         statContext));
   }
 

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -751,8 +751,7 @@ namespace orc {
     return *(contents_->schema.get());
   }
 
-  std::unique_ptr<Statistics>
-  ReaderImpl::getStripeStatisticsOnly(uint64_t stripeIndex) const {
+  std::unique_ptr<Statistics> ReaderImpl::getStripeStatisticsOnly(uint64_t stripeIndex) const {
     if (!isMetadataLoaded_) {
       readMetadata();
     }

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -760,7 +760,7 @@ namespace orc {
       throw std::logic_error("No stripe statistics in file");
     }
     StatContext statContext(hasCorrectStatistics());
-    return std::make_unique<Statistics>(
+    return std::make_unique<StatisticsImpl>(
         contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)), statContext);
   }
 

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -751,39 +751,35 @@ namespace orc {
     return *(contents_->schema.get());
   }
 
-  std::unique_ptr<Statistics> ReaderImpl::getStripeStatisticsOnly(uint64_t stripeIndex) const {
+  std::unique_ptr<StripeStatistics> ReaderImpl::getStripeStatistics(uint64_t stripeIndex,
+                                                                    bool includeRowIndex) const {
     if (!isMetadataLoaded_) {
       readMetadata();
     }
     if (contents_->metadata == nullptr) {
       throw std::logic_error("No stripe statistics in file");
     }
-    StatContext statContext(hasCorrectStatistics());
-    return std::make_unique<StatisticsImpl>(
-        contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)), statContext);
-  }
-
-  std::unique_ptr<StripeStatistics> ReaderImpl::getStripeStatistics(uint64_t stripeIndex) const {
-    if (!isMetadataLoaded_) {
-      readMetadata();
-    }
-    if (contents_->metadata == nullptr) {
-      throw std::logic_error("No stripe statistics in file");
-    }
-    size_t num_cols = static_cast<size_t>(
-        contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)).col_stats_size());
-    std::vector<std::vector<proto::ColumnStatistics>> indexStats(num_cols);
 
     proto::StripeInformation currentStripeInfo = footer_->stripes(static_cast<int>(stripeIndex));
     proto::StripeFooter currentStripeFooter = getStripeFooter(currentStripeInfo, *contents_.get());
-
-    getRowIndexStatistics(currentStripeInfo, stripeIndex, currentStripeFooter, &indexStats);
 
     const Timezone& writerTZ = currentStripeFooter.has_writer_timezone()
                                    ? getTimezoneByName(currentStripeFooter.writer_timezone())
                                    : getLocalTimezone();
     StatContext statContext(hasCorrectStatistics(), &writerTZ);
-    return std::make_unique<StripeStatisticsImpl>(
+
+    if (!includeRowIndex) {
+      return std::make_unique<StripeStatisticsImpl>(
+          contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)), statContext);
+    }
+
+    size_t num_cols = static_cast<size_t>(
+        contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)).col_stats_size());
+    std::vector<std::vector<proto::ColumnStatistics>> indexStats(num_cols);
+
+    getRowIndexStatistics(currentStripeInfo, stripeIndex, currentStripeFooter, &indexStats);
+
+    return std::make_unique<StripeStatisticsWithRowGroupIndexImpl>(
         contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)), indexStats, statContext);
   }
 

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -760,9 +760,8 @@ namespace orc {
       throw std::logic_error("No stripe statistics in file");
     }
     StatContext statContext(hasCorrectStatistics());
-    return std::unique_ptr<Statistics>(new StatisticsImpl(
-        contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)),
-        statContext));
+    return std::make_unique<Statistics>(
+        contents_->metadata->stripe_stats(static_cast<int>(stripeIndex)), statContext);
   }
 
   std::unique_ptr<StripeStatistics> ReaderImpl::getStripeStatistics(uint64_t stripeIndex) const {

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -751,6 +751,20 @@ namespace orc {
     return *(contents_->schema.get());
   }
 
+  std::unique_ptr<Statistics>
+  ReaderImpl::getStripeStatisticsOnly(uint64_t stripeIndex) const {
+    if (!isMetadataLoaded_) {
+      readMetadata();
+    }
+    if (contents_->metadata == nullptr) {
+      throw std::logic_error("No stripe statistics in file");
+    }
+    StatContext statContext(hasCorrectStatistics());
+    return std::unique_ptr<Statistics>(new StatisticsImpl(
+        contents_->metadata->stripestats(static_cast<int>(stripeIndex)),
+        statContext));
+  }
+
   std::unique_ptr<StripeStatistics> ReaderImpl::getStripeStatistics(uint64_t stripeIndex) const {
     if (!isMetadataLoaded_) {
       readMetadata();

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -346,6 +346,8 @@ namespace orc {
 
     std::unique_ptr<ColumnStatistics> getColumnStatistics(uint32_t columnId) const override;
 
+    std::unique_ptr<Statistics> getStripeStatisticsOnly(uint64_t stripeIndex) const override;
+
     std::string getSerializedFileTail() const override;
 
     const Type& getType() const override;

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -330,7 +330,8 @@ namespace orc {
 
     const std::string& getStreamName() const override;
 
-    std::unique_ptr<StripeStatistics> getStripeStatistics(uint64_t stripeIndex) const override;
+    std::unique_ptr<StripeStatistics> getStripeStatistics(
+        uint64_t stripeIndex, bool includeRowIndex = true) const override;
 
     std::unique_ptr<RowReader> createRowReader() const override;
 
@@ -345,8 +346,6 @@ namespace orc {
     std::unique_ptr<Statistics> getStatistics() const override;
 
     std::unique_ptr<ColumnStatistics> getColumnStatistics(uint32_t columnId) const override;
-
-    std::unique_ptr<Statistics> getStripeStatisticsOnly(uint64_t stripeIndex) const override;
 
     std::string getSerializedFileTail() const override;
 

--- a/c++/src/Statistics.cc
+++ b/c++/src/Statistics.cc
@@ -81,11 +81,20 @@ namespace orc {
     // PASS
   }
 
-  StripeStatisticsImpl::StripeStatisticsImpl(
+  StripeStatisticsImpl::StripeStatisticsImpl(const proto::StripeStatistics& stripeStats,
+                                             const StatContext& statContext) {
+    columnStats_ = std::make_unique<StatisticsImpl>(stripeStats, statContext);
+  }
+
+  StripeStatisticsWithRowGroupIndexImpl::~StripeStatisticsWithRowGroupIndexImpl() {
+    // PASS
+  }
+
+  StripeStatisticsWithRowGroupIndexImpl::StripeStatisticsWithRowGroupIndexImpl(
       const proto::StripeStatistics& stripeStats,
       std::vector<std::vector<proto::ColumnStatistics> >& indexStats,
-      const StatContext& statContext) {
-    columnStats_ = std::make_unique<StatisticsImpl>(stripeStats, statContext);
+      const StatContext& statContext)
+      : StripeStatisticsImpl(stripeStats, statContext) {
     rowIndexStats_.resize(indexStats.size());
     for (size_t i = 0; i < rowIndexStats_.size(); i++) {
       for (size_t j = 0; j < indexStats[i].size(); j++) {

--- a/c++/src/Statistics.hh
+++ b/c++/src/Statistics.hh
@@ -1713,7 +1713,6 @@ namespace orc {
   class StripeStatisticsImpl : public StripeStatistics {
    private:
     std::unique_ptr<StatisticsImpl> columnStats_;
-    std::vector<std::vector<std::shared_ptr<const ColumnStatistics> > > rowIndexStats_;
 
     // DELIBERATELY NOT IMPLEMENTED
     StripeStatisticsImpl(const StripeStatisticsImpl&);
@@ -1721,7 +1720,6 @@ namespace orc {
 
    public:
     StripeStatisticsImpl(const proto::StripeStatistics& stripeStats,
-                         std::vector<std::vector<proto::ColumnStatistics> >& indexStats,
                          const StatContext& statContext);
 
     virtual const ColumnStatistics* getColumnStatistics(uint32_t columnId) const override {
@@ -1732,13 +1730,38 @@ namespace orc {
       return columnStats_->getNumberOfColumns();
     }
 
+    virtual const ColumnStatistics* getRowIndexStatistics(uint32_t, uint32_t) const override {
+      throw NotImplementedYet("set includeRowIndex true to get row index stats");
+    }
+
+    virtual ~StripeStatisticsImpl() override;
+
+    virtual uint32_t getNumberOfRowIndexStats(uint32_t) const override {
+      throw NotImplementedYet("set includeRowIndex true to get row index stats");
+    }
+  };
+
+  class StripeStatisticsWithRowGroupIndexImpl : public StripeStatisticsImpl {
+   private:
+    std::vector<std::vector<std::shared_ptr<const ColumnStatistics> > > rowIndexStats_;
+
+    // DELIBERATELY NOT IMPLEMENTED
+    StripeStatisticsWithRowGroupIndexImpl(const StripeStatisticsWithRowGroupIndexImpl&);
+    StripeStatisticsWithRowGroupIndexImpl& operator=(const StripeStatisticsWithRowGroupIndexImpl&);
+
+   public:
+    StripeStatisticsWithRowGroupIndexImpl(
+        const proto::StripeStatistics& stripeStats,
+        std::vector<std::vector<proto::ColumnStatistics> >& indexStats,
+        const StatContext& statContext);
+
     virtual const ColumnStatistics* getRowIndexStatistics(uint32_t columnId,
                                                           uint32_t rowIndex) const override {
       // check id indices are valid
       return rowIndexStats_[columnId][rowIndex].get();
     }
 
-    virtual ~StripeStatisticsImpl() override;
+    virtual ~StripeStatisticsWithRowGroupIndexImpl() override;
 
     uint32_t getNumberOfRowIndexStats(uint32_t columnId) const override {
       return static_cast<uint32_t>(rowIndexStats_[columnId].size());

--- a/c++/test/TestStripeIndexStatistics.cc
+++ b/c++/test/TestStripeIndexStatistics.cc
@@ -83,6 +83,31 @@ namespace orc {
         "length: "
         "8000\n",
         stringColStats->toString());
+
+    std::unique_ptr<orc::Statistics> stripeLevelStats = reader->getStripeStatisticsOnly(0);
+    const orc::IntegerColumnStatistics* stripeLevelIntColStats;
+    stripeLevelIntColStats = reinterpret_cast<const orc::IntegerColumnStatistics*>(
+        stripeLevelStats->getColumnStatistics(1));
+    EXPECT_EQ(
+        "Data type: Integer\nValues: 6000\nHas null: no\nMinimum: 1\nMaximum: 6000\nSum: "
+        "18003000\n",
+        stripeLevelIntColStats->toString());
+
+    const orc::StringColumnStatistics* stripeLevelStringColStats;
+    stripeLevelStringColStats = reinterpret_cast<const orc::StringColumnStatistics*>(
+        stripeLevelStats->getColumnStatistics(2));
+    EXPECT_EQ(
+        "Data type: String\nValues: 6000\nHas null: no\nMinimum: 1000\nMaximum: 9a\nTotal length: "
+        "23892\n",
+        stripeLevelStringColStats->toString());
+
+    intColStats =
+        reinterpret_cast<const orc::IntegerColumnStatistics*>(stripeStats->getColumnStatistics(1));
+    stringColStats =
+        reinterpret_cast<const orc::StringColumnStatistics*>(stripeStats->getColumnStatistics(2));
+
+    EXPECT_EQ(intColStats->toString(), stripeLevelStringColStats->toString());
+    EXPECT_EQ(stringColStats->toString(), stripeLevelStringColStats->toString());
   }
 
 }  // namespace orc

--- a/c++/test/TestStripeIndexStatistics.cc
+++ b/c++/test/TestStripeIndexStatistics.cc
@@ -84,7 +84,7 @@ namespace orc {
         "8000\n",
         stringColStats->toString());
 
-    std::unique_ptr<orc::Statistics> stripeLevelStats = reader->getStripeStatisticsOnly(0);
+    std::unique_ptr<orc::Statistics> stripeLevelStats = reader->getStripeStatistics(0, false);
     const orc::IntegerColumnStatistics* stripeLevelIntColStats;
     stripeLevelIntColStats = reinterpret_cast<const orc::IntegerColumnStatistics*>(
         stripeLevelStats->getColumnStatistics(1));

--- a/c++/test/TestStripeIndexStatistics.cc
+++ b/c++/test/TestStripeIndexStatistics.cc
@@ -89,7 +89,7 @@ namespace orc {
     stripeLevelIntColStats = reinterpret_cast<const orc::IntegerColumnStatistics*>(
         stripeLevelStats->getColumnStatistics(1));
     EXPECT_EQ(
-        "Data type: Integer\nValues: 6000\nHas null: no\nMinimum: 1\nMaximum: 6000\nSum: "
+        "Data type: Integer\nValues: 6000\nHas null: yes\nMinimum: 1\nMaximum: 6000\nSum: "
         "18003000\n",
         stripeLevelIntColStats->toString());
 
@@ -97,7 +97,7 @@ namespace orc {
     stripeLevelStringColStats = reinterpret_cast<const orc::StringColumnStatistics*>(
         stripeLevelStats->getColumnStatistics(2));
     EXPECT_EQ(
-        "Data type: String\nValues: 6000\nHas null: no\nMinimum: 1000\nMaximum: 9a\nTotal length: "
+        "Data type: String\nValues: 6000\nHas null: yes\nMinimum: 1000\nMaximum: 9a\nTotal length: "
         "23892\n",
         stripeLevelStringColStats->toString());
 
@@ -106,7 +106,7 @@ namespace orc {
     stringColStats =
         reinterpret_cast<const orc::StringColumnStatistics*>(stripeStats->getColumnStatistics(2));
 
-    EXPECT_EQ(intColStats->toString(), stripeLevelStringColStats->toString());
+    EXPECT_EQ(intColStats->toString(), stripeLevelIntColStats->toString());
     EXPECT_EQ(stringColStats->toString(), stripeLevelStringColStats->toString());
   }
 

--- a/c++/test/TestTimestampStatistics.cc
+++ b/c++/test/TestTimestampStatistics.cc
@@ -68,6 +68,19 @@ namespace orc {
         "00:00:00.688\nLowerBound: 1995-01-01 00:00:00.688\nMaximum: 2037-01-01 "
         "00:00:00.0\nUpperBound: 2037-01-01 00:00:00.1\n",
         stripeColStats->toString());
+
+    std::unique_ptr<orc::StripeStatistics> stripeStatsWithOutRowIndex =
+        reader->getStripeStatistics(0, false);
+    const orc::TimestampColumnStatistics* stripeColStatsOnly =
+        reinterpret_cast<const orc::TimestampColumnStatistics*>(
+            stripeStatsWithOutRowIndex->getColumnStatistics(0));
+
+    EXPECT_TRUE(stripeColStatsOnly->hasMinimum());
+    EXPECT_TRUE(stripeColStatsOnly->hasMaximum());
+    EXPECT_EQ(stripeColStats->toString(), stripeColStatsOnly->toString());
+    EXPECT_EQ(stripeStats->getNumberOfColumns(), stripeStatsWithOutRowIndex->getNumberOfColumns());
+    EXPECT_THROW(stripeStatsWithOutRowIndex->getRowIndexStatistics(1, 1), NotImplementedYet);
+    EXPECT_THROW(stripeStatsWithOutRowIndex->getNumberOfRowIndexStats(1), NotImplementedYet);
   }
 
   TEST(TestTimestampStatistics, testTimezoneUTC) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
add a C++ API in reader to get stripe level statistics without reading row group index.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To #2137 

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT PASS

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO