### PR TITLE
ORC-1985: Upgrade `actions/checkout` to v5

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -52,7 +52,7 @@ jobs:
           - amazonlinux23
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: "Test"
       run: |
         cd docker
@@ -87,7 +87,7 @@ jobs:
       MAVEN_SKIP_RC: true
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install Java ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
@@ -128,7 +128,7 @@ jobs:
       ORC_USER_SIMD_LEVEL: AVX512
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: "Test"
       run: |
         mkdir -p ~/.m2
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         fetch-depth: 0
     - name: Super-Linter
@@ -167,7 +167,7 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run build
         run: |
           mkdir build && cd build
@@ -197,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Check license header
         uses: apache/skywalking-eyes@main
         env:
@@ -214,7 +214,7 @@ jobs:
     runs-on: macos-${{ matrix.version }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install dependencies
       run: |
         brew update
@@ -242,7 +242,7 @@ jobs:
           - macos-15
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,7 +40,7 @@ jobs:
     if: github.repository == 'apache/orc'
     steps:
       - name: Checkout ORC repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: apache/orc
           ref: 'main'

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository == 'apache/orc'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - uses: actions/setup-java@v3
       with:

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -46,7 +46,7 @@ jobs:
             cxx: clang++
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `actions/checkout` to v5.

### Why are the changes needed?

`v5.0.0` was released 3 weeks ago with a major improvement upgrading `NodeJS` from `20` to `24`, which will be LTS soon.
- https://github.com/actions/checkout/releases/tag/v5.0.0
  - https://github.com/actions/checkout/pull/2226

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.