### PR TITLE
ORC-2154: Upgrade Guava to 33.6.0-jre

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -238,7 +238,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>33.5.0-jre</version>
+        <version>33.6.0-jre</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Guava to 33.6.0-jre.

### Why are the changes needed?

To bring the latest bug fixes and improvements from the upstream Guava project.

- https://github.com/google/guava/releases/tag/v33.6.0

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7