### PR TITLE
ORC-1984: Add `debian13` to docker tests, docs, and GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -47,6 +47,7 @@ jobs:
         os:
           - debian11
           - debian12
+          - debian13
           - ubuntu24
           - oraclelinux8
           - oraclelinux9

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -538,7 +538,8 @@ else ()
                           -DCMAKE_INSTALL_LIBDIR=lib
                           -DCMAKE_POLICY_VERSION_MINIMUM=3.12
                           -DBUILD_SHARED_LIBS=OFF
-                          -Dprotobuf_BUILD_TESTS=OFF)
+                          -Dprotobuf_BUILD_TESTS=OFF
+                          -Wno-stringop-overread)
 
   if (BUILD_POSITION_INDEPENDENT_LIB)
     set(PROTOBUF_CMAKE_ARGS ${PROTOBUF_CMAKE_ARGS} -DCMAKE_POSITION_INDEPENDENT_CODE=ON)

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 ## Supported OSes
 
-* Debian 11 and 12
+* Debian 11, 12, and 13
 * Fedora 37
 * Ubuntu 22 and 24
 * Oracle Linux 9

--- a/docker/debian13/Dockerfile
+++ b/docker/debian13/Dockerfile
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Debian 13
+#
+
+FROM debian:trixie-backports
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Debian 13"
+LABEL org.opencontainers.image.version=""
+ARG jdk=21
+
+RUN apt-get update
+RUN apt-get install -y \
+  cmake \
+  gcc \
+  g++ \
+  git \
+  libsasl2-dev \
+  libssl-dev \
+  make \
+  curl \
+  maven \
+  openjdk-${jdk}-jdk
+
+WORKDIR /root
+
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -1,5 +1,6 @@
 debian11
 debian12
+debian13
 ubuntu22
 ubuntu24
 oraclelinux8

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -10,7 +10,7 @@ dockerUrl: https://github.com/apache/orc/blob/main/docker
 The C++ library is supported on the following operating systems:
 
 * MacOS 14 to 26
-* Debian 11 to 12
+* Debian 11 to 13
 * Ubuntu 22.04 to 24.04
 * Oracle Linux 8 to 9
 * Amazon Linux 2023
@@ -28,6 +28,7 @@ is in the docker subdirectory, for the list of packages required to build ORC:
 
 * [Debian 11]({{ page.dockerUrl }}/debian11/Dockerfile)
 * [Debian 12]({{ page.dockerUrl }}/debian12/Dockerfile)
+* [Debian 13]({{ page.dockerUrl }}/debian13/Dockerfile)
 * [Ubuntu 22]({{ page.dockerUrl }}/ubuntu22/Dockerfile)
 * [Ubuntu 24]({{ page.dockerUrl }}/ubuntu24/Dockerfile)
 * [Oracle Linux 8]({{ page.dockerUrl }}/oraclelinux8/Dockerfile)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support `Debian 13` official by adding `debian13` to docker tests, docs, and GitHub Action.

### Why are the changes needed?

To have a test coverage on `Debian 13`.
- https://www.debian.org/News/2025/20250809

Note that `apache/orc-dev:debian13` is published like the following.

- https://hub.docker.com/layers/apache/orc-dev/debian13/images/sha256-003546d80163fe45069fc6ced11163f11748703c3b449c205e05b286f44f8021

```
$ docker run -it --rm apache/orc-dev:debian13 cat /etc/os-release | head -n1
PRETTY_NAME="Debian GNU/Linux 13 (trixie)"
```

### How was this patch tested?

Pass the CIs with newly added `debian13` test pipeline.

<img width="376" height="117" alt="Screenshot 2025-08-29 at 14 19 05" src="https://github.com/user-attachments/assets/f118efe8-836c-4edb-aad2-b8d39e59adaa" />


### Was this patch authored or co-authored using generative AI tooling?

No.