### PR TITLE
ORC-1937: Remove generating release build in Meson config by default

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -252,6 +252,6 @@ jobs:
         pip install meson
     - name: Test
       run: |
-        meson setup build
+        meson setup build -Dbuildtype=release
         meson compile -C build
         meson test -C build

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ meson compile -C build
 meson test -C build
 ```
 
-By default, Meson will build release libraries. If you would instead like debug libraries, you can use the ``-Dbuildtype=debug`` argument to setup. You must either remove the existing build directory before changing that setting, or alternatively pass the ``--reconfigure`` flag:
+By default, Meson will build unoptimized libraries with debug symbols. By contrast, the CMake build system generates release libraries by default. If you would like to create release libraries ala CMake, you should set the buildtype option. You must either remove the existing build directory before changing that setting, or alternatively pass the ``--reconfigure`` flag:
 
 ```shell
-meson setup build -Dbuildtype=debug --reconfigure
+meson setup build -Dbuildtype=release --reconfigure
 meson compile -C build
 meson test -C build
 ```

--- a/meson.build
+++ b/meson.build
@@ -22,7 +22,6 @@ project(
     license: 'Apache-2.0',
     meson_version: '>=1.3.0',
     default_options: [
-        'buildtype=release',
         'warning_level=2',
         'cpp_std=c++17',
     ],


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
This removes setting the Meson configuration to remove the buildtype of release by default. 

### Why are the changes needed?
While coming from CMake it may seem like a good idea to build release builds by default, the setting is either ignored or problematic when orc is used as a subproject in other projects, especially on Windows where a main project building a library with debug symbols may fail if a subproject tries to force release symbols.


### How was this patch tested?
Compiled locally

### Was this patch authored or co-authored using generative AI tooling?
No
