### PR TITLE
ORC-2096: Remove `doc` dependency from `build` GitHub Actions job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -64,7 +64,7 @@ jobs:
 
   build:
     name: "Java ${{ matrix.java }} and ${{ matrix.cxx }} on ${{ matrix.os }}"
-    needs: [license-check, doc]
+    needs: [license-check]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove `doc` dependency from `build` GitHub Actions job.

### Why are the changes needed?

The Javadoc generation step fails during Apache Hadoop 3.4.3 RC1 testing because RC1 doesn't have a publish doc.
- https://github.com/apache/orc/pull/2503

Since we need to run `build` GitHub Actions job step to validate new Hadoop RCs, we need to remove this dependency.

### How was this patch tested?

Pass the CIs and check the build dependency.

<img width="1177" height="619" alt="Screenshot 2026-02-18 at 15 10 47" src="https://github.com/user-attachments/assets/c339d390-9f1b-4405-b6fc-bb8ad5a4c06b" />

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`