### PR TITLE
ORC-2159: [C++] Fix C++ build with nodiscard return values

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -144,7 +144,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -G "Visual Studio 17 2022" \
+        cmake .. -G "Visual Studio 18 2026" \
           -DCMAKE_BUILD_TYPE=RELEASE \
           -DBUILD_TOOLS=OFF \
           -DBUILD_JAVA=OFF \

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -435,7 +435,7 @@ namespace orc {
       const size_t cap = static_cast<size_t>(std::numeric_limits<int>::max());
       while (sizeToSkip != 0) {
         size_t step = sizeToSkip > cap ? cap : sizeToSkip;
-        inputStream_->Skip(static_cast<int>(step));
+        static_cast<void>(inputStream_->Skip(static_cast<int>(step)));
         sizeToSkip -= step;
       }
       bufferEnd_ = nullptr;
@@ -681,7 +681,7 @@ namespace orc {
       const size_t cap = static_cast<size_t>(std::numeric_limits<int>::max());
       while (totalBytes != 0) {
         size_t step = totalBytes > cap ? cap : totalBytes;
-        blobStream_->Skip(static_cast<int>(step));
+        static_cast<void>(blobStream_->Skip(static_cast<int>(step)));
         totalBytes -= step;
       }
       lastBufferLength_ = 0;

--- a/c++/src/ColumnReader.cc
+++ b/c++/src/ColumnReader.cc
@@ -19,6 +19,7 @@
 #include "ColumnReader.hh"
 
 #include <cmath>
+#include <tuple>
 
 #include "Adaptor.hh"
 #include "ByteRLE.hh"
@@ -435,7 +436,7 @@ namespace orc {
       const size_t cap = static_cast<size_t>(std::numeric_limits<int>::max());
       while (sizeToSkip != 0) {
         size_t step = sizeToSkip > cap ? cap : sizeToSkip;
-        static_cast<void>(inputStream_->Skip(static_cast<int>(step)));
+        std::ignore = inputStream_->Skip(static_cast<int>(step));
         sizeToSkip -= step;
       }
       bufferEnd_ = nullptr;
@@ -681,7 +682,7 @@ namespace orc {
       const size_t cap = static_cast<size_t>(std::numeric_limits<int>::max());
       while (totalBytes != 0) {
         size_t step = totalBytes > cap ? cap : totalBytes;
-        static_cast<void>(blobStream_->Skip(static_cast<int>(step)));
+        std::ignore = blobStream_->Skip(static_cast<int>(step));
         totalBytes -= step;
       }
       lastBufferLength_ = 0;

--- a/c++/src/ColumnWriter.cc
+++ b/c++/src/ColumnWriter.cc
@@ -212,7 +212,9 @@ namespace orc {
       }
     }
     // write row index to output stream
-    rowIndex->SerializeToZeroCopyStream(indexStream.get());
+    if (!rowIndex->SerializeToZeroCopyStream(indexStream.get())) {
+      throw std::logic_error("Failed to write row index stream.");
+    }
 
     // construct row index stream
     proto::Stream stream;

--- a/c++/test/TestBufferedOutputStream.cc
+++ b/c++/test/TestBufferedOutputStream.cc
@@ -122,7 +122,7 @@ namespace orc {
     EXPECT_EQ(ps.ByteSizeLong(), memStream.getLength());
 
     proto::PostScript ps2;
-    ps2.ParseFromArray(memStream.getData(), static_cast<int>(memStream.getLength()));
+    EXPECT_TRUE(ps2.ParseFromArray(memStream.getData(), static_cast<int>(memStream.getLength())));
 
     EXPECT_EQ(ps.footer_length(), ps2.footer_length());
     EXPECT_EQ(ps.compression(), ps2.compression());

--- a/c++/test/TestCompression.cc
+++ b/c++/test/TestCompression.cc
@@ -218,7 +218,7 @@ namespace orc {
         kind, std::move(inputStream), capacity, *pool, getDefaultReaderMetrics());
 
     proto::PostScript ps2;
-    ps2.ParseFromZeroCopyStream(decompressStream.get());
+    EXPECT_TRUE(ps2.ParseFromZeroCopyStream(decompressStream.get()));
 
     EXPECT_EQ(ps.footer_length(), ps2.footer_length());
     EXPECT_EQ(ps.compression(), ps2.compression());
@@ -351,14 +351,14 @@ namespace orc {
 
     // seek to positions between first two batches
     decompressStream->seek(provider1);
-    decompressStream->Next(&data, &size);
+    ASSERT_TRUE(decompressStream->Next(&data, &size));
     std::string data1(static_cast<const char*>(data), 4);
     std::string expected1 = "1024";
     EXPECT_EQ(expected1, data1);
 
     // seek to positions between last two batches
     decompressStream->seek(provider2);
-    decompressStream->Next(&data, &size);
+    ASSERT_TRUE(decompressStream->Next(&data, &size));
     std::string data2(static_cast<const char*>(data), 4);
     std::string expected2 = "2048";
     EXPECT_EQ(expected2, data2);

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -189,7 +189,7 @@ namespace orc {
     EXPECT_EQ(20, len);
     stream.BackUp(10);
     EXPECT_EQ(10, stream.ByteCount());
-    stream.Skip(4);
+    ASSERT_TRUE(stream.Skip(4));
     EXPECT_EQ(14, stream.ByteCount());
     ASSERT_EQ(true, stream.Next(&ptr, &len));
     EXPECT_EQ(bytes.data() + 14, static_cast<const char*>(ptr));
@@ -268,7 +268,7 @@ namespace orc {
     EXPECT_EQ(20, len);
     stream.BackUp(10);
     EXPECT_EQ(10, stream.ByteCount());
-    stream.Skip(4);
+    ASSERT_TRUE(stream.Skip(4));
     EXPECT_EQ(14, stream.ByteCount());
     ASSERT_EQ(true, stream.Next(&ptr, &len));
     checkBytes(static_cast<const char*>(ptr), len, 14);
@@ -322,7 +322,7 @@ namespace orc {
                            32768, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
-    result->Next(&ptr, &length);
+    ASSERT_TRUE(result->Next(&ptr, &length));
     for (unsigned int i = 0; i < bytes.size(); ++i) {
       EXPECT_EQ(static_cast<char>(i), static_cast<const char*>(ptr)[i]);
     }
@@ -412,7 +412,12 @@ namespace orc {
         128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
     const void* ptr;
     int length;
-    EXPECT_THROW(result->Next(&ptr, &length), ParseError);
+    EXPECT_THROW(
+        {
+          bool next = result->Next(&ptr, &length);
+          static_cast<void>(next);
+        },
+        ParseError);
   }
 
   TEST_F(TestDecompression, testLz4Empty) {
@@ -600,7 +605,7 @@ namespace orc {
     int length;
     ASSERT_EQ(true, result->Next(&ptr, &length));
     ASSERT_EQ(2, length);
-    result->Skip(2);
+    ASSERT_TRUE(result->Skip(2));
     ASSERT_EQ(true, result->Next(&ptr, &length));
     ASSERT_EQ(3, length);
     EXPECT_EQ(4, static_cast<const char*>(ptr)[0]);
@@ -611,7 +616,7 @@ namespace orc {
     ASSERT_EQ(2, length);
     EXPECT_EQ(5, static_cast<const char*>(ptr)[0]);
     EXPECT_EQ(6, static_cast<const char*>(ptr)[1]);
-    result->Skip(8);
+    ASSERT_TRUE(result->Skip(8));
     ASSERT_EQ(true, result->Next(&ptr, &length));
     ASSERT_EQ(2, length);
     EXPECT_EQ(15, static_cast<const char*>(ptr)[0]);

--- a/tools/src/FileMetadata.cc
+++ b/tools/src/FileMetadata.cc
@@ -27,8 +27,8 @@
 #include "orc/OrcFile.hh"
 
 // #include "Adaptor.hh"
-#include "wrap/orc-proto-wrapper.hh"
 #include <google/protobuf/text_format.h>
+#include "wrap/orc-proto-wrapper.hh"
 
 void printStripeInformation(std::ostream& out, uint64_t index, uint64_t columns,
                             std::unique_ptr<orc::StripeInformation> stripe, bool verbose) {
@@ -85,7 +85,9 @@ void printRawTail(std::ostream& out, const char* filename) {
   }
   google::protobuf::TextFormat::Printer printer;
   std::string text_output;
-  printer.PrintToString(tail, &text_output);
+  if (!printer.PrintToString(tail, &text_output)) {
+    throw orc::ParseError("Failed to print the file tail");
+  }
   out << text_output;
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Handle protobuf and ZeroCopyStream boolean results required by newer headers. Check serialization and text-format failures in writer/tool code, and make affected tests assert parse, next, and skip results explicitly while preserving existing reader skip behavior.

### Why are the changes needed?

The C++ build fails with newer protobuf / compiler headers because several boolean-returning APIs are marked nodiscard and their return values are ignored. Since the C++ build treats warnings as errors, these become hard build failures.

The build fails with errors like:

  ColumnReader.cc:438:9: error: ignoring return value of function declared with 'nodiscard' attribute [-Werror,-Wunused-result]
    inputStream_->Skip(static_cast<int>(step));

  ColumnReader.cc:684:9: error: ignoring return value of function declared with 'nodiscard' attribute [-Werror,-Wunused-result]
    blobStream_->Skip(static_cast<int>(step));

  ColumnWriter.cc:215:5: error: ignoring return value of function declared with 'nodiscard' attribute [-Werror,-Wunused-result]
    rowIndex->SerializeToZeroCopyStream(indexStream.get());


### How was this patch tested?

Pass CIs and build are happy locally.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Codex Version 26.429.61741 (2429)
