### PR TITLE
ORC-2167: [C++] Fix integer overflow in PostScript footer length validation

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -1253,10 +1253,8 @@ namespace orc {
           stripeTotalLength >= fileLength) {
         std::stringstream msg;
         msg << "Malformed StripeInformation at stripe index " << currentStripe_
-            << ": fileLength=" << fileLength
-            << ", StripeInfo=(offset=" << stripeOffset
-            << ", indexLength=" << indexLength
-            << ", dataLength=" << dataLength
+            << ": fileLength=" << fileLength << ", StripeInfo=(offset=" << stripeOffset
+            << ", indexLength=" << indexLength << ", dataLength=" << dataLength
             << ", footerLength=" << footerLength << ")";
         throw ParseError(msg.str());
       }
@@ -1664,8 +1662,7 @@ namespace orc {
           addOverflow(tailSize, footerSize, &tailSize) || tailSize >= fileLength) {
         std::stringstream msg;
         msg << "Invalid tail size: footerSize=" << footerSize
-            << ", postscriptLength=" << postscriptLength
-            << ", fileLength=" << fileLength;
+            << ", postscriptLength=" << postscriptLength << ", fileLength=" << fileLength;
         throw ParseError(msg.str());
       }
       uint64_t footerOffset;

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -885,20 +885,12 @@ namespace orc {
     uint64_t metadataSize = contents_->postscript->metadata_length();
     uint64_t footerLength = contents_->postscript->footer_length();
 
-    // Check for potential overflow before bounds validation
-    if (footerLength > fileLength_ || metadataSize > fileLength_ ||
-        postscriptLength_ > fileLength_) {
-      std::stringstream msg;
-      msg << "Invalid length values: footerLength=" << footerLength
-          << ", metadataLength=" << metadataSize
-          << ", postscriptLength=" << postscriptLength_
-          << ", fileLength=" << fileLength_;
-      throw ParseError(msg.str());
-    }
-
-    // Use subtraction-based check to avoid integer overflow
-    if (fileLength_ - footerLength < postscriptLength_ + 1 ||
-        fileLength_ - footerLength - postscriptLength_ - 1 < metadataSize) {
+    // Check for overflow in length calculations
+    uint64_t totalTail;
+    if (__builtin_add_overflow(footerLength, metadataSize, &totalTail) ||
+        __builtin_add_overflow(totalTail, postscriptLength_, &totalTail) ||
+        __builtin_add_overflow(totalTail, 1ULL, &totalTail) ||
+        totalTail > fileLength_) {
       std::stringstream msg;
       msg << "Invalid Metadata length: fileLength=" << fileLength_
           << ", metadataLength=" << metadataSize << ", footerLength=" << footerLength
@@ -906,7 +898,7 @@ namespace orc {
       throw ParseError(msg.str());
     }
 
-    uint64_t metadataStart = fileLength_ - metadataSize - footerLength - postscriptLength_ - 1;
+    uint64_t metadataStart = fileLength_ - totalTail;
     if (metadataSize != 0) {
       std::unique_ptr<SeekableInputStream> pbStream = createDecompressor(
           contents_->compression,
@@ -1242,25 +1234,17 @@ namespace orc {
       currentStripeInfo_ = footer_->stripes(static_cast<int>(currentStripe_));
       uint64_t fileLength = contents_->stream->getLength();
 
-      // Check for potential overflow in stripe length calculations
       uint64_t stripeOffset = currentStripeInfo_.offset();
       uint64_t indexLength = currentStripeInfo_.index_length();
       uint64_t dataLength = currentStripeInfo_.data_length();
       uint64_t footerLength = currentStripeInfo_.footer_length();
 
-      if (stripeOffset > fileLength || indexLength > fileLength ||
-          dataLength > fileLength || footerLength > fileLength) {
-        std::stringstream msg;
-        msg << "Invalid stripe length values at stripe index " << currentStripe_
-            << ": offset=" << stripeOffset << ", indexLength=" << indexLength
-            << ", dataLength=" << dataLength << ", footerLength=" << footerLength
-            << ", fileLength=" << fileLength;
-        throw ParseError(msg.str());
-      }
-
-      // Use subtraction-based checks to avoid addition overflow
-      uint64_t remainingSpace = fileLength - stripeOffset;
-      if (remainingSpace <= indexLength) {
+      // Check for overflow and bounds validity
+      uint64_t stripeTotalLength;
+      if (__builtin_add_overflow(indexLength, dataLength, &stripeTotalLength) ||
+          __builtin_add_overflow(stripeTotalLength, footerLength, &stripeTotalLength) ||
+          __builtin_add_overflow(stripeOffset, stripeTotalLength, &stripeTotalLength) ||
+          stripeTotalLength >= fileLength) {
         std::stringstream msg;
         msg << "Malformed StripeInformation at stripe index " << currentStripe_
             << ": fileLength=" << fileLength
@@ -1270,30 +1254,6 @@ namespace orc {
             << ", footerLength=" << footerLength << ")";
         throw ParseError(msg.str());
       }
-
-      if (remainingSpace - indexLength <= dataLength) {
-        std::stringstream msg;
-        msg << "Malformed StripeInformation at stripe index " << currentStripe_
-            << ": fileLength=" << fileLength
-            << ", StripeInfo=(offset=" << stripeOffset
-            << ", indexLength=" << indexLength
-            << ", dataLength=" << dataLength
-            << ", footerLength=" << footerLength << ")";
-        throw ParseError(msg.str());
-      }
-
-      if (remainingSpace - indexLength - dataLength <= footerLength) {
-        std::stringstream msg;
-        msg << "Malformed StripeInformation at stripe index " << currentStripe_
-            << ": fileLength=" << fileLength
-            << ", StripeInfo=(offset=" << stripeOffset
-            << ", indexLength=" << indexLength
-            << ", dataLength=" << dataLength
-            << ", footerLength=" << footerLength << ")";
-        throw ParseError(msg.str());
-      }
-
-      uint64_t stripeTotalLength = indexLength + dataLength + footerLength;
       rowsInCurrentStripe_ = currentStripeInfo_.number_of_rows();
       processingStripe_ = currentStripe_;
 
@@ -1692,28 +1652,15 @@ namespace orc {
       contents->postscript = readPostscript(stream.get(), buffer.get(), postscriptLength);
       uint64_t footerSize = contents->postscript->footer_length();
 
-      // Check for potential overflow before calculating tailSize
-      if (footerSize > fileLength || postscriptLength > fileLength) {
-        std::stringstream msg;
-        msg << "Invalid length values: footerSize=" << footerSize
-            << ", postscriptLength=" << postscriptLength
-            << ", fileLength=" << fileLength;
-        throw ParseError(msg.str());
-      }
-
-      // Use subtraction-based check to avoid addition overflow
-      if (fileLength - footerSize < postscriptLength + 1) {
+      // Check for overflow before calculating tailSize
+      uint64_t tailSize;
+      if (__builtin_add_overflow(1ULL, postscriptLength, &tailSize) ||
+          __builtin_add_overflow(tailSize, footerSize, &tailSize) ||
+          tailSize >= fileLength) {
         std::stringstream msg;
         msg << "Invalid tail size: footerSize=" << footerSize
             << ", postscriptLength=" << postscriptLength
             << ", fileLength=" << fileLength;
-        throw ParseError(msg.str());
-      }
-
-      uint64_t tailSize = 1 + postscriptLength + footerSize;
-      if (tailSize >= fileLength) {
-        std::stringstream msg;
-        msg << "Invalid ORC tailSize=" << tailSize << ", fileLength=" << fileLength;
         throw ParseError(msg.str());
       }
       uint64_t footerOffset;

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -44,6 +44,13 @@ namespace orc {
       "1.6.0", "1.6.1", "1.6.2", "1.6.3",  "1.6.4",  "1.6.5", "1.6.6",
       "1.6.7", "1.6.8", "1.6.9", "1.6.10", "1.6.11", "1.7.0"};
 
+  // Portable unsigned addition overflow check. Returns true on overflow.
+  // Relies on defined wrap-around behavior of unsigned integer arithmetic.
+  static inline bool addOverflow(uint64_t a, uint64_t b, uint64_t* result) {
+    *result = a + b;
+    return *result < a;
+  }
+
   ReaderMetrics* getDefaultReaderMetrics() {
     static ReaderMetrics internal;
     return &internal;
@@ -887,10 +894,9 @@ namespace orc {
 
     // Check for overflow in length calculations
     uint64_t totalTail;
-    if (__builtin_add_overflow(footerLength, metadataSize, &totalTail) ||
-        __builtin_add_overflow(totalTail, postscriptLength_, &totalTail) ||
-        __builtin_add_overflow(totalTail, 1ULL, &totalTail) ||
-        totalTail > fileLength_) {
+    if (addOverflow(footerLength, metadataSize, &totalTail) ||
+        addOverflow(totalTail, postscriptLength_, &totalTail) ||
+        addOverflow(totalTail, 1ULL, &totalTail) || totalTail > fileLength_) {
       std::stringstream msg;
       msg << "Invalid Metadata length: fileLength=" << fileLength_
           << ", metadataLength=" << metadataSize << ", footerLength=" << footerLength
@@ -1241,9 +1247,9 @@ namespace orc {
 
       // Check for overflow and bounds validity
       uint64_t stripeTotalLength;
-      if (__builtin_add_overflow(indexLength, dataLength, &stripeTotalLength) ||
-          __builtin_add_overflow(stripeTotalLength, footerLength, &stripeTotalLength) ||
-          __builtin_add_overflow(stripeOffset, stripeTotalLength, &stripeTotalLength) ||
+      if (addOverflow(indexLength, dataLength, &stripeTotalLength) ||
+          addOverflow(stripeTotalLength, footerLength, &stripeTotalLength) ||
+          addOverflow(stripeOffset, stripeTotalLength, &stripeTotalLength) ||
           stripeTotalLength >= fileLength) {
         std::stringstream msg;
         msg << "Malformed StripeInformation at stripe index " << currentStripe_
@@ -1654,9 +1660,8 @@ namespace orc {
 
       // Check for overflow before calculating tailSize
       uint64_t tailSize;
-      if (__builtin_add_overflow(1ULL, postscriptLength, &tailSize) ||
-          __builtin_add_overflow(tailSize, footerSize, &tailSize) ||
-          tailSize >= fileLength) {
+      if (addOverflow(1ULL, postscriptLength, &tailSize) ||
+          addOverflow(tailSize, footerSize, &tailSize) || tailSize >= fileLength) {
         std::stringstream msg;
         msg << "Invalid tail size: footerSize=" << footerSize
             << ", postscriptLength=" << postscriptLength

--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -884,13 +884,28 @@ namespace orc {
   void ReaderImpl::readMetadata() const {
     uint64_t metadataSize = contents_->postscript->metadata_length();
     uint64_t footerLength = contents_->postscript->footer_length();
-    if (fileLength_ < metadataSize + footerLength + postscriptLength_ + 1) {
+
+    // Check for potential overflow before bounds validation
+    if (footerLength > fileLength_ || metadataSize > fileLength_ ||
+        postscriptLength_ > fileLength_) {
+      std::stringstream msg;
+      msg << "Invalid length values: footerLength=" << footerLength
+          << ", metadataLength=" << metadataSize
+          << ", postscriptLength=" << postscriptLength_
+          << ", fileLength=" << fileLength_;
+      throw ParseError(msg.str());
+    }
+
+    // Use subtraction-based check to avoid integer overflow
+    if (fileLength_ - footerLength < postscriptLength_ + 1 ||
+        fileLength_ - footerLength - postscriptLength_ - 1 < metadataSize) {
       std::stringstream msg;
       msg << "Invalid Metadata length: fileLength=" << fileLength_
           << ", metadataLength=" << metadataSize << ", footerLength=" << footerLength
           << ", postscriptLength=" << postscriptLength_;
       throw ParseError(msg.str());
     }
+
     uint64_t metadataStart = fileLength_ - metadataSize - footerLength - postscriptLength_ - 1;
     if (metadataSize != 0) {
       std::unique_ptr<SeekableInputStream> pbStream = createDecompressor(
@@ -1226,18 +1241,59 @@ namespace orc {
     do {
       currentStripeInfo_ = footer_->stripes(static_cast<int>(currentStripe_));
       uint64_t fileLength = contents_->stream->getLength();
-      if (currentStripeInfo_.offset() + currentStripeInfo_.index_length() +
-              currentStripeInfo_.data_length() + currentStripeInfo_.footer_length() >=
-          fileLength) {
+
+      // Check for potential overflow in stripe length calculations
+      uint64_t stripeOffset = currentStripeInfo_.offset();
+      uint64_t indexLength = currentStripeInfo_.index_length();
+      uint64_t dataLength = currentStripeInfo_.data_length();
+      uint64_t footerLength = currentStripeInfo_.footer_length();
+
+      if (stripeOffset > fileLength || indexLength > fileLength ||
+          dataLength > fileLength || footerLength > fileLength) {
+        std::stringstream msg;
+        msg << "Invalid stripe length values at stripe index " << currentStripe_
+            << ": offset=" << stripeOffset << ", indexLength=" << indexLength
+            << ", dataLength=" << dataLength << ", footerLength=" << footerLength
+            << ", fileLength=" << fileLength;
+        throw ParseError(msg.str());
+      }
+
+      // Use subtraction-based checks to avoid addition overflow
+      uint64_t remainingSpace = fileLength - stripeOffset;
+      if (remainingSpace <= indexLength) {
         std::stringstream msg;
         msg << "Malformed StripeInformation at stripe index " << currentStripe_
             << ": fileLength=" << fileLength
-            << ", StripeInfo=(offset=" << currentStripeInfo_.offset()
-            << ", indexLength=" << currentStripeInfo_.index_length()
-            << ", dataLength=" << currentStripeInfo_.data_length()
-            << ", footerLength=" << currentStripeInfo_.footer_length() << ")";
+            << ", StripeInfo=(offset=" << stripeOffset
+            << ", indexLength=" << indexLength
+            << ", dataLength=" << dataLength
+            << ", footerLength=" << footerLength << ")";
         throw ParseError(msg.str());
       }
+
+      if (remainingSpace - indexLength <= dataLength) {
+        std::stringstream msg;
+        msg << "Malformed StripeInformation at stripe index " << currentStripe_
+            << ": fileLength=" << fileLength
+            << ", StripeInfo=(offset=" << stripeOffset
+            << ", indexLength=" << indexLength
+            << ", dataLength=" << dataLength
+            << ", footerLength=" << footerLength << ")";
+        throw ParseError(msg.str());
+      }
+
+      if (remainingSpace - indexLength - dataLength <= footerLength) {
+        std::stringstream msg;
+        msg << "Malformed StripeInformation at stripe index " << currentStripe_
+            << ": fileLength=" << fileLength
+            << ", StripeInfo=(offset=" << stripeOffset
+            << ", indexLength=" << indexLength
+            << ", dataLength=" << dataLength
+            << ", footerLength=" << footerLength << ")";
+        throw ParseError(msg.str());
+      }
+
+      uint64_t stripeTotalLength = indexLength + dataLength + footerLength;
       rowsInCurrentStripe_ = currentStripeInfo_.number_of_rows();
       processingStripe_ = currentStripe_;
 
@@ -1635,6 +1691,25 @@ namespace orc {
       postscriptLength = buffer->data()[readSize - 1] & 0xff;
       contents->postscript = readPostscript(stream.get(), buffer.get(), postscriptLength);
       uint64_t footerSize = contents->postscript->footer_length();
+
+      // Check for potential overflow before calculating tailSize
+      if (footerSize > fileLength || postscriptLength > fileLength) {
+        std::stringstream msg;
+        msg << "Invalid length values: footerSize=" << footerSize
+            << ", postscriptLength=" << postscriptLength
+            << ", fileLength=" << fileLength;
+        throw ParseError(msg.str());
+      }
+
+      // Use subtraction-based check to avoid addition overflow
+      if (fileLength - footerSize < postscriptLength + 1) {
+        std::stringstream msg;
+        msg << "Invalid tail size: footerSize=" << footerSize
+            << ", postscriptLength=" << postscriptLength
+            << ", fileLength=" << fileLength;
+        throw ParseError(msg.str());
+      }
+
       uint64_t tailSize = 1 + postscriptLength + footerSize;
       if (tailSize >= fileLength) {
         std::stringstream msg;

--- a/c++/test/TestReader.cc
+++ b/c++/test/TestReader.cc
@@ -1298,8 +1298,7 @@ namespace orc {
     maliciousData.push_back(static_cast<char>(postscriptLen));
 
     // Create reader and expect ParseError
-    auto stream = std::make_unique<MemoryInputStream>(
-        maliciousData.data(), maliciousData.size());
+    auto stream = std::make_unique<MemoryInputStream>(maliciousData.data(), maliciousData.size());
 
     ReaderOptions options;
     EXPECT_THROW(createReader(std::move(stream), options), ParseError);
@@ -1346,8 +1345,7 @@ namespace orc {
     uint8_t postscriptLen = 16;
     maliciousData.push_back(static_cast<char>(postscriptLen));
 
-    auto stream = std::make_unique<MemoryInputStream>(
-        maliciousData.data(), maliciousData.size());
+    auto stream = std::make_unique<MemoryInputStream>(maliciousData.data(), maliciousData.size());
 
     ReaderOptions options;
     EXPECT_THROW(createReader(std::move(stream), options), ParseError);

--- a/c++/test/TestReader.cc
+++ b/c++/test/TestReader.cc
@@ -1240,4 +1240,117 @@ namespace orc {
     EXPECT_LT(largeLimitIOCount, smallLimitIOCount);
   }
 
+  /**
+   * Test that reading a malformed ORC file with extremely large footer_length
+   * throws ParseError instead of causing integer overflow or crash.
+   * This tests the fix for ORC-2167.
+   */
+  TEST(TestReader, testMalformedFooterLengthOverflow) {
+    // Construct a minimal malformed ORC file with footer_length = UINT64_MAX
+    // ORC file tail structure:
+    // - Footer (not included here, will be invalid anyway)
+    // - PostScript (protobuf encoded)
+    // - 1 byte: postscript length
+    //
+    // PostScript protobuf fields:
+    // - field 1: footer_length (varint) - we set this to UINT64_MAX
+    // - field 8000: magic "ORC"
+    //
+    // Protobuf encoding for footer_length = UINT64_MAX:
+    // - tag = (field_number << 3 | wire_type) = (1 << 3 | 0) = 0x08
+    // - value = varint(UINT64_MAX) = 0xFF,FF,FF,FF,FF,FF,FF,FF,FF,01 (10 bytes)
+    //
+    // Protobuf encoding for magic "ORC":
+    // - field 8000 is a special field, but simpler to include "ORC" at end
+
+    // Create a minimal byte sequence simulating malicious file
+    // We need at least: PostScript + postscriptLength byte
+    // PostScript: footer_length(UINT64_MAX) encoded as protobuf varint
+
+    std::vector<char> maliciousData;
+
+    // Add some dummy footer bytes (not valid, but we're testing bounds check)
+    for (int i = 0; i < 20; i++) {
+      maliciousData.push_back(0x00);
+    }
+
+    // PostScript with footer_length = UINT64_MAX
+    // tag (field 1, varint): 0x08
+    maliciousData.push_back(0x08);
+    // value: UINT64_MAX as varint (10 bytes)
+    for (int i = 0; i < 9; i++) {
+      maliciousData.push_back(0xFF);
+    }
+    maliciousData.push_back(0x01);
+
+    // Add compression field (field 2) - NONE = 0
+    maliciousData.push_back(0x10);  // tag: field 2, wire type 0
+    maliciousData.push_back(0x00);  // value: compression NONE
+
+    // Add magic "ORC" at the end (this is a simplified approach)
+    maliciousData.push_back('O');
+    maliciousData.push_back('R');
+    maliciousData.push_back('C');
+
+    // PostScript length byte - points to all bytes before it (excluding magic)
+    // This is a simplified structure; real ORC has magic inside PostScript
+    uint8_t postscriptLen = 14;  // footer_length encoding + compression encoding
+    maliciousData.push_back(static_cast<char>(postscriptLen));
+
+    // Create reader and expect ParseError
+    auto stream = std::make_unique<MemoryInputStream>(
+        maliciousData.data(), maliciousData.size());
+
+    ReaderOptions options;
+    EXPECT_THROW(createReader(std::move(stream), options), ParseError);
+  }
+
+  /**
+   * Test that reading a malformed ORC file with extremely large metadata_length
+   * throws ParseError instead of causing integer overflow.
+   */
+  TEST(TestReader, testMalformedMetadataLengthOverflow) {
+    // Similar to testMalformedFooterLengthOverflow but with metadata_length overflow
+    // PostScript field 3 is metadata_length (actually it's field 4 in proto)
+    // Let's create a file with both footer_length and metadata_length set to large values
+
+    std::vector<char> maliciousData;
+
+    // Add some dummy bytes
+    for (int i = 0; i < 20; i++) {
+      maliciousData.push_back(0x00);
+    }
+
+    // PostScript:
+    // footer_length = 100 (reasonable small value)
+    maliciousData.push_back(0x08);  // tag: field 1
+    maliciousData.push_back(0x64);  // value: 100
+
+    // metadata_length = UINT64_MAX (field 4)
+    maliciousData.push_back(0x20);  // tag: field 4, wire type 0 (4 << 3 | 0 = 32 = 0x20)
+    for (int i = 0; i < 9; i++) {
+      maliciousData.push_back(0xFF);
+    }
+    maliciousData.push_back(0x01);
+
+    // compression = NONE
+    maliciousData.push_back(0x10);
+    maliciousData.push_back(0x00);
+
+    // magic "ORC"
+    maliciousData.push_back('O');
+    maliciousData.push_back('R');
+    maliciousData.push_back('C');
+
+    // postscript length
+    uint8_t postscriptLen = 16;
+    maliciousData.push_back(static_cast<char>(postscriptLen));
+
+    auto stream = std::make_unique<MemoryInputStream>(
+        maliciousData.data(), maliciousData.size());
+
+    ReaderOptions options;
+    EXPECT_THROW(createReader(std::move(stream), options), ParseError);
+  }
+
 }  // namespace orc


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. File a JIRA issue first and use it as a prefix of your PR title, e.g., `ORC-001: Fix ABC`.
  2. Use your PR title to summarize what this PR proposes instead of describing the problem.
  3. Make PR title and description complete because these will be the permanent commit log.
  4. If possible, provide a concise and reproducible example to reproduce the issue for a faster review.
  5. If the PR is unfinished, use GitHub PR Draft feature.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If there is a discussion in the mailing list, please add the link.
-->
 Added overflow-safe bounds checking in three locations in c++/src/Reader.cc using __builtin_add_overflow to prevent integer overflow when parsing malformed
   ORC files with extremely large length values in PostScript:

  1. readMetadata() - Use __builtin_add_overflow to safely compute total tail size (footerLength + metadataSize + postscriptLength + 1) before comparing
  against fileLength
  2. createReader() - Use __builtin_add_overflow to safely compute tailSize (1 + postscriptLength + footerSize) before bounds validation
  3. startNextStripe() - Use __builtin_add_overflow to safely sum stripe length components (offset + indexLength + dataLength + footerLength) before
  comparing against fileLength

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When an ORC file's PostScript is crafted with footer_length or metadata_length set to UINT64_MAX, the bounds check using unsigned addition (e.g.,
  metadataSize + footerLength + postscriptLength_ + 1) can overflow and wrap around to a small value, bypassing validation.

  For example, given a 58-byte file with footerLength = UINT64_MAX, metadataSize = 0, and postscriptLength_ = 23:
  - The sum wraps to 23 (mod 2^64)
  - The check 58 < 23 evaluates to false, allowing invalid offset calculation
  - This can cause SIGBUS crash due to out-of-bounds memory access

  Using __builtin_add_overflow (a GCC/Clang builtin) provides a standard, efficient way to detect overflow without manual subtraction logic.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added two unit tests in c++/test/TestReader.cc:

  1. testMalformedFooterLengthOverflow - Constructs a minimal malformed ORC file with footer_length = UINT64_MAX and verifies that createReader() throws
  ParseError
  2. testMalformedMetadataLengthOverflow - Constructs a malformed file with metadata_length = UINT64_MAX and verifies ParseError is thrown


### Was this patch authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude code