### PR TITLE
ORC-2064: Update `oraclelinux9` to use `dnf` instead of `yum`

### DIFF
--- a/docker/oraclelinux9/Dockerfile
+++ b/docker/oraclelinux9/Dockerfile
@@ -21,8 +21,8 @@ FROM oraclelinux:9
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-RUN yum check-update || true
-RUN yum install -y \
+RUN dnf check-update || true
+RUN dnf install -y \
   cmake3 \
   curl-devel \
   cyrus-sasl-devel \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `oraclelinux9` to use `dnf` instead of `yum`.

### Why are the changes needed?

Since `Oracle Linux 8`, `yum` is an alias of `dnf` command. We had better use `dnf` directly.

```
$ docker run -it --rm apache/orc-dev:oraclelinux9 ls -al /usr/bin/yum
lrwxrwxrwx 1 root root 5 Aug 13 03:53 /usr/bin/yum -> dnf-3
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.