### PR TITLE
ORC-1988: Upgrade `Parquet` to 1.16.0 in `bench` module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -38,7 +38,7 @@
     <jmh.version>1.37</jmh.version>
     <junit.version>5.13.4</junit.version>
     <orc.version>${project.version}</orc.version>
-    <parquet.version>1.15.2</parquet.version>
+    <parquet.version>1.16.0</parquet.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scala.version>2.13.16</scala.version>
     <spark.version>4.0.0</spark.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Parquet to 1.16.0.

### Why are the changes needed?

To use the latest one to test.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.