### PR TITLE
ORC-2037: Upgrade Spark to 4.1.0 and Scala to 2.13.17

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -40,8 +40,8 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.16.0</parquet.version>
     <scala.binary.version>2.13</scala.binary.version>
-    <scala.version>2.13.16</scala.version>
-    <spark.version>4.0.1</spark.version>
+    <scala.version>2.13.17</scala.version>
+    <spark.version>4.1.0</spark.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to 4.1.0 and Scala to 2.13.17 .

### Why are the changes needed?

Apache Spark 4.1.0 is released officially.
- https://github.com/apache/spark/releases/tag/v4.1.0
- https://spark.apache.org/docs/4.1.0/

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.