### PR TITLE
ORC-2016: Upgrade `CMake` to 3.26.0 in `amazonlinux:2023`

### DIFF
--- a/docker/amazonlinux23/Dockerfile
+++ b/docker/amazonlinux23/Dockerfile
@@ -17,7 +17,7 @@
 # ORC compile for Amazon Linux 2023
 #
 
-FROM amazonlinux:2023
+FROM amazonlinux:2023.9.20250929.0
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache ORC on Amazon Linux 2023"
@@ -25,7 +25,6 @@ LABEL org.opencontainers.image.version=""
 
 RUN yum check-update || true
 RUN yum install -y \
-  cmake3 \
   curl-devel \
   cyrus-sasl-devel \
   expat-devel \
@@ -41,6 +40,12 @@ RUN yum install -y \
   which \
   zlib-devel \
   java-17-amazon-corretto-devel
+
+ARG cmake=3.26.0
+RUN curl -L \
+    "https://github.com/Kitware/CMake/releases/download/v${cmake}/cmake-${cmake}-linux-$(uname -m).tar.gz" | \
+    tar -xzf - --directory /usr/local --strip-components=1 && \
+    ln -fs /usr/local/bin/cmake /usr/bin/cmake
 
 ENV TZ=America/Los_Angeles
 WORKDIR /root


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `CMake` to 3.26.0 in `amazonlinux:2023`.

### Why are the changes needed?

Currently, it has 3.22.2 which is blocking #2416 .

```
$ docker run -it --rm apache/orc-dev:amazonlinux23 cmake --version
cmake version 3.22.2
```

### How was this patch tested?

Manual build and tests.

```
$ ./reinit.sh amazonlinux23
```

```
$ docker run -it --rm apache/orc-dev:amazonlinux23 cmake --version
cmake version 3.26.0

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```
$ ./run-one.sh local x amazonlinux23
Started local run for main on amazonlinux23 at Wed Oct  8 00:03:37 PDT 2025
...
Test project /root/build
    Start 1: orc-test
1/9 Test #1: orc-test .........................   Passed    7.77 sec
    Start 2: java-test
2/9 Test #2: java-test ........................   Passed  118.90 sec
    Start 3: java-examples-test
3/9 Test #3: java-examples-test ...............   Passed    0.43 sec
    Start 4: java-tools-test
4/9 Test #4: java-tools-test ..................   Passed    0.07 sec
    Start 5: java-bench-gen-test
5/9 Test #5: java-bench-gen-test ..............   Passed    0.77 sec
    Start 6: java-bench-scan-test
6/9 Test #6: java-bench-scan-test .............   Passed    0.71 sec
    Start 7: java-bench-hive-test
7/9 Test #7: java-bench-hive-test .............   Passed   11.41 sec
    Start 8: java-bench-spark-test
8/9 Test #8: java-bench-spark-test ............   Passed  216.61 sec
    Start 9: tool-test
9/9 Test #9: tool-test ........................   Passed    4.37 sec

100% tests passed, 0 tests failed out of 9

Total Test time (real) = 361.08 sec
Built target test-out
Finished amazonlinux23 at Wed Oct  8 00:16:38 PDT 2025
```

### Was this patch authored or co-authored using generative AI tooling?

No.