### PR TITLE
ORC-1978: Upgrade `maven-enforcer-plugin` to 3.6.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -72,6 +72,7 @@
     <junit.version>5.13.1</junit.version>
     <maven-assembly-plugin.version>3.7.1</maven-assembly-plugin.version>
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
+    <maven-enforcer-plugin.version>3.6.1</maven-enforcer-plugin.version>
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
@@ -608,7 +609,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>${maven-enforcer-plugin.version}</version>
         <dependencies>
           <dependency>
             <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `maven-enforcer-plugin` to 3.6.1.

### Why are the changes needed?

To use the latest improvement and bug fixed version:
- https://github.com/apache/maven-enforcer/releases/tag/enforcer-3.6.1
  - https://github.com/apache/maven-enforcer/pull/904
  - https://github.com/apache/maven-enforcer/pull/905
  - https://github.com/apache/maven-enforcer/pull/910

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.

Closes #2335