### PR TITLE
ORC-1936: Get build and example dir from build system rather than gtest

### DIFF
--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -45,6 +45,11 @@ target_include_directories(tool-test PRIVATE
   ${PROJECT_SOURCE_DIR}/tools-c++/src
 )
 
+target_compile_definitions(tool-test PRIVATE
+  "-DORC_EXAMPLE_DIR=${PROJECT_SOURCE_DIR}/examples"
+  "-DORC_BUILD_DIR=${PROJECT_BINARY_DIR}"
+)
+
 add_dependencies(tool-test tool-set)
 
 if (TEST_VALGRIND_MEMCHECK)

--- a/tools/test/ToolTest.cc
+++ b/tools/test/ToolTest.cc
@@ -29,28 +29,9 @@
 #include <string>
 #include <vector>
 
-namespace {
-  const char* exampleDirectory = 0;
-  const char* buildDirectory = 0;
-}  // namespace
-
 GTEST_API_ int main(int argc, char** argv) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
   std::cout << "ORC version: " << ORC_VERSION << "\n";
-  if (argc >= 2) {
-    exampleDirectory = argv[1];
-  } else {
-    exampleDirectory = "../examples";
-  }
-  if (argc >= 3) {
-    buildDirectory = argv[2];
-  } else {
-    buildDirectory = ".";
-  }
-  std::cout << "example dir = " << exampleDirectory << "\n";
-  if (buildDirectory) {
-    std::cout << "build dir = " << buildDirectory << "\n";
-  }
   testing::InitGoogleTest(&argc, argv);
   int result = RUN_ALL_TESTS();
   google::protobuf::ShutdownProtobufLibrary();
@@ -77,12 +58,16 @@ int runProgram(const std::vector<std::string>& args, std::string& out, std::stri
   return WEXITSTATUS(status);
 }
 
+#define ORC_TOOL_TEST_STRINGIFY(path) ORC_TOOL_TEST_STR(path)
+#define ORC_TOOL_TEST_STR(path) #path
+
 /**
  * Get the name of the given example file.
  * @param name the simple name of the example file
  */
 std::string findExample(const std::string& name) {
-  std::string result = exampleDirectory;
+#define ORC_EXAMPLE_DIR_STR ORC_TOOL_TEST_STRINGIFY(ORC_EXAMPLE_DIR)
+  std::string result = ORC_EXAMPLE_DIR_STR;
   result += "/";
   result += name;
   return result;
@@ -93,7 +78,8 @@ std::string findExample(const std::string& name) {
  * @param name the simple name of the executable
  */
 std::string findProgram(const std::string& name) {
-  std::string result = buildDirectory;
+#define ORC_BUILD_DIR_STR ORC_TOOL_TEST_STRINGIFY(ORC_BUILD_DIR)
+  std::string result = ORC_BUILD_DIR_STR;
   result += "/";
   result += name;
   return result;

--- a/tools/test/meson.build
+++ b/tools/test/meson.build
@@ -36,5 +36,9 @@ exc = executable(
         gtest_dep,
         gmock_dep,
     ],
+    cpp_args: [
+        '-DORC_EXAMPLE_DIR=@0@'.format(meson.project_source_root() / 'examples'),
+        '-DORC_BUILD_DIR=@0@'.format(meson.project_build_root()),
+    ],
 )
 test('tool-test', exc)


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->

Rather than pulling the build and example directory from gtest arguments, this pulls it from the build system.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When orc is used as a subproject, the current method of grabbing the arguments from the build system fails

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tests were run locally

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No
