### PR TITLE
ORC-1997: Add a daily build-and-test GitHub Action Job for `main` branch

### DIFF
--- a/.github/workflows/daily_main.yml
+++ b/.github/workflows/daily_main.yml
@@ -1,0 +1,11 @@
+name: Daily (main)
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-build-and-test:
+    if: github.repository == 'apache/orc'
+    uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a daily build-and-test GitHub Action job for `main` branch.

### Why are the changes needed?

Daily CI helps us to monitor the CI failures due to the GitHub Action virtual environment changes .

### How was this patch tested?

Manual review because this is not triggered by this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.