### PR TITLE
ORC-1968: Upgrade `commons-cli` to 1.10.0

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -82,7 +82,7 @@
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>1.9.0</version>
+        <version>${commons-cli.version}</version>
       </dependency>
       <dependency>
         <groupId>io.airlift</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -63,6 +63,7 @@
     <bouncycastle.version>1.80</bouncycastle.version>
     <brotli4j.version>1.18.0</brotli4j.version>
     <checkstyle.version>10.26.1</checkstyle.version>
+    <commons-cli.version>1.10.0</commons-cli.version>
     <example.dir>${project.basedir}/../../examples</example.dir>
     <hadoop.version>3.4.1</hadoop.version>
     <java.version>17</java.version>
@@ -146,7 +147,7 @@
       <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
-        <version>1.9.0</version>
+        <version>${commons-cli.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `commons-cli` to 1.10.0 which is the first release tested with **Java 25-ea**.

### Why are the changes needed?

To bring the latest improvements and bug fixes.
- https://commons.apache.org/proper/commons-cli/changes.html#a1.10.0 (2025-07-30)
  - [Run Java 24 and 25-ea](https://github.com/apache/commons-cli/commit/e6a611f80f8cca0128b9a0579ae2937caca8fc7a)
  - [[CLI-333] org.apache.commons.cli.Option.Builder implements](https://github.com/apache/commons-cli/commit/c9698e622f3e0d2fe1d304056b28c24ff7d02e81)
  - https://github.com/apache/commons-cli/pull/314
  - https://github.com/apache/commons-cli/pull/334
  - [[CLI-341] HelpFormatter infinite loop with 0 width input](https://github.com/apache/commons-cli/commit/bce0f6a9899830eaa5161ea6fd2af04d5679257b)
  - [[CLI-343] OptionFormatter.getBothOpt() lacks validation for Options](https://github.com/apache/commons-cli/commit/859d5e5e749c1ec6a4c7f7ead88a587f316d8065)
  - [[CLI-344] Option.processValue() throws NullPointerException when passed](https://github.com/apache/commons-cli/commit/4e0cdd0f96762df26e6335be8a1ab1afd55234f1)
  - [[CLI-347] Options.addOptionGroup(OptionGroup) does not remove required](https://github.com/apache/commons-cli/commit/42be7926be5599342a812c170b03ab73f8cbb35c)
  - [[CLI-349] DefaultParser.parse() throws NullPointerException when options](https://github.com/apache/commons-cli/commit/ff678b0ac3019e621d23b2eb2230096206baae78)

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.