### PR TITLE
ORC-1894: Add `CMAKE_POLICY_VERSION_MINIMUM=3.12` to `PROTOBUF_CMAKE_ARGS`

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -535,6 +535,7 @@ else ()
   set(PROTOBUF_INCLUDE_DIR "${PROTOBUF_PREFIX}/include")
   set(PROTOBUF_CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROTOBUF_PREFIX}
                           -DCMAKE_INSTALL_LIBDIR=lib
+                          -DCMAKE_POLICY_VERSION_MINIMUM=3.12
                           -DBUILD_SHARED_LIBS=OFF
                           -Dprotobuf_BUILD_TESTS=OFF)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `CMAKE_POLICY_VERSION_MINIMUM=3.12` to `PROTOBUF_CMAKE_ARGS` explicitly.

### Why are the changes needed?

The minimum requirement of Apache ORC is `CMake 3.12`.

https://github.com/apache/orc/blob/463137faedea7f9138d20451d554707dcaf29850/CMakeLists.txt#L18

To support `CMake 4`, we need to make it sure Apache ORC's minimum requirement. Otherwise, `Protobuf` fails to build.
- https://github.com/Kitware/CMake/releases/tag/v4.0.0 (2025-03-27)
- https://github.com/Kitware/CMake/releases/tag/v4.0.1 (2025-04-10)
- https://github.com/Kitware/CMake/releases/tag/v4.0.2 (2025-05-07)

### How was this patch tested?

Pass the CIs and do the manual test with `cmake 4 or higher`.

```
$ cmake --version
cmake version 4.0.1
```

### Was this patch authored or co-authored using generative AI tooling?

No.