### PR TITLE
ORC-1880: [C++] Add invalid argument check for NOT Operator in ExpressionTree

### DIFF
--- a/c++/src/sargs/ExpressionTree.cc
+++ b/c++/src/sargs/ExpressionTree.cc
@@ -110,10 +110,10 @@ namespace orc {
         return result;
       }
       case Operator::NOT:
-        if (mChildren.size() != 1) {
+        if (children_.size() != 1) {
           throw std::invalid_argument("NOT operator must have exactly one child");
         }
-        return !mChildren.at(0)->evaluate(leaves);
+        return !children_.at(0)->evaluate(leaves);
       case Operator::LEAF:
         return leaves[leaf_];
       case Operator::CONSTANT:
@@ -162,10 +162,10 @@ namespace orc {
         sstream << ')';
         break;
       case Operator::NOT:
-        if (mChildren.size() != 1) {
+        if (children_.size() != 1) {
           throw std::invalid_argument("NOT operator must have exactly one child");
         }
-        sstream << "(not " << mChildren.at(0)->toString() << ')';
+        sstream << "(not " << children_.at(0)->toString() << ')';
         break;
       case Operator::LEAF:
         sstream << "leaf-" << leaf_;

--- a/c++/src/sargs/ExpressionTree.cc
+++ b/c++/src/sargs/ExpressionTree.cc
@@ -110,7 +110,10 @@ namespace orc {
         return result;
       }
       case Operator::NOT:
-        return !children_.at(0)->evaluate(leaves);
+        if (mChildren.size() != 1) {
+          throw std::invalid_argument("NOT operator must have exactly one child");
+        }
+        return !mChildren.at(0)->evaluate(leaves);
       case Operator::LEAF:
         return leaves[leaf_];
       case Operator::CONSTANT:
@@ -159,7 +162,10 @@ namespace orc {
         sstream << ')';
         break;
       case Operator::NOT:
-        sstream << "(not " << children_.at(0)->toString() << ')';
+        if (mChildren.size() != 1) {
+          throw std::invalid_argument("NOT operator must have exactly one child");
+        }
+        sstream << "(not " << mChildren.at(0)->toString() << ')';
         break;
       case Operator::LEAF:
         sstream << "leaf-" << leaf_;

--- a/c++/test/TestSearchArgument.cc
+++ b/c++/test/TestSearchArgument.cc
@@ -481,4 +481,13 @@ namespace orc {
                  std::invalid_argument);
   }
 
+  TEST(TestSearchArgument, testBadTreeNode) {
+    auto invalidNode = std::make_shared<ExpressionTree>(ExpressionTree::Operator::NOT, NodeList{});
+    EXPECT_THROW(invalidNode->toString(), std::invalid_argument);
+
+    std::vector<TruthValue> leaves;
+    leaves.push_back(TruthValue::YES);
+    EXPECT_THROW(invalidNode->evaluate(leaves), std::invalid_argument);
+  }
+
 }  // namespace orc


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Add invalid argument check for NOT Operator in ExpressionTree.cc

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Operator::NOT expects to have exactly one child, but there is currently no validation to enforce this requirement. If no child is provided, it may result in a crash during the construction of the SearchArgument.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
The unit tests in TestSearchArgument.cc can effectively cover this patch.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO
