### PR TITLE
ORC-2085: Set `strategy.max-parrallel` to 20 for all GitHub Action jobs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -44,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         os:
           - debian12
@@ -66,6 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         os:
           - ubuntu-24.04
@@ -125,6 +127,7 @@ jobs:
     runs-on: windows-2025
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         simd:
           - General
@@ -178,6 +181,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         os:
           - ubuntu-22.04
@@ -270,6 +274,7 @@ jobs:
     needs: [cpp-linter]
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         version: [15, 26]
     runs-on: macos-${{ matrix.version }}
@@ -289,6 +294,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         os:
           - ubuntu-22.04

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 20
       matrix:
         compiler: [gcc, clang]
         include:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to set `strategy.max-parrallel` to 20 for all GitHub Action jobs.

### Why are the changes needed?

To guarantee the max parallelism meets ASF policy for the future.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`