### PR TITLE
ORC-2003: Upgrade `guava` to 33.5.0-jre

### DIFF
--- a/java/core/src/test/org/apache/orc/impl/TestSerializationUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSerializationUtils.java
@@ -135,21 +135,21 @@ public class TestSerializationUtils {
       LongMath.checkedSubtract(22222222222L, Long.MIN_VALUE);
       fail("expected ArithmeticException for overflow");
     } catch (ArithmeticException ex) {
-      assertEquals("overflow: checkedSubtract(22222222222, -9223372036854775808)", ex.getMessage());
+      assertEquals("long overflow", ex.getMessage());
     }
 
     try {
       LongMath.checkedSubtract(-22222222222L, Long.MAX_VALUE);
       fail("expected ArithmeticException for overflow");
     } catch (ArithmeticException ex) {
-      assertEquals("overflow: checkedSubtract(-22222222222, 9223372036854775807)", ex.getMessage());
+      assertEquals("long overflow", ex.getMessage());
     }
 
     try {
       LongMath.checkedSubtract(Long.MIN_VALUE, Long.MAX_VALUE);
       fail("expected ArithmeticException for overflow");
     } catch (ArithmeticException ex) {
-      assertEquals("overflow: checkedSubtract(-9223372036854775808, 9223372036854775807)", ex.getMessage());
+      assertEquals("long overflow", ex.getMessage());
     }
 
     assertEquals(-8106206116692740190L,

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -221,7 +221,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.4.0-jre</version>
+        <version>33.5.0-jre</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade `guava` to 33.5.0-jre.

### Why are the changes needed?

https://github.com/apache/orc/actions/runs/17914579352/job/50933668060?pr=2410

```
TestSerializationUtils.testSubtractionOverflowGuava:138 expected: <overflow: checkedSubtract(22222222222, -9223372036854775808)> but was: <long overflow>
```

https://github.com/google/guava/commit/fec36dc383ac3388bfcb1decb1cb94ba63eabad2




### How was this patch tested?
GA

### Was this patch authored or co-authored using generative AI tooling?
No
