### PR TITLE
ORC-1955: Make `commons-lang3` as a test dependency explicitly

### DIFF
--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -51,6 +51,8 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <!-- Spark uses org.apache.commons.lang3.SystemUtils -->
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -152,6 +152,7 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>3.18.0</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>io.airlift</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `commons-lang3` test dependency

### Why are the changes needed?

Since ORC-1791, we remove `commons-lang3` dependency requirement. This is only used during testing or `bench` module.
- #2053 

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.