### PR TITLE
ORC-2027: [C++] Fix undefined behavior in DoubleColumnReader::readFloat()

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -421,7 +421,7 @@ namespace orc {
       int32_t bits = 0;
       if (bufferEnd_ - bufferPointer_ >= 4) {
         if (isLittleEndian) {
-          bits = *(reinterpret_cast<const int32_t*>(bufferPointer_));
+          memcpy(&bits, bufferPointer_, sizeof(bits));
         } else {
           bits = static_cast<unsigned char>(bufferPointer_[0]);
           bits |= static_cast<unsigned char>(bufferPointer_[1]) << 8;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
Unaligned reads are UB in C++. We can not guarantee that the `bufferPointer_` pointer is aligned by `alignof(int32_t)`.


### How was this patch tested?
Use UBsan to test in private repo.


### Was this patch authored or co-authored using generative AI tooling?
No.