### PR TITLE
ORC-2078: Fix `TestConverter` to respect `test.tmp.dir`

### DIFF
--- a/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
+++ b/java/tools/src/test/org/apache/orc/tools/convert/TestConvert.java
@@ -69,7 +69,7 @@ public class TestConvert implements TestConf {
 
   @Test
   public void testConvertCustomTimestampFromCsv() throws IOException, ParseException {
-    Path csvFile = new Path("test.csv");
+    Path csvFile = new Path(workDir + File.separator + "test.csv");
     FSDataOutputStream stream = fs.create(csvFile, true);
     String[] timeValues = new String[] {"0001-01-01 00:00:00.000", "2021-12-01 18:36:00.800"};
     stream.writeBytes(String.join("\n", timeValues));


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix `TestConverter` to respect `test.tmp.dir`.

### Why are the changes needed?

To avoid generating temporary files in a wrong place. It makes `git` confused like the following.

```
$ cd java
$ mvn package
$ git status
On branch main
Your branch is up to date with 'apache/main'.

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	tools/.test.csv.crc
	tools/test.csv

nothing added to commit but untracked files present (use "git add" to track)
```

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`