### PR TITLE
ORC-1938: Update `tools` module to set `fs.file.impl.disable.cache` only for Java 22+

### DIFF
--- a/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
+++ b/java/tools/src/java/org/apache/orc/tools/ColumnSizes.java
@@ -217,7 +217,9 @@ public class ColumnSizes {
 
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();
-    conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    if (Runtime.version().feature() > 21) {
+      conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    }
     main(conf, args);
   }
 

--- a/java/tools/src/java/org/apache/orc/tools/Driver.java
+++ b/java/tools/src/java/org/apache/orc/tools/Driver.java
@@ -103,7 +103,9 @@ public class Driver {
       System.exit(1);
     }
     Configuration conf = new Configuration();
-    conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    if (Runtime.version().feature() > 21) {
+      conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    }
     Properties confSettings = options.genericOptions.getOptionProperties("D");
     for(Map.Entry pair: confSettings.entrySet()) {
       conf.set(pair.getKey().toString(), pair.getValue().toString());

--- a/java/tools/src/java/org/apache/orc/tools/FileDump.java
+++ b/java/tools/src/java/org/apache/orc/tools/FileDump.java
@@ -142,7 +142,9 @@ public final class FileDump {
 
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();
-    conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    if (Runtime.version().feature() > 21) {
+      conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    }
     main(conf, args);
   }
 

--- a/java/tools/src/java/org/apache/orc/tools/RowCount.java
+++ b/java/tools/src/java/org/apache/orc/tools/RowCount.java
@@ -73,7 +73,9 @@ public class RowCount {
 
   public static void main(String[] args) throws Exception {
     Configuration conf = new Configuration();
-    conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    if (Runtime.version().feature() > 21) {
+      conf.setIfUnset("fs.file.impl.disable.cache", "true");
+    }
     main(conf, args);
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `tools` module to set `fs.file.impl.disable.cache=true` only for Java 22+.

### Why are the changes needed?

Recently, we successfully finished to refactor `tools` module for Java 25-ea support. Before releasing Apache ORC 2.2, we want to minimize any potential side-effects by applying new changes to the Java 22+ versions.

- ORC-1926: Use `TestConf` interface in `tools` module
- ORC-1927: Add Java `25-ea` test coverage for `tools` module
- ORC-1931: Suppress Hadoop logs lower than ERROR level in `orc-tools`
- ORC-1932: Use `setIfUnset` for `fs.defaultFS` and `fs.file.impl.disable.cache`

### How was this patch tested?

Pass the CIs (with Java 25-ea tool tests)

### Was this patch authored or co-authored using generative AI tooling?

No.