### PR TITLE
ORC-2069: Fix convert tool failed to read csv

### DIFF
--- a/java/tools/pom.xml
+++ b/java/tools/pom.xml
@@ -57,6 +57,12 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <!-- convert tool CSVParser uses org.apache.commons.lang3 -->
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
This PR aims to fix convert tool failed to read csv.

### Why are the changes needed?

`orc-tools-2.2.2-uber.jar` is not packaged `commons-lang3`, which causes its convert command to fail to read csv.

```java
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/orc/shade/commons/lang3/ObjectUtils
	at com.opencsv.CSVParser.<init>(CSVParser.java:110)
	at com.opencsv.CSVParserBuilder.build(CSVParserBuilder.java:139)
	at org.apache.orc.tools.convert.CsvReader.<init>(CsvReader.java:89)
	at org.apache.orc.tools.convert.ConvertTool$FileInformation.getRecordReader(ConvertTool.java:162)
	at org.apache.orc.tools.convert.ConvertTool.run(ConvertTool.java:221)
	at org.apache.orc.tools.convert.ConvertTool.main(ConvertTool.java:174)
	at org.apache.orc.tools.Driver.main(Driver.java:118)
Caused by: java.lang.ClassNotFoundException: org.apache.orc.shade.commons.lang3.ObjectUtils
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:580)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
	... 7 more
```

### How was this patch tested?
local test

### Was this patch authored or co-authored using generative AI tooling?
No