### PR TITLE
ORC-1912: Suppress Hadoop logs lower than ERROR level during testing

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -721,6 +721,7 @@
           <systemPropertyVariables>
             <test.tmp.dir>${test.tmp.dir}</test.tmp.dir>
             <example.dir>${example.dir}</example.dir>
+            <org.slf4j.simpleLogger.log.org.apache.hadoop>error</org.slf4j.simpleLogger.log.org.apache.hadoop>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to suppress Hadoop verbose logs which is lower than ERROR level during testing.

### Why are the changes needed?

Hadoop INFO/WARN logs are too verbose and there is nothing for us to do during testing.
```
$ mvn package | grep org.apache.hadoop
...
[main] WARN org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[main] WARN org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[main] WARN org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[main] WARN org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
[main] WARN org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
```

### How was this patch tested?

Manually check the log.

### Was this patch authored or co-authored using generative AI tooling?

No.