### PR TITLE
ORC-2031:Document orc.dictionary.max.size.bytes and orc.stripe.size.check.ratio

### DIFF
--- a/site/_docs/core-java-config.md
+++ b/site/_docs/core-java-config.md
@@ -166,6 +166,13 @@ permalink: /docs/core-java-config.html
   </td>
 </tr>
 <tr>
+  <td><code>orc.dictionary.max.size.bytes</code></td>
+  <td>16777216</td>
+  <td>
+    If the total size of the dictionary is greater than this, turn off dictionary encoding. Use 0 to disable this check.
+  </td>
+</tr>
+<tr>
   <td><code>orc.dictionary.early.check</code></td>
   <td>true</td>
   <td>
@@ -282,6 +289,13 @@ permalink: /docs/core-java-config.html
   <td>5000</td>
   <td>
     How often should MemoryManager check the memory sizes? Measured in rows added to all of the writers.  Valid range is [1,10000] and is primarily meant fortesting.  Setting this too low may negatively affect performance. Use orc.stripe.row.count instead if the value larger than orc.stripe.row.count.
+  </td>
+</tr>
+<tr>
+  <td><code>orc.stripe.size.check.ratio</code></td>
+  <td>2.0</td>
+  <td>
+    Flush stripe if the tree writer size in bytes is larger than (this * orc.stripe.size). Use 0 to disable this check.
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?

Add documentation for two ORC configuration options to core-java-config.md:
- orc.dictionary.max.size.bytes (default: 16777216)
- orc.stripe.size.check.ratio (default: 2.0)


### Why are the changes needed?

These configuration options were defined in OrcConf.java but missing from the official documentation. Users need official guidance on their purpose and usage.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

### Was this patch authored or co-authored using generative AI tooling?

No
