### PR TITLE
ORC-2032: Upgrade `zstd-jni` to 1.5.7-6

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -87,7 +87,7 @@
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.5.3</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
-    <zstd-jni.version>1.5.7-5</zstd-jni.version>
+    <zstd-jni.version>1.5.7-6</zstd-jni.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `zstd-jni` to 1.5.7-6.

### Why are the changes needed?

To fix a regression
- https://github.com/luben/zstd-jni/commit/1941118e0923cc992b165d78bca11e08a1d53dfa

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.