### PR TITLE
ORC-2057: Add `Pandas` page at `Using in Python` section

### DIFF
--- a/site/_data/docs.yml
+++ b/site/_data/docs.yml
@@ -18,6 +18,7 @@
 - title: Using in Python
   docs:
   - pyarrow
+  - pandas
   - dask
 
 - title: Using in Hive

--- a/site/_docs/pandas.md
+++ b/site/_docs/pandas.md
@@ -1,0 +1,41 @@
+---
+layout: docs
+title: Pandas
+permalink: /docs/pandas.html
+---
+
+## How to install
+
+[Pandas](https://pandas.pydata.org/) is a fast, powerful, flexible and easy to use open source data analysis and manipulation tool.
+Since Pandas relies on [pyarrow](https://pypi.org/project/pyarrow/) for ORC support, it is required.
+
+```
+pip3 install pandas==2.3.3
+pip3 install pyarrow
+```
+
+## How to write and read an ORC file
+
+```
+In [1]: import pandas as pd
+
+In [2]: df = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", None]})
+
+In [3]: df.to_orc("test.orc")
+
+In [4]: pd.read_orc("test.orc")
+Out[4]:
+   col1  col2
+0     1     a
+1     2     b
+2     3  None
+
+In [5]: pd.read_orc("test.orc", columns=["col1"])
+Out[5]:
+   col1
+0     1
+1     2
+2     3
+```
+
+[Pandas](https://pandas.pydata.org/docs/) page provides more information.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Pandas` page at `Using in Python` section.

### Why are the changes needed?

To helps `Pandas` users.

### How was this patch tested?

Manually generate the page and check.

<img width="627" height="706" alt="Screenshot 2026-01-05 at 10 32 58" src="https://github.com/user-attachments/assets/816c20e2-8682-491a-90f2-3614da188aa8" />

### Was this patch authored or co-authored using generative AI tooling?

Yes (`Gemini 3 Pro` on `Antigravity`)