### PR TITLE
ORC-1942: Fix `PhysicalFsWriter` not to change `ZstdCodec`'s default option

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/PhysicalFsWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/PhysicalFsWriter.java
@@ -116,8 +116,7 @@ public class PhysicalFsWriter implements PhysicalWriter {
     CompressionCodec codec = OrcCodecPool.getCodec(opts.getCompress());
     if (codec != null){
       CompressionCodec.Options tempOptions = codec.getDefaultOptions();
-      if (codec instanceof ZstdCodec &&
-              codec.getDefaultOptions() instanceof ZstdCodec.ZstdOptions options) {
+      if (codec instanceof ZstdCodec && tempOptions instanceof ZstdCodec.ZstdOptions options) {
         OrcFile.ZstdCompressOptions zstdCompressOptions = opts.getZstdCompressOptions();
         if (zstdCompressOptions != null) {
           options.setLevel(zstdCompressOptions.getCompressionZstdLevel());

--- a/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/ZstdCodec.java
@@ -152,7 +152,7 @@ public class ZstdCodec implements CompressionCodec, DirectDecompressionCodec {
 
   @Override
   public Options getDefaultOptions() {
-    return DEFAULT_OPTIONS;
+    return DEFAULT_OPTIONS.copy();
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `PhysicalFsWriter` to change `tempOptions` directly.

### Why are the changes needed?

In the following code path, `tempOptions` is supposed to be updated and used. However, `codec.getDefaultOptions() instanceof ZstdCodec.ZstdOptions options` code is currently updating the return value of `codec.getDefaultOptions()` via a variable `options`.

https://github.com/apache/orc/blob/d3843bc043bea97bdd81a0f8e1fab3329efc7308/java/core/src/java/org/apache/orc/impl/PhysicalFsWriter.java#L118-L127

Technically, `ZstdCodec.getDefaultOptions()` returns the final static variable. This AS-IS code is trying to change this static object which leads unintended side-effects. We should avoid this code pattern.

https://github.com/apache/orc/blob/d3843bc043bea97bdd81a0f8e1fab3329efc7308/java/core/src/java/org/apache/orc/impl/ZstdCodec.java#L150-L156

### How was this patch tested?

Pass the CIs with a newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

No.