### PR TITLE
ORC-1965: Ban `org.apache.commons.lang` package

### DIFF
--- a/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
+++ b/java/bench/hive/src/java/org/apache/orc/bench/hive/rowfilter/RowFilterInputState.java
@@ -17,7 +17,7 @@
  */
 package org.apache.orc.bench.hive.rowfilter;
 
-import org.apache.commons.lang.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -61,5 +61,8 @@
       <property name="lineWrappingIndentation" value="4"/>
       <property name="arrayInitIndent" value="2"/>
     </module>
+    <module name="IllegalImport">
+      <property name="illegalPkgs" value="org.apache.commons.lang" />
+    </module>
   </module>
 </module>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to ban `Commons Lang` in favor of `Commons Lang3`.

### Why are the changes needed?

Apache ORC should use only `Apache Commons Lang3` in the test code.

### How was this patch tested?

Pass the CIs with the newly added Checkstyle rule.

### Was this patch authored or co-authored using generative AI tooling?

No.