### PR TITLE
ORC-1895: Add `MacOS 15` to `macos-cpp-check` GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -223,7 +223,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [13, 14]
+        version: [13, 14, 15]
     runs-on: macos-${{ matrix.version }}
     steps:
     - name: Checkout repository


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `MacOS 15` to `macos-cpp-check` GitHub Action job additionally.

### Why are the changes needed?

To have additional test coverage.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.