### PR TITLE
ORC-1929: Fix the Javadoc of `ZstdCodec.compress`

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -165,7 +165,7 @@ public class ZstdCodec implements CompressionCodec, DirectDecompressionCodec {
    * @param out      the compressed bytes
    * @param overflow put any additional bytes here
    * @param options  the options to control compression
-   * @return ZstdOptions
+   * @return true if input data is compressed. Otherwise, false.
    */
   @Override
   public boolean compress(ByteBuffer in, ByteBuffer out,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix the javadoc of `ZstdCodec.compress` method.

### Why are the changes needed?

The return type is `boolean` instead of `ZstdOptions`.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.