### PR TITLE
ORC-1828: [C++] Update LZ4 to 1.10.0

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -16,7 +16,7 @@
 # under the License.
 
 set(ORC_FORMAT_VERSION "1.0.0")
-set(LZ4_VERSION "1.9.3")
+set(LZ4_VERSION "1.10.0")
 set(SNAPPY_VERSION "1.2.2")
 set(ZLIB_VERSION "1.3.1")
 set(GTEST_VERSION "1.12.1")


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update LZ4 to 1.10.0.

### Why are the changes needed?

To use the latest version.
- https://github.com/lz4/lz4/releases/tag/v1.9.4
- https://github.com/lz4/lz4/releases/tag/v1.10.0

In addition, we need to recover the CI because currently `branch-2.0` CI is broken due to `LZ4` compilation failure like the following.

- https://github.com/apache/orc/actions/runs/17686548024/job/50272495675

```
[ 25%] Performing configure step for 'lz4_ep'
CMake Error at /Users/runner/work/orc/orc/build/lz4_ep-prefix/src/lz4_ep-stamp/lz4_ep-configure-RELWITHDEBINFO.cmake:49 (message):
  Command failed: 1

   '/opt/homebrew/bin/cmake' '-DCMAKE_INSTALL_PREFIX=/Users/runner/work/orc/orc/build/c++/libs/thirdparty/lz4_ep-install' '-DCMAKE_INSTALL_LIBDIR=lib' '-DBUILD_SHARED_LIBS=OFF' '-GUnix Makefiles' '-S' '/Users/runner/work/orc/orc/build/lz4_ep-prefix/src/lz4_ep/build/cmake' '-B' '/Users/runner/work/orc/orc/build/lz4_ep-prefix/src/lz4_ep-build'

  See also

    /Users/runner/work/orc/orc/build/lz4_ep-prefix/src/lz4_ep-stamp/lz4_ep-configure-*.log


make[2]: *** [lz4_ep-prefix/src/lz4_ep-stamp/lz4_ep-configure] Error 1
make[1]: *** [CMakeFiles/lz4_ep.dir/all] Error 2
make: *** [all] Error 2
```

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.