### PR TITLE
ORC-1869: Upgrade Spark to 3.5.5 in bench module for Apache ORC 1.9.x

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,7 +40,7 @@
     <junit.version>5.9.3</junit.version>
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.13.1</parquet.version>
-    <spark.version>3.5.4</spark.version>
+    <spark.version>3.5.5</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Apache Spark 3.5.5 in the corresponding Apache ORC 1.9.x `bench` module.

### Why are the changes needed?

Due to the minimum Java requirement,
- Apache ORC 2 matches with Apache Spark 4.
- Apache ORC 1 matches with Apache Spark 3.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.