### PR TITLE
ORC-2090: Add a new label rule for `MESON` build

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,3 +41,7 @@ JAVA:
 CPP:
   - "c++/**/*"
   - "tools/**/*"
+MESON:
+  - "**/meson.build"
+  - "**/meson.options"
+  - "subprojects/**/*"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a new label rule for `MESON` build.

### Why are the changes needed?

To highlight `MESON` PRs.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.5` on `Claude Code`