### PR TITLE
ORC-2092: Add `ubuntu26` to docker tests and GitHub Action

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -50,6 +50,7 @@ jobs:
           - debian12
           - debian13
           - ubuntu24
+          - ubuntu26
           - oraclelinux9
           - oraclelinux10
           - amazonlinux23

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,7 @@
 
 * Debian 12, and 13
 * Fedora 37
-* Ubuntu 22 and 24
+* Ubuntu 22, 24 and 26
 * Oracle Linux 9 and 10
 * Amazon Linux 2023
 

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -2,6 +2,7 @@ debian12
 debian13
 ubuntu22
 ubuntu24
+ubuntu26
 oraclelinux9
 oraclelinux10
 amazonlinux23

--- a/docker/ubuntu26/Dockerfile
+++ b/docker/ubuntu26/Dockerfile
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for Ubuntu 26
+#
+
+FROM ubuntu:26.04
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on Ubuntu 26"
+LABEL org.opencontainers.image.version=""
+ARG jdk=21
+ARG cc=gcc
+
+RUN apt-get update
+RUN apt-get install -y \
+  cmake \
+  git \
+  make \
+  curl \
+  maven \
+  openjdk-${jdk}-jdk \
+  tzdata; \
+  if [ "${cc}" = "gcc" ] ; then \
+    apt-get install -y \
+    gcc \
+    g++ \
+  ; else \
+    apt-get install -y \
+    clang \
+    && \
+    update-alternatives --set cc  /usr/bin/clang && \
+    update-alternatives --set c++ /usr/bin/clang++ \
+  ; fi
+RUN update-alternatives --set java $(update-alternatives --list java | grep ${jdk}) && \
+    update-alternatives --set javac $(update-alternatives --list javac | grep ${jdk})
+
+ENV CC=cc
+ENV CXX=c++
+
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD if [ ! -d orc ]; then \
+      echo "No volume provided, building from apache main."; \
+      echo "Pass '-v`pwd`:/root/orc' to docker run to build local source."; \
+      git clone https://github.com/apache/orc.git -b main; \
+    fi && \
+    mkdir build && \
+    cd build && \
+    cmake ../orc && \
+    make package test-out

--- a/site/_docs/building.md
+++ b/site/_docs/building.md
@@ -11,7 +11,7 @@ The C++ library is supported on the following operating systems:
 
 * MacOS 15 to 26
 * Debian 12 to 13
-* Ubuntu 22.04 to 24.04
+* Ubuntu 22.04 to 26.04
 * Oracle Linux 9 to 10
 * Amazon Linux 2023
 
@@ -30,6 +30,7 @@ is in the docker subdirectory, for the list of packages required to build ORC:
 * [Debian 13]({{ page.dockerUrl }}/debian13/Dockerfile)
 * [Ubuntu 22]({{ page.dockerUrl }}/ubuntu22/Dockerfile)
 * [Ubuntu 24]({{ page.dockerUrl }}/ubuntu24/Dockerfile)
+* [Ubuntu 26]({{ page.dockerUrl }}/ubuntu26/Dockerfile)
 * [Oracle Linux 9]({{ page.dockerUrl }}/oraclelinux9/Dockerfile)
 * [Oracle Linux 10]({{ page.dockerUrl }}/oraclelinux10/Dockerfile)
 * [Amazon Linux 2023]({{ page.dockerUrl }}/amazonlinux23/Dockerfile)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `ubuntu26` to docker tests and GitHub Action.

### Why are the changes needed?

`Ubuntu 26.04` is coming soon. This aims to be ready for this in advance as a test coverage.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

No.