### PR TITLE
ORC-1913: Fix `TestColumnStatistics` to set `testFilePath` with absolute path

### DIFF
--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -753,9 +753,9 @@ public class TestColumnStatistics {
   @BeforeEach
   public void openFileSystem(TestInfo testInfo) throws Exception {
     conf = new Configuration();
+    conf.set("fs.file.impl.disable.cache", "true");
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
-    testFilePath = new Path(
+    testFilePath = new Path(workDir + File.separator +
         "TestOrcFile." + testInfo.getTestMethod().get().getName() + ".orc");
     fs.delete(testFilePath, false);
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `TestColumnStatistics` to set `testFilePath` with absolute path.

### Why are the changes needed?

The test case is fragile because it depends on the assumption that new FileSystem will be identical.

For example, it fails when we set `fs.file.impl.disable.cache=false`.

```
$ git diff
...
     conf = new Configuration();
+    conf.set("fs.file.impl.disable.cache", "true");
     fs = FileSystem.getLocal(conf);

$ mvn package --pl core -Dtest=TestColumnStatistics
...
[ERROR] Errors:
[ERROR]   TestColumnStatistics.testDecimalMinMaxStatistics:695 » FileNotFound File TestOrcFile.testDecimalMinMaxStatistics.orc does not exist
```

### How was this patch tested?

Pass the CIs with the updated code.

### Was this patch authored or co-authored using generative AI tooling?

No.