### PR TITLE
ORC-2106: Add `Build Status` table of all live branches to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ Releases:
 
 The current build status:
 
-* Main branch [![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain)
+| Branch | Build Status |
+| :--- | :--- |
+| main | [![main build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=main)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Amain) |
+| branch-2.3 | [![branch-2.3 build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=branch-2.3)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Abranch-2.3) |
+| branch-2.2 | [![branch-2.2 build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=branch-2.2)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Abranch-2.2) |
+| branch-2.1 | [![branch-2.1 build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=branch-2.1)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Abranch-2.1) |
+| branch-2.0 | [![branch-2.0 build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=branch-2.0)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Abranch-2.0) |
+| branch-1.9 | [![branch-1.9 build status](https://github.com/apache/orc/actions/workflows/build_and_test.yml/badge.svg?branch=branch-1.9)](https://github.com/apache/orc/actions/workflows/build_and_test.yml?query=branch%3Abranch-1.9) |
 
 Bug tracking: [Apache Jira](https://orc.apache.org/bugs)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `Build Status` table of all live branches to `README.md`.

### Why are the changes needed?

To improve the visibility of all live release branches.

### How was this patch tested?

Check the PR branch.

- https://github.com/dongjoon-hyun/orc/tree/ORC-2106

<img width="370" height="382" alt="Screenshot 2026-02-22 at 21 02 28" src="https://github.com/user-attachments/assets/b61922ca-6c63-4943-87f2-eaf1caa4365b" />

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`