### PR TITLE
ORC-1977: Add `Deprecated` annotations for all deprecated APIs

### DIFF
--- a/java/core/src/java/org/apache/orc/DateColumnStatistics.java
+++ b/java/core/src/java/org/apache/orc/DateColumnStatistics.java
@@ -54,6 +54,7 @@ public interface DateColumnStatistics extends ColumnStatistics {
    * @return minimum value
    * @deprecated Use #getMinimumLocalDate instead
    */
+  @Deprecated
   Date getMinimum();
 
   /**
@@ -61,5 +62,6 @@ public interface DateColumnStatistics extends ColumnStatistics {
    * @return maximum value
    * @deprecated Use #getMaximumLocalDate instead
    */
+  @Deprecated
   Date getMaximum();
 }

--- a/java/core/src/java/org/apache/orc/FileMetadata.java
+++ b/java/core/src/java/org/apache/orc/FileMetadata.java
@@ -26,6 +26,7 @@ import java.util.List;
  * ORC stop depending on them too. Luckily, they shouldn't be very big.
  * @deprecated Use {@link org.apache.orc.impl.OrcTail} instead
  */
+@Deprecated
 public interface FileMetadata {
   boolean isOriginalFormat();
 

--- a/java/core/src/java/org/apache/orc/MemoryManager.java
+++ b/java/core/src/java/org/apache/orc/MemoryManager.java
@@ -65,6 +65,7 @@ public interface MemoryManager {
    * @throws IOException
    * @deprecated Use {@link MemoryManager#checkMemory} instead
    */
+  @Deprecated
   void addedRow(int rows) throws IOException;
 
   /**

--- a/java/core/src/java/org/apache/orc/OrcFile.java
+++ b/java/core/src/java/org/apache/orc/OrcFile.java
@@ -357,6 +357,7 @@ public class OrcFile {
     /**
      * @deprecated Use {@link #orcTail(OrcTail)} instead.
      */
+    @Deprecated
     public ReaderOptions fileMetadata(final FileMetadata metadata) {
       fileMetadata = metadata;
       return this;

--- a/java/core/src/java/org/apache/orc/Reader.java
+++ b/java/core/src/java/org/apache/orc/Reader.java
@@ -145,6 +145,7 @@ public interface Reader extends Closeable {
    * @deprecated use getSchema instead
    * @since 1.1.0
    */
+  @Deprecated
   List<OrcProto.Type> getTypes();
 
   /**
@@ -756,6 +757,7 @@ public interface Reader extends Closeable {
    * @deprecated Use {@link #getStripeStatistics()} instead.
    * @since 1.1.0
    */
+  @Deprecated
   List<OrcProto.StripeStatistics> getOrcProtoStripeStatistics();
 
   /**
@@ -779,6 +781,7 @@ public interface Reader extends Closeable {
    * @deprecated Use {@link #getStatistics()} instead.
    * @since 1.1.0
    */
+  @Deprecated
   List<OrcProto.ColumnStatistics> getOrcProtoFileStatistics();
 
   /**

--- a/java/core/src/java/org/apache/orc/Writer.java
+++ b/java/core/src/java/org/apache/orc/Writer.java
@@ -139,6 +139,7 @@ public interface Writer extends Closeable {
    * @deprecated use {@link #addUserMetadata(String, ByteBuffer)} instead
    * @since 1.1.0
    */
+  @Deprecated
   void appendUserMetadata(List<OrcProto.UserMetadataItem> userMetadata);
 
   /**

--- a/java/core/src/java/org/apache/orc/impl/MemoryManagerImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/MemoryManagerImpl.java
@@ -134,6 +134,7 @@ public class MemoryManagerImpl implements MemoryManager {
    * Obsolete method left for Hive, which extends this class.
    * @deprecated remove this method
    */
+  @Deprecated
   public void notifyWriters() throws IOException {
     // PASS
   }

--- a/java/core/src/java/org/apache/orc/impl/OrcTail.java
+++ b/java/core/src/java/org/apache/orc/impl/OrcTail.java
@@ -207,6 +207,7 @@ public final class OrcTail {
    * @return the stripe statistics
    * @deprecated the user should use Reader.getStripeStatistics instead.
    */
+  @Deprecated
   public List<StripeStatistics> getStripeStatistics() throws IOException {
     if (reader == null) {
       LOG.warn("Please use Reader.getStripeStatistics or give `Reader` to OrcTail constructor.");

--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -480,6 +480,7 @@ public class ReaderImpl implements Reader {
    * @param buffer the tail of the file
    * @deprecated Use {@link ReaderImpl#ensureOrcFooter(FSDataInputStream, Path, int, ByteBuffer)} instead.
    */
+  @Deprecated
   protected static void ensureOrcFooter(ByteBuffer buffer, int psLen) throws IOException {
     int magicLength = OrcFile.MAGIC.length();
     int fullLength = magicLength + 1;
@@ -717,6 +718,7 @@ public class ReaderImpl implements Reader {
    * @deprecated Use {@link ReaderImpl#extractFileTail(FileSystem, Path, long)} instead.
    * This is for backward compatibility.
    */
+  @Deprecated
   public static OrcTail extractFileTail(ByteBuffer buffer)
       throws IOException {
     return extractFileTail(buffer, -1,-1);
@@ -738,6 +740,7 @@ public class ReaderImpl implements Reader {
    * @deprecated Use {@link ReaderImpl#extractFileTail(FileSystem, Path, long)} instead.
    * This is for backward compatibility.
    */
+  @Deprecated
   public static OrcTail extractFileTail(ByteBuffer buffer, long fileLen, long modificationTime)
       throws IOException {
     OrcProto.PostScript ps;

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderImpl.java
@@ -1119,6 +1119,7 @@ public class RecordReaderImpl implements RecordReader {
     /**
      * @deprecated Use the constructor having full parameters. This exists for backward compatibility.
      */
+    @Deprecated
     public SargApplier(SearchArgument sarg,
                        long rowIndexStride,
                        SchemaEvolution evolution,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Deprecated` annotations for all deprecated APIs.

### Why are the changes needed?

To improve the visibility of deprecations. Currently, only Javadoc informs the deprecation for these APIs.

**BEFORE**

```
$ mvn clean package -DskipTests | grep Deprecated | wc -l
      15
```

**AFTER**

```
$ mvn clean package -DskipTests | grep Deprecated | wc -l
       0
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.
