### PR TITLE
ORC-1932: Use `setIfUnset` for `fs.defaultFS` and `fs.file.impl.disable.cache`

### DIFF
--- a/java/core/src/test/org/apache/orc/TestConf.java
+++ b/java/core/src/test/org/apache/orc/TestConf.java
@@ -30,14 +30,14 @@ public interface TestConf {
   @BeforeEach
   default void clear() {
     conf.clear();
-    conf.set("fs.defaultFS", "file:///");
-    conf.set("fs.file.impl.disable.cache", "true");
+    conf.setIfUnset("fs.defaultFS", "file:///");
+    conf.setIfUnset("fs.file.impl.disable.cache", "true");
   }
 
   private static Configuration getNewConf() {
     Configuration conf = new Configuration();
-    conf.set("fs.defaultFS", "file:///");
-    conf.set("fs.file.impl.disable.cache", "true");
+    conf.setIfUnset("fs.defaultFS", "file:///");
+    conf.setIfUnset("fs.file.impl.disable.cache", "true");
     return conf;
   }
 }

--- a/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
+++ b/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
@@ -217,7 +217,7 @@ public class ColumnSizes {
 
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();
-    conf.set("fs.file.impl.disable.cache", "true");
+    conf.setIfUnset("fs.file.impl.disable.cache", "true");
     main(conf, args);
   }
 

--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -103,7 +103,7 @@ public class Driver {
       System.exit(1);
     }
     Configuration conf = new Configuration();
-    conf.set("fs.file.impl.disable.cache", "true");
+    conf.setIfUnset("fs.file.impl.disable.cache", "true");
     Properties confSettings = options.genericOptions.getOptionProperties("D");
     for(Map.Entry pair: confSettings.entrySet()) {
       conf.set(pair.getKey().toString(), pair.getValue().toString());

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -142,7 +142,7 @@ public final class FileDump {
 
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();
-    conf.set("fs.file.impl.disable.cache", "true");
+    conf.setIfUnset("fs.file.impl.disable.cache", "true");
     main(conf, args);
   }
 

--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -73,7 +73,7 @@ public class RowCount {
 
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();
-    conf.set("fs.file.impl.disable.cache", "true");
+    conf.setIfUnset("fs.file.impl.disable.cache", "true");
     main(conf, args);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `setIfUnset` instead of `set` for `fs.defaultFS` and `fs.file.impl.disable.cache` in `TestConf` and `tools` module.

### Why are the changes needed?

These are newly added to Apache ORC 2.2, and `setIfUnset` is better because it respects the existing setting.

### How was this patch tested?

Pass the CIs (including Java 25-ea CI)

### Was this patch authored or co-authored using generative AI tooling?

No.