### PR TITLE
ORC-2101: Enable GitHub Action CI in `branch-2.3`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -23,13 +23,13 @@ on:
     - 'site/**'
     - 'conan/**'
     branches:
-    - main
+    - branch-2.3
   pull_request:
     paths-ignore:
     - 'site/**'
     - 'conan/**'
     branches:
-    - main
+    - branch-2.3
   workflow_call:
 
 # Cancel previous PR build and test
@@ -60,7 +60,7 @@ jobs:
     - name: "Test"
       run: |
         cd docker
-        ./run-one.sh local main ${{ matrix.os }}
+        ./run-one.sh local branch-2.3 ${{ matrix.os }}
 
   build:
     name: "Java ${{ matrix.java }} and ${{ matrix.cxx }} on ${{ matrix.os }}"

--- a/.github/workflows/publish_snapshot.yml
+++ b/.github/workflows/publish_snapshot.yml
@@ -3,7 +3,7 @@ name: Publish Snapshot
 on:
   push:
     branches:
-    - main
+    - branch-2.3
 
 jobs:
   publish-snapshot:

--- a/.github/workflows/sanitizer_test.yml
+++ b/.github/workflows/sanitizer_test.yml
@@ -23,7 +23,7 @@ on:
     - 'site/**'
     - 'conan/**'
     branches:
-    - main
+    - branch-2.3
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to enable GitHub Action CI in `branch-2.3`.

### Why are the changes needed?

Since `branch-2.3` is newly created, we need to enable CIs.
- https://github.com/apache/orc/tree/branch-2.3

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`