### PR TITLE
ORC-2056: Remove `MacOS 14` from GitHub Action CI and docs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,8 +82,6 @@ jobs:
             cxx: g++
           - os: ubuntu-latest
             java: 25
-          - os: macos-14
-            java: 21
     env:
       MAVEN_OPTS: -Xmx2g
       MAVEN_SKIP_RC: true
@@ -264,7 +262,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [14, 15, 26]
+        version: [15, 26]
     runs-on: macos-${{ matrix.version }}
     steps:
     - name: Checkout repository
@@ -287,7 +285,6 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-14
           - macos-15
           - macos-26
     steps:

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -9,7 +9,7 @@ dockerUrl: https://github.com/apache/orc/blob/main/docker
 
 The C++ library is supported on the following operating systems:
 
-* MacOS 14 to 26
+* MacOS 15 to 26
 * Debian 12 to 13
 * Ubuntu 22.04 to 24.04
 * Oracle Linux 8 to 9


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `MacOS 14` from GitHub Action CI and docs for Apache ORC 2.3+

### Why are the changes needed?

Since we support `MacOS 15` and `MacOS 26` mainly, we can remove `MacOS 14` from our test coverage.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.