### PR TITLE
ORC-1885: Update all `ubuntu-20.04` to `ubuntu-22.04` in CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,10 +56,10 @@ jobs:
         cxx:
           - clang++
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             java: 8
             cxx: g++
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             java: 21
             cxx: g++
     env:
@@ -161,7 +161,7 @@ jobs:
 
   formatting-check:
     name: "C++ format check"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         path:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update all `ubuntu-20.04` to `ubuntu-22.04` in CI.

This is a leftover which were missed at the following backporting
- https://github.com/apache/orc/pull/2177

### Why are the changes needed?

To recover CIs. Currently, CI fails like the following.
- https://github.com/apache/orc/pull/2199

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.