### PR TITLE
ORC-1943: Add `com.google.protobuf.use_unsafe_pre22_gencode` to Surefire testing

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -724,6 +724,7 @@
             <test.tmp.dir>${test.tmp.dir}</test.tmp.dir>
             <example.dir>${example.dir}</example.dir>
             <org.slf4j.simpleLogger.log.org.apache.hadoop>error</org.slf4j.simpleLogger.log.org.apache.hadoop>
+            <com.google.protobuf.use_unsafe_pre22_gencode></com.google.protobuf.use_unsafe_pre22_gencode>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `com.google.protobuf.use_unsafe_pre22_gencode` to Surefire testing.

### Why are the changes needed?

To suppress the following warnings during testing which occurs since ORC-1934
- #2246

```
[INFO] Running org.apache.orc.impl.TestZlib
Jun 30, 2025 2:50:15 PM com.google.protobuf.GeneratedMessage warnPre22Gencode
WARNING: Vulnerable protobuf generated type in use: org.apache.orc.OrcProto$PostScript
As of 2022/09/29 (release 21.7) makeExtensionsImmutable should not be called from protobuf gencode. If you are seeing this message, your gencode is vulnerable to a denial of service attack. You should regenerate your code using protobuf 25.6 or later. Use the latest version that meets your needs. However, if you understand the risks and wish to continue with vulnerable gencode, you can set the system property `-Dcom.google.protobuf.use_unsafe_pre22_gencode` on the command line to silence this warning. You also can set `-Dcom.google.protobuf.error_on_unsafe_pre22_gencode` to throw an error instead. See security vulnerability: https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-h4h5-3hr4-j3g2
```

### How was this patch tested?

Manual tests because this is a warning log message.

### Was this patch authored or co-authored using generative AI tooling?

No.