### PR TITLE
ORC-1996: Remove `MacOS 13` from GitHub Action CI and docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -68,7 +68,6 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
           - macos-14
           - macos-15
         java:
@@ -212,7 +211,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [13, 14, 15]
+        version: [14, 15]
     runs-on: macos-${{ matrix.version }}
     steps:
     - name: Checkout repository
@@ -239,7 +238,6 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
           - macos-14
           - macos-15
     steps:

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -9,7 +9,7 @@ dockerUrl: https://github.com/apache/orc/blob/main/docker
 
 The C++ library is supported on the following operating systems:
 
-* MacOS 13 to 26
+* MacOS 14 to 26
 * Debian 11 to 12
 * Ubuntu 22.04 to 24.04
 * Oracle Linux 8 to 9


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `MacOS 13` from GitHub Action CI and docs.

### Why are the changes needed?

https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/

> The macOS 13 hosted runner image is closing down, following our [N-1 OS support policy](https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support). This process will begin October 1, 2025, and the image will be fully retired on December 4, 2025. We recommend updating workflows to use

### How was this patch tested?

Check the CIs triggered on this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.