### PR TITLE
ORC-2013: [C++][FOLLOWUP] Respect externally set CMake variable PROTOBUF_EXECUTABLE

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -245,7 +245,9 @@ else ()
 
     add_library(orc_protobuf INTERFACE IMPORTED)
     target_link_libraries(orc_protobuf INTERFACE protobuf::libprotobuf)
-    set(PROTOBUF_EXECUTABLE protobuf::protoc)
+    if(NOT PROTOBUF_EXECUTABLE)
+      set(PROTOBUF_EXECUTABLE protobuf::protoc)
+    endif()
   endblock()
 endif ()
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Respect externally set `PROTOBUF_EXECUTABLE` variable.

### Why are the changes needed?

`conda` may cross-compile `Protobuf` so sometimes it is required to explicitly set what `protoc` to use.

### How was this patch tested?

See https://github.com/conda-forge/orc-feedstock/pull/94.

### Was this patch authored or co-authored using generative AI tooling?

No
