### PR TITLE
ORC-1893: [C++] Upgrade `zstd` to 1.5.7

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -21,7 +21,7 @@ set(SNAPPY_VERSION "1.2.2")
 set(ZLIB_VERSION "1.3.1")
 set(GTEST_VERSION "1.12.1")
 set(PROTOBUF_VERSION "3.5.1")
-set(ZSTD_VERSION "1.5.5")
+set(ZSTD_VERSION "1.5.7")
 
 option(ORC_PREFER_STATIC_PROTOBUF "Prefer static protobuf library, if available" ON)
 option(ORC_PREFER_STATIC_SNAPPY   "Prefer static snappy library, if available"   ON)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd` to 1.5.7 in `cmake_modules` module.

`GitHub Action MacOS 15` is updated to ZSTD 1.5.7.

- https://github.com/actions/runner-images/blob/macos-15-arm64/20250911.2324/images/macos/macos-15-arm64-Readme.md

### Why are the changes needed?

To bring the latest bug fixes,
- https://github.com/facebook/zstd/releases/tag/v1.5.6
- https://github.com/facebook/zstd/releases/tag/v1.5.7

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.