### PR TITLE
ORC-1963: Enforce Apache release profile with maven install

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -163,7 +163,8 @@ jobs:
       run: |
         mkdir -p ~/.m2
         cd java
-        ./mvnw install -DskipTests -Papache-release
+        echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
+        ./mvnw --settings settings.xml install -DskipTests -Papache-release
         ./mvnw javadoc:javadoc
 
   cpp-linter:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -151,6 +151,8 @@ jobs:
         DEFAULT_BRANCH: main
         VALIDATE_MARKDOWN: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ASF_USERNAME: ${{ secrets.NEXUS_USER }}
+        ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
     - name: Install Java 17
       uses: actions/setup-java@v4
       with:
@@ -161,7 +163,7 @@ jobs:
       run: |
         mkdir -p ~/.m2
         cd java
-        ./mvnw install -DskipTests
+        ./mvnw install -DskipTests -Papache-release
         ./mvnw javadoc:javadoc
 
   cpp-linter:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -151,8 +151,6 @@ jobs:
         DEFAULT_BRANCH: main
         VALIDATE_MARKDOWN: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        ASF_USERNAME: ${{ secrets.NEXUS_USER }}
-        ASF_PASSWORD: ${{ secrets.NEXUS_PW }}
     - name: Install Java 17
       uses: actions/setup-java@v4
       with:
@@ -163,8 +161,7 @@ jobs:
       run: |
         mkdir -p ~/.m2
         cd java
-        echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
-        ./mvnw --settings settings.xml install -DskipTests -Papache-release
+        ./mvnw install -DskipTests
         ./mvnw javadoc:javadoc
 
   cpp-linter:

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -24,4 +24,6 @@ jobs:
       run: |
         cd java
         echo "<settings><servers><server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username><password>$ASF_PASSWORD</password></server></servers></settings>" > settings.xml
+        # We should use local installation to test `apache-release` profile
+        ./mvnw --settings settings.xml -nsu -ntp -DskipTests install -Papache-release
         ./mvnw --settings settings.xml -nsu -ntp -DskipTests deploy


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enforce `apache-release` profile with Maven install in CIs.

### Why are the changes needed?

To detect a release blocker as early as possible.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.