### PR TITLE
ORC-2081: Support ORC LZ4 in bench module

### DIFF
--- a/java/bench/core/src/java/org/apache/orc/bench/core/CompressionKind.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/CompressionKind.java
@@ -18,6 +18,7 @@
 
 package org.apache.orc.bench.core;
 
+import io.airlift.compress.lz4.Lz4Codec;
 import io.airlift.compress.snappy.SnappyCodec;
 import org.apache.hadoop.fs.Path;
 
@@ -34,6 +35,7 @@ public enum CompressionKind {
   NONE("none"),
   ZLIB("gz"),
   SNAPPY("snappy"),
+  LZ4("lz4"),
   ZSTD("zstd");
 
   CompressionKind(String extension) {
@@ -54,6 +56,8 @@ public enum CompressionKind {
         return new GZIPOutputStream(out);
       case SNAPPY:
         return new SnappyCodec().createOutputStream(out);
+      case LZ4:
+        return new Lz4Codec().createOutputStream(out);
       default:
         throw new IllegalArgumentException("Unhandled kind " + this);
     }
@@ -67,6 +71,8 @@ public enum CompressionKind {
         return new GZIPInputStream(in);
       case SNAPPY:
         return new SnappyCodec().createInputStream(in);
+      case LZ4:
+        return new Lz4Codec().createInputStream(in);
       default:
         throw new IllegalArgumentException("Unhandled kind " + this);
     }

--- a/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
+++ b/java/bench/core/src/java/org/apache/orc/bench/core/Utilities.java
@@ -58,6 +58,8 @@ public class Utilities {
         return org.apache.orc.CompressionKind.ZLIB;
       case SNAPPY:
         return org.apache.orc.CompressionKind.SNAPPY;
+      case LZ4:
+        return org.apache.orc.CompressionKind.LZ4;
       case ZSTD:
         return org.apache.orc.CompressionKind.ZSTD;
       default:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support ORC LZ4 in bench module.

### Why are the changes needed?

To benchmark `LZ4` like the other codecs.

### How was this patch tested?

Manually run the following.

**BUILD**
```
$ cd java

$ mvn package -DskipTests -Pbenchmark
```

**WRITE**
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar generate data -d sales -c lz4 -f orc
Processing sales [orc]
```

**FILE NAME**
```
$ ls -alR data/generated/sales
total 6029680
drwxr-xr-x@ 3 dongjoon  staff          96 Feb  6 15:10 .
drwxr-xr-x@ 3 dongjoon  staff          96 Feb  6 14:50 ..
-rw-r--r--@ 1 dongjoon  staff  3083885325 Feb  6 15:07 orc.lz4
```

**READ**
```
$ java -jar core/target/orc-benchmarks-core-*-uber.jar scan data -d sales -c lz4 -f orc
data/generated/sales/orc.lz4 rows: 25000000 batches: 24415
```

**ORC-TOOLS**
```
$ orc-tools meta data/generated/sales/orc.lz4 | head -n4
Processing data file data/generated/sales/orc.lz4 [length: 3083885325]
Structure for data/generated/sales/orc.lz4
File Version: 0.12 with ORC_14 by ORC Java 2.3.0-SNAPSHOT
Rows: 25000000
Compression: LZ4
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`