### PR TITLE
ORC-1879: [C++] Fix Heap Buffer Overflow in LZO Decompression

### DIFF
--- a/c++/src/LzoDecompressor.cc
+++ b/c++/src/LzoDecompressor.cc
@@ -355,7 +355,7 @@ namespace orc {
         char *literalOutputLimit = output + literalLength;
         if (literalOutputLimit > fastOutputLimit ||
             input + literalLength > inputLimit - SIZE_OF_LONG) {
-          if (literalOutputLimit > outputLimit) {
+          if (literalOutputLimit > outputLimit || input + literalLength > inputLimit) {
             throw MalformedInputException(input - inputAddress);
           }
 

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -426,7 +426,7 @@ namespace orc {
     std::unique_ptr<SeekableInputStream> result = createDecompressor(
         CompressionKind_LZO,
         std::make_unique<SeekableArrayInputStream>(bad_lzo_data, ARRAY_SIZE(bad_lzo_data)),
-        128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
+        128 * 1024, *getDefaultPool());
     const void* ptr;
     int length;
     EXPECT_THROW(result->Next(&ptr, &length), ParseError);

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -412,6 +412,26 @@ namespace orc {
     ASSERT_TRUE(!result->Next(&ptr, &length));
   }
 
+  TEST_F(TestDecompression, testLzoOverflow) {
+    const unsigned char bad_lzo_data[] = {// Header: compressedSize = 12, original = false
+                                          0x18, 0x00, 0x00,
+
+                                          // LZO body: token and literal length extension
+                                          0x00,  // token: extended literal length
+                                          0xFF,  // extension byte 1
+
+                                          // Literal data: only 10 bytes far less than 273
+                                          'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A', 'A'};
+
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_LZO,
+        std::make_unique<SeekableArrayInputStream>(bad_lzo_data, ARRAY_SIZE(bad_lzo_data)),
+        128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
+    const void* ptr;
+    int length;
+    EXPECT_THROW(result->Next(&ptr, &length), ParseError);
+  }
+
   TEST_F(TestDecompression, testLz4Empty) {
     const unsigned char buffer[] = {0};
     std::unique_ptr<SeekableInputStream> result =

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -425,7 +425,8 @@ namespace orc {
 
     std::unique_ptr<SeekableInputStream> result = createDecompressor(
         CompressionKind_LZO,
-        std::make_unique<SeekableArrayInputStream>(bad_lzo_data, ARRAY_SIZE(bad_lzo_data)),
+        std::unique_ptr<SeekableInputStream>(new SeekableArrayInputStream(
+            bad_lzo_data, ARRAY_SIZE(bad_lzo_data))),
         128 * 1024, *getDefaultPool());
     const void* ptr;
     int length;


### PR DESCRIPTION
### What changes were proposed in this pull request? 
Fix Heap Buffer Overflow Vulnerability in LZO Decompression

### Why are the changes needed?
This vulnerability has several security implications

### How was this patch tested?
UT passed

### Was this patch authored or co-authored using generative AI tooling? 
NO
