### PR TITLE
ORC-1902: Use `super-linter` for `README.md` files

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -159,11 +159,19 @@ jobs:
         make package test-out
 
   doc:
-    name: "Javadoc generation"
+    name: "Markdown check and Javadoc generation"
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: Super-Linter
+      uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88
+      env:
+        DEFAULT_BRANCH: main
+        VALIDATE_MARKDOWN: true
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Java 17
       uses: actions/setup-java@v4
       with:

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+MD013: false

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+site

--- a/README.md
+++ b/README.md
@@ -18,20 +18,21 @@ lists, maps, and unions.
 This project includes both a Java library and a C++ library for reading and writing the _Optimized Row Columnar_ (ORC) file format. The C++ and Java libraries are completely independent of each other and will each read all versions of ORC files.
 
 Releases:
-* Latest: <a href="https://orc.apache.org/releases">Apache ORC releases</a>
-* Maven Central: <a href="https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.orc%22">![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.orc/orc/badge.svg)</a>
-* Downloads: <a href="https://orc.apache.org/downloads">Apache ORC downloads</a>
-* Release tags: <a href="https://github.com/apache/orc/releases">Apache ORC release tags</a>
-* Plan: <a href="https://github.com/apache/orc/milestones">Apache ORC future release plan</a>
+
+* Latest: [Apache ORC releases](https://orc.apache.org/releases)
+* Maven Central: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.orc/orc/badge.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.orc%22)
+* Downloads: [Apache ORC downloads](https://orc.apache.org/downloads)
+* Release tags: [Apache ORC release tags](https://github.com/apache/orc/releases)
+* Plan: [Apache ORC future release plan](https://github.com/apache/orc/milestones)
 
 The current build status:
-* Main branch <a href="https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain">
-![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)</a>
 
-Bug tracking: <a href="https://orc.apache.org/bugs">Apache Jira</a>
+* Main branch [![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain)
 
+Bug tracking: [Apache Jira](https://orc.apache.org/bugs)
 
 The subdirectories are:
+
 * c++ - the c++ reader and writer
 * cmake_modules - the cmake modules
 * docker - docker scripts to build and test on various linuxes
@@ -47,6 +48,7 @@ The subdirectories are:
 * Install cmake 3.12 or higher
 
 To build a release version with debug information:
+
 ```shell
 % mkdir build
 % cd build
@@ -57,6 +59,7 @@ To build a release version with debug information:
 ```
 
 To build a debug version:
+
 ```shell
 % mkdir build
 % cd build
@@ -67,6 +70,7 @@ To build a debug version:
 ```
 
 To build a release version without debug information:
+
 ```shell
 % mkdir build
 % cd build
@@ -77,6 +81,7 @@ To build a release version without debug information:
 ```
 
 To build only the Java library:
+
 ```shell
 % cd java
 % ./mvnw package
@@ -84,6 +89,7 @@ To build only the Java library:
 ```
 
 To build only the C++ library:
+
 ```shell
 % mkdir build
 % cd build
@@ -94,6 +100,7 @@ To build only the C++ library:
 ```
 
 To build the C++ library with AVX512 enabled:
+
 ```shell
 export ORC_USER_SIMD_LEVEL=AVX512
 % mkdir build
@@ -102,6 +109,7 @@ export ORC_USER_SIMD_LEVEL=AVX512
 % make package
 % make test-out
 ```
+
 Cmake option BUILD_ENABLE_AVX512 can be set to "ON" or (default value)"OFF" at the compile time. At compile time, it defines the SIMD level(AVX512) to be compiled into the binaries.
 
 Environment variable ORC_USER_SIMD_LEVEL can be set to "AVX512" or (default value)"NONE" at the run time. At run time, it defines the SIMD level to dispatch the code which can apply SIMD optimization.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,5 @@
+# Docker Test
+
 ## Supported OSes
 
 * Debian 11 and 12
@@ -26,6 +28,7 @@ To test against all of the Linux OSes against Apache's main branch:
 Using `local` as the owner will cause the scripts to use the local repository.
 
 The scripts are:
+
 * `run-all.sh` *owner* *branch* - test the given owner's branch on all OSes
 * `run-one.sh` *owner* *branch* *os* - test the owner's branch on one OS
 * `reinit.sh` - rebuild all of the base images without the image cache

--- a/java/bench/README.md
+++ b/java/bench/README.md
@@ -15,7 +15,7 @@ There are three sub-modules to try to mitigate dependency hell:
 
 To build this library, run the following in the parent directory:
 
-```
+```bash
 % ./mvnw clean package -Pbenchmark -DskipTests
 % cd bench
 ```
@@ -57,4 +57,3 @@ To run row-filter benchmark:
 To run spark benchmark:
 
 ```% java -jar spark/target/orc-benchmarks-spark-${ORC_VERSION}.jar spark data```
-

--- a/site/README.md
+++ b/site/README.md
@@ -9,7 +9,7 @@ the site is to use docker to use a standard environment.
 1. `cd site`
 2. `git clone git@github.com:apache/orc.git -b asf-site target`
 
-## Run the docker container with the preview of the site.
+## Run the docker container with the preview of the site
 
 1. `docker run -d --name orc-container -p 4000:4000 -v $PWD:/home/orc/site apache/orc-dev:site`
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `super-linter` for `README.md` files.

### Why are the changes needed?

For consistency in documentations.

### How was this patch tested?

Pass the CIs with the newly added `super-linter` CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.