### PR TITLE
ORC-1950: [C++] Replace std::unorder_map with google dense_hash_map in SortedStringDictionary and remove reorder to improve write performance of dict-encoding columns

### DIFF
--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -211,6 +211,7 @@ target_link_libraries (orc
     $<BUILD_INTERFACE:orc::snappy>
     $<BUILD_INTERFACE:orc::lz4>
     $<BUILD_INTERFACE:orc::zstd>
+    $<BUILD_INTERFACE:orc::sparsehash>
     $<BUILD_INTERFACE:${LIBHDFSPP_LIBRARIES}>
   )
 

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -959,12 +959,6 @@ namespace orc {
     void clear();
 
    private:
-    struct LessThan {
-      bool operator()(const DictEntry& l, const DictEntry& r) {
-        return l.data < r.data;  // use std::string's operator<
-      }
-    };
-
     // store dictionary entries in insertion order
     mutable std::vector<DictEntry> flatDict_;
 

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1019,7 +1019,6 @@ namespace orc {
   void SortedStringDictionary::clear() {
     totalLength_ = 0;
     keyToIndex_.clear();
-    keyToIndex_.set_empty_key(std::string_view{});
     flatDict_.clear();
   }
 

--- a/c++/src/meson.build
+++ b/c++/src/meson.build
@@ -187,6 +187,7 @@ orc_lib = library(
         lz4_dep,
         zstd_dep,
         threads_dep,
+        sparsehash_c11_dep,
     ],
     include_directories: incdir,
     install: true,

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries (orc-test
   orc::zlib
   orc::gtest
   orc::gmock
+  orc::sparsehash
   orc-test-include
 )
 

--- a/c++/test/TestDictionaryEncoding.cc
+++ b/c++/test/TestDictionaryEncoding.cc
@@ -408,7 +408,7 @@ namespace orc {
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithoutIndex) {
     testCharDictionary(false, DICT_THRESHOLD);
-    // testCharDictionar(false, FALLBACK_THRESHOLD);
+    testCharDictionary(false, FALLBACK_THRESHOLD);
   }
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithIndex) {

--- a/c++/test/TestDictionaryEncoding.cc
+++ b/c++/test/TestDictionaryEncoding.cc
@@ -408,7 +408,7 @@ namespace orc {
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithoutIndex) {
     testCharDictionary(false, DICT_THRESHOLD);
-    testCharDictionary(false, FALLBACK_THRESHOLD);
+    // testCharDictionar(false, FALLBACK_THRESHOLD);
   }
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithIndex) {

--- a/c++/test/meson.build
+++ b/c++/test/meson.build
@@ -70,6 +70,7 @@ orc_test = executable(
         zlib_dep,
         gtest_dep,
         gmock_dep,
+        sparsehash_c11_dep,
     ],
 )
 

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -28,12 +28,12 @@ set(PROTOBUF_VERSION "3.5.1")
 set(ZSTD_VERSION "1.5.7")
 set(SPARSEHASH_C11_VERSION "2.11.1")
 
-option(ORC_PREFER_STATIC_PROTOBUF       "Prefer static protobuf library, if available"          ON)
-option(ORC_PREFER_STATIC_SNAPPY         "Prefer static snappy library, if available"            ON)
-option(ORC_PREFER_STATIC_LZ4            "Prefer static lz4 library, if available"               ON)
-option(ORC_PREFER_STATIC_ZSTD           "Prefer static zstd library, if available"              ON)
-option(ORC_PREFER_STATIC_ZLIB           "Prefer static zlib library, if available"              ON)
-option(ORC_PREFER_STATIC_GMOCK          "Prefer static gmock library, if available"             ON)
+option(ORC_PREFER_STATIC_PROTOBUF "Prefer static protobuf library, if available" ON)
+option(ORC_PREFER_STATIC_SNAPPY   "Prefer static snappy library, if available"   ON)
+option(ORC_PREFER_STATIC_LZ4      "Prefer static lz4 library, if available"      ON)
+option(ORC_PREFER_STATIC_ZSTD     "Prefer static zstd library, if available"     ON)
+option(ORC_PREFER_STATIC_ZLIB     "Prefer static zlib library, if available"     ON)
+option(ORC_PREFER_STATIC_GMOCK    "Prefer static gmock library, if available"    ON)
 
 # zstd requires us to add the threads
 FIND_PACKAGE(Threads REQUIRED)
@@ -100,10 +100,6 @@ endif ()
 
 if (DEFINED ENV{GTEST_HOME})
   set (GTEST_HOME "$ENV{GTEST_HOME}")
-endif ()
-
-if (DEFINED ENV{SPARSEHASH_C11_HOME})
-  set (SPARSEHASH_C11_HOME "$ENV{SPARSEHASH_C11_HOME}")
 endif ()
 
 # ----------------------------------------------------------------------

--- a/subprojects/sparsehash-c11.wrap
+++ b/subprojects/sparsehash-c11.wrap
@@ -15,26 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# required dependencies
-protobuf_dep = dependency('protobuf', fallback: ['protobuf', 'protobuf_dep'])
-lz4_dep = dependency('liblz4')
-snappy_dep = dependency('snappy')
-zlib_dep = dependency('zlib')
-zstd_dep = dependency('libzstd')
-sparsehash_c11_dep = dependency('sparsehash-c11')
+[wrap-file]
+directory = sparsehash-c11-2.11.1
+source_url = https://github.com/sparsehash/sparsehash-c11/archive/refs/tags/v2.11.1.tar.gz
+source_filename = sparsehash-c11-2.11.1.tar.gz
+source_hash = d4a43cad1e27646ff0ef3a8ce3e18540dbcb1fdec6cc1d1cb9b5095a9ca2a755
+patch_filename = sparsehash-c11_2.11.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sparsehash-c11_2.11.1-1/get_patch
+patch_hash = d04ddea94db2a0a7ad059c26186e3f6f37b02ddfba8fea11352767becb3d0cfa
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sparsehash-c11_2.11.1-1/sparsehash-c11-2.11.1.tar.gz
+wrapdb_version = 2.11.1-1
 
-# optional dependencies (should be set later in configuration)
-gtest_dep = disabler()
-gmock_dep = disabler()
-
-subdir('include/orc')
-subdir('src')
-
-if get_option('tests').enabled()
-    gtest_dep = dependency('gtest')
-    gmock_dep = dependency('gmock')
-    subdir('test')
-endif
-
-pkg = import('pkgconfig')
-pkg.generate(orc_lib)
+[provide]
+sparsehash-c11 = sparsehash_c11_dep


### PR DESCRIPTION
### What changes were proposed in this pull request?

Replace std::unorder_map with google dense_hash_map in SortedStringDictionary and remove reorder to improve write performance of dict-encoding columns 


### Why are the changes needed?

For performance improvement.s

### How was this patch tested?

Pass the CIs.

I tested it in clickhouse. Here are the results

``` sql
Query: select concat('gluten ', cast(rand()%1000 as String)) from numbers(10000000) into outfile 'dict.orc' truncate;

-- Enable dictionary encoding before optimization
set max_threads =1 ;
set output_format_orc_dictionary_key_size_threshold = 1;

10000000 rows in set. Elapsed: 0.760 sec. Processed 10.00 million rows, 80.00 MB (13.16 million rows/s., 105.31 MB/s.)
10000000 rows in set. Elapsed: 0.796 sec. Processed 10.00 million rows, 80.00 MB (12.56 million rows/s., 100.51 MB/s.)
10000000 rows in set. Elapsed: 0.803 sec. Processed 10.00 million rows, 80.00 MB (12.45 million rows/s., 99.63 MB/s.)


-- Enable dictionary encoding after optimization
set max_threads =1 ;
set output_format_orc_dictionary_key_size_threshold = 1;

10000000 rows in set. Elapsed: 0.645 sec. Processed 10.00 million rows, 80.00 MB (15.50 million rows/s., 124.00 MB/s.)
10000000 rows in set. Elapsed: 0.622 sec. Processed 10.00 million rows, 80.00 MB (16.08 million rows/s., 128.64 MB/s.)
10000000 rows in set. Elapsed: 0.631 sec. Processed 10.00 million rows, 80.00 MB (15.85 million rows/s., 126.83 MB/s.)  



-- Disable dictionary encoding
set max_threads =1 ;
set output_format_orc_dictionary_key_size_threshold = 0;

10000000 rows in set. Elapsed: 0.707 sec. Processed 10.00 million rows, 80.00 MB (14.14 million rows/s., 113.15 MB/s.)
10000000 rows in set. Elapsed: 0.671 sec. Processed 10.00 million rows, 80.00 MB (14.90 million rows/s., 119.17 MB/s.)
10000000 rows in set. Elapsed: 0.727 sec. Processed 10.00 million rows, 80.00 MB (13.75 million rows/s., 109.98 MB/s.)
```

We can conclude that 
- Dictionary encoded writing speeds up by 1.24x. 
- Now dictionary encoded writing is 1.11x faster than plain encoded writing.

### Was this patch authored or co-authored using generative AI tooling?

No.