### PR TITLE
ORC-2012: Remove `US` timezone workaround from `Debian 13` Docker image

### DIFF
--- a/docker/debian13/Dockerfile
+++ b/docker/debian13/Dockerfile
@@ -36,8 +36,6 @@ RUN apt-get install -y \
   curl \
   maven \
   openjdk-${jdk}-jdk
-RUN mkdir -p /usr/share/zoneinfo/US
-RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /usr/share/zoneinfo/US/Pacific
 
 WORKDIR /root
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `US` timezone workaround from `Debian 13` Docker image

### Why are the changes needed?

We don't need this after the following fixes:
- ORC-2010: Use `IANA` Identifier `America/Los_Angeles` instead of `US/Pacific` in Java
- ORC-2011: [C++] Fix `Timezone` to support legacy `US` TimeZone identifiers

### How was this patch tested?

Pass the CIs. Manually tests like the following.

```
$ cd docker
$ ./reinit.sh debian13
$ ./run-one.sh local x debian13
Started local run for ORC-2012 on debian13 at Sat Sep 27 08:11:00 PDT 2025
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
...
Test project /root/build
    Start 1: orc-test
1/9 Test #1: orc-test .........................   Passed    7.05 sec
    Start 2: java-test
2/9 Test #2: java-test ........................   Passed   77.28 sec
    Start 3: java-examples-test
3/9 Test #3: java-examples-test ...............   Passed    0.27 sec
    Start 4: java-tools-test
4/9 Test #4: java-tools-test ..................   Passed    0.05 sec
    Start 5: java-bench-gen-test
5/9 Test #5: java-bench-gen-test ..............   Passed    0.56 sec
    Start 6: java-bench-scan-test
6/9 Test #6: java-bench-scan-test .............   Passed    0.50 sec
    Start 7: java-bench-hive-test
7/9 Test #7: java-bench-hive-test .............   Passed   10.71 sec
    Start 8: java-bench-spark-test
8/9 Test #8: java-bench-spark-test ............   Passed  213.82 sec
    Start 9: tool-test
9/9 Test #9: tool-test ........................   Passed    4.67 sec

100% tests passed, 0 tests failed out of 9

Total Test time (real) = 314.92 sec
Built target test-out
Finished debian13 at Sat Sep 27 08:22:09 PDT 2025
```

### Was this patch authored or co-authored using generative AI tooling?

No.