### PR TITLE
ORC-1973: [C++] Use `int64_t` instead of `google::protobuf::int64` for `Protobuf` v22+

### DIFF
--- a/c++/src/io/InputStream.cc
+++ b/c++/src/io/InputStream.cc
@@ -112,8 +112,8 @@ namespace orc {
     return false;
   }
 
-  google::protobuf::int64 SeekableArrayInputStream::ByteCount() const {
-    return static_cast<google::protobuf::int64>(position_);
+  int64_t SeekableArrayInputStream::ByteCount() const {
+    return static_cast<int64_t>(position_);
   }
 
   void SeekableArrayInputStream::seek(PositionProvider& seekPosition) {

--- a/c++/src/io/InputStream.hh
+++ b/c++/src/io/InputStream.hh
@@ -72,7 +72,7 @@ namespace orc {
     virtual bool Next(const void** data, int* size) override;
     virtual void BackUp(int count) override;
     virtual bool Skip(int count) override;
-    virtual google::protobuf::int64 ByteCount() const override;
+    virtual int64_t ByteCount() const override;
     virtual void seek(PositionProvider& position) override;
     virtual std::string getName() const override;
   };

--- a/c++/src/io/OutputStream.cc
+++ b/c++/src/io/OutputStream.cc
@@ -65,8 +65,8 @@ namespace orc {
     // PASS
   }
 
-  google::protobuf::int64 BufferedOutputStream::ByteCount() const {
-    return static_cast<google::protobuf::int64>(dataBuffer_->size());
+  int64_t BufferedOutputStream::ByteCount() const {
+    return static_cast<int64_t>(dataBuffer_->size());
   }
 
   bool BufferedOutputStream::WriteAliasedRaw(const void*, int) {

--- a/c++/src/io/OutputStream.hh
+++ b/c++/src/io/OutputStream.hh
@@ -61,7 +61,7 @@ namespace orc {
 
     virtual bool Next(void** data, int* size) override;
     virtual void BackUp(int count) override;
-    virtual google::protobuf::int64 ByteCount() const override;
+    virtual int64_t ByteCount() const override;
     virtual bool WriteAliasedRaw(const void* data, int size) override;
     virtual bool AllowsAliasing() const override;
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `int64_t` instead of `google::protobuf::int64` to follow ProtocolBuff v22.0 changes.

- https://github.com/protocolbuffers/protobuf/releases/tag/v22.0

> Fixed C++ code generation for protos that use int32_t, uint32_t, int64_t, uint64_t, size_t as field names.

### Why are the changes needed?

Currently, `main` branch CIs are broken like the following.
- https://github.com/apache/orc/pull/2356
  - https://github.com/apache/orc/actions/runs/16997271813/job/48190883401?pr=2356

```
/Users/runner/work/orc/orc/c++/src/io/InputStream.hh:76:31: error: no type named 'int64' in namespace 'google::protobuf'
    virtual google::protobuf::int64 ByteCount() const override;
            ~~~~~~~~~~~~~~~~~~^
/Users/runner/work/orc/orc/c++/src/io/InputStream.cc:115:21: error: no type named 'int64' in namespace 'google::protobuf'
  google::protobuf::int64 SeekableArrayInputStream::ByteCount() const {
  ~~~~~~~~~~~~~~~~~~^
/Users/runner/work/orc/orc/c++/src/io/InputStream.cc:116:42: error: no type named 'int64' in namespace 'google::protobuf'
    return static_cast<google::protobuf::int64>(position_);
                       ~~~~~~~~~~~~~~~~~~^
3 errors generated.
make[2]: *** [c++/src/CMakeFiles/orc.dir/io/InputStream.cc.o] Error 1
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.