### PR TITLE
ORC-2083: Support `XerialSnappyCodec`

### DIFF
--- a/java/core/pom.xml
+++ b/java/core/pom.xml
@@ -53,6 +53,10 @@
       <artifactId>aircompressor</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+    </dependency>
+    <dependency>
       <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
     </dependency>

--- a/java/core/src/java/org/apache/orc/impl/WriterImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/WriterImpl.java
@@ -295,7 +295,11 @@ public class WriterImpl implements WriterInternal, MemoryManager.Callback {
       case ZLIB:
         return new ZlibCodec();
       case SNAPPY:
-        return new SnappyCodec();
+        if ("aircompressor".equalsIgnoreCase(System.getProperty("orc.compress.snappy.impl"))) {
+          return new SnappyCodec();
+        } else {
+          return new XerialSnappyCodec();
+        }
       case LZO:
         return new AircompressorCodec(kind, new LzoCompressor(),
             new LzoDecompressor());

--- a/java/core/src/java/org/apache/orc/impl/XerialSnappyCodec.java
+++ b/java/core/src/java/org/apache/orc/impl/XerialSnappyCodec.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.orc.CompressionCodec;
+import org.apache.orc.CompressionKind;
+import org.xerial.snappy.Snappy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+public class XerialSnappyCodec implements CompressionCodec, DirectDecompressionCodec {
+  private static final ThreadLocal<byte[]> threadBuffer = ThreadLocal.withInitial(() -> null);
+
+  static {
+    Snappy.getNativeLibraryVersion();
+  }
+
+  public XerialSnappyCodec() {}
+
+  protected static byte[] getBuffer(int size) {
+    byte[] result = threadBuffer.get();
+    if (result == null || result.length < size || result.length > size * 2) {
+      result = new byte[size];
+      threadBuffer.set(result);
+    }
+    return result;
+  }
+
+  @Override
+  public Options getDefaultOptions() {
+    return CompressionCodec.NullOptions.INSTANCE;
+  }
+
+  @Override
+  public boolean compress(ByteBuffer in, ByteBuffer out,
+                          ByteBuffer overflow,
+                          Options options) throws IOException {
+    int inBytes = in.remaining();
+    // Skip with minimum size check similar to ZstdCodec
+    if (inBytes < 10) return false;
+
+    int maxOutputLength = Snappy.maxCompressedLength(inBytes);
+    byte[] compressed = getBuffer(maxOutputLength);
+
+    int outBytes = Snappy.compress(in.array(), in.arrayOffset() + in.position(), inBytes,
+        compressed, 0);
+
+    if (outBytes < inBytes) {
+      int remaining = out.remaining();
+      if (remaining >= outBytes) {
+        System.arraycopy(compressed, 0, out.array(), out.arrayOffset() +
+                out.position(), outBytes);
+        out.position(out.position() + outBytes);
+      } else {
+        System.arraycopy(compressed, 0, out.array(), out.arrayOffset() +
+                out.position(), remaining);
+        out.position(out.limit());
+        System.arraycopy(compressed, remaining, overflow.array(),
+                overflow.arrayOffset(), outBytes - remaining);
+        overflow.position(outBytes - remaining);
+      }
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public void decompress(ByteBuffer in, ByteBuffer out) throws IOException {
+    if (in.isDirect() && out.isDirect()) {
+      directDecompress(in, out);
+      return;
+    }
+
+    int srcOffset = in.arrayOffset() + in.position();
+    int srcSize = in.remaining();
+    int dstOffset = out.arrayOffset() + out.position();
+
+    int decompressedBytes = Snappy.uncompress(in.array(), srcOffset, srcSize, out.array(),
+        dstOffset);
+
+    in.position(in.limit());
+    out.position(dstOffset + decompressedBytes);
+    out.flip();
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  public void directDecompress(ByteBuffer in, ByteBuffer out) throws IOException {
+    // Xerial Snappy supports direct ByteBuffer decompression
+    int outPos = out.position();
+    int decompressedBytes = Snappy.uncompress(in, out);
+    out.position(outPos + decompressedBytes);
+    out.flip();
+  }
+
+  @Override
+  public void reset() {
+  }
+
+  @Override
+  public void destroy() {
+  }
+
+  @Override
+  public CompressionKind getKind() {
+    return CompressionKind.SNAPPY;
+  }
+
+  @Override
+  public void close() {
+    OrcCodecPool.returnCodec(CompressionKind.SNAPPY, this);
+  }
+}

--- a/java/core/src/test/org/apache/orc/impl/TestSnappy.java
+++ b/java/core/src/test/org/apache/orc/impl/TestSnappy.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl;
+
+import org.apache.orc.CompressionCodec;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class TestSnappy {
+
+  @Test
+  public void testNoOverflow() throws Exception {
+    ByteBuffer in = ByteBuffer.allocate(10);
+    ByteBuffer out = ByteBuffer.allocate(10);
+    in.put(new byte[]{1, 2, 3, 4, 5, 6, 7, 10});
+    in.flip();
+    CompressionCodec codec = new XerialSnappyCodec();
+    assertFalse(codec.compress(in, out, null,
+            codec.getDefaultOptions()));
+  }
+
+  @Test
+  public void testCorrupt() throws Exception {
+    ByteBuffer buf = ByteBuffer.allocate(1000);
+    buf.put(new byte[] {127, 125, 1, 99, 98, 1});
+    buf.flip();
+    CompressionCodec codec = new XerialSnappyCodec();
+    ByteBuffer out = ByteBuffer.allocate(1000);
+    try {
+      codec.decompress(buf, out);
+      fail();
+    } catch (IOException e) {
+      // EXPECTED
+    }
+  }
+
+  @Test
+  public void testSnappyCompressDecompress() throws Exception {
+    int inputSize = 10000;
+    CompressionCodec codec = new XerialSnappyCodec();
+
+    ByteBuffer in = ByteBuffer.allocate(inputSize);
+    ByteBuffer out = ByteBuffer.allocate(inputSize);
+    ByteBuffer compressed = ByteBuffer.allocate(inputSize * 2); // Ample space for compressed data
+    ByteBuffer decompressed = ByteBuffer.allocate(inputSize);
+
+    for (int i = 0; i < inputSize; i++) {
+      in.put((byte) i);
+    }
+    in.flip();
+
+    // Compress
+    assertTrue(codec.compress(in, compressed, null, codec.getDefaultOptions()));
+    compressed.flip();
+
+    // Decompress
+    codec.decompress(compressed, decompressed);
+
+    assertArrayEquals(in.array(), decompressed.array());
+  }
+
+  @Test
+  public void testSnappyDirectDecompress() {
+    ByteBuffer in = ByteBuffer.allocate(10000);
+    ByteBuffer out = ByteBuffer.allocate(10000); // Heap buffer for initial compression
+    ByteBuffer directOut = ByteBuffer.allocateDirect(10000);
+    ByteBuffer directResult = ByteBuffer.allocateDirect(10000);
+    for (int i = 0; i < 10000; i++) {
+      in.put((byte) i);
+    }
+    in.flip();
+    try (XerialSnappyCodec codec = new XerialSnappyCodec()) {
+      assertTrue(codec.compress(in, out, null, codec.getDefaultOptions()));
+      out.flip();
+      directOut.put(out);
+      directOut.flip();
+
+      codec.decompress(directOut, directResult);
+
+      // copy result from direct buffer to heap.
+      byte[] heapBytes = new byte[in.array().length];
+      directResult.get(heapBytes, 0, directResult.limit());
+
+      assertArrayEquals(in.array(), heapBytes);
+    } catch (Exception e) {
+      fail(e);
+    }
+  }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -89,6 +89,7 @@
     <project.build.outputTimestamp>2025-07-08T15:22:41Z</project.build.outputTimestamp>
     <protobuf.version>3.25.8</protobuf.version>
     <slf4j.version>2.0.17</slf4j.version>
+    <snappy.version>1.1.10.8</snappy.version>
     <storage-api.version>2.8.1</storage-api.version>
     <surefire.version>3.5.3</surefire.version>
     <test.tmp.dir>${project.build.directory}/testing-tmp</test.tmp.dir>
@@ -165,6 +166,11 @@
         <groupId>io.airlift</groupId>
         <artifactId>aircompressor</artifactId>
         <version>2.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>${snappy.version}</version>
       </dependency>
       <dependency>
         <groupId>at.yawk.lz4</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to support new `XerialSnappyCodec ` to resolve the following.

- https://github.com/apache/orc/security/dependabot/33

### Why are the changes needed?

Aircompressor is not usable in these days because 2.0.x version is frozen. We had better switch to `snappy-java`.

- https://github.com/xerial/snappy-java

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`