### PR TITLE
ORC-1975: Improve `merge_orc_pr.py` to accept PR numbers as a CLI argument

### DIFF
--- a/dev/merge_orc_pr.py
+++ b/dev/merge_orc_pr.py
@@ -449,7 +449,11 @@ def main():
     branch_names = sorted(branch_names, reverse=True)
     branch_iter = iter(branch_names)
 
-    pr_num = input("Which pull request would you like to merge? (e.g. 34): ")
+    if len(sys.argv) == 1:
+        pr_num = input("Which pull request would you like to merge? (e.g. 34): ")
+    else:
+        pr_num = sys.argv[1]
+        print("Start to merge pull request #%s" % (pr_num))
     pr = get_json("%s/pulls/%s" % (GITHUB_API_BASE, pr_num))
     pr_events = get_json("%s/issues/%s/events" % (GITHUB_API_BASE, pr_num))
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to improve `merge_orc_pr.py` to accept PR numbers as a CLI argument.

### Why are the changes needed?

To provide a new easy way for the committers to use this script.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.