### PR TITLE
ORC-1974: [C++] Use `google::protobuf::TextFormat` instead of `DebugString` for `Protobuf` v30+

### DIFF
--- a/tools/src/FileMetadata.cc
+++ b/tools/src/FileMetadata.cc
@@ -28,6 +28,7 @@
 
 // #include "Adaptor.hh"
 #include "wrap/orc-proto-wrapper.hh"
+#include <google/protobuf/text_format.h>
 
 void printStripeInformation(std::ostream& out, uint64_t index, uint64_t columns,
                             std::unique_ptr<orc::StripeInformation> stripe, bool verbose) {
@@ -82,7 +83,10 @@ void printRawTail(std::ostream& out, const char* filename) {
   if (!tail.ParseFromString(reader->getSerializedFileTail())) {
     throw orc::ParseError("Failed to parse the file tail from string");
   }
-  out << tail.DebugString();
+  google::protobuf::TextFormat::Printer printer;
+  std::string text_output;
+  printer.PrintToString(tail, &text_output);
+  out << text_output;
 }
 
 void printAttributes(std::ostream& out, const orc::Type& type, const std::string& name,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `google::protobuf::TextFormat` instead of `DebugString` for Protobuf v30+.

- https://github.com/protocolbuffers/protobuf/releases/tag/v30.0

    > Make DebugString print debug output, enable debug markers for debug output

### Why are the changes needed?

Otherwise, our C++ `orc-metadata` tool will have a regression to expose the debug marker string, `goo.gle/debugstr`.

Currently, `branch-2.0` CI is broken on `MacOS` due to this.
- https://github.com/apache/orc/actions/runs/17683726166/job/50263664096

> +goo.gle/debugonly

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.