### PR TITLE
ORC-1914: Ensure `Annotation Processing` in `core` module compilation

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -139,6 +139,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-proc:full</arg>
+          </compilerArgs>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ensure `Annotation Processing` in `core` module compilation.

### Why are the changes needed?

Since JDK 23, `Annotation Processing` is disabled.
- [JDK 23: Changes Default Annotation Processing Policy](https://inside.java/2024/06/18/quality-heads-up/)

### How was this patch tested?

Manual review since we didn't add JDK23+ CI yet.

### Was this patch authored or co-authored using generative AI tooling?

No.