### PR TITLE
ORC-2049: Move `MAX_ARRAY_SIZE` to `RecordReaderUtils` from `IOUtils`

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/IOUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/IOUtils.java
@@ -31,11 +31,6 @@ public final class IOUtils {
   public static final int DEFAULT_BUFFER_SIZE = 8192;
 
   /**
-   * The maximum size of array to allocate, value being the same as {@link java.util.Hashtable}
-   */
-  public static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
-
-  /**
    * Returns a new byte array of size {@link #DEFAULT_BUFFER_SIZE}.
    *
    * @return a new byte array of size {@link #DEFAULT_BUFFER_SIZE}.

--- a/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
+++ b/java/core/src/java/org/apache/orc/impl/RecordReaderUtils.java
@@ -47,6 +47,11 @@ import java.util.function.Supplier;
  * Stateless methods shared between RecordReaderImpl and EncodedReaderImpl.
  */
 public class RecordReaderUtils {
+  /**
+   * The maximum size of array to allocate, value being the same as {@link java.util.Hashtable}
+   */
+  public static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+
   private static final HadoopShims SHIMS = HadoopShimsFactory.get();
   private static final boolean supportVectoredIO =
       SHIMS.supportVectoredIO(VersionInfo.getVersion());
@@ -836,12 +841,12 @@ public class RecordReaderUtils {
         current = (BufferChunk) current.next;
       }
       reqBytes += currentEnd - currentStart;
-      if (reqBytes > IOUtils.MAX_ARRAY_SIZE) {
-        throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + IOUtils.MAX_ARRAY_SIZE);
+      if (reqBytes > MAX_ARRAY_SIZE) {
+        throw new IllegalArgumentException("invalid reqBytes value " + reqBytes + ",out of bounds " + MAX_ARRAY_SIZE);
       }
       long readBytes = end - start;
-      if (readBytes > IOUtils.MAX_ARRAY_SIZE) {
-        throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + IOUtils.MAX_ARRAY_SIZE);
+      if (readBytes > MAX_ARRAY_SIZE) {
+        throw new IllegalArgumentException("invalid readBytes value " + readBytes + ",out of bounds " + MAX_ARRAY_SIZE);
       }
       return new ChunkReader(from, to, (int) readBytes, (int) reqBytes);
     }

--- a/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
+++ b/java/core/src/test/org/apache/orc/impl/TestRecordReaderUtils.java
@@ -209,30 +209,31 @@ class TestRecordReaderUtils {
 
   @Test
   public void testChunkReaderCreateReqBytesAndReadBytesValidation() {
+    int MAX_ARRAY_SIZE = RecordReaderUtils.MAX_ARRAY_SIZE;
     BufferChunkList rangeList = new TestOrcLargeStripe.RangeBuilder()
-      .range(0, IOUtils.MAX_ARRAY_SIZE)
-      .range(1L + IOUtils.MAX_ARRAY_SIZE, IOUtils.MAX_ARRAY_SIZE + 1)
-      .range(2L * IOUtils.MAX_ARRAY_SIZE, IOUtils.MAX_ARRAY_SIZE - 4)
-      .range(3L * IOUtils.MAX_ARRAY_SIZE, 2)
+      .range(0, MAX_ARRAY_SIZE)
+      .range(1L + MAX_ARRAY_SIZE, MAX_ARRAY_SIZE + 1)
+      .range(2L * MAX_ARRAY_SIZE, MAX_ARRAY_SIZE - 4)
+      .range(3L * MAX_ARRAY_SIZE, 2)
       .build();
 
     // reqBytes,readBytes boundary value
     RecordReaderUtils.ChunkReader chunkReader = RecordReaderUtils.ChunkReader.create(rangeList.get(0), 0);
-    assertEquals(chunkReader.getReadBytes(), IOUtils.MAX_ARRAY_SIZE);
-    assertEquals(chunkReader.getReqBytes(), IOUtils.MAX_ARRAY_SIZE);
+    assertEquals(chunkReader.getReadBytes(), MAX_ARRAY_SIZE);
+    assertEquals(chunkReader.getReqBytes(), MAX_ARRAY_SIZE);
 
-    // reqBytes > IOUtils.MAX_ARRAY_SIZE validation
+    // reqBytes > MAX_ARRAY_SIZE validation
     assertThrowsExactly(IllegalArgumentException.class,
       () -> RecordReaderUtils.ChunkReader.create(rangeList.get(1), 0),
       () -> String.format("invalid reqBytes value %d,out of bounds %d",
-                          rangeList.get(1).getLength(), IOUtils.MAX_ARRAY_SIZE)
+                          rangeList.get(1).getLength(), MAX_ARRAY_SIZE)
     );
 
-    // readBytes > IOUtils.MAX_ARRAY_SIZE validation
+    // readBytes > MAX_ARRAY_SIZE validation
     assertThrowsExactly(IllegalArgumentException.class,
       () -> RecordReaderUtils.ChunkReader.create(rangeList.get(2), 100),
       () -> String.format("invalid readBytes value %d,out of bounds %d",
-                          rangeList.get(3).getEnd() - rangeList.get(2).getOffset(), IOUtils.MAX_ARRAY_SIZE)
+                          rangeList.get(3).getEnd() - rangeList.get(2).getOffset(), MAX_ARRAY_SIZE)
     );
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to move `MAX_ARRAY_SIZE` to `RecordReaderUtils` from `IOUtils`.

### Why are the changes needed?

Only `RecordReaderUtils` uses `IOUtils.MAX_ARRAY_SIZE`. We had better move it to `RecordReaderUtils` to improve modularity.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.