### PR TITLE
ORC-2098: Exclude `.mvn/maven.config` for `apache-rat-plugin`

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -442,6 +442,7 @@
               <exclude>**/*.iml</exclude>
               <exclude>**/dependency-reduced-pom.xml</exclude>
               <exclude>.mvn/jvm.config</exclude>
+              <exclude>.mvn/maven.config</exclude>
             </excludes>
           </configuration>
           <executions>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to exclude `.mvn/maven.config` for `apache-rat-plugin`.

### Why are the changes needed?

To avoid the build failures.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Opus 4.6 (1M context)` on `Claude Code`