### PR TITLE
ORC-2079: Add `lz4` codec pool test coverage

### DIFF
--- a/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
+++ b/java/core/src/test/org/apache/orc/TestVectorOrcFile.java
@@ -2346,7 +2346,7 @@ public class TestVectorOrcFile implements TestConf {
     WriterOptions opts = OrcFile.writerOptions(conf)
         .setSchema(schema).stripeSize(1000).bufferSize(100).version(fileFormat);
 
-    CompressionCodec snappyCodec, zlibCodec, zstdCodec;
+    CompressionCodec snappyCodec, zlibCodec, zstdCodec, lz4Codec;
     snappyCodec = writeBatchesAndGetCodec(10, 1000, opts.compress(CompressionKind.SNAPPY), batch);
     assertEquals(1, OrcCodecPool.getPoolSize(CompressionKind.SNAPPY));
     Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf).filesystem(fs));
@@ -2374,6 +2374,13 @@ public class TestVectorOrcFile implements TestConf {
     codec = writeBatchesAndGetCodec(10, 1000, opts.compress(CompressionKind.ZSTD), batch);
     assertEquals(1, OrcCodecPool.getPoolSize(CompressionKind.ZSTD));
     assertSame(zstdCodec, codec);
+
+    lz4Codec = writeBatchesAndGetCodec(10, 1000, opts.compress(CompressionKind.LZ4), batch);
+    assertNotSame(zstdCodec, lz4Codec);
+    assertEquals(1, OrcCodecPool.getPoolSize(CompressionKind.LZ4));
+    codec = writeBatchesAndGetCodec(10, 1000, opts.compress(CompressionKind.LZ4), batch);
+    assertEquals(1, OrcCodecPool.getPoolSize(CompressionKind.LZ4));
+    assertSame(lz4Codec, codec);
 
     assertSame(snappyCodec, OrcCodecPool.getCodec(CompressionKind.SNAPPY));
     CompressionCodec snappyCodec2 = writeBatchesAndGetCodec(


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `lz4` codec pool test coverage.

### Why are the changes needed?

To improve test coverage and help the future LZ4 migration like the following.
- #2511 

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

`Gemini 3 Pro (High)` on `Antigravity`.