### PR TITLE
ORC-2042: Upgrade maven.version to 3.9.12

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -76,7 +76,7 @@
     <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
     <maven.compiler.release>${java.version}</maven.compiler.release>
     <maven.compiler.useIncrementalCompilation>false</maven.compiler.useIncrementalCompilation>
-    <maven.version>3.9.11</maven.version>
+    <maven.version>3.9.12</maven.version>
 
     <mockito.version>5.10.0</mockito.version>
     <orc-format.version>1.1.1</orc-format.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to upgrade maven version to 3.9.12.


### Why are the changes needed?
This is the newest version of maven and will bring the newest bug fixes.
- https://maven.apache.org/docs/3.9.12/release-notes.html

### How was this patch tested?
Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?
No.