### PR TITLE
ORC-1998: Use Java 25 instead of 25-ea

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -80,7 +80,7 @@ jobs:
             java: 17
             cxx: g++
           - os: ubuntu-latest
-            java: 25-ea
+            java: 25
           - os: macos-26
             java: 21
     env:
@@ -98,7 +98,7 @@ jobs:
     - name: "Test"
       run: |
         mkdir -p ~/.m2
-        if [ "${{ matrix.java }}" = "25-ea" ]; then
+        if [ "${{ matrix.java }}" = "25" ]; then
           cd java
           # JDK 25 Build
           ./mvnw package -DskipTests


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 25 instead of 25-ea.

### Why are the changes needed?

Java 25 is officially released. Although we are not supporting Java 25-ea yet due to the Hadoop issue, we need to use Java 25 instead of 25-ea.
- https://www.oracle.com/news/announcement/oracle-releases-java-25-2025-09-16/

### How was this patch tested?

Pass the CIs and check the CI logs.

```
  Trying to resolve the latest version from remote
  Resolved latest version as 25.0.0+36
  Trying to download...
  Downloading Java 25.0.0+36 (Zulu) from https://cdn.azul.com/zulu/bin/zulu25.28.85-ca-jdk25.0.0-linux_x64.tar.gz ...
  Extracting Java archive...
  /usr/bin/tar xz --warning=no-unknown-keyword --overwrite -C /home/runner/work/_temp/bd879994-5c5d-435e-b101-b0c369ad2e3a -f /home/runner/work/_temp/5ee102e3-3ddb-4277-a371-cee4d8c1335a
  Java 25.0.0+36 was downloaded
  Setting Java 25.0.0+36 as the default
  Creating toolchains.xml for JDK version 25 from zulu
  Writing to /home/runner/.m2/toolchains.xml
  
  Java configuration:
    Distribution: zulu
    Version: 25.0.0+36
    Path: /opt/hostedtoolcache/Java_Zulu_jdk/25.0.0-36/x64
```

### Was this patch authored or co-authored using generative AI tooling?

No.