### PR TITLE
ORC-1916: Add Java `25-ea` build CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -79,6 +79,8 @@ jobs:
           - os: ubuntu-22.04
             java: 17
             cxx: g++
+          - os: ubuntu-latest
+            java: 25-ea
     env:
       MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true
@@ -94,10 +96,16 @@ jobs:
     - name: "Test"
       run: |
         mkdir -p ~/.m2
-        mkdir build
-        cd build
-        cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl@1.1` ..
-        make package test-out
+        if [ "${{ matrix.java }}" = "25-ea" ]; then
+          cd java
+          # JDK 25 Build
+          ./mvnw package -DskipTests
+        else
+          mkdir build
+          cd build
+          cmake -DANALYZE_JAVA=ON -DOPENSSL_ROOT_DIR=`brew --prefix openssl@1.1` ..
+          make package test-out
+        fi
     - name: Step on failure
       if: ${{ failure() }}
       run: |


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Java 25-ea` build GitHub Action CI. Note that `testing` is not a goal.

### Why are the changes needed?

As a part of Apache ORC 2.2.0 preparation, we had better protect the build capability with `Java 25-ea`.

### How was this patch tested?

Pass the CIs with the newly added `Java 25-ea` test pipeline.

https://github.com/apache/orc/actions/runs/15551252384/job/43782178949?pr=2264

<img width="593" alt="Screenshot 2025-06-09 at 10 24 39 PM" src="https://github.com/user-attachments/assets/b574c4ed-009e-4798-a84f-f74390fb2fd0" />

### Was this patch authored or co-authored using generative AI tooling?

No.