### PR TITLE
ORC-2054: Fix `Meson` build version string to `2.3.0-SNAPSHOT`

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project(
     'orc',
     'cpp',
-    version: '2.2.0-SNAPSHOT',
+    version: '2.3.0-SNAPSHOT',
     license: 'Apache-2.0',
     meson_version: '>=1.3.0',
     default_options: [


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `Meson` build version string to `2.3.0-SNAPSHOT`.

### Why are the changes needed?

`main` branch is `2.3.0-SNAPSHOT`.
- #2322

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.