### PR TITLE
ORC-1906: Support `Meson` build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -248,3 +248,31 @@ jobs:
         cmake .. -DBUILD_JAVA=OFF -DPROTOBUF_HOME=${CMAKE_PREFIX_PATH}
         make package test-out
 
+  meson:
+    name: "Meson C++ configuration"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-13
+          - macos-14
+          - macos-15
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install meson
+      run: |
+        pip install --upgrade pip
+        pip install meson
+    - name: Test
+      run: |
+        meson setup build
+        meson compile -C build
+        meson test -C build

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ dependency-reduced-pom.xml
 java/bench/data
 *.swp
 .cache/*
+subprojects/*
+!subprojects/packagefiles
+!subprojects/*.wrap

--- a/README.md
+++ b/README.md
@@ -115,3 +115,43 @@ Cmake option BUILD_ENABLE_AVX512 can be set to "ON" or (default value)"OFF" at t
 Environment variable ORC_USER_SIMD_LEVEL can be set to "AVX512" or (default value)"NONE" at the run time. At run time, it defines the SIMD level to dispatch the code which can apply SIMD optimization.
 
 Note that if ORC_USER_SIMD_LEVEL is set to "NONE" at run time, AVX512 will not take effect at run time even if BUILD_ENABLE_AVX512 is set to "ON" at compile time.
+
+### Building with Meson
+
+While CMake is the official build system for orc, there is unofficial support for using Meson to build select parts of the project. To build a debug version of the library and test it using Meson, from the project root you can run:
+
+```shell
+meson setup build
+meson compile -C build
+meson test -C build
+```
+
+By default, Meson will build release libraries. If you would instead like debug libraries, you can use the ``-Dbuildtype=debug`` argument to setup. You must either remove the existing build directory before changing that setting, or alternatively pass the ``--reconfigure`` flag:
+
+```shell
+meson setup build -Dbuildtype=debug --reconfigure
+meson compile -C build
+meson test -C build
+```
+
+Meson supports running your test suite through valgrind out of the box:
+
+```shell
+meson test -C build --wrap=valgrind
+```
+
+If you'd like to enable sanitizers, you can leverage the ``-Db_sanitize=`` option. For example, to enable both ASAN and UBSAN, you can run:
+
+```shell
+meson setup build -Dbuildtype=debug -Db_sanitize=address,undefined --reconfigure
+meson compile -C build
+meson test
+```
+
+Meson takes care of detecting all dependencies on your system, and downloading missing ones as required through its [Wrap system](https://mesonbuild.com/Wrap-dependency-system-manual.html). The dependencies for the project are all stored in the ``subprojects`` directory in individual wrap files. The majority of these are system generated files created by running:
+
+```shell
+meson wrap install <depencency_name>
+```
+
+From the project root. If you are developing orc and need to add a new dependency in the future, be sure to check Meson's [WrapDB](https://mesonbuild.com/Wrapdb-projects.html) to check if a pre-configured wrap entry exists. If not, you may still manually configure the dependency as outlined in the aforementioned Wrap system documentation.

--- a/c++/include/orc/meson.build
+++ b/c++/include/orc/meson.build
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+cdata = configuration_data()
+cdata.set('ORC_VERSION', meson.project_version())
+cdata.set('ORC_CXX_HAS_CSTDINT', 1)
+
+configure_file(
+    input: 'orc-config.hh.in',
+    output: 'orc-config.hh',
+    configuration: cdata,
+    format: 'cmake',
+    install: true,
+    install_dir: 'orc',
+)
+
+install_headers(
+    [
+        'BloomFilter.hh',
+        'ColumnPrinter.hh',
+        'Common.hh',
+        'Exceptions.hh',
+        'Int128.hh',
+        'MemoryPool.hh',
+        'OrcFile.hh',
+        'Reader.hh',
+        'Statistics.hh',
+        'Type.hh',
+        'Vector.hh',
+        'Writer.hh',
+    ],
+    subdir: 'orc',
+)
+
+install_headers(
+    [
+        'sargs/Literal.hh',
+        'sargs/SearchArgument.hh',
+        'sargs/TruthValue.hh',
+    ],
+    subdir: 'orc/sargs',
+)

--- a/c++/meson.build
+++ b/c++/meson.build
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# required dependencies
+protobuf_dep = dependency('protobuf', fallback: ['protobuf', 'protobuf_dep'])
+lz4_dep = dependency('liblz4')
+snappy_dep = dependency('snappy')
+zlib_dep = dependency('zlib')
+zstd_dep = dependency('libzstd')
+
+# optional dependencies (should be set later in configuration)
+gtest_dep = disabler()
+gmock_dep = disabler()
+
+subdir('include/orc')
+subdir('src')
+
+if get_option('tests').enabled()
+    gtest_dep = dependency('gtest')
+    gmock_dep = dependency('gmock')
+    subdir('test')
+endif
+
+pkg = import('pkgconfig')
+pkg.generate(orc_lib)

--- a/c++/src/meson.build
+++ b/c++/src/meson.build
@@ -1,0 +1,196 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+compiler = meson.get_compiler('cpp')
+has_pread = compiler.compiles('''
+    #include<fcntl.h>
+    #include<unistd.h>
+    int main(int,char*[]){
+      int f = open("/x/y", O_RDONLY);
+      char buf[100];
+      return pread(f, buf, 100, 1000) == 0;
+    }
+''')
+
+has_strptime = compiler.compiles('''
+    #include<time.h>
+    int main(int,char*[]){
+      struct tm time2020;
+      return !strptime("2020-02-02 12:34:56", "%Y-%m-%d %H:%M:%S", &time2020);
+    }
+''')
+
+has_builtin_overflow_check = compiler.compiles('''
+    int main(){
+      int a;
+      return __builtin_add_overflow(1, 2, &a);
+    }
+''')
+
+has_diagnostic_push = compiler.compiles('''
+    #ifdef __clang__
+      #pragma clang diagnostic push
+      #pragma clang diagnostic ignored "-Wdeprecated"
+      #pragma clang diagnostic pop
+   #elif defined(__GNUC__)
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wdeprecated"
+      #pragma GCC diagnostic pop
+   #elif defined(_MSC_VER)
+      #pragma warning( push )
+      #pragma warning( disable : 4996 )
+      #pragma warning( pop )
+   #else
+     unknownCompiler!
+   #endif
+   int main(int, char *[]) {}
+''')
+
+has_std_isnan = compiler.compiles('''
+    #include<cmath>
+    int main(int, char *[]) {
+      return std::isnan(1.0f);
+    }
+''')
+
+has_double_to_string = compiler.compiles('''
+    #include<string>
+    int main(int, char *[]) {
+      double d = 5;
+      std::to_string(d);
+    }
+''')
+
+has_int64_to_string = compiler.compiles('''
+    #include<cstdint>
+    #include<string>
+    int main(int, char *[]) {
+      int64_t d = 5;
+      std::to_string(d);
+    }
+''')
+
+has_pre_1970 = compiler.run('''
+    #include<time.h>
+    int main(int, char *[]) {
+      time_t t = -14210715; // 1969-07-20 12:34:45
+      struct tm *ptm = gmtime(&t);
+      return !(ptm && ptm->tm_year == 69);
+    }
+''')
+
+has_post_2038 = compiler.run('''
+    #include<stdlib.h>
+    #include<time.h>
+    int main(int, char *[]) {
+      setenv("TZ", "America/Los_Angeles", 1);
+      tzset();
+      struct tm time2037;
+      struct tm time2038;
+      strptime("2037-05-05 12:34:56", "%Y-%m-%d %H:%M:%S", &time2037);
+      strptime("2038-05-05 12:34:56", "%Y-%m-%d %H:%M:%S", &time2038);
+      return (mktime(&time2038) - mktime(&time2037)) <= 31500000;
+    }
+''')
+
+cdata = configuration_data()
+cdata.set10('HAS_PREAD', has_pread)
+cdata.set10('HAS_STRPTIME', has_strptime)
+cdata.set10('HAS_DIAGNOSTIC_PUSH', has_diagnostic_push)
+cdata.set10('HAS_DOUBLE_TO_STRING', has_double_to_string)
+cdata.set10('HAS_INT64_TO_STRING', has_int64_to_string)
+cdata.set('HAS_PRE_1970', has_pre_1970.returncode() == 0)
+cdata.set('HAS_POST_2038', has_post_2038.returncode() == 0)
+cdata.set10('HAS_STD_ISNAN', has_std_isnan)
+cdata.set10('HAS_BUILTIN_OVERFLOW_CHECK', has_builtin_overflow_check)
+cdata.set10('NEEDS_Z_PREFIX', false)  # Meson zlib subproject does not need this
+
+adaptor_header = configure_file(
+    input: 'Adaptor.hh.in',
+    output: 'Adaptor.hh',
+    configuration: cdata,
+    format: 'cmake',
+)
+
+source_files = [adaptor_header]
+source_files += files(
+    'io/InputStream.cc',
+    'io/OutputStream.cc',
+    'io/Cache.cc',
+    'sargs/ExpressionTree.cc',
+    'sargs/Literal.cc',
+    'sargs/PredicateLeaf.cc',
+    'sargs/SargsApplier.cc',
+    'sargs/SearchArgument.cc',
+    'sargs/TruthValue.cc',
+    'wrap/orc-proto-wrapper.cc',
+    'Adaptor.cc',
+    'BlockBuffer.cc',
+    'BloomFilter.cc',
+    'BpackingDefault.cc',
+    'ByteRLE.cc',
+    'ColumnPrinter.cc',
+    'ColumnReader.cc',
+    'ColumnWriter.cc',
+    'Common.cc',
+    'Compression.cc',
+    'ConvertColumnReader.cc',
+    'CpuInfoUtil.cc',
+    'Exceptions.cc',
+    'Int128.cc',
+    'LzoDecompressor.cc',
+    'MemoryPool.cc',
+    'Murmur3.cc',
+    'OrcFile.cc',
+    'Reader.cc',
+    'RLEv1.cc',
+    'RLEV2Util.cc',
+    'RleDecoderV2.cc',
+    'RleEncoderV2.cc',
+    'RLE.cc',
+    'SchemaEvolution.cc',
+    'Statistics.cc',
+    'StripeStream.cc',
+    'Timezone.cc',
+    'TypeImpl.cc',
+    'Vector.cc',
+    'Writer.cc',
+)
+
+incdir = include_directories('../include')
+orc_format_proto_dep = dependency('orc_format_proto')
+
+orc_lib = library(
+    'orc',
+    sources: source_files,
+    dependencies: [
+        orc_format_proto_dep,
+        protobuf_dep,
+        zlib_dep,
+        snappy_dep,
+        lz4_dep,
+        zstd_dep,
+    ],
+    include_directories: incdir,
+    install: true,
+)
+
+orc_dep = declare_dependency(
+    link_with: orc_lib,
+    include_directories: incdir,
+    dependencies: orc_format_proto_dep,
+)

--- a/c++/test/meson.build
+++ b/c++/test/meson.build
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+test_incdir = include_directories(
+    '../include',
+    '../src',
+)
+
+test_sources = [
+    'MemoryInputStream.cc',
+    'MemoryOutputStream.cc',
+    'MockStripeStreams.cc',
+    'TestAttributes.cc',
+    'TestBlockBuffer.cc',
+    'TestBufferedOutputStream.cc',
+    'TestBloomFilter.cc',
+    'TestByteRle.cc',
+    'TestByteRLEEncoder.cc',
+    'TestColumnPrinter.cc',
+    'TestColumnReader.cc',
+    'TestColumnStatistics.cc',
+    'TestCompression.cc',
+    'TestConvertColumnReader.cc',
+    'TestDecompression.cc',
+    'TestDecimal.cc',
+    'TestDictionaryEncoding.cc',
+    'TestDriver.cc',
+    'TestInt128.cc',
+    'TestMurmur3.cc',
+    'TestPredicateLeaf.cc',
+    'TestPredicatePushdown.cc',
+    'TestReader.cc',
+    'TestRleDecoder.cc',
+    'TestRleEncoder.cc',
+    'TestRLEV2Util.cc',
+    'TestSargsApplier.cc',
+    'TestSearchArgument.cc',
+    'TestSchemaEvolution.cc',
+    'TestStripeIndexStatistics.cc',
+    'TestTimestampStatistics.cc',
+    'TestTimezone.cc',
+    'TestType.cc',
+    'TestWriter.cc',
+    'TestCache.cc',        
+]
+
+orc_test = executable(
+    'orc-test',
+    sources: test_sources,
+    include_directories: test_incdir,
+    dependencies: [
+        orc_dep,
+        lz4_dep,
+        protobuf_dep,
+        snappy_dep,
+        zlib_dep,
+        gtest_dep,
+        gmock_dep,
+    ],
+)
+
+exc = executable(
+    'create-test-files',
+    sources: ['CreateTestFiles.cc'],
+    include_directories: test_incdir,    
+    dependencies: [
+        orc_dep,
+        protobuf_dep,
+    ],
+)
+test('orc-test', exc)

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+project(
+    'orc',
+    'cpp',
+    version: '2.2.0-SNAPSHOT',
+    license: 'Apache-2.0',
+    meson_version: '>=1.3.0',
+    default_options: [
+        'buildtype=release',
+        'warning_level=2',
+        'cpp_std=c++17',
+    ],
+)
+
+subdir('c++')
+
+install_data(
+    [
+        'LICENSE',
+        'NOTICE',
+    ],
+    install_dir: 'share/doc/orc',
+)
+
+if get_option('tools').enabled()
+    subdir('tools')
+endif

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+option(
+    'tests',
+    type: 'feature',
+    value: 'enabled',    
+    description: 'Build the googletest unit tests',
+)
+
+option(
+    'tools',
+    type: 'feature',
+    value: 'enabled',
+    description: 'Build the tools',
+)

--- a/subprojects/abseil-cpp.wrap
+++ b/subprojects/abseil-cpp.wrap
@@ -1,0 +1,125 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = abseil-cpp-20240722.0
+source_url = https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz
+source_filename = abseil-cpp-20240722.0.tar.gz
+source_hash = f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
+patch_filename = abseil-cpp_20240722.0-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20240722.0-3/get_patch
+patch_hash = 12dd8df1488a314c53e3751abd2750cf233b830651d168b6a9f15e7d0cf71f7b
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20240722.0-3/abseil-cpp-20240722.0.tar.gz
+wrapdb_version = 20240722.0-3
+
+[provide]
+absl_base = absl_base_dep
+absl_container = absl_container_dep
+absl_debugging = absl_debugging_dep
+absl_log = absl_log_dep
+absl_flags = absl_flags_dep
+absl_hash = absl_hash_dep
+absl_crc = absl_crc_dep
+absl_numeric = absl_numeric_dep
+absl_profiling = absl_profiling_dep
+absl_random = absl_random_dep
+absl_status = absl_status_dep
+absl_strings = absl_strings_dep
+absl_synchronization = absl_synchronization_dep
+absl_time = absl_time_dep
+absl_types = absl_types_dep
+absl_algorithm_container = absl_base_dep
+absl_any_invocable = absl_base_dep
+absl_bad_any_cast_impl = absl_types_dep
+absl_bad_optional_access = absl_types_dep
+absl_bad_variant_access = absl_types_dep
+absl_bind_front = absl_base_dep
+absl_city = absl_hash_dep
+absl_civil_time = absl_time_dep
+absl_cleanup = absl_base_dep
+absl_cord = absl_strings_dep
+absl_cord_internal = absl_strings_dep
+absl_cordz_functions = absl_strings_dep
+absl_cordz_handle = absl_strings_dep
+absl_cordz_info = absl_strings_dep
+absl_cordz_sample_token = absl_strings_dep
+absl_core_headers = absl_base_dep
+absl_crc32c = absl_crc_dep
+absl_debugging_internal = absl_debugging_dep
+absl_demangle_internal = absl_debugging_dep
+absl_die_if_null = absl_log_dep
+absl_examine_stack = absl_debugging_dep
+absl_exponential_biased = absl_profiling_dep
+absl_failure_signal_handler = absl_debugging_dep
+absl_flags_commandlineflag = absl_flags_dep
+absl_flags_commandlineflag_internal = absl_flags_dep
+absl_flags_config = absl_flags_dep
+absl_flags_internal = absl_flags_dep
+absl_flags_marshalling = absl_flags_dep
+absl_flags_parse = absl_flags_dep
+absl_flags_private_handle_accessor = absl_flags_dep
+absl_flags_program_name = absl_flags_dep
+absl_flags_reflection = absl_flags_dep
+absl_flags_usage = absl_flags_dep
+absl_flags_usage_internal = absl_flags_dep
+absl_flat_hash_map = absl_container_dep
+absl_flat_hash_set = absl_container_dep
+absl_function_ref = absl_base_dep
+absl_graphcycles_internal = absl_synchronization_dep
+absl_hashtablez_sampler = absl_container_dep
+absl_inlined_vector = absl_container_dep
+absl_int128 = absl_numeric_dep
+absl_leak_check = absl_debugging_dep
+absl_log_initialize = absl_log_dep
+absl_log_internal_check_op = absl_log_dep
+absl_log_internal_message = absl_log_dep
+absl_log_severity = absl_base_dep
+absl_low_level_hash = absl_hash_dep
+absl_memory = absl_base_dep
+absl_optional = absl_types_dep
+absl_periodic_sampler = absl_profiling_dep
+absl_random_bit_gen_ref = absl_random_dep
+absl_random_distributions = absl_random_dep
+absl_random_internal_distribution_test_util = absl_random_dep
+absl_random_internal_platform = absl_random_dep
+absl_random_internal_pool_urbg = absl_random_dep
+absl_random_internal_randen = absl_random_dep
+absl_random_internal_randen_hwaes = absl_random_dep
+absl_random_internal_randen_hwaes_impl = absl_random_dep
+absl_random_internal_randen_slow = absl_random_dep
+absl_random_internal_seed_material = absl_random_dep
+absl_random_random = absl_random_dep
+absl_random_seed_gen_exception = absl_random_dep
+absl_random_seed_sequences = absl_random_dep
+absl_raw_hash_set = absl_container_dep
+absl_raw_logging_internal = absl_base_dep
+absl_scoped_set_env = absl_base_dep
+absl_span = absl_types_dep
+absl_spinlock_wait = absl_base_dep
+absl_stacktrace = absl_debugging_dep
+absl_statusor = absl_status_dep
+absl_str_format = absl_strings_dep
+absl_str_format_internal = absl_strings_dep
+absl_strerror = absl_base_dep
+absl_string_view = absl_strings_dep
+absl_strings_internal = absl_strings_dep
+absl_symbolize = absl_debugging_dep
+absl_throw_delegate = absl_base_dep
+absl_time_zone = absl_time_dep
+absl_type_traits = absl_base_dep
+absl_utility = absl_base_dep
+absl_variant = absl_types_dep

--- a/subprojects/google-snappy.wrap
+++ b/subprojects/google-snappy.wrap
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = snappy-1.2.2
+source_url = https://github.com/google/snappy/archive/1.2.2.tar.gz
+source_filename = 1.2.2.tar.gz
+source_hash = 90f74bc1fbf78a6c56b3c4a082a05103b3a56bb17bca1a27e052ea11723292dc
+patch_filename = google-snappy_1.2.2-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-snappy_1.2.2-1/get_patch
+patch_hash = 831c36bf1eca64e95cee892cae5a7eade382b1a13bb74a5038cd2703a8fc158c
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-snappy_1.2.2-1/1.2.2.tar.gz
+wrapdb_version = 1.2.2-1
+
+[provide]
+snappy = snappy_dep

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = googletest-release-1.12.1
+source_url = https://github.com/google/googletest/archive/release-1.12.1.tar.gz
+source_filename = gtest-1.12.1.tar.gz
+source_hash = 81964fe578e9bd7c94dfdb09c8e4d6e6759e19967e397dbea48d1c10e45d0df2
+patch_filename = gtest_1.12.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.12.1-1/get_patch
+patch_hash = 75143f11e174952bc768699fde3176511fe8e33b25dc6f6347d89e41648e99cf
+wrapdb_version = 1.12.1-1
+
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/subprojects/lz4.wrap
+++ b/subprojects/lz4.wrap
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = lz4-1.10.0
+source_url = https://github.com/lz4/lz4/archive/v1.10.0.tar.gz
+source_filename = lz4-1.10.0.tgz
+source_hash = 537512904744b35e232912055ccf8ec66d768639ff3abe5788d90d792ec5f48b
+patch_filename = lz4_1.10.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/lz4_1.10.0-1/get_patch
+patch_hash = 17aea915e4597716afd08330f780ac9ffac0b979e713b718e0563d240f2c28c8
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/lz4_1.10.0-1/lz4-1.10.0.tgz
+wrapdb_version = 1.10.0-1
+
+[provide]
+liblz4 = liblz4_dep

--- a/subprojects/orc-format.wrap
+++ b/subprojects/orc-format.wrap
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = orc-format-1.1.0
+source_url = https://www.apache.org/dyn/closer.lua/orc/orc-format-1.1.0/orc-format-1.1.0.tar.gz?action=download
+source_filename = orc-format-1-1.0.tar.gz
+source_hash = d4a7ac76c5442abf7119e2cb84e71b677e075aff53518aa866055e2ead0450d7
+patch_directory = orc-format
+
+[provide]
+orc_format_proto = orc_format_proto_dep

--- a/subprojects/packagefiles/orc-format/meson.build
+++ b/subprojects/packagefiles/orc-format/meson.build
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+project(
+    'orc-format',
+    'cpp',
+    version: '1.1.0',
+    license: 'Apache-2.0',
+    meson_version: '>=1.3.0',
+)
+
+protobuf_dep = dependency('protobuf', fallback: ['protobuf', 'protobuf_dep'])
+# in newer versions of protobuf from the wrapdb, find_program('protoc') will
+# "do the right thing", but the protobuf wrapdb version we are using now does
+# not call override_find_program('protoc', ...)
+if protobuf_dep.type_name() == 'internal'
+    protoc = subproject('protobuf').get_variable('protoc')
+else
+    protoc = find_program('protoc')
+endif
+
+fs = import('fs')
+proto_file = meson.project_source_root() / 'src/main/proto/orc/proto/orc_proto.proto'
+proto_parent_dir = fs.parent(proto_file)
+
+orc_proto_files = custom_target(
+    'orc-proto',
+    input: [proto_file],
+    output: ['orc_proto.pb.h', 'orc_proto.pb.cc'],
+    command: [
+        protoc,
+        '-I',
+        proto_parent_dir,
+        '--cpp_out',
+        meson.current_build_dir(),
+        '@INPUT@',
+    ],
+)
+
+orc_format_proto_dep = declare_dependency(
+    sources: orc_proto_files[0],
+    include_directories: include_directories('.'),
+)

--- a/subprojects/protobuf.wrap
+++ b/subprojects/protobuf.wrap
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = protobuf-3.5.1
+source_url = https://github.com/google/protobuf/releases/download/v3.5.1/protobuf-all-3.5.1.tar.gz
+source_filename = protobuf-all-3.5.1.tar.gz
+source_hash = 72d43863f58567a9ea2054671fdb667867f9cf7865df623c7be630978ff97dff
+patch_url = https://wrapdb.mesonbuild.com/v2/protobuf_3.5.1-3/get_patch
+patch_filename = protobuf-3.5.1-3-wrap.zip
+patch_hash = 9316ee29244a590545d8175136fd916149ca81e3f33f20d3cffc5bd3e6812e67

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = zlib-1.3.1
+source_url = http://zlib.net/fossils/zlib-1.3.1.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.3.1-1/zlib-1.3.1.tar.gz
+source_filename = zlib-1.3.1.tar.gz
+source_hash = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+patch_filename = zlib_1.3.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3.1-1/get_patch
+patch_hash = e79b98eb24a75392009cec6f99ca5cdca9881ff20bfa174e8b8926d5c7a47095
+wrapdb_version = 1.3.1-1
+
+[provide]
+zlib = zlib_dep

--- a/subprojects/zstd.wrap
+++ b/subprojects/zstd.wrap
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = zstd-1.5.7
+source_url = https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
+source_filename = zstd-1.5.7.tar.gz
+source_hash = eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3
+patch_filename = zstd_1.5.7-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zstd_1.5.7-1/get_patch
+patch_hash = 454f6610c12489434533932a11c2c29043903da1c10d20de1fb8ccf5a1e0908b
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zstd_1.5.7-1/zstd-1.5.7.tar.gz
+wrapdb_version = 1.5.7-1
+
+[provide]
+libzstd = libzstd_dep

--- a/tools/meson.build
+++ b/tools/meson.build
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+subdir('src')
+
+if get_option('tests').enabled()
+  subdir('test')
+endif

--- a/tools/src/meson.build
+++ b/tools/src/meson.build
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+tools_incdir = include_directories(
+    '../../c++/include',
+    '../../c++/src',    
+)
+
+tools = {
+    'orc-contents': {
+        'sources': ['FileContents.cc', 'ToolsHelper.cc'],
+    },
+    'orc-scan': {
+        'sources': ['FileScan.cc', 'ToolsHelper.cc'],
+    },
+    'orc-metadata': {
+        'sources': ['FileMetadata.cc', 'ToolsHelper.cc'],
+    },
+    'orc-statistics': {
+        'sources': ['FileStatistics.cc'],
+    },
+    'orc-memory': {
+        'sources': ['FileMemory.cc', 'ToolsHelper.cc'],
+    },
+    'timezone-dump': {
+        'sources': ['TimezoneDump.cc'],        
+    },
+    'csv-import': {
+        'sources': ['CSVFileImport.cc'],        
+    },
+}
+
+foreach tool_name, val : tools
+    executable(
+        tool_name,
+        sources: val['sources'],
+        include_directories: tools_incdir,
+        dependencies: [orc_dep, protobuf_dep],
+        install: true,
+    )
+endforeach

--- a/tools/test/meson.build
+++ b/tools/test/meson.build
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+exc = executable(
+    'tool-test',
+    sources: [
+        'gzip.cc',
+        'TestCSVFileImport.cc',
+        'TestFileContents.cc',
+        'TestFileMetadata.cc',
+        'TestFileScan.cc',
+        'TestFileStatistics.cc',
+        'TestMatch.cc',
+        'ToolTest.cc',
+    ],
+    include_directories: tools_incdir,
+    dependencies: [
+        orc_dep,
+        protobuf_dep,
+        zlib_dep,
+        snappy_dep,
+        gtest_dep,
+        gmock_dep,
+    ],
+)
+test('tool-test', exc)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds a Meson configuration for the default C++ options in ORC. By adding this configuration, users of the Meson build system will have an easier time including Orc into their projects. In the mid to longer term, this could help the Apache Arrow project also become easier to include in other C++ project


### Why are the changes needed?
The current motivating factor is for Apache Arrow, where incremental improvements to the Meson build system are underway

### How was this patch tested?
A new CI job for Meson has been configured

### Was this patch authored or co-authored using generative AI tooling?
No

Closes #2244