### PR TITLE
ORC-1925: Add `oraclelinux8` to docker tests and GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,6 +47,7 @@ jobs:
           - debian11
           - debian12
           - ubuntu24
+          - oraclelinux8
           - oraclelinux9
           - amazonlinux23
     steps:

--- a/docker/oraclelinux8/Dockerfile
+++ b/docker/oraclelinux8/Dockerfile
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Oracle Linux 8
+#
+
+FROM oraclelinux:8
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+RUN yum check-update || true
+RUN yum install -y \
+  cmake3 \
+  curl-devel \
+  cyrus-sasl-devel \
+  expat-devel \
+  gcc \
+  gcc-c++ \
+  gettext-devel \
+  git \
+  libtool \
+  make \
+  openssl-devel \
+  tar \
+  wget \
+  which \
+  zlib-devel \
+  java-17-openjdk-devel
+
+ENV TZ=America/Los_Angeles
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -2,5 +2,6 @@ debian11
 debian12
 ubuntu22
 ubuntu24
+oraclelinux8
 oraclelinux9
 amazonlinux23

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -29,6 +29,7 @@ is in the docker subdirectory, for the list of packages required to build ORC:
 * [Debian 12]({{ page.dockerUrl }}/debian12/Dockerfile)
 * [Ubuntu 22]({{ page.dockerUrl }}/ubuntu22/Dockerfile)
 * [Ubuntu 24]({{ page.dockerUrl }}/ubuntu24/Dockerfile)
+* [Oracle Linux 8]({{ page.dockerUrl }}/oraclelinux8/Dockerfile)
 * [Oracle Linux 9]({{ page.dockerUrl }}/oraclelinux9/Dockerfile)
 
 To build a normal release:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `oraclelinux8` to docker tests and GitHub Action.

### Why are the changes needed?

To have a test coverage for `Oracle Linux 8`.

### How was this patch tested?

Pass the CIs with the newly added test job.

https://github.com/apache/orc/actions/runs/15719240051/job/44296538916?pr=2279

![Screenshot 2025-06-17 at 3 24 11 PM](https://github.com/user-attachments/assets/7f1f61b8-ebd4-4855-adcd-fcba6e902bd3)


```
$ docker run -it --rm apache/orc-dev:oraclelinux8 cat /etc/os-release
NAME="Oracle Linux Server"
VERSION="8.10"
ID="ol"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="8.10"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Oracle Linux Server 8.10"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:oracle:linux:8:10:server"
HOME_URL="https://linux.oracle.com/"
BUG_REPORT_URL="https://github.com/oracle/oracle-linux"

ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
ORACLE_BUGZILLA_PRODUCT_VERSION=8.10
ORACLE_SUPPORT_PRODUCT="Oracle Linux"
ORACLE_SUPPORT_PRODUCT_VERSION=8.10
```

```
$ docker run -it --rm apache/orc-dev:oraclelinux8 java --version
openjdk 17.0.15 2025-04-15 LTS
OpenJDK Runtime Environment (Red_Hat-17.0.15.0.6-2.0.1) (build 17.0.15+6-LTS)
OpenJDK 64-Bit Server VM (Red_Hat-17.0.15.0.6-2.0.1) (build 17.0.15+6-LTS, mixed mode, sharing)
```

```
$ docker run -it --rm apache/orc-dev:oraclelinux8 g++ --version
g++ (GCC) 8.5.0 20210514 (Red Hat 8.5.0-26.0.1)
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

### Was this patch authored or co-authored using generative AI tooling?

No.