### PR TITLE
ORC-2000: [C++] Add support to prefetch small stripes

### DIFF
--- a/c++/include/orc/Reader.hh
+++ b/c++/include/orc/Reader.hh
@@ -398,6 +398,16 @@ namespace orc {
      * Whether to enable async I/O prefetch of next stripe.
      */
     bool getEnableAsyncPrefetch() const;
+
+    /**
+     * Set the number of stripes to look ahead for small stripe prefetch.
+     */
+    RowReaderOptions& setSmallStripeLookAheadLimit(uint64_t numStripes);
+
+    /**
+     * Get the number of stripes to look ahead for small stripe prefetch.
+     */
+    uint64_t getSmallStripeLookAheadLimit() const;
   };
 
   class RowReader;

--- a/c++/src/Options.hh
+++ b/c++/src/Options.hh
@@ -155,6 +155,7 @@ namespace orc {
     std::shared_ptr<Type> readType;
     bool throwOnSchemaEvolutionOverflow;
     bool enableAsyncPrefetch;
+    uint64_t smallStripeLookAheadLimit;
 
     RowReaderOptionsPrivate() {
       selection = ColumnSelection_NONE;
@@ -167,6 +168,7 @@ namespace orc {
       useTightNumericVector = false;
       throwOnSchemaEvolutionOverflow = false;
       enableAsyncPrefetch = false;
+      smallStripeLookAheadLimit = 8;
     }
   };
 
@@ -349,6 +351,15 @@ namespace orc {
 
   bool RowReaderOptions::getEnableAsyncPrefetch() const {
     return privateBits_->enableAsyncPrefetch;
+  }
+
+  RowReaderOptions& RowReaderOptions::setSmallStripeLookAheadLimit(uint64_t numStripes) {
+    privateBits_->smallStripeLookAheadLimit = numStripes;
+    return *this;
+  }
+
+  uint64_t RowReaderOptions::getSmallStripeLookAheadLimit() const {
+    return privateBits_->smallStripeLookAheadLimit;
   }
 
 }  // namespace orc

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1171,6 +1171,8 @@ namespace orc {
 
     if (currentStripe_ < lastStripe_) {
       if (enableAsyncPrefetch_) {
+        contents_->evictCache(currentStripeInfo_.offset());
+
         if (fullyCachedStripes_.find(currentStripe_) != fullyCachedStripes_.cend()) {
           // Current stripe has been fully cached, do nothing.
         } else if (isSmallStripe(currentStripeInfo_, contents_->cacheOptions.rangeSizeLimit)) {
@@ -1200,8 +1202,6 @@ namespace orc {
                 nextStripe.footer_length()}});
           }
         }
-
-        contents_->evictCache(currentStripeInfo_.offset());
       }
 
       // get writer timezone info from stripe footer to help understand timestamp values.

--- a/c++/src/Reader.hh
+++ b/c++/src/Reader.hh
@@ -25,12 +25,11 @@
 #include "orc/Reader.hh"
 
 #include "ColumnReader.hh"
-#include "RLE.hh"
-#include "io/Cache.hh"
-
 #include "SchemaEvolution.hh"
-#include "TypeImpl.hh"
+#include "io/Cache.hh"
 #include "sargs/SargsApplier.hh"
+
+#include <unordered_set>
 
 namespace orc {
 
@@ -148,6 +147,7 @@ namespace orc {
     const bool throwOnHive11DecimalOverflow_;
     const int32_t forcedScaleOnHive11Decimal_;
     const bool enableAsyncPrefetch_;
+    const uint64_t smallStripeLookAheadLimit_;
 
     // inputs
     std::vector<bool> selectedColumns_;
@@ -171,6 +171,8 @@ namespace orc {
     proto::StripeInformation currentStripeInfo_;
     proto::StripeFooter currentStripeFooter_;
     std::unique_ptr<ColumnReader> reader_;
+    // stripe indices that whose entire I/O ranges have been fully cached.
+    std::unordered_set<uint64_t> fullyCachedStripes_;
 
     bool enableEncodedBlock_;
     bool useTightNumericVector_;


### PR DESCRIPTION
### What changes were proposed in this pull request?

- Support reader to prefetch and coalesce small stripes.
- Add a reader option to limit number of stripes to prefetch.

### Why are the changes needed?

Sometimes ORC files may have a lot of small stripes which hurt performance a lot.

### How was this patch tested?

Added a test case to verify that the prefetch works and so as the limit.

### Was this patch authored or co-authored using generative AI tooling?

No.
