### PR TITLE
ORC-1956: Enable GitHub Action CI in `branch-2.2`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,13 +23,13 @@ on:
     - 'site/**'
     - 'conan/**'
     branches:
-    - main
+    - branch-2.2
   pull_request:
     paths-ignore:
     - 'site/**'
     - 'conan/**'
     branches:
-    - main
+    - branch-2.2
 
 # Cancel previous PR build and test
 concurrency:
@@ -56,7 +56,7 @@ jobs:
     - name: "Test"
       run: |
         cd docker
-        ./run-one.sh local main ${{ matrix.os }}
+        ./run-one.sh local branch-2.2 ${{ matrix.os }}
 
   build:
     name: "Java ${{ matrix.java }} and ${{ matrix.cxx }} on ${{ matrix.os }}"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable GitHub Action CI in `branch-2.2`.

### Why are the changes needed?

We need to have a test coverage in order to prepare Apache ORC 2.2.0.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.