### PR TITLE
ORC-2061: Upgrade `byte-buddy` to 1.18.4

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -257,13 +257,13 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.17.5</version>
+        <version>1.18.4</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `byte-buddy` to 1.18.4.

### Why are the changes needed?

To bring the latest bug fixes:
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.4
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.3
  - [Use ASM 9.9.1](https://github.com/raphw/byte-buddy/commit/6698c45b1591ba3a26d52054a543e23b6d68ef47#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8)
  - [Avoid using class file API when loaded on the boot path as multi release jar files are not available then](https://github.com/raphw/byte-buddy/commit/04a89c6b16b70482f60976bd4fab20932e441a0c)
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.2
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.1
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.18.0
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.8
  - [Support Java 26 by using ASM 9.9](https://github.com/raphw/byte-buddy/commit/8b7c507bdabf3115b9e19e5297f02961e102afff)
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.7
- https://github.com/raphw/byte-buddy/releases/tag/byte-buddy-1.17.6

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.