### PR TITLE
ORC-1911: Update CIs to use `actions/checkout@v4` consistently

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,7 +52,7 @@ jobs:
           - amazonlinux23
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: "Test"
       run: |
         cd docker
@@ -85,7 +85,7 @@ jobs:
       MAVEN_SKIP_RC: true
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
@@ -117,7 +117,7 @@ jobs:
       ORC_USER_SIMD_LEVEL: AVX512
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
       with:
@@ -149,7 +149,7 @@ jobs:
       ORC_USER_SIMD_LEVEL: AVX512
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: "Test"
       run: |
         mkdir -p ~/.m2
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     - name: Super-Linter
@@ -218,7 +218,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check license header
         uses: apache/skywalking-eyes@main
         env:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'apache/orc'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
 
     - uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update CIs to use `actions/checkout@v4` consistently.

### Why are the changes needed?

**BEFORE**
```
$ git grep actions/checkout | awk '{print $NF}' | sort | uniq -c
   1 actions/checkout@master
   5 actions/checkout@v2
   1 actions/checkout@v3
   4 actions/checkout@v4
```

**AFTER**
```
$ git grep actions/checkout | awk '{print $NF}' | sort | uniq -c
  11 actions/checkout@v4
```

### How was this patch tested?

Manual check with the following.
```
$ git grep actions/checkout | awk '{print $NF}' | sort | uniq -c
  11 actions/checkout@v4
```

### Was this patch authored or co-authored using generative AI tooling?

No.