### PR TITLE
ORC-1881: [C++] Populate dstBatch's scale and precision in DecimalConvertColumnReader

### DIFF
--- a/c++/src/ConvertColumnReader.cc
+++ b/c++/src/ConvertColumnReader.cc
@@ -579,6 +579,8 @@ namespace orc {
 
       const auto& srcBatch = *SafeCastBatchTo<const FileTypeBatch*>(data.get());
       auto& dstBatch = *SafeCastBatchTo<ReadTypeBatch*>(&rowBatch);
+      dstBatch.precision = toPrecision_;
+      dstBatch.scale = toScale_;
       for (uint64_t i = 0; i < numValues; ++i) {
         if (!rowBatch.hasNulls || rowBatch.notNull[i]) {
           convertDecimalToDecimal(dstBatch, i, srcBatch);

--- a/c++/test/TestConvertColumnReader.cc
+++ b/c++/test/TestConvertColumnReader.cc
@@ -651,6 +651,10 @@ namespace orc {
     auto& readC2 = dynamic_cast<Decimal128VectorBatch&>(*readStructBatch.fields[1]);
     auto& readC3 = dynamic_cast<Decimal64VectorBatch&>(*readStructBatch.fields[2]);
     auto& readC4 = dynamic_cast<Decimal128VectorBatch&>(*readStructBatch.fields[3]);
+    EXPECT_TRUE(9 == readC1.precision && 5 == readC1.scale);
+    EXPECT_TRUE(20 == readC2.precision && 5 == readC2.scale);
+    EXPECT_TRUE(10 == readC3.precision && 3 == readC3.scale);
+    EXPECT_TRUE(19 == readC4.precision && 3 == readC4.scale);
     EXPECT_EQ(TEST_CASES, readBatch->numElements);
     for (int i = 0; i < TEST_CASES / 2; i++) {
       size_t idx = static_cast<size_t>(i);


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Set dstBatch's decimal and precision when `DecimalConvertColumnReader::next`.
Fix ORC-1881.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
During decimal-to-decimal conversion in `SchemaEvolution`, the target decimal's scale and precision are incorrectly initialized to zero, producing a corrupted `ColumnVectorBatch`.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
