### PR TITLE
ORC-2086: Upgrade Spark to 4.2.0-preview2 and Netty to 4.2.10.Final

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -45,8 +45,8 @@
     <orc.version>${project.version}</orc.version>
     <parquet.version>1.17.0</parquet.version>
     <scala.binary.version>2.13</scala.binary.version>
-    <scala.version>2.13.17</scala.version>
-    <spark.version>4.1.1</spark.version>
+    <scala.version>2.13.18</scala.version>
+    <spark.version>4.2.0-preview2</spark.version>
   </properties>
 
   <dependencyManagement>
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.110.Final</version>
+        <version>4.2.10.Final</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -293,6 +293,10 @@
 
   <repositories>
     <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+    <repository>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to 4.2.0-preview2 and Netty to 4.2.10.Final.

- Spark from 4.1.1 to 4.2.0-preview2
- Scala from 2.13.17 to 2.13.18

And, although Spark 4.2.0-preview2 depends on Netty 4.2.9.Final. This PR bumps Netty to 4.2.10.Final.
- apache/spark#54203

### Why are the changes needed?

To test with the upcoming Apache Spark 4.2.x

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`