### PR TITLE
ORC-2048: Use Java `InputStream.skipNBytes` instead of `IOUtils.skipFully`

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
+++ b/java/core/src/java/org/apache/orc/impl/RunLengthByteReader.java
@@ -55,7 +55,7 @@ public class RunLengthByteReader {
       repeat = true;
       numLiterals = control + RunLengthByteWriter.MIN_REPEAT_SIZE;
       if (numSkipRows >= numLiterals) {
-        IOUtils.skipFully(input,1);
+        input.skipNBytes(1);
       } else {
         int val = input.read();
         if (val == -1) {
@@ -68,7 +68,7 @@ public class RunLengthByteReader {
       numLiterals = 0x100 - control;
       numSkipRows = Math.min(numSkipRows, numLiterals);
       if (numSkipRows > 0) {
-        IOUtils.skipFully(input, numSkipRows);
+        input.skipNBytes(numSkipRows);
       }
       int bytes = numSkipRows;
       while (bytes < numLiterals) {

--- a/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/SerializationUtils.java
@@ -108,7 +108,7 @@ public final class SerializationUtils {
   }
 
   public void skipFloat(InputStream in, int numOfFloats) throws IOException {
-    IOUtils.skipFully(in, numOfFloats * 4L);
+    in.skipNBytes(numOfFloats * 4L);
   }
 
   public void writeFloat(OutputStream output,
@@ -154,7 +154,7 @@ public final class SerializationUtils {
   }
 
   public void skipDouble(InputStream in, int numOfDoubles) throws IOException {
-    IOUtils.skipFully(in, numOfDoubles * 8L);
+    in.skipNBytes(numOfDoubles * 8L);
   }
 
   public void writeDouble(OutputStream output, double value)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `InputStream.skipNBytes` instead of `IOUtils.skipFully`.

```scala
- IOUtils.skipFully(input, numSkipRows);
+ input.skipNBytes(numSkipRows);
```

### Why are the changes needed?

Java 12+ supports `skipNBytes` natively. We had better use this simple style.

- [JDK-8214072: InputStream.skipNBytes(long k) to skip exactly k bytes](https://bugs.openjdk.org/browse/JDK-8214072)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.