### PR TITLE
ORC-1899: Upgrade Spark to 4.0.0 and Scala to 2.13.16

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,8 +40,8 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.15.2</parquet.version>
     <scala.binary.version>2.13</scala.binary.version>
-    <scala.version>2.13.14</scala.version>
-    <spark.version>4.0.0-preview2</spark.version>
+    <scala.version>2.13.16</scala.version>
+    <spark.version>4.0.0</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to 4.0.0 and Scala to 2.13.16.

### Why are the changes needed?

To use the latest Apache Spark 4.0.0 instead of 4.0.0-preview2.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.