### PR TITLE
ORC-1933: Change `org.jetbrains:annotations` dependency to the `provided` scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,3 @@ updates:
       # Pin jodd-core to 3.5.2
       - dependency-name: "org.jodd:jodd-core"
         versions: "[3.5.3,)"
-      # Pin annotations to 17.0.0
-      - dependency-name: "org.jetbrains.annotations"
-        versions: "[17.0.1,)"

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -188,7 +188,8 @@
       <dependency>
         <groupId>org.jetbrains</groupId>
         <artifactId>annotations</artifactId>
-        <version>17.0.0</version>
+        <version>26.0.2</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to lower `org.jetbrains:annotations` dependency from `compile` scope to `provided` scope for Apache ORC 2.2.0.

From now, we can update it to the latest version because this doesn't affect the downstream. So, this PR also
- Remove the pinning the dependency.
- Upgrade it to the latest version

### Why are the changes needed?

To simplify Apache ORC dependency because this is not required at the runtime.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.