### PR TITLE
ORC-2041: Update `cpp-linter-action` hash to match ASF infra

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -175,7 +175,7 @@ jobs:
           mkdir build && cd build
           cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_JAVA=OFF
           cmake --build .
-      - uses: cpp-linter/cpp-linter-action@f91c446a32ae3eb9f98fef8c9ed4c7cb613a4f8a
+      - uses: cpp-linter/cpp-linter-action@0f6d1b8d7e38b584cbee606eb23d850c217d54f8
         id: linter
         continue-on-error: true
         env:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to. update `cpp-linter-action` hash to match ASF infra.

### Why are the changes needed?

Currently, the AS-IS `branch-2.2` CI is broken due to the ASF INFRA change.
- https://github.com/apache/orc/actions/runs/20675429466

> The action cpp-linter/cpp-linter-action@f91c446a32ae3eb9f98fef8c9ed4c7cb613a4f8a is not allowed in apache/orc because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns: ...

As of now, the value is the following.

- https://github.com/apache/infrastructure-actions/blob/main/actions.yml#L278

```
cpp-linter/cpp-linter-action:
  0f6d1b8d7e38b584cbee606eb23d850c217d54f8:
    tag: v2.15.1
```

### How was this patch tested?

Pass the CIs on this PR.

### Was this patch authored or co-authored using generative AI tooling?

No.