### PR TITLE
ORC-1927: Add Java `25-ea` test coverage for `tools` module

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -101,8 +101,8 @@ jobs:
           cd java
           # JDK 25 Build
           ./mvnw package -DskipTests
-          # JDK 25 Test: shims and core modules
-          ./mvnw package --pl core --am
+          # JDK 25 Test: shims, core, tools modules
+          ./mvnw package --pl tools --am
         else
           mkdir build
           cd build

--- a/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
+++ b/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
@@ -216,7 +216,9 @@ public class ColumnSizes {
   }
 
   public static void main(String[] args) throws Exception {
-    main(new Configuration(), args);
+    Configuration conf = new Configuration();
+    conf.set("fs.file.impl.disable.cache", "true");
+    main(conf, args);
   }
 
   private static Options createOptions() {

--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -102,6 +102,7 @@ public class Driver {
       System.exit(1);
     }
     Configuration conf = new Configuration();
+    conf.set("fs.file.impl.disable.cache", "true");
     Properties confSettings = options.genericOptions.getOptionProperties("D");
     for(Map.Entry pair: confSettings.entrySet()) {
       conf.set(pair.getKey().toString(), pair.getValue().toString());

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -142,6 +142,7 @@ public final class FileDump {
 
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();
+    conf.set("fs.file.impl.disable.cache", "true");
     main(conf, args);
   }
 

--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -72,7 +72,9 @@ public class RowCount {
   }
 
   public static void main(String[] args) throws Exception {
-    main(new Configuration(), args);
+    Configuration conf = new Configuration();
+    conf.set("fs.file.impl.disable.cache", "true");
+    main(conf, args);
   }
 
   private static Options createOptions() {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Java 25-ea` test coverage for `tools` module in addition to the existing `shims` and `core` modules.

### Why are the changes needed?

To improve a test coverage.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.