### PR TITLE
ORC-2077: Introduce `NullOptions` class for `CompressionCodec`

### DIFF
--- a/java/core/src/java/org/apache/orc/CompressionCodec.java
+++ b/java/core/src/java/org/apache/orc/CompressionCodec.java
@@ -63,6 +63,39 @@ public interface CompressionCodec extends Closeable {
   }
 
   /**
+   * A null implementation of Options that ignores all settings.
+   * Useful for codecs that don't support any configuration options.
+   */
+  class NullOptions implements Options {
+    public static final NullOptions INSTANCE = new NullOptions();
+
+    @Override
+    public Options copy() {
+      return this;
+    }
+
+    @Override
+    public Options setSpeed(SpeedModifier newValue) {
+      return this;
+    }
+
+    @Override
+    public Options setData(DataKind newValue) {
+      return this;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other != null && getClass() == other.getClass();
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+  }
+
+  /**
    * Get the default options for this codec.
    * @return the default options object
    */

--- a/java/core/src/java/org/apache/orc/impl/AircompressorCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/AircompressorCodec.java
@@ -98,36 +98,9 @@ public class AircompressorCodec implements CompressionCodec {
     out.flip();
   }
 
-  private static final Options NULL_OPTION = new Options() {
-    @Override
-    public Options copy() {
-      return this;
-    }
-
-    @Override
-    public Options setSpeed(SpeedModifier newValue) {
-      return this;
-    }
-
-    @Override
-    public Options setData(DataKind newValue) {
-      return this;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      return other != null && getClass() == other.getClass();
-    }
-
-    @Override
-    public int hashCode() {
-      return 0;
-    }
-  };
-
   @Override
   public Options getDefaultOptions() {
-    return NULL_OPTION;
+    return CompressionCodec.NullOptions.INSTANCE;
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to introduce `NullOptions` class for `CompressionCodec`.

### Why are the changes needed?

To reuse this class in another codec.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`