### PR TITLE
ORC-1921: Upgrade Hadoop to 3.4.2

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
     <checkstyle.version>10.26.1</checkstyle.version>
     <commons-cli.version>1.10.0</commons-cli.version>
     <example.dir>${project.basedir}/../../examples</example.dir>
-    <hadoop.version>3.4.1</hadoop.version>
+    <hadoop.version>3.4.2</hadoop.version>
     <java.version>17</java.version>
     <javadoc.location>${project.basedir}/../target/javadoc</javadoc.location>
     <jts.version>1.20.0</jts.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache Hadoop to 3.4.2.

### Why are the changes needed?

To bring the latest bug fixes.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.