### PR TITLE
ORC-1875: Support `ubuntu-24.04-arm` in GitHub Action CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,6 +67,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
+          - ubuntu-24.04-arm
           - macos-13
           - macos-14
           - macos-15


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `ubuntu-24.04-arm` in GitHub Action CIs.

### Why are the changes needed?

`Linux` arm64 architecture becomes public preview as a new GitHub Action runner. We had better utilize this resource in our test infra.
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.