### PR TITLE
ORC-2158: Add 7-day cooldown to Dependabot maven updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,8 @@ updates:
     directory: "/java"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     ignore:
       # Pin gson to 2.9.0 because of Hive
       - dependency-name: "com.google.code.gson:gson"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR adds a 7-day `cooldown` to Dependabot for the Maven ecosystem.

```yaml
cooldown:
  default-days: 7
```

### Why are the changes needed?

To skip newly released versions until 7 days have passed, reducing the risk of importing early-release regressions and supply-chain attacks (e.g., compromised or malicious releases that are typically yanked or flagged within days of publication).

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)