### PR TITLE
ORC-2029: [C++] support Float fast read by memcpy in DoubleColumnReader

### DIFF
--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -472,8 +472,7 @@ namespace orc {
       // Number of values in the buffer that we can copy directly.
       // Only viable when the machine is little-endian.
       uint64_t bufferNum = 0;
-      if constexpr (isLittleEndian &&
-                    (columnKind == TypeKind::DOUBLE ? true : std::is_same_v<ValueType, float>)) {
+      if constexpr (isLittleEndian && std::is_same_v<ValueType, ItemType>) {
         bufferNum =
             std::min(numValues, static_cast<size_t>(bufferEnd_ - bufferPointer_) / bytesPerValue_);
         uint64_t bufferBytes = bufferNum * bytesPerValue_;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
1. Simplfy `DoubleColumnReader::readXXX()`.
2. Support memcpy Float array in `DoubleColumnReader::next`.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  3. If you fix a bug, you can clarify why it is a bug.
-->
Optimize `DoubleColumnReader::next` speed.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Ran existing tests.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.