### PR TITLE
ORC-2055: Use Java `ArrayList` constructors instead of `Lists.newArrayList`

### DIFF
--- a/java/checkstyle.xml
+++ b/java/checkstyle.xml
@@ -56,6 +56,10 @@
       <property name="format" value="Collections\.emptySet"/>
       <property name="message" value="Use Set.of() instead." />
     </module>
+    <module name="RegexpSinglelineJava">
+      <property name="format" value="com\.google\.common\.collect\.Lists"/>
+      <property name="message" value="Use Java API instead." />
+    </module>
     <module name="Indentation">
       <property name="severity" value="error"/>
       <property name="basicOffset" value="2"/>

--- a/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
+++ b/java/core/src/test/org/apache/orc/TestNewIntegerEncoding.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -33,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
@@ -121,7 +121,7 @@ public class TestNewIntegerEncoding implements TestConf {
         2, 5, 1, 3, 7, 1, 9, 2, 6, 3, 7, 1, 9, 2, 6, 3, 7, 1, 9, 2, 6, 3, 7, 1,
         9, 2, 6, 3, 7, 1, 9, 2, 6, 2000, 2, 1, 1, 1, 1, 1, 3, 7, 1, 9, 2, 6, 1,
         1, 1, 1, 1 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
     Writer writer = OrcFile.createWriter(testFilePath,
                                          OrcFile.writerOptions(conf)
                                          .setSchema(schema)
@@ -159,7 +159,7 @@ public class TestNewIntegerEncoding implements TestConf {
         2, 5, 1, 3, 7, 1, 9, 2, 6, 3, 7, 1, 9, 2, 6, 3, 7, 1, 9, 2, 6, 3, 7, 1,
         9, 2, 6, 3, 7, 1, 9, 2, 6, 2000, 2, 1, 1, 1, 1, 1, 3, 7, 1, 9, 2, 6, 1,
         1, 1, 1, 1 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -194,7 +194,7 @@ public class TestNewIntegerEncoding implements TestConf {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { -500, -400, -350, -325, -310 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -229,7 +229,7 @@ public class TestNewIntegerEncoding implements TestConf {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { -500, -600, -650, -675, -710 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -264,7 +264,7 @@ public class TestNewIntegerEncoding implements TestConf {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 500, 400, 350, 325, 310 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -299,7 +299,7 @@ public class TestNewIntegerEncoding implements TestConf {
     TypeDescription schema = TypeDescription.createLong();
 
     long[] inp = new long[] { 500, 600, 650, 675, 710 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -335,7 +335,7 @@ public class TestNewIntegerEncoding implements TestConf {
     long[] inp = new long[]{4513343538618202719L, 4513343538618202711L,
         2911390882471569739L,
         -9181829309989854913L};
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(
         testFilePath,
@@ -368,7 +368,7 @@ public class TestNewIntegerEncoding implements TestConf {
     long[] inp = new long[]{Long.MAX_VALUE, 4513343538618202711L,
         2911390882471569739L,
         Long.MIN_VALUE};
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(
         testFilePath,
@@ -400,7 +400,7 @@ public class TestNewIntegerEncoding implements TestConf {
 
     long[] inp = new long[]{-4513343538618202711L, -2911390882471569739L, -2,
         Long.MAX_VALUE};
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(
         testFilePath,
@@ -431,7 +431,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testIntegerMin(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     input.add((long) Integer.MIN_VALUE);
 
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -465,7 +465,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testIntegerMax(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     input.add((long) Integer.MAX_VALUE);
 
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -500,7 +500,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testLongMin(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     input.add(Long.MIN_VALUE);
 
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -535,7 +535,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testLongMax(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     input.add(Long.MAX_VALUE);
 
     Writer writer = OrcFile.createWriter(testFilePath,
@@ -570,7 +570,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testRandomInt(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 100000; i++) {
       input.add((long) rand.nextInt());
@@ -608,7 +608,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testRandomLong(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 100000; i++) {
       input.add(rand.nextLong());
@@ -658,7 +658,7 @@ public class TestNewIntegerEncoding implements TestConf {
         2, 2, 1, 1, 8, 1, 1, 2, 1, 5, 9, 2, 3, 112, 13, 2, 2, 1, 5, 10, 3, 1,
         1, 13, 2, 3, 4, 1, 3, 1, 1, 2, 1, 1, 2, 4, 2, 207, 1, 1, 2, 4, 3, 3, 2,
         2, 16 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -704,7 +704,7 @@ public class TestNewIntegerEncoding implements TestConf {
         2, 2, 1, 1, 8, 1, 1, 2, 1, 5, 9, 2, 3, 112, 13, 2, 2, 1, 5, 10, 3, 1,
         1, 13, 2, 3, 4, 1, 3, 1, 1, 2, 1, 1, 2, 4, 2, 207, 1, 1, 2, 4, 3, 3, 2,
         2, 16 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -750,7 +750,7 @@ public class TestNewIntegerEncoding implements TestConf {
         2, 2, 1, 1, 8, 1, 1, 2, 1, 5, 9, 2, 3, 112, 13, 2, 2, 1, 5, 10, 3, 1,
         1, 13, 2, 3, 4, 1, 3, 1, 1, 2, 1, 1, 2, 4, 2, 207, 1, 1, 2, 4, 3, 3, 2,
         2, 16 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -787,7 +787,7 @@ public class TestNewIntegerEncoding implements TestConf {
     long[] inp = new long[] { 13, 13, 11, 8, 13, 10, 10, 11, 11, 14, 11, 7, 13,
         12, 12, 11, 15, 12, 12, 9, 8, 10, 13, 11, 8, 6, 5, 6, 11, 7, 15, 10, 7,
         6, 8, 7, 9, 9, 11, 33, 11, 3, 7, 4, 6, 10, 14, 12, 5, 14, 7, 6 };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf)
@@ -821,7 +821,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseAt0(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(100));
@@ -860,7 +860,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseAt1(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(100));
@@ -898,7 +898,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseAt255(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(100));
@@ -936,7 +936,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseAt256(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(100));
@@ -974,7 +974,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBase510(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(100));
@@ -1012,7 +1012,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBase511(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(100));
@@ -1050,7 +1050,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseMax1(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for (int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(60));
@@ -1088,7 +1088,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseMax2(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for (int i = 0; i < 5120; i++) {
       input.add((long) rand.nextInt(60));
@@ -1128,7 +1128,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseMax3(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     input.add(371946367L);
     input.add(11963367L);
     input.add(68639400007L);
@@ -1180,7 +1180,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testPatchedBaseMax4(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     for (int i = 0; i < 25; i++) {
       input.add(371292224226367L);
       input.add(119622332222267L);
@@ -1245,7 +1245,7 @@ public class TestNewIntegerEncoding implements TestConf {
             .encodingStrategy(encodingStrategy));
     VectorizedRowBatch batch = schema.createRowBatch();
 
-    List<Timestamp> tslist = Lists.newArrayList();
+    List<Timestamp> tslist = new ArrayList<>();
     tslist.add(Timestamp.valueOf("2099-01-01 00:00:00"));
     tslist.add(Timestamp.valueOf("2003-01-01 00:00:00"));
     tslist.add(Timestamp.valueOf("1999-01-01 00:00:00"));
@@ -1346,7 +1346,7 @@ public class TestNewIntegerEncoding implements TestConf {
   public void testSeek(OrcFile.EncodingStrategy encodingStrategy) throws Exception {
     TypeDescription schema = TypeDescription.createLong();
 
-    List<Long> input = Lists.newArrayList();
+    List<Long> input = new ArrayList<>();
     Random rand = new Random();
     for(int i = 0; i < 100000; i++) {
       input.add((long) rand.nextInt());

--- a/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
+++ b/java/core/src/test/org/apache/orc/TestOrcNullOptimization.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -33,6 +32,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
@@ -158,7 +158,7 @@ public class TestOrcNullOptimization implements TestConf {
 
     RecordReader rows = reader.rows();
 
-    List<Boolean> expected = Lists.newArrayList();
+    List<Boolean> expected = new ArrayList<>();
     for (StripeInformation sinfo : reader.getStripes()) {
       expected.add(false);
     }
@@ -166,7 +166,7 @@ public class TestOrcNullOptimization implements TestConf {
     expected.set(0, true);
     expected.set(expected.size() - 1, true);
 
-    List<Boolean> got = Lists.newArrayList();
+    List<Boolean> got = new ArrayList<>();
     // check if the strip footer contains PRESENT stream
     for (StripeInformation sinfo : reader.getStripes()) {
       OrcProto.StripeFooter sf = ((RecordReaderImpl) rows).readStripeFooter(sinfo);
@@ -273,12 +273,12 @@ public class TestOrcNullOptimization implements TestConf {
     RecordReader rows = reader.rows();
 
     // none of the stripes will have PRESENT stream
-    List<Boolean> expected = Lists.newArrayList();
+    List<Boolean> expected = new ArrayList<>();
     for (StripeInformation sinfo : reader.getStripes()) {
       expected.add(false);
     }
 
-    List<Boolean> got = Lists.newArrayList();
+    List<Boolean> got = new ArrayList<>();
     // check if the strip footer contains PRESENT stream
     for (StripeInformation sinfo : reader.getStripes()) {
       OrcProto.StripeFooter sf = ((RecordReaderImpl) rows).readStripeFooter(sinfo);
@@ -372,13 +372,13 @@ public class TestOrcNullOptimization implements TestConf {
 
     RecordReader rows = reader.rows();
     // only the last strip will have PRESENT stream
-    List<Boolean> expected = Lists.newArrayList();
+    List<Boolean> expected = new ArrayList<>();
     for (StripeInformation sinfo : reader.getStripes()) {
       expected.add(false);
     }
     expected.set(expected.size() - 1, true);
 
-    List<Boolean> got = Lists.newArrayList();
+    List<Boolean> got = new ArrayList<>();
     // check if the strip footer contains PRESENT stream
     for (StripeInformation sinfo : reader.getStripes()) {
       OrcProto.StripeFooter sf = ((RecordReaderImpl) rows).readStripeFooter(sinfo);

--- a/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimestampPPD.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -34,6 +33,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -81,7 +81,7 @@ public class TestOrcTimestampPPD implements TestConf {
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000).bufferSize(10000)
             .version(OrcFile.Version.CURRENT));
 
-    List<Timestamp> tslist = Lists.newArrayList();
+    List<Timestamp> tslist = new ArrayList<>();
     tslist.add(Timestamp.valueOf("1970-01-01 00:00:00.0005"));
 
     VectorizedRowBatch batch = schema.createRowBatch();
@@ -138,7 +138,7 @@ public class TestOrcTimestampPPD implements TestConf {
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000).bufferSize(10000)
             .version(OrcFile.Version.CURRENT));
 
-    List<Timestamp> tslist = Lists.newArrayList();
+    List<Timestamp> tslist = new ArrayList<>();
     tslist.add(Timestamp.valueOf("2037-01-01 00:00:00.001109"));
     tslist.add(Timestamp.valueOf("2037-01-01 00:00:00.001279"));
     tslist.add(Timestamp.valueOf("2037-01-01 00:00:00.001499"));

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone1.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -31,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Stream;
@@ -98,7 +98,7 @@ public class TestOrcTimezone1 implements TestConf {
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
             .bufferSize(10000));
     assertEquals(writerTimeZone, TimeZone.getDefault().getID());
-    List<String> ts = Lists.newArrayList();
+    List<String> ts = new ArrayList<>();
     ts.add("2003-01-01 01:00:00.000000222");
     ts.add("1996-08-02 09:00:00.723100809");
     ts.add("1999-01-01 02:00:00.999999999");

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone2.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone2.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -31,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.TimeZone;
@@ -85,7 +85,7 @@ public class TestOrcTimezone2 implements TestConf {
         OrcFile.writerOptions(conf).setSchema(schema)
             .stripeSize(100000).bufferSize(10000));
     assertEquals(writerTimeZone, TimeZone.getDefault().getID());
-    List<String> ts = Lists.newArrayList();
+    List<String> ts = new ArrayList<>();
     ts.add("2003-01-01 01:00:00.000000222");
     ts.add("1999-01-01 02:00:00.999999999");
     ts.add("1995-01-02 03:00:00.688888888");

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone3.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone3.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -31,6 +30,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.sql.Timestamp;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.stream.Stream;
@@ -74,7 +74,7 @@ public class TestOrcTimezone3 implements TestConf {
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
             .bufferSize(10000));
     assertEquals(writerTimeZone, TimeZone.getDefault().getID());
-    List<String> ts = Lists.newArrayList();
+    List<String> ts = new ArrayList<>();
     ts.add("1969-12-31 16:00:14.007");
     ts.add("1969-12-31 16:00:06.021");
     ts.add("1969-12-31 16:00:03.963");

--- a/java/core/src/test/org/apache/orc/TestOrcTimezone4.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezone4.java
@@ -17,7 +17,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -30,6 +29,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.io.File;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.TimeZone;
 
@@ -72,7 +72,7 @@ public class TestOrcTimezone4 implements TestConf {
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
             .bufferSize(10000));
-    List<String> ts = Lists.newArrayList();
+    List<String> ts = new ArrayList<>();
     ts.add("1969-12-31 15:59:56.007");
     ts.add("1969-12-31 16:00:14.007");
     ts.add("1969-12-31 16:00:06.021");

--- a/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
+++ b/java/core/src/test/org/apache/orc/TestOrcTimezonePPD.java
@@ -15,7 +15,6 @@
  */
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -42,6 +41,7 @@ import java.io.File;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.TimeZone;
@@ -118,7 +118,7 @@ public class TestOrcTimezonePPD implements TestConf {
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
         .bufferSize(10000));
     assertEquals(writerTimeZone, TimeZone.getDefault().getID());
-    List<String> ts = Lists.newArrayList();
+    List<String> ts = new ArrayList<>();
     ts.add("2007-08-01 00:00:00.0");
     ts.add("2007-08-01 04:00:00.0");
     VectorizedRowBatch batch = schema.createRowBatch();
@@ -204,7 +204,7 @@ public class TestOrcTimezonePPD implements TestConf {
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
         .bufferSize(10000).bloomFilterColumns("ts").writerVersion(OrcFile.WriterVersion.ORC_101));
     assertEquals(writerTimeZone, TimeZone.getDefault().getID());
-    List<String> ts = Lists.newArrayList();
+    List<String> ts = new ArrayList<>();
     ts.add("2007-08-01 00:00:00.0");
     ts.add("2007-08-01 04:00:00.0");
     VectorizedRowBatch batch = schema.createRowBatch();
@@ -277,7 +277,7 @@ public class TestOrcTimezonePPD implements TestConf {
       OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
         .bufferSize(10000).bloomFilterColumns("ts"));
     assertEquals(writerTimeZone, TimeZone.getDefault().getID());
-    List<String> ts = Lists.newArrayList();
+    List<String> ts = new ArrayList<>();
     ts.add("2007-08-01 00:00:00.0");
     ts.add("2007-08-01 04:00:00.0");
     VectorizedRowBatch batch = schema.createRowBatch();

--- a/java/core/src/test/org/apache/orc/TestUnrolledBitPack.java
+++ b/java/core/src/test/org/apache/orc/TestUnrolledBitPack.java
@@ -18,7 +18,6 @@
 
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import com.google.common.primitives.Longs;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -31,6 +30,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -77,7 +77,7 @@ public class TestUnrolledBitPack implements TestConf {
         0, val, 0, 0, val, 0, val, 0, val, 0, 0, val, 0, val, 0, val, 0, 0, val, 0, val, 0, val, 0,
         0, val, 0, val, 0, val, 0, 0, val, 0, val, 0, val, 0, 0, val, 0, val, 0, val, 0, 0, val, 0,
         val, 0, val, 0, 0, val, 0, val, 0, 0, val, val };
-    List<Long> input = Lists.newArrayList(Longs.asList(inp));
+    List<Long> input = new ArrayList<>(Longs.asList(inp));
 
     Writer writer = OrcFile.createWriter(
         testFilePath,

--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -18,7 +18,6 @@
 
 package org.apache.orc;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -436,7 +435,7 @@ public class TestVectorOrcFile implements TestConf {
     Writer writer = OrcFile.createWriter(testFilePath,
         OrcFile.writerOptions(conf).setSchema(schema).stripeSize(100000)
             .bufferSize(10000).version(fileFormat));
-    List<Timestamp> tslist = Lists.newArrayList();
+    List<Timestamp> tslist = new ArrayList<>();
     tslist.add(Timestamp.valueOf("2037-01-01 00:00:00.000999"));
     tslist.add(Timestamp.valueOf("2003-01-01 00:00:00.000000222"));
     tslist.add(Timestamp.valueOf("1999-01-01 00:00:00.999999999"));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use Java `ArrayList` constructors instead of `Lists.newArrayList` in Java code and add a new checkstyle rule to ban `com.google.common.collect.Lists`.

### Why are the changes needed?

Java native usage is simpler than the `Lists.newArrayList` wrapper.

```java
- List<Object> out = Lists.newArrayList();
+ List<Object> out = new ArrayList<>();
```

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.