### PR TITLE
ORC-2164: [C++] Add external-buffer support in DataBuffer lifecycle management

### DIFF
--- a/c++/include/orc/MemoryPool.hh
+++ b/c++/include/orc/MemoryPool.hh
@@ -42,13 +42,15 @@ namespace orc {
     uint64_t currentSize_;
     // maximal capacity (actual allocated memory)
     uint64_t currentCapacity_;
+    // whether this buffer owns memory lifecycle
+    bool ownBuffer_;
 
     // not implemented
     DataBuffer(DataBuffer& buffer);
     DataBuffer& operator=(DataBuffer& buffer);
 
    public:
-    DataBuffer(MemoryPool& pool, uint64_t size = 0);
+    DataBuffer(MemoryPool& pool, uint64_t size = 0, bool ownBuf = true);
 
     DataBuffer(DataBuffer<T>&& buffer) noexcept;
 
@@ -81,6 +83,9 @@ namespace orc {
     void reserve(uint64_t size);
     void resize(uint64_t size);
     void zeroOut();
+
+    // Attach to an external raw buffer. bufSize is in bytes.
+    void setData(T* buf, size_t bufSize);
   };
 
   // Specializations for char

--- a/c++/src/MemoryPool.cc
+++ b/c++/src/MemoryPool.cc
@@ -54,11 +54,7 @@ namespace orc {
 
   template <class T>
   DataBuffer<T>::DataBuffer(MemoryPool& pool, uint64_t newSize, bool ownBuf)
-      : memoryPool_(pool),
-        buf_(nullptr),
-        currentSize_(0),
-        currentCapacity_(0),
-        ownBuffer_(ownBuf) {
+      : memoryPool_(pool), buf_(nullptr), currentSize_(0), currentCapacity_(0), ownBuffer_(ownBuf) {
     if (ownBuffer_) {
       reserve(newSize);
       currentSize_ = newSize;

--- a/c++/src/MemoryPool.cc
+++ b/c++/src/MemoryPool.cc
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <cstdlib>
 #include <iostream>
+#include <type_traits>
 
 namespace orc {
 
@@ -52,10 +53,16 @@ namespace orc {
   }
 
   template <class T>
-  DataBuffer<T>::DataBuffer(MemoryPool& pool, uint64_t newSize)
-      : memoryPool_(pool), buf_(nullptr), currentSize_(0), currentCapacity_(0) {
-    reserve(newSize);
-    currentSize_ = newSize;
+  DataBuffer<T>::DataBuffer(MemoryPool& pool, uint64_t newSize, bool ownBuf)
+      : memoryPool_(pool),
+        buf_(nullptr),
+        currentSize_(0),
+        currentCapacity_(0),
+        ownBuffer_(ownBuf) {
+    if (ownBuffer_) {
+      reserve(newSize);
+      currentSize_ = newSize;
+    }
   }
 
   template <class T>
@@ -63,24 +70,34 @@ namespace orc {
       : memoryPool_(buffer.memoryPool_),
         buf_(buffer.buf_),
         currentSize_(buffer.currentSize_),
-        currentCapacity_(buffer.currentCapacity_) {
+        currentCapacity_(buffer.currentCapacity_),
+        ownBuffer_(buffer.ownBuffer_) {
     buffer.buf_ = nullptr;
     buffer.currentSize_ = 0;
     buffer.currentCapacity_ = 0;
+    buffer.ownBuffer_ = true;
   }
 
   template <class T>
   DataBuffer<T>::~DataBuffer() {
+    if (!ownBuffer_) {
+      return;
+    }
     for (uint64_t i = currentSize_; i > 0; --i) {
       (buf_ + i - 1)->~T();
     }
     if (buf_) {
+      static_assert(std::is_trivially_copyable<T>::value,
+                    "Only trivially copyable type is supported for DataBuffer reserve");
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <class T>
   void DataBuffer<T>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (currentSize_ > newSize) {
       for (uint64_t i = currentSize_; i > newSize; --i) {
@@ -96,6 +113,9 @@ namespace orc {
 
   template <class T>
   void DataBuffer<T>::reserve(uint64_t newCapacity) {
+    if (!ownBuffer_) {
+      return;
+    }
     if (newCapacity > currentCapacity_ || !buf_) {
       if (buf_) {
         T* buf_old = buf_;
@@ -114,6 +134,18 @@ namespace orc {
     memset(buf_, 0, sizeof(T) * currentCapacity_);
   }
 
+  template <class T>
+  void DataBuffer<T>::setData(T* buffer, size_t bufSize) {
+    if (ownBuffer_ && buf_) {
+      static_assert(std::is_trivially_copyable<T>::value,
+                    "Only trivially copyable type is supported for DataBuffer reserve");
+      memoryPool_.free(reinterpret_cast<char*>(buf_));
+    }
+    ownBuffer_ = false;
+    buf_ = buffer;
+    currentSize_ = currentCapacity_ = static_cast<uint64_t>(bufSize / sizeof(T));
+  }
+
   // Specializations for Int128
   template <>
   void DataBuffer<Int128>::zeroOut() {
@@ -126,13 +158,16 @@ namespace orc {
 
   template <>
   DataBuffer<char>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<char>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, newSize - currentSize_);
@@ -144,13 +179,16 @@ namespace orc {
 
   template <>
   DataBuffer<char*>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<char*>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(char*));
@@ -162,13 +200,16 @@ namespace orc {
 
   template <>
   DataBuffer<double>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<double>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(double));
@@ -180,13 +221,16 @@ namespace orc {
 
   template <>
   DataBuffer<float>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<float>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(float));
@@ -198,13 +242,16 @@ namespace orc {
 
   template <>
   DataBuffer<int64_t>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<int64_t>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(int64_t));
@@ -216,13 +263,16 @@ namespace orc {
 
   template <>
   DataBuffer<int32_t>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<int32_t>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(int32_t));
@@ -234,13 +284,16 @@ namespace orc {
 
   template <>
   DataBuffer<int16_t>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<int16_t>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(int16_t));
@@ -252,13 +305,16 @@ namespace orc {
 
   template <>
   DataBuffer<int8_t>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<int8_t>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(int8_t));
@@ -270,13 +326,16 @@ namespace orc {
 
   template <>
   DataBuffer<uint64_t>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<uint64_t>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, (newSize - currentSize_) * sizeof(uint64_t));
@@ -288,13 +347,16 @@ namespace orc {
 
   template <>
   DataBuffer<unsigned char>::~DataBuffer() {
-    if (buf_) {
+    if (ownBuffer_ && buf_) {
       memoryPool_.free(reinterpret_cast<char*>(buf_));
     }
   }
 
   template <>
   void DataBuffer<unsigned char>::resize(uint64_t newSize) {
+    if (!ownBuffer_) {
+      return;
+    }
     reserve(newSize);
     if (newSize > currentSize_) {
       memset(buf_ + currentSize_, 0, newSize - currentSize_);

--- a/c++/test/TestCache.cc
+++ b/c++/test/TestCache.cc
@@ -172,7 +172,8 @@ namespace orc {
       EXPECT_EQ(sizeof(external), buffer.size());
     }
 
-    // setData may release previously owned internal memory, but destruction should not free external.
+    // setData may release previously owned internal memory, but destruction should not free
+    // external.
     EXPECT_EQ(freeCountAfterSetData, pool.freeCount);
   }
 }  // namespace orc

--- a/c++/test/TestCache.cc
+++ b/c++/test/TestCache.cc
@@ -26,6 +26,22 @@
 
 namespace orc {
 
+  class CountingMemoryPool : public MemoryPool {
+   public:
+    uint64_t allocCount = 0;
+    uint64_t freeCount = 0;
+
+    char* malloc(uint64_t size) override {
+      ++allocCount;
+      return static_cast<char*>(std::malloc(size));
+    }
+
+    void free(char* p) override {
+      ++freeCount;
+      std::free(p);
+    }
+  };
+
   TEST(TestReadRangeCombiner, testBasics) {
     ReadRangeCombiner combinator{0, 100};
     /// Ranges with partial overlap and identical offsets
@@ -138,5 +154,25 @@ namespace orc {
     assert_slice_equal(slice, "klmn");
     slice = cache.read({20, 2});
     assert_slice_equal(slice, "uv");
+  }
+
+  TEST(TestDataBuffer, testExternalBufferNonOwning) {
+    CountingMemoryPool pool;
+    char external[16] = {0};
+    uint64_t freeCountAfterSetData = 0;
+
+    {
+      DataBuffer<char> buffer(pool, 0);
+      buffer.setData(external, sizeof(external));
+      freeCountAfterSetData = pool.freeCount;
+
+      // Non-owning buffer should keep external size and ignore resize.
+      EXPECT_EQ(sizeof(external), buffer.size());
+      buffer.resize(8);
+      EXPECT_EQ(sizeof(external), buffer.size());
+    }
+
+    // setData may release previously owned internal memory, but destruction should not free external.
+    EXPECT_EQ(freeCountAfterSetData, pool.freeCount);
   }
 }  // namespace orc


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->

This PR adds non-owning buffer support to DataBuffer so it can attach externally managed memory (via setData) without taking ownership of allocation/free, updates reserve/resize/destructor paths to be ownership-aware, and adds a focused unit test to verify that non-owning buffers keep external size semantics and do not free external memory during destruction.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

These changes are needed to safely integrate with external prebuffer cache scenarios where memory is managed outside ORC, avoiding unnecessary reallocations and preventing ownership/lifecycle mismatches.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: GPT-5.3-codex
