### PR TITLE
ORC-2148: Upgrade `lz4-java` to 1.11.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.10.4</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `at.yawk.lz4:lz4-java` to 1.11.0.

### Why are the changes needed?

To keep up with the latest version of `lz4-java`.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.6