### PR TITLE
ORC-2103: Update CMake requirements to 3.25+ consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The subdirectories are:
 
 * Install java 17 or higher
 * Install maven 3.9.9 or higher
-* Install cmake 3.12 or higher
+* Install cmake 3.25.0 or higher
 * Install meson 1.3.0 or higher (Optional)
 
 To build a release version with debug information:

--- a/conan/all/test_package/CMakeLists.txt
+++ b/conan/all/test_package/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.25.0)
 project(test_package LANGUAGES CXX)
 
 find_package(orc REQUIRED CONFIG)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update CMake requirements to 3.25+ consistently.

### Why are the changes needed?

We had better fix these outdated information because we already bumped the minimum requirement to 3.25+.
- https://github.com/apache/orc/pull/2416

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`