### PR TITLE
ORC-1995: Add `MacOS 26` to GitHub Action CI and docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,6 +82,8 @@ jobs:
             cxx: g++
           - os: ubuntu-latest
             java: 25-ea
+          - os: macos-26
+            java: 21
     env:
       MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -9,7 +9,7 @@ dockerUrl: https://github.com/apache/orc/blob/main/docker
 
 The C++ library is supported on the following operating systems:
 
-* MacOS 13 to 15
+* MacOS 13 to 26
 * Debian 11 to 12
 * Ubuntu 22.04 to 24.04
 * Oracle Linux 8 to 9


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `MacOS 26` to `GitHub Action CI` and docs.

### Why are the changes needed?

To prepare the test coverage for `MacOS 26`.

### How was this patch tested?

Pass the CIs.

- https://github.com/apache/orc/actions/runs/17681793839/job/50257419468?pr=2382

<img width="443" height="40" alt="Screenshot 2025-09-12 at 10 38 19" src="https://github.com/user-attachments/assets/999c10b3-b910-49db-a245-4480ee2c0c64" />

### Was this patch authored or co-authored using generative AI tooling?

No.