### PR TITLE
ORC-2155: Upgrade `spotbugs-maven-plugin` to 4.9.8.3

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -416,7 +416,7 @@
         <plugin>
           <groupId>com.github.spotbugs</groupId>
           <artifactId>spotbugs-maven-plugin</artifactId>
-          <version>4.9.8.2</version>
+          <version>4.9.8.3</version>
           <configuration>
             <includeFilterFile>spotbugs-include.xml</includeFilterFile>
             <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `spotbugs-maven-plugin` to 4.9.8.3.

### Why are the changes needed?

To bring the latest bug fixes.
- https://github.com/spotbugs/spotbugs-maven-plugin/releases/tag/spotbugs-maven-plugin-4.9.8.3

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7