### PR TITLE
ORC-2051: Fix `Meson` build to use `ORC Format` 1.1.1

### DIFF
--- a/subprojects/packagefiles/orc-format/meson.build
+++ b/subprojects/packagefiles/orc-format/meson.build
@@ -18,7 +18,7 @@
 project(
     'orc-format',
     'cpp',
-    version: '1.1.0',
+    version: '1.1.1',
     license: 'Apache-2.0',
     meson_version: '>=1.3.0',
 )


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Meson` build to use `ORC Format` 1.1.1.

### Why are the changes needed?

Since ORC 2.2.1, we has been using `ORC Format` 1.1.1 in `Java/CMake` build except `Meson` build. We should fix it to be consistent.
- #2355 

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.