### PR TITLE
ORC-1910: Add `-XX:+EnableDynamicAgentLoading` to Surefire argLine

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -711,7 +711,7 @@
         <configuration>
           <trimStackTrace>false</trimStackTrace>
           <reuseForks>false</reuseForks>
-          <argLine>-Xmx2048m -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --enable-native-access=ALL-UNNAMED</argLine>
+          <argLine>-Xmx2048m -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED --enable-native-access=ALL-UNNAMED -XX:+EnableDynamicAgentLoading</argLine>
           <environmentVariables>
             <TZ>US/Pacific</TZ>
             <LANG>en_US.UTF-8</LANG>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `-XX:+EnableDynamicAgentLoading` to Surefire argLine.

### Why are the changes needed?

To suppress the following during testing.

```
WARNING: A Java agent has been loaded dynamically (/Users/dongjoon/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.5/byte-buddy-agent-1.17.5.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

### How was this patch tested?

Manual tests.

**BEFORE**

```
$ mvn package --pl core -Dtest=TestOrcLargeStripe
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.orc.impl.TestOrcLargeStripe
WARNING: A Java agent has been loaded dynamically (/Users/dongjoon/.m2/repository/net/bytebuddy/byte-buddy-agent/1.17.5/byte-buddy-agent-1.17.5.jar)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information
WARNING: Dynamic loading of agents will be disallowed by default in a future release
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```

**AFTER**

```
$ mvn package --pl core -Dtest=TestOrcLargeStripe
...
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.orc.impl.TestOrcLargeStripe
OpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
```

### Was this patch authored or co-authored using generative AI tooling?

No.