### PR TITLE
ORC-1952: [C++] Fix the issue where the value of headerThirdByte exceeds the valid byte range

### DIFF
--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -123,7 +123,7 @@ namespace orc {
     int64_t* zigzagLiterals_;
     int64_t* baseRedLiterals_;
     int64_t* adjDeltas_;
-    static const int64_t BASE_VALUE_LIMIT = int64_t(1) << 56;
+    static constexpr int64_t BASE_VALUE_LIMIT = int64_t(1) << 56;
 
     uint32_t getOpCode(EncodingType encoding);
     int64_t* prepareForDirectOrPatchedBase(EncodingOption& option);

--- a/c++/src/RLEv2.hh
+++ b/c++/src/RLEv2.hh
@@ -123,6 +123,7 @@ namespace orc {
     int64_t* zigzagLiterals_;
     int64_t* baseRedLiterals_;
     int64_t* adjDeltas_;
+    static const int64_t BASE_VALUE_LIMIT = int64_t(1) << 56;
 
     uint32_t getOpCode(EncodingType encoding);
     int64_t* prepareForDirectOrPatchedBase(EncodingOption& option);

--- a/c++/src/RleEncoderV2.cc
+++ b/c++/src/RleEncoderV2.cc
@@ -423,7 +423,7 @@ namespace orc {
       // fallback to DIRECT encoding.
       // The decision to use patched base was based on zigzag values, but the
       // actual patching is done on base reduced literals.
-      if ((option.brBits100p - option.brBits95p) != 0) {
+      if ((option.brBits100p - option.brBits95p) != 0 && std::abs(option.min) < BASE_VALUE_LIMIT) {
         option.encoding = PATCHED_BASE;
         preparePatchedBlob(option);
         return;

--- a/c++/test/TestRleEncoder.cc
+++ b/c++/test/TestRleEncoder.cc
@@ -285,5 +285,43 @@ namespace orc {
     runExampleTest(data, 9, expectedEncoded, 13);
   }
 
+  TEST_P(RleTest, RleV2_value_limit_test) {
+    std::vector<int64_t> inputData = {-9007199254740992l,
+                                      -8725724278030337l,
+                                      -1125762467889153l,
+                                      -1l,
+                                      -9007199254740992l,
+                                      -9007199254740992l,
+                                      -497l,
+                                      127l,
+                                      -1l,
+                                      -72057594037927936l,
+                                      -4194304l,
+                                      -9007199254740992l,
+                                      -4503599593816065l,
+                                      -4194304l,
+                                      -8936830510563329l,
+                                      -9007199254740992l,
+                                      -1l,
+                                      -70334384439312l,
+                                      -4063233l,
+                                      -6755399441973249l};
+    int numValues = inputData.size();
+
+    // Invoke the encoder.
+    const bool isSigned = true;
+    MemoryOutputStream memStream(DEFAULT_MEM_STREAM_SIZE);
+
+    std::unique_ptr<RleEncoder> encoder = getEncoder(RleVersion_2, memStream, isSigned);
+    encoder->add(inputData.data(), numValues, nullptr);
+    encoder->finishEncode();
+
+    encoder->add(inputData.data(), numValues, nullptr);
+    encoder->flush();
+
+    // Decode and verify.
+    decodeAndVerify(RleVersion_2, memStream, inputData.data(), numValues, nullptr, isSigned);
+  }
+
   INSTANTIATE_TEST_SUITE_P(OrcTest, RleTest, Values(true, false));
 }  // namespace orc


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Ensure DIRECT encoding is employed when the input value exceeds the valid byte range.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In Patched Base Encoding, the value of headerThirdByte exceeds the valid byte range.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Add the RleV2_value_limit_test to the RleTest suite.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
