### PR TITLE
ORC-1891: Upgrade to Apache parent pom 34

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -399,7 +399,7 @@
             <dependency>
               <groupId>com.github.spotbugs</groupId>
               <artifactId>spotbugs</artifactId>
-              <version>4.9.3</version>
+              <version>4.7.3</version>
             </dependency>
           </dependencies>
           <executions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -17,7 +17,7 @@
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>27</version>
+    <version>34</version>
   </parent>
   <groupId>org.apache.orc</groupId>
   <artifactId>orc</artifactId>
@@ -71,7 +71,7 @@
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
-    <maven.compiler.release>17</maven.compiler.release>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
     <maven.version>3.9.9</maven.version>
 
@@ -82,7 +82,7 @@
     <protobuf.version>3.25.5</protobuf.version>
     <slf4j.version>2.0.17</slf4j.version>
     <storage-api.version>2.8.1</storage-api.version>
-    <surefire.version>3.5.2</surefire.version>
+    <surefire.version>3.5.3</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
     <zstd-jni.version>1.5.7-3</zstd-jni.version>
   </properties>
@@ -399,7 +399,7 @@
             <dependency>
               <groupId>com.github.spotbugs</groupId>
               <artifactId>spotbugs</artifactId>
-              <version>4.7.3</version>
+              <version>4.9.3</version>
             </dependency>
           </dependencies>
           <executions>
@@ -746,7 +746,7 @@
       <plugin>
         <groupId>org.cyclonedx</groupId>
         <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.11</version>
+        <version>2.9.1</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade to Apache parent pom version 34

### Why are the changes needed?
Version 27 is almost 10 years old.


### How was this patch tested?
Running maven build

### Was this patch authored or co-authored using generative AI tooling?
No
