### PR TITLE
ORC-2097: Make `actions/*` GitHub Actions jobs up-to-date

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -56,7 +56,7 @@ jobs:
           - amazonlinux23
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: "Test"
       run: |
         cd docker
@@ -95,9 +95,9 @@ jobs:
       MAVEN_SKIP_RC: true
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Install Java ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: ${{ matrix.java }}
@@ -138,7 +138,7 @@ jobs:
       VCPKG_ROOT: C:/vcpkg
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
       with:
@@ -170,7 +170,7 @@ jobs:
         ctest -C Release --output-on-failure
     - name: "Upload Build Artifacts"
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: windows-build-logs-${{ matrix.simd }}
         path: build/
@@ -192,7 +192,7 @@ jobs:
       ORC_USER_SIMD_LEVEL: AVX512
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: "Test"
       run: |
         mkdir -p ~/.m2
@@ -206,7 +206,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Super-Linter
@@ -216,7 +216,7 @@ jobs:
         VALIDATE_MARKDOWN: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Java 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: 17
@@ -232,7 +232,7 @@ jobs:
     runs-on: ubuntu-24.04
     needs: [license-check]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Run build
         run: |
           mkdir build && cd build
@@ -262,7 +262,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Check license header
         uses: apache/skywalking-eyes@main
         env:
@@ -281,7 +281,7 @@ jobs:
     runs-on: macos-${{ matrix.version }}
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Test
       run: |
         CMAKE_PREFIX_PATH=$(brew --prefix protobuf)
@@ -305,8 +305,8 @@ jobs:
           - macos-26
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.x'
     - name: Install meson

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,12 +40,12 @@ jobs:
     if: github.repository == 'apache/orc'
     steps:
       - name: Checkout ORC repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: apache/orc
           ref: 'main'
       - name: Install Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 17
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'site/target'
       - name: Deploy to GitHub Pages

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -10,9 +10,9 @@ jobs:
     if: github.repository == 'apache/orc'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v5
       with:
         distribution: zulu
         java-version: 17

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -47,7 +47,7 @@ jobs:
             cxx: clang++
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - name: Install dependencies
       run: |
         sudo apt-get update
@@ -70,7 +70,7 @@ jobs:
         ctest -V --output-on-failure
     - name: Save the test output
       if: always()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@v6
       with:
         name: test-output
         path: "**/out.log*"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -27,7 +27,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@c201d45ef4b0ccbd3bb0616f93bae13e73d0a080 # pin@v1.1.0
+    - uses: actions/stale@v10
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-pr-message: >


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to make `actions/*` GitHub Actions jobs up-to-date.

### Why are the changes needed?

To keep the CIs up-to-date.

| Action | Old Version | New Version |
| :--- | :--- | :--- |
| actions/checkout | v4, v5 | v6 |
| actions/setup-java | v3, v4 | v5 |
| actions/upload-artifact | v4, v4.6.2 | v6 |
| actions/setup-python | v5 | v6 |
| actions/upload-pages-artifact | v3 | v4 |
| actions/stale | v1.1.0 | v10 |


### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3 Pro (High)` on `Antigravity`