### PR TITLE
ORC-1958: Upgrade Maven to 3.9.11

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -74,7 +74,7 @@
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-    <maven.version>3.9.10</maven.version>
+    <maven.version>3.9.11</maven.version>
 
     <mockito.version>5.10.0</mockito.version>
     <orc-format.version>1.1.0</orc-format.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Maven to 3.9.11.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/apache/maven/releases/tag/maven-3.9.11
  - https://github.com/apache/maven/pull/2489
  - https://github.com/apache/maven/pull/2470
  - https://github.com/apache/maven/pull/10896
  - https://github.com/apache/maven/pull/2574

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.