### PR TITLE
ORC-2053: Use Java `Set.of` instead of `Collections.emptySet`

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -52,6 +52,10 @@
       <property name="ignoreComments" value="true"/>
       <property name="message" value="No starting LAND and LOR allowed."/>
     </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="Collections\.emptySet"/>
+      <property name="message" value="Use Set.of() instead." />
+    </module>
     <module name="Indentation">
       <property name="severity" value="error"/>
       <property name="basicOffset" value="2"/>

--- a/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/TreeReaderFactory.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -143,7 +142,7 @@ public class TreeReaderFactory {
     private ReaderEncryption encryption;
     private boolean useProlepticGregorian;
     private boolean fileUsedProlepticGregorian;
-    private Set<Integer> filterColumnIds = Collections.emptySet();
+    private Set<Integer> filterColumnIds = Set.of();
     Consumer<OrcFilterContext> filterCallback;
 
     public ReaderContext setSchemaEvolution(SchemaEvolution evolution) {

--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -44,7 +44,6 @@ import java.nio.ByteBuffer;
 import java.security.Key;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -123,7 +122,7 @@ public class StripePlanner {
                        boolean ignoreNonUtf8BloomFilter,
                        long maxBufferSize) {
     this(schema, encryption, dataReader, version, ignoreNonUtf8BloomFilter, maxBufferSize,
-         Collections.emptySet());
+         Set.of());
   }
 
   public StripePlanner(StripePlanner old) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java 9+ `Set.of()` API instead of `Collections.emptySet()` and add a new checkstyle rule to ban `Collections.emptySet`.

### Why are the changes needed?

We had better use `Set` simply and uniformly.

```java
- import java.util.Collections;
...
- private Set<Integer> filterColumnIds = Collections.emptySet();
+ private Set<Integer> filterColumnIds = Set.of();
```

### Does this PR introduce _any_ user-facing change?

No behavior change.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.