### PR TITLE
ORC-1996: Remove `MacOS 13` from GitHub Action CI and docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -67,7 +67,6 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
           - macos-14
           - macos-15
         java:
@@ -191,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [13, 14, 15]
+        version: [14, 15]
     runs-on: macos-${{ matrix.version }}
     steps:
     - name: Checkout repository

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -11,7 +11,7 @@ The C++ library is supported on the following operating systems:
 
 * CentOS 7
 * Debian 10 to 12
-* MacOS 13 to 15
+* MacOS 14 to 15
 * Ubuntu 22.04 to 24.04
 
 You'll want to install the usual set of developer tools, but at least:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `MacOS 13` from GitHub Action CI and docs.

### Why are the changes needed?

https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/

> The macOS 13 hosted runner image is closing down, following our [N-1 OS support policy](https://github.com/actions/runner-images?tab=readme-ov-file#software-and-image-support). This process will begin October 1, 2025, and the image will be fully retired on December 4, 2025. We recommend updating workflows to use

### How was this patch tested?

Check the CIs triggered on this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.