### PR TITLE
ORC-1950: [C++] Replace std::unorder_map with google dense_hash_map in SortedStringDictionary

### DIFF
--- a/c++/src/CMakeLists.txt
+++ b/c++/src/CMakeLists.txt
@@ -211,6 +211,7 @@ target_link_libraries (orc
     $<BUILD_INTERFACE:orc::snappy>
     $<BUILD_INTERFACE:orc::lz4>
     $<BUILD_INTERFACE:orc::zstd>
+    $<BUILD_INTERFACE:orc::sparsehash>
     $<BUILD_INTERFACE:${LIBHDFSPP_LIBRARIES}>
   )
 

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -959,12 +959,6 @@ namespace orc {
     void clear();
 
    private:
-    struct LessThan {
-      bool operator()(const DictEntry& l, const DictEntry& r) {
-        return l.data < r.data;  // use std::string's operator<
-      }
-    };
-
     // store dictionary entries in insertion order
     mutable std::vector<DictEntry> flatDict_;
 

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -1019,7 +1019,6 @@ namespace orc {
   void SortedStringDictionary::clear() {
     totalLength_ = 0;
     keyToIndex_.clear();
-    keyToIndex_.set_empty_key(std::string_view{});
     flatDict_.clear();
   }
 

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -936,6 +936,14 @@ namespace orc {
       std::unique_ptr<std::string> data;
     };
 
+    struct DictEntryWithIndex {
+      DictEntryWithIndex(const char* str, size_t len, size_t index)
+          : entry(str, len), index(index) {}
+
+      DictEntry entry;
+      size_t index;
+    };
+
     SortedStringDictionary() : totalLength_(0) {
       /// Need to set empty key otherwise dense_hash_map will not work correctly
       keyToIndex_.set_empty_key(std::string_view{});
@@ -947,8 +955,11 @@ namespace orc {
     // write dictionary data & length to output buffer
     void flush(AppendOnlyBufferedStream* dataStream, RleEncoder* lengthEncoder) const;
 
+    // reorder input index buffer from insertion order to dictionary order
+    void reorder(std::vector<int64_t>& idxBuffer) const;
+
     // get dict entries in insertion order
-    const std::vector<DictEntry>& getEntriesInInsertionOrder() const;
+    void getEntriesInInsertionOrder(std::vector<const DictEntry*>&) const;
 
     // return count of entries
     size_t size() const;
@@ -959,8 +970,13 @@ namespace orc {
     void clear();
 
    private:
+    struct LessThan {
+      bool operator()(const DictEntryWithIndex& l, const DictEntryWithIndex& r) {
+        return l.entry.data < r.entry.data;  // use std::string's operator<
+      }
+    };
     // store dictionary entries in insertion order
-    mutable std::vector<DictEntry> flatDict_;
+    mutable std::vector<DictEntryWithIndex> flatDict_;
 
     // map from string to its insertion order index
     google::dense_hash_map<std::string_view, size_t> keyToIndex_;
@@ -982,10 +998,10 @@ namespace orc {
     if (it != keyToIndex_.end()) {
       return it->second;
     } else {
-      flatDict_.emplace_back(str, len);
+      flatDict_.emplace_back(str, len, index);
       totalLength_ += len;
 
-      const auto& lastEntry = flatDict_.back();
+      const auto& lastEntry = flatDict_.back().entry;
       keyToIndex_.emplace(std::string_view{lastEntry.data->data(), lastEntry.data->size()}, index);
       return index;
     }
@@ -994,16 +1010,45 @@ namespace orc {
   // write dictionary data & length to output buffer
   void SortedStringDictionary::flush(AppendOnlyBufferedStream* dataStream,
                                      RleEncoder* lengthEncoder) const {
-    for (const auto& entry : flatDict_) {
-      dataStream->write(entry.data->data(), entry.data->size());
-      lengthEncoder->write(static_cast<int64_t>(entry.data->size()));
+    std::sort(flatDict_.begin(), flatDict_.end(), LessThan());
+
+    for (const auto& entryWithIndex : flatDict_) {
+      dataStream->write(entryWithIndex.entry.data->data(), entryWithIndex.entry.data->size());
+      lengthEncoder->write(static_cast<int64_t>(entryWithIndex.entry.data->size()));
+    }
+  }
+
+  /**
+   * Reorder input index buffer from insertion order to dictionary order
+   *
+   * We require this function because string values are buffered by indexes
+   * in their insertion order. Until the entire dictionary is complete can
+   * we get their sorted indexes in the dictionary in that ORC specification
+   * demands dictionary should be ordered. Therefore this function transforms
+   * the indexes from insertion order to dictionary value order for final
+   * output.
+   */
+  void SortedStringDictionary::reorder(std::vector<int64_t>& idxBuffer) const {
+    // iterate the dictionary to get mapping from insertion order to value order
+    std::vector<size_t> mapping(flatDict_.size());
+    for (size_t i = 0; i < flatDict_.size(); ++i) {
+      mapping[flatDict_[i].index] = i;
+    }
+
+    // do the transformation
+    for (size_t i = 0; i != idxBuffer.size(); ++i) {
+      idxBuffer[i] = static_cast<int64_t>(mapping[static_cast<size_t>(idxBuffer[i])]);
     }
   }
 
   // get dict entries in insertion order
-  const std::vector<SortedStringDictionary::DictEntry>&
-  SortedStringDictionary::getEntriesInInsertionOrder() const {
-    return flatDict_;
+  void SortedStringDictionary::getEntriesInInsertionOrder(
+      std::vector<const DictEntry*>& entries) const {
+    /// flatDict_ is sorted in insertion order before [[SortedStringDictionary::flush]] is invoked.
+    entries.resize(flatDict_.size());
+    for (size_t i = 0; i < flatDict_.size(); ++i) {
+      entries[i] = &(flatDict_[i].entry);
+    }
   }
 
   // return count of entries
@@ -1321,6 +1366,9 @@ namespace orc {
       // flush dictionary data & length streams
       dictionary.flush(dictStream.get(), dictLengthEncoder.get());
 
+      // convert index from insertion order to dictionary order
+      dictionary.reorder(dictionary.idxInDictBuffer_);
+
       // write data sequences
       int64_t* data = dictionary.idxInDictBuffer_.data();
       if (enableIndex) {
@@ -1364,14 +1412,15 @@ namespace orc {
     }
 
     // get dictionary entries in insertion order
-    const auto& entries = dictionary.getEntriesInInsertionOrder();
+    std::vector<const SortedStringDictionary::DictEntry*> entries;
+    dictionary.getEntriesInInsertionOrder(entries);
 
     // store each length of the data into a vector
     for (uint64_t i = 0; i != dictionary.idxInDictBuffer_.size(); ++i) {
       // write one row data in direct encoding
       const auto& dictEntry = entries[static_cast<size_t>(dictionary.idxInDictBuffer_[i])];
-      directDataStream->write(dictEntry.data->data(), dictEntry.data->size());
-      directLengthEncoder->write(static_cast<int64_t>(dictEntry.data->size()));
+      directDataStream->write(dictEntry->data->data(), dictEntry->data->size());
+      directLengthEncoder->write(static_cast<int64_t>(dictEntry->data->size()));
     }
 
     deleteDictStreams();

--- a/c++/src/meson.build
+++ b/c++/src/meson.build
@@ -187,6 +187,7 @@ orc_lib = library(
         lz4_dep,
         zstd_dep,
         threads_dep,
+        sparsehash_c11_dep,
     ],
     include_directories: incdir,
     install: true,

--- a/c++/test/CMakeLists.txt
+++ b/c++/test/CMakeLists.txt
@@ -75,6 +75,7 @@ target_link_libraries (orc-test
   orc::zlib
   orc::gtest
   orc::gmock
+  orc::sparsehash
   orc-test-include
 )
 

--- a/c++/test/TestDictionaryEncoding.cc
+++ b/c++/test/TestDictionaryEncoding.cc
@@ -408,7 +408,7 @@ namespace orc {
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithoutIndex) {
     testCharDictionary(false, DICT_THRESHOLD);
-    // testCharDictionar(false, FALLBACK_THRESHOLD);
+    testCharDictionary(false, FALLBACK_THRESHOLD);
   }
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithIndex) {

--- a/c++/test/TestDictionaryEncoding.cc
+++ b/c++/test/TestDictionaryEncoding.cc
@@ -408,7 +408,7 @@ namespace orc {
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithoutIndex) {
     testCharDictionary(false, DICT_THRESHOLD);
-    testCharDictionary(false, FALLBACK_THRESHOLD);
+    // testCharDictionar(false, FALLBACK_THRESHOLD);
   }
 
   TEST(DictionaryEncoding, writeCharDictionaryEncodingWithIndex) {

--- a/c++/test/meson.build
+++ b/c++/test/meson.build
@@ -70,6 +70,7 @@ orc_test = executable(
         zlib_dep,
         gtest_dep,
         gmock_dep,
+        sparsehash_c11_dep,
     ],
 )
 

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -28,12 +28,12 @@ set(PROTOBUF_VERSION "3.5.1")
 set(ZSTD_VERSION "1.5.7")
 set(SPARSEHASH_C11_VERSION "2.11.1")
 
-option(ORC_PREFER_STATIC_PROTOBUF       "Prefer static protobuf library, if available"          ON)
-option(ORC_PREFER_STATIC_SNAPPY         "Prefer static snappy library, if available"            ON)
-option(ORC_PREFER_STATIC_LZ4            "Prefer static lz4 library, if available"               ON)
-option(ORC_PREFER_STATIC_ZSTD           "Prefer static zstd library, if available"              ON)
-option(ORC_PREFER_STATIC_ZLIB           "Prefer static zlib library, if available"              ON)
-option(ORC_PREFER_STATIC_GMOCK          "Prefer static gmock library, if available"             ON)
+option(ORC_PREFER_STATIC_PROTOBUF "Prefer static protobuf library, if available" ON)
+option(ORC_PREFER_STATIC_SNAPPY   "Prefer static snappy library, if available"   ON)
+option(ORC_PREFER_STATIC_LZ4      "Prefer static lz4 library, if available"      ON)
+option(ORC_PREFER_STATIC_ZSTD     "Prefer static zstd library, if available"     ON)
+option(ORC_PREFER_STATIC_ZLIB     "Prefer static zlib library, if available"     ON)
+option(ORC_PREFER_STATIC_GMOCK    "Prefer static gmock library, if available"    ON)
 
 # zstd requires us to add the threads
 FIND_PACKAGE(Threads REQUIRED)
@@ -100,10 +100,6 @@ endif ()
 
 if (DEFINED ENV{GTEST_HOME})
   set (GTEST_HOME "$ENV{GTEST_HOME}")
-endif ()
-
-if (DEFINED ENV{SPARSEHASH_C11_HOME})
-  set (SPARSEHASH_C11_HOME "$ENV{SPARSEHASH_C11_HOME}")
 endif ()
 
 # ----------------------------------------------------------------------

--- a/subprojects/sparsehash-c11.wrap
+++ b/subprojects/sparsehash-c11.wrap
@@ -15,26 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# required dependencies
-protobuf_dep = dependency('protobuf', fallback: ['protobuf', 'protobuf_dep'])
-lz4_dep = dependency('liblz4')
-snappy_dep = dependency('snappy')
-zlib_dep = dependency('zlib')
-zstd_dep = dependency('libzstd')
-sparsehash_c11_dep = dependency('sparsehash-c11')
+[wrap-file]
+directory = sparsehash-c11-2.11.1
+source_url = https://github.com/sparsehash/sparsehash-c11/archive/refs/tags/v2.11.1.tar.gz
+source_filename = sparsehash-c11-2.11.1.tar.gz
+source_hash = d4a43cad1e27646ff0ef3a8ce3e18540dbcb1fdec6cc1d1cb9b5095a9ca2a755
+patch_filename = sparsehash-c11_2.11.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/sparsehash-c11_2.11.1-1/get_patch
+patch_hash = d04ddea94db2a0a7ad059c26186e3f6f37b02ddfba8fea11352767becb3d0cfa
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/sparsehash-c11_2.11.1-1/sparsehash-c11-2.11.1.tar.gz
+wrapdb_version = 2.11.1-1
 
-# optional dependencies (should be set later in configuration)
-gtest_dep = disabler()
-gmock_dep = disabler()
-
-subdir('include/orc')
-subdir('src')
-
-if get_option('tests').enabled()
-    gtest_dep = dependency('gtest')
-    gmock_dep = dependency('gmock')
-    subdir('test')
-endif
-
-pkg = import('pkgconfig')
-pkg.generate(orc_lib)
+[provide]
+sparsehash-c11 = sparsehash_c11_dep


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->

Replace std::unorder_map with google dense_hash_map in SortedStringDictionary to improve write performance of dict-encoding columns


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
