### PR TITLE
ORC-1948: Fix `GeospatialTreeWriter#writeBatch` updating ColumnStatistics with incorrect values

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/writer/GeospatialTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/GeospatialTreeWriter.java
@@ -20,7 +20,6 @@ package org.apache.orc.impl.writer;
 
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
-import org.apache.hadoop.io.BytesWritable;
 import org.apache.orc.OrcProto;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.CryptoUtils;

--- a/java/core/src/java/org/apache/orc/impl/writer/GeospatialTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/GeospatialTreeWriter.java
@@ -96,10 +96,8 @@ public class GeospatialTreeWriter extends TreeWriterBase {
                   vec.start[offset + i], vec.length[offset + i]);
           this.length.write(vec.length[offset + i]);
           rawDataSize += vec.length[offset + i];
-          BytesWritable bw = new BytesWritable();
-          bw.set(vec.vector[offset + i], vec.start[offset + i], vec.length[offset + i]);
           if (isGeometry) {
-            indexStatistics.updateGeometry(vec.vector[i], vec.start[i], vec.length[i]);
+            indexStatistics.updateGeometry(vec.vector[offset + i], vec.start[offset + i], vec.length[offset + i]);
           }
           if (createBloomFilter) {
             if (bloomFilter != null) {

--- a/java/core/src/java/org/apache/orc/impl/writer/GeospatialTreeWriter.java
+++ b/java/core/src/java/org/apache/orc/impl/writer/GeospatialTreeWriter.java
@@ -96,7 +96,8 @@ public class GeospatialTreeWriter extends TreeWriterBase {
           this.length.write(vec.length[offset + i]);
           rawDataSize += vec.length[offset + i];
           if (isGeometry) {
-            indexStatistics.updateGeometry(vec.vector[offset + i], vec.start[offset + i], vec.length[offset + i]);
+            indexStatistics.updateGeometry(vec.vector[offset + i],
+                    vec.start[offset + i], vec.length[offset + i]);
           }
           if (createBloomFilter) {
             if (bloomFilter != null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix incorrect values in column statistics for geometry type. 

### Why are the changes needed?
`GeospatialTreeWriter#writeBatch` uses incorrect values to update column statistics when `vector.isRepeating` is false.

### How was this patch tested?
The unit test `TestWriterImpl#testGeospatialColumnStatistics` covers cases where the `offset` parameter in `GeospatialTreeWriter#writeBatch` is either 0 or greater than 0.

### Was this patch authored or co-authored using generative AI tooling?
No
