### PR TITLE
ORC-2070: Add `oraclelinux10` to docker tests and GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,6 +50,7 @@ jobs:
           - ubuntu24
           - oraclelinux8
           - oraclelinux9
+          - oraclelinux10
           - amazonlinux23
     steps:
     - name: Checkout

--- a/docker/README.md
+++ b/docker/README.md
@@ -5,7 +5,7 @@
 * Debian 12, and 13
 * Fedora 37
 * Ubuntu 22 and 24
-* Oracle Linux 9
+* Oracle Linux 9 and 10
 * Amazon Linux 2023
 
 ## Pre-built Images

--- a/docker/oraclelinux10/Dockerfile
+++ b/docker/oraclelinux10/Dockerfile
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Oracle Linux 10
+#
+
+FROM oraclelinux:10
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+RUN dnf check-update || true
+RUN dnf install -y \
+  git \
+  cmake \
+  gcc \
+  gcc-c++ \
+  java-21-openjdk-devel
+
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -4,4 +4,5 @@ ubuntu22
 ubuntu24
 oraclelinux8
 oraclelinux9
+oraclelinux10
 amazonlinux23

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -12,7 +12,7 @@ The C++ library is supported on the following operating systems:
 * MacOS 15 to 26
 * Debian 12 to 13
 * Ubuntu 22.04 to 24.04
-* Oracle Linux 8 to 9
+* Oracle Linux 8 to 10
 * Amazon Linux 2023
 
 You'll want to install the usual set of developer tools, but at least:
@@ -32,6 +32,7 @@ is in the docker subdirectory, for the list of packages required to build ORC:
 * [Ubuntu 24]({{ page.dockerUrl }}/ubuntu24/Dockerfile)
 * [Oracle Linux 8]({{ page.dockerUrl }}/oraclelinux8/Dockerfile)
 * [Oracle Linux 9]({{ page.dockerUrl }}/oraclelinux9/Dockerfile)
+* [Oracle Linux 10]({{ page.dockerUrl }}/oraclelinux10/Dockerfile)
 * [Amazon Linux 2023]({{ page.dockerUrl }}/amazonlinux23/Dockerfile)
 
 To build a normal release:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `oraclelinux10` to docker tests and GitHub Action.

### Why are the changes needed?

To have a test coverage for `Oracle Linux 10`.

### How was this patch tested?

Pass the CIs with the newly added test job.

<img width="397" height="78" alt="Screenshot 2026-02-02 at 08 25 18" src="https://github.com/user-attachments/assets/4a0c0158-3976-447b-a637-d9333036e8e9" />

```
$ docker run -it --rm apache/orc-dev:oraclelinux10 cat /etc/os-release
NAME="Oracle Linux Server"
VERSION="10.1"
ID="ol"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="10.1"
PLATFORM_ID="platform:el10"
PRETTY_NAME="Oracle Linux Server 10.1"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:oracle:linux:10:1:server"
HOME_URL="https://linux.oracle.com/"
BUG_REPORT_URL="https://github.com/oracle/oracle-linux"

ORACLE_BUGZILLA_PRODUCT="Oracle Linux 10"
ORACLE_BUGZILLA_PRODUCT_VERSION=10.1
ORACLE_SUPPORT_PRODUCT="Oracle Linux"
ORACLE_SUPPORT_PRODUCT_VERSION=10.1
```

```
$ docker run -it --rm apache/orc-dev:oraclelinux10 cmake --version
cmake version 3.30.5

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

```
$ docker run -it --rm apache/orc-dev:oraclelinux10 g++ --version
g++ (GCC) 14.3.1 20250617 (Red Hat 14.3.1-2)
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
$ docker run -it --rm apache/orc-dev:oraclelinux10 java --version
openjdk 21.0.10 2026-01-20 LTS
OpenJDK Runtime Environment (Red_Hat-21.0.10.0.7-1.0.1) (build 21.0.10+7-LTS)
OpenJDK 64-Bit Server VM (Red_Hat-21.0.10.0.7-1.0.1) (build 21.0.10+7-LTS, mixed mode, sharing)
```

### Was this patch authored or co-authored using generative AI tooling?

No.