### PR TITLE
ORC-2080: [FOLLOWUP] Add `-a` option for `commit` command

### DIFF
--- a/dev/create_orc_jira.py
+++ b/dev/create_orc_jira.py
@@ -77,7 +77,7 @@ def create_and_checkout_branch(jira_id):
 
 def create_commit(jira_id, title):
     try:
-        run_cmd(['git', 'commit', '-m', '%s: %s' % (jira_id, title)])
+        run_cmd(['git', 'commit', '-a', '-m', '%s: %s' % (jira_id, title)])
         print("Created a commit with message: %s: %s" % (jira_id, title))
     except subprocess.CalledProcessError as e:
         fail("Failed to create commit: %s" % e)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `-a` option for commit command as a follow-up of
- #2518 

### Why are the changes needed?

To add files.

### How was this patch tested?

Manually tests.

### Was this patch authored or co-authored using generative AI tooling?

No.