### PR TITLE
ORC-2153: Upgrade `bcpkix-jdk18on` to 1.84

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,7 @@
   </modules>
 
   <properties>
-    <bouncycastle.version>1.83</bouncycastle.version>
+    <bouncycastle.version>1.84</bouncycastle.version>
     <brotli4j.version>1.22.0</brotli4j.version>
     <checkstyle.version>12.3.1</checkstyle.version>
     <commons-cli.version>1.11.0</commons-cli.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `bcpkix-jdk18on` to 1.84.

### Why are the changes needed?

To bring the latest bug fixes.
- https://www.bouncycastle.org/download/bouncy-castle-java/#releasenotes

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7