### PR TITLE
[C++] add missing include for protobuf types

### DIFF
--- a/c++/src/io/InputStream.hh
+++ b/c++/src/io/InputStream.hh
@@ -23,6 +23,8 @@
 #include "orc/OrcFile.hh"
 #include "wrap/zero-copy-stream-wrapper.h"
 
+#include "google/protobuf/stubs/port.h"
+
 #include <fstream>
 #include <iostream>
 #include <list>

--- a/c++/src/io/OutputStream.hh
+++ b/c++/src/io/OutputStream.hh
@@ -24,6 +24,8 @@
 #include "orc/OrcFile.hh"
 #include "wrap/zero-copy-stream-wrapper.h"
 
+#include "google/protobuf/stubs/port.h"
+
 namespace orc {
 
   /**


### PR DESCRIPTION
Fixes #2315