### PR TITLE
ORC-1901: Remove `threeten-extra` exclusion in `enforceBytecodeVersion` rule

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -630,9 +630,6 @@
                   <maxJdkVersion>${java.version}</maxJdkVersion>
                   <ignoredScopes>test</ignoredScopes>
                   <ignoredScopes>provided</ignoredScopes>
-                  <excludes>
-                    <exclude>org.threeten:threeten-extra</exclude>
-                  </excludes>
                 </enforceBytecodeVersion>
                 <bannedDependencies>
                   <excludes>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `threeten-extra` exclusion in `enforceBytecodeVersion` rule.

### Why are the changes needed?

The previous exclusion rule was added at ORC 1.9.0 with Java 1.8. It's not required for Java 17 since ORC 2.0.
- #1536 

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.