### PR TITLE
ORC-1940: Add threads dependency to orc lib in Meson

### DIFF
--- a/c++/src/meson.build
+++ b/c++/src/meson.build
@@ -173,6 +173,8 @@ source_files += files(
 
 incdir = include_directories('../include')
 orc_format_proto_dep = dependency('orc_format_proto')
+# zstd requires us to add the threads
+threads_dep = dependency('threads')
 
 orc_lib = library(
     'orc',
@@ -184,6 +186,7 @@ orc_lib = library(
         snappy_dep,
         lz4_dep,
         zstd_dep,
+        threads_dep,
     ],
     include_directories: incdir,
     install: true,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This explicitly adds the threads dependency to the orc library when built in the Meson configuration

### Why are the changes needed?

In the current CI, no failure is reported because the threads dependency is transitively provided by the protobuf dependency, when protobuf is included from source. However, some older protobuf libraries do not correctly specify in their pkg-config files that threads is a transitive dependency, so if built on a system where an older protobuf version exists orc will fail to build. This is exactly the case in the Apache Arrow CI, which you can see https://github.com/apache/arrow/actions/runs/15878114506/job/44770826425?pr=46906#step:6:1669

### How was this patch tested?

Compiled and tested locally

### Was this patch authored or co-authored using generative AI tooling?

No
