### PR TITLE
ORC-1931: Suppress Hadoop logs lower than ERROR level in `orc-tools`

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -77,6 +77,7 @@ public class Driver {
   }
 
   public static void main(String[] args) throws Exception {
+    System.setProperty("org.slf4j.simpleLogger.log.org.apache.hadoop", "error");
     DriverOptions options = new DriverOptions(args);
 
     if (options.command == null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to suppress `orc-tools` Hadoop logs which is lower than ERROR level.

### Why are the changes needed?

**BEFORE**

```
$ orc-tools count /Users/dongjoon/APACHE/orc-merge/java/core/src/test/resources/orc-file-11-format.orc
[main] WARN org.apache.hadoop.util.NativeCodeLoader - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
file:/Users/dongjoon/APACHE/orc-merge/java/core/src/test/resources/orc-file-11-format.orc 7500
```

**AFTER**

```
$ java -jar tools/target/orc-tools-2.2.0-SNAPSHOT-uber.jar count file:////Users/dongjoon/APACHE/orc-merge/java/core/src/test/resources/orc-file-11-format.orc
file:/Users/dongjoon/APACHE/orc-merge/java/core/src/test/resources/orc-file-11-format.orc 7500
```

### How was this patch tested?

Manual tests.

### Was this patch authored or co-authored using generative AI tooling?

No.