### PR TITLE
MINOR: Clarify optional `meson` 1.3.0+ requirement in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The subdirectories are:
 * Install java 17 or higher
 * Install maven 3.9.9 or higher
 * Install cmake 3.12 or higher
+* Install meson 1.3.0 or higher (Optional)
 
 To build a release version with debug information:
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to clarify optional `meson` `1.3.0+` requirement in `README.md`.

### Why are the changes needed?

This is only specified in the code. We had better document it.

https://github.com/apache/orc/blob/95ab53d04267711befc3d8401f50a82190396b11/meson.build#L23

### How was this patch tested?

Manual review because this is a doc-only change.

### Was this patch authored or co-authored using generative AI tooling?

No.