### PR TITLE
ORC-1989: Upgrade Hive to 4.1.0 in `bench` module

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <avro.version>1.12.0</avro.version>
-    <hive.version>4.0.1</hive.version>
+    <hive.version>4.1.0</hive.version>
     <jmh.version>1.37</jmh.version>
     <junit.version>5.13.4</junit.version>
     <orc.version>${project.version}</orc.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Hive to 4.1.0 in `bench` module

### Why are the changes needed?

To use the latest Hive version in benchmark.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.