### PR TITLE
ORC-1871: Include `iomanip` at `Test(DictionaryEncoding|ConvertColumnReader)`

### DIFF
--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -27,6 +27,7 @@
 #include "ConvertColumnReader.hh"
 #include "MemoryInputStream.hh"
 #include "MemoryOutputStream.hh"
+#include <iomanip>
 
 namespace orc {
 

--- a/c++/test/TestDictionaryEncoding.cc
+++ b/c++/test/TestDictionaryEncoding.cc
@@ -25,6 +25,7 @@
 #include "wrap/gtest-wrapper.h"
 
 #include <cmath>
+#include <iomanip>
 #include <sstream>
 
 namespace orc {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?

Add missing includes in source files

### Why are the changes needed?

To package `orc` in The Linux NixOS distribution. The [PR](https://github.com/NixOS/nixpkgs/pull/395541) has already be merged, it will be available to the public very soon ([PR tracker](https://nixpkgs-tracker.ocfox.me/?pr=395541)). This is [the commit](https://github.com/NixOS/nixpkgs/pull/395541/commits/48ff1824abfabd61bd9ff30eff49a943122ada3e) to add `apache-orc` to NixOS in a **reproducible way**.

### How was this patch tested?

Compilation is now successfully achieved with the patch.

### Was this patch authored or co-authored using generative AI tooling?

Absolutely not.