### PR TITLE
ORC-1957: Upgrade `zstd-jni` to 1.5.7-4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -85,7 +85,7 @@
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.5.3</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
-    <zstd-jni.version>1.5.7-3</zstd-jni.version>
+    <zstd-jni.version>1.5.7-4</zstd-jni.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.7-4.

### Why are the changes needed?

To bring the latest bug fixes and improvements.
- https://github.com/luben/zstd-jni/issues/360
- https://github.com/luben/zstd-jni/pull/361
- https://github.com/luben/zstd-jni/pull/362

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.