### PR TITLE
ORC-1969: [C++] Support async I/O prefetch of next stripe

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -173,7 +173,7 @@ jobs:
           mkdir build && cd build
           cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_JAVA=OFF
           cmake --build .
-      - uses: cpp-linter/cpp-linter-action@v2.13.3
+      - uses: cpp-linter/cpp-linter-action@f91c446a32ae3eb9f98fef8c9ed4c7cb613a4f8a
         id: linter
         continue-on-error: true
         env:

--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -388,6 +388,16 @@ namespace orc {
      * Whether reader throws or returns null when value overflows for schema evolution.
      */
     bool getThrowOnSchemaEvolutionOverflow() const;
+
+    /**
+     * Set whether to enable async I/O prefetch of next stripe.
+     */
+    RowReaderOptions& setEnableAsyncPrefetch(bool enable);
+
+    /**
+     * Whether to enable async I/O prefetch of next stripe.
+     */
+    bool getEnableAsyncPrefetch() const;
   };
 
   class RowReader;

--- a/c++/src/Options.hh
+++ b/c++/src/Options.hh
@@ -25,6 +25,7 @@
 
 #include "io/Cache.hh"
 
+#include <iostream>
 #include <limits>
 
 namespace orc {
@@ -153,6 +154,7 @@ namespace orc {
     bool useTightNumericVector;
     std::shared_ptr<Type> readType;
     bool throwOnSchemaEvolutionOverflow;
+    bool enableAsyncPrefetch;
 
     RowReaderOptionsPrivate() {
       selection = ColumnSelection_NONE;
@@ -164,6 +166,7 @@ namespace orc {
       readerTimezone = "GMT";
       useTightNumericVector = false;
       throwOnSchemaEvolutionOverflow = false;
+      enableAsyncPrefetch = false;
     }
   };
 
@@ -338,6 +341,16 @@ namespace orc {
   std::shared_ptr<Type>& RowReaderOptions::getReadType() const {
     return privateBits_->readType;
   }
+
+  RowReaderOptions& RowReaderOptions::setEnableAsyncPrefetch(bool enable) {
+    privateBits_->enableAsyncPrefetch = enable;
+    return *this;
+  }
+
+  bool RowReaderOptions::getEnableAsyncPrefetch() const {
+    return privateBits_->enableAsyncPrefetch;
+  }
+
 }  // namespace orc
 
 #endif

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -73,10 +73,17 @@ namespace orc {
     std::unique_ptr<proto::Metadata> metadata;
     ReaderMetrics* readerMetrics;
 
+    // cache options to advise io coalescing in the read cache.
+    CacheOptions cacheOptions;
     // mutex to protect readCache_ from concurrent access
     std::mutex readCacheMutex;
     // cached io ranges. only valid when preBuffer is invoked.
     std::shared_ptr<ReadRangeCache> readCache;
+
+    // A thread-safe convenience method to cache ranges.
+    void cacheRanges(std::vector<ReadRange> ranges);
+    // A thread-safe convenience method to evict cache entries fully before a given boundary.
+    void evictCache(uint64_t boundary);
   };
 
   proto::StripeFooter getStripeFooter(const proto::StripeInformation& info,
@@ -140,6 +147,7 @@ namespace orc {
     std::shared_ptr<FileContents> contents_;
     const bool throwOnHive11DecimalOverflow_;
     const int32_t forcedScaleOnHive11Decimal_;
+    const bool enableAsyncPrefetch_;
 
     // inputs
     std::vector<bool> selectedColumns_;


### PR DESCRIPTION
### What changes were proposed in this pull request?

Add a reader option to support prefetch next stripe automatically.

### Why are the changes needed?

The C++ reader has added two functions (preBuffer and releaseBuffer) to support manual async I/O prefetch. This is not easy to use since it requires manual control of I/O operations.

### How was this patch tested?

Added test cases to verify that async prefetch is triggered and worked as expected.

### Was this patch authored or co-authored using generative AI tooling?

No.
