### PR TITLE
ORC-2108: Add connection timeout to JIRA client to prevent hanging and enable retries

### DIFF
--- a/dev/create_orc_jira.py
+++ b/dev/create_orc_jira.py
@@ -53,7 +53,8 @@ import argparse
 def create_jira_issue(title, parent_jira_id=None, issue_type=None):
     asf_jira = jira.client.JIRA(
         {"server": JIRA_API_BASE},
-        token_auth=JIRA_ACCESS_TOKEN
+        token_auth=JIRA_ACCESS_TOKEN,
+        timeout=(3.05, 30)
     )
 
     versions = asf_jira.project_versions("ORC")

--- a/dev/merge_orc_pr.py
+++ b/dev/merge_orc_pr.py
@@ -249,7 +249,8 @@ def fix_version_from_branch(branch, versions):
 def resolve_jira_issue(merge_branches, comment, default_jira_id=""):
     asf_jira = jira.client.JIRA(
         {"server": JIRA_API_BASE},
-        token_auth=JIRA_ACCESS_TOKEN
+        token_auth=JIRA_ACCESS_TOKEN,
+        timeout=(3.05, 30)
     )
 
     jira_id = input("Enter a JIRA id [%s]: " % default_jira_id)


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add a generic connection and read timeout parameter timeout=(3.05, 30) to the `jira.client.JIRA()` initializations in the dev/ scripts:
- `create_orc_jira.py`
- `merge_orc_pr.py`

### Why are the changes needed?

By default, the requests library (used by the jira python package) can hang indefinitely when attempting to establish a connection if the server is unresponsive. Setting a short connection timeout of 3.05 seconds (slightly larger than a standard 3-second TCP packet retransmission window) ensures that the client will quickly fail the connection attempt and properly trigger its internal retry logic, rather than stalling the entire script. The 30-second read timeout allows sufficient time for normal API responses once the connection is successfully established.

### How was this patch tested?

Manual tests.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: `Gemini 3.1 Pro (High)` on `Antigravity`