### PR TITLE
ORC-1918: Add Java `25-ea` test coverage for `shims` and `core` modules

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -100,6 +100,8 @@ jobs:
           cd java
           # JDK 25 Build
           ./mvnw package -DskipTests
+          # JDK 25 Test: shims and core modules
+          ./mvnw package --pl core --am
         else
           mkdir build
           cd build

--- a/java/core/src/test/org/apache/orc/TestColumnStatistics.java
+++ b/java/core/src/test/org/apache/orc/TestColumnStatistics.java
@@ -750,7 +750,6 @@ public class TestColumnStatistics implements TestConf {
 
   @BeforeEach
   public void openFileSystem(TestInfo testInfo) throws Exception {
-    conf.set("fs.file.impl.disable.cache", "true");
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir + File.separator +
         "TestOrcFile." + testInfo.getTestMethod().get().getName() + ".orc");

--- a/java/core/src/test/org/apache/orc/TestConf.java
+++ b/java/core/src/test/org/apache/orc/TestConf.java
@@ -30,10 +30,14 @@ public interface TestConf {
   @BeforeEach
   default void clear() {
     conf.clear();
+    conf.set("fs.defaultFS", "file:///");
+    conf.set("fs.file.impl.disable.cache", "true");
   }
 
   private static Configuration getNewConf() {
     Configuration conf = new Configuration();
+    conf.set("fs.defaultFS", "file:///");
+    conf.set("fs.file.impl.disable.cache", "true");
     return conf;
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Java 25-ea` test coverage for `shims` and `core` modules.

### Why are the changes needed?

Currently, Apache ORC supports `Java 25-ea` testing. We had better prevent a regression by adding a CI explicitly.

```
$ java -version
openjdk version "25-ea" 2025-09-16
OpenJDK Runtime Environment (build 25-ea+26-3358)
OpenJDK 64-Bit Server VM (build 25-ea+26-3358, mixed mode, sharing)

$ mvn package --pl core --am
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ORC 2.2.0-SNAPSHOT:
[INFO]
[INFO] Apache ORC ......................................... SUCCESS [  0.816 s]
[INFO] ORC Shims .......................................... SUCCESS [  1.561 s]
[INFO] ORC Core ........................................... SUCCESS [01:05 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  01:07 min
[INFO] Finished at: 2025-06-09T23:49:45-07:00
[INFO] ------------------------------------------------------------------------
```

### How was this patch tested?

Pass the CIs and check the logs.

- https://github.com/apache/orc/actions/runs/15552545475/job/43785802164?pr=2266

<img width="593" alt="Screenshot 2025-06-09 at 10 24 39 PM" src="https://github.com/user-attachments/assets/42f1dc17-36e6-468d-901f-d9c5205439ec" />

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Apache ORC 2.2.0-SNAPSHOT:
[INFO] 
[INFO] Apache ORC ......................................... SUCCESS [  1.918 s]
[INFO] ORC Shims .......................................... SUCCESS [  4.395 s]
[INFO] ORC Core ........................................... SUCCESS [01:57 min]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:03 min
[INFO] Finished at: 2025-06-10T06:50:59Z
[INFO] ------------------------------------------------------------------------
```

### Was this patch authored or co-authored using generative AI tooling?

No.