### PR TITLE
ORC-1907: Upgrade `byte-buddy` to 1.17.5

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -252,13 +252,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.5</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.17.0</version>
+        <version>1.17.5</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `byte-buddy` to 1.17.5.

### Why are the changes needed?

To bring the latest bug fixes:
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.5
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.4
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.3
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.2
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.1

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.