### PR TITLE
MINOR: Fix broken maven badge image

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project includes both a Java library and a C++ library for reading and writ
 Releases:
 
 * Latest: [Apache ORC releases](https://orc.apache.org/releases)
-* Maven Central: [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.orc/orc/badge.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.orc%22)
+* Maven Central: [![Maven Central](https://img.shields.io/maven-central/v/org.apache.orc/orc.svg)](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.orc%22)
 * Downloads: [Apache ORC downloads](https://orc.apache.org/downloads)
 * Release tags: [Apache ORC release tags](https://github.com/apache/orc/releases)
 * Plan: [Apache ORC future release plan](https://github.com/apache/orc/milestones)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix the broken maven badge image.

### Why are the changes needed?

**BEFORE**

<img width="339" height="158" alt="Screenshot 2026-02-05 at 01 21 31" src="https://github.com/user-attachments/assets/b124cbaf-b92f-4301-8a81-717e491bda5f" />

**AFTER**

<img width="325" height="156" alt="Screenshot 2026-02-05 at 01 20 43" src="https://github.com/user-attachments/assets/4574d8f7-9537-4944-ae01-12f9135c78ee" />

### How was this patch tested?

Check in the PR branch.
- https://github.com/dongjoon-hyun/orc/tree/MINOR_FIX_IMAGE

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`