### PR TITLE
ORC-1923: Remove `Windows 2019` GitHub Action job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -113,37 +113,6 @@ jobs:
       run: |
         cat /home/runner/work/orc/orc/build/java/rat.txt
 
-  windows:
-    name: "C++ ${{ matrix.simd }} Test on Windows"
-    runs-on: windows-2019
-    strategy:
-      fail-fast: false
-      matrix:
-        simd:
-          - General
-          - AVX512
-    env:
-      ORC_USER_SIMD_LEVEL: AVX512
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-      with:
-        msbuild-architecture: x64
-    - name: "Test"
-      shell: bash
-      run: |
-        mkdir build
-        cd build
-        if [ "${{ matrix.simd }}" = "General" ]; then
-          cmake .. -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Debug -DBUILD_LIBHDFSPP=OFF -DBUILD_TOOLS=OFF -DBUILD_JAVA=OFF
-        else
-          cmake .. -G "Visual Studio 16 2019" -DCMAKE_BUILD_TYPE=Debug -DBUILD_LIBHDFSPP=OFF -DBUILD_TOOLS=OFF -DBUILD_JAVA=OFF -DBUILD_ENABLE_AVX512=ON
-        fi
-        cmake --build . --config Debug
-        ctest -C Debug --output-on-failure
-
   simdUbuntu:
     name: "SIMD programming using C++ intrinsic functions on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `Windows 2019` GitHub Action job.

Note that ORC-1924 is created in order to recover Windows test coverage later.
- #2273

### Why are the changes needed?

`Windows 2019` is deprecated already and will be removed soon.
- https://github.com/actions/runner-images/issues/12045

### How was this patch tested?

Manual review because this is a removal of CI.

### Was this patch authored or co-authored using generative AI tooling?

No.