### PR TITLE
ORC-1870: Remove Java 18 test pipeline from `branch-1.8`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -54,9 +54,6 @@ jobs:
           - os: ubuntu-20.04
             java: 8
             cxx: g++
-          - os: ubuntu-20.04
-            java: 18
-            cxx: g++
     env:
       MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Java 18` test pipeline from `branch-1.8`.

### Why are the changes needed?

Since Java 18 is not a LTS version, we can remove this from `branch-1.8`.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.