### PR TITLE
ORC-2047: Add `.vscode` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dependency-reduced-pom.xml
 *.ipr
 *.iws
 .idea
+.vscode
 .DS_Store
 .java-version
 java/bench/data


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `.vscode` to `.gitignore` like `.idea`.

### Why are the changes needed?

To help `vscode`-based IDE users.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.