### PR TITLE
[ORC-1926][TESTS] Use `TestConf` interface in `tools` module

### DIFF
--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -77,6 +77,13 @@
 
     <!-- test inter-project -->
     <dependency>
+      <groupId>org.apache.orc</groupId>
+      <artifactId>orc-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk18on</artifactId>
       <version>${bouncycastle.version}</version>

--- a/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
+++ b/java/tools/src/test/org/apache/orc/impl/TestRLEv2.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc.impl;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
@@ -27,6 +26,7 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.PhysicalWriter;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.impl.writer.StreamOptions;
@@ -50,16 +50,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestRLEv2 {
+public class TestRLEv2 implements TestConf {
   Path workDir = new Path(System.getProperty("test.tmp.dir",
       "target" + File.separator + "test" + File.separator + "tmp"));
   Path testFilePath;
-  Configuration conf;
   FileSystem fs;
 
   @BeforeEach
   public void openFileSystem (TestInfo testInfo) throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
     testFilePath = new Path(workDir, "TestRLEv2." +
         testInfo.getTestMethod().get().getName() + ".orc");

--- a/java/tools/src/test/org/apache/orc/tools/TestCheckTool.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestCheckTool.java
@@ -18,13 +18,13 @@
 
 package org.apache.orc.tools;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.tools.CheckTool;
@@ -32,24 +32,22 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestCheckTool {
+public class TestCheckTool implements TestConf {
   private Path workDir = new Path(System.getProperty("test.tmp.dir"));
-  private Configuration conf;
   private FileSystem fs;
   private Path testFilePath;
 
   @BeforeEach
   public void openFileSystem() throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
-    testFilePath = new Path("TestCheckTool.testCheckTool.orc");
+    testFilePath = new Path(workDir + File.separator + "TestCheckTool.testCheckTool.orc");
     fs.delete(testFilePath, false);
     createFile();
   }

--- a/java/tools/src/test/org/apache/orc/tools/TestColumnSizes.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestColumnSizes.java
@@ -18,13 +18,13 @@
 
 package org.apache.orc.tools;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.tools.ColumnSizes;
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -40,17 +41,14 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestColumnSizes {
+public class TestColumnSizes implements TestConf {
   private Path workDir = new Path(
       Paths.get(System.getProperty("test.tmp.dir"), "orc-test-sizes").toString());
-  private Configuration conf;
   private FileSystem fs;
 
   @BeforeEach
   public void openFileSystem() throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
     fs.mkdirs(workDir);
     fs.deleteOnExit(workDir);
   }
@@ -59,8 +57,8 @@ public class TestColumnSizes {
   public void testSizes() throws Exception {
     TypeDescription schema = TypeDescription.fromString("struct<x:int,y:string>");
     Map<String, Integer> fileToRowCountMap = new LinkedHashMap<>();
-    fileToRowCountMap.put("test-sizes-1.orc", 10000);
-    fileToRowCountMap.put("test-sizes-2.orc", 20000);
+    fileToRowCountMap.put(workDir + File.separator + "test-sizes-1.orc", 10000);
+    fileToRowCountMap.put(workDir + File.separator + "test-sizes-2.orc", 20000);
     for (Map.Entry<String, Integer> fileToRowCount : fileToRowCountMap.entrySet()) {
       Writer writer = OrcFile.createWriter(new Path(fileToRowCount.getKey()),
           OrcFile.writerOptions(conf)

--- a/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestJsonFileDump.java
@@ -18,7 +18,6 @@
 
 package org.apache.orc.tools;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -28,6 +27,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcConf;
 import org.apache.orc.OrcFile;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +42,7 @@ import java.util.Random;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class TestJsonFileDump {
+public class TestJsonFileDump implements TestConf {
 
   public static String getFileFromClasspath(String name) {
     URL url = ClassLoader.getSystemResource(name);
@@ -53,16 +53,13 @@ public class TestJsonFileDump {
   }
 
   Path workDir = new Path(System.getProperty("test.tmp.dir"));
-  Configuration conf;
   FileSystem fs;
   Path testFilePath;
 
   @BeforeEach
   public void openFileSystem () throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
-    testFilePath = new Path("TestFileDump.testDump.orc");
+    testFilePath = new Path(workDir + File.separator + "TestFileDump.testDump.orc");
     fs.delete(testFilePath, false);
   }
 

--- a/java/tools/src/test/org/apache/orc/tools/TestMergeFiles.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestMergeFiles.java
@@ -18,7 +18,6 @@
 
 package org.apache.orc.tools;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -27,6 +26,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.CompressionKind;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.tools.MergeFiles;
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -43,21 +44,18 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestMergeFiles {
+public class TestMergeFiles implements TestConf {
   private Path workDir = new Path(
       Paths.get(System.getProperty("test.tmp.dir"), "orc-test-merge").toString());
-  private Configuration conf;
   private FileSystem fs;
   private Path testFilePath;
 
   @BeforeEach
   public void openFileSystem() throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
     fs.mkdirs(workDir);
     fs.deleteOnExit(workDir);
-    testFilePath = new Path("TestMergeFiles.testMerge.orc");
+    testFilePath = new Path(workDir + File.separator + "TestMergeFiles.testMerge.orc");
     fs.delete(testFilePath, false);
   }
 
@@ -65,8 +63,8 @@ public class TestMergeFiles {
   public void testMerge() throws Exception {
     TypeDescription schema = TypeDescription.fromString("struct<x:int,y:string>");
     Map<String, Integer> fileToRowCountMap = new LinkedHashMap<>();
-    fileToRowCountMap.put("test-merge-1.orc", 10000);
-    fileToRowCountMap.put("test-merge-2.orc", 20000);
+    fileToRowCountMap.put(workDir + File.separator + "test-merge-1.orc", 10000);
+    fileToRowCountMap.put(workDir + File.separator + "test-merge-2.orc", 20000);
     for (Map.Entry<String, Integer> fileToRowCount : fileToRowCountMap.entrySet()) {
       Writer writer = OrcFile.createWriter(new Path(fileToRowCount.getKey()),
           OrcFile.writerOptions(conf)

--- a/java/tools/src/test/org/apache/orc/tools/TestRowCount.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestRowCount.java
@@ -18,12 +18,12 @@
 
 package org.apache.orc.tools;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.orc.tools.RowCount;
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
@@ -39,17 +40,14 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestRowCount {
+public class TestRowCount implements TestConf {
   private Path workDir = new Path(
       Paths.get(System.getProperty("test.tmp.dir"), "orc-test-count").toString());
-  private Configuration conf;
   private FileSystem fs;
 
   @BeforeEach
   public void openFileSystem() throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
     fs.mkdirs(workDir);
     fs.deleteOnExit(workDir);
   }
@@ -58,8 +56,8 @@ public class TestRowCount {
   public void testCount() throws Exception {
     TypeDescription schema = TypeDescription.fromString("struct<x:int>");
     Map<String, Integer> fileToRowCountMap = new LinkedHashMap<>();
-    fileToRowCountMap.put("test-count-1.orc", 10000);
-    fileToRowCountMap.put("test-count-2.orc", 20000);
+    fileToRowCountMap.put(workDir + File.separator + "test-count-1.orc", 10000);
+    fileToRowCountMap.put(workDir + File.separator + "test-count-2.orc", 20000);
     for (Map.Entry<String, Integer> fileToRowCount : fileToRowCountMap.entrySet()) {
       Writer writer = OrcFile.createWriter(new Path(fileToRowCount.getKey()),
           OrcFile.writerOptions(conf)

--- a/java/tools/src/test/org/apache/orc/tools/TestScanData.java
+++ b/java/tools/src/test/org/apache/orc/tools/TestScanData.java
@@ -18,36 +18,34 @@
 
 package org.apache.orc.tools;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestScanData {
+public class TestScanData implements TestConf {
   private Path workDir = new Path(System.getProperty("test.tmp.dir"));
-  private Configuration conf;
   private FileSystem fs;
   private Path testFilePath;
 
   @BeforeEach
   public void openFileSystem() throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
-    testFilePath = new Path("TestScanData.testScan.orc");
+    testFilePath = new Path(workDir + File.separator + "TestScanData.testScan.orc");
     fs.delete(testFilePath, false);
   }
 
@@ -86,6 +84,6 @@ public class TestScanData {
     assertTrue(output.contains("{\"category\": \"struct\", \"id\": 0, \"max\": 2, \"fields\": [\n" +
         "{  \"x\": {\"category\": \"int\", \"id\": 1, \"max\": 1}},\n" +
         "{  \"y\": {\"category\": \"string\", \"id\": 2, \"max\": 2}}]}"));
-    assertTrue(output.contains("File: TestScanData.testScan.orc, bad batches: 0, rows: 10000/10000"));
+    assertTrue(output.contains("TestScanData.testScan.orc, bad batches: 0, rows: 10000/10000"));
   }
 }

--- a/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
@@ -19,7 +19,6 @@
 package org.apache.orc.tools.convert;
 
 import org.apache.commons.cli.ParseException;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -28,12 +27,14 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.orc.OrcFile;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
+import org.apache.orc.TestConf;
 import org.apache.orc.TypeDescription;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.TimeZone;
@@ -41,21 +42,18 @@ import java.util.TimeZone;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class TestConvert {
+public class TestConvert implements TestConf {
 
   public static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getDefault();
 
   Path workDir = new Path(System.getProperty("test.tmp.dir"));
-  Configuration conf;
   FileSystem fs;
   Path testFilePath;
 
   @BeforeEach
   public void openFileSystem () throws Exception {
-    conf = new Configuration();
     fs = FileSystem.getLocal(conf);
-    fs.setWorkingDirectory(workDir);
-    testFilePath = new Path("TestConvert.testConvert.orc");
+    testFilePath = new Path(workDir + File.separator + "TestConvert.testConvert.orc");
     fs.delete(testFilePath, false);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `TestConf` interface in `tools` module like `core` module.

### Why are the changes needed?

To unify the test framework with the same way.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.