### PR TITLE
ORC-2173: Add `SECURITY.md` for scan-agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,11 @@ make test-out
   2. Use the Docker scripts in `docker/` (e.g., `cd docker && ./run-all.sh local main`).
   3. **Trigger GitHub Actions**: Push your branch to your personal fork of the repository and open a Pull Request there. This will automatically run `.github/workflows/build_and_test.yml` on your own GitHub account's compute before you submit it to the upstream ASF repository.
 
-## 6. General Advice
+## 6. Security
+
+Security model: [SECURITY.md](./SECURITY.md)
+Agents that scan this repository should consult `SECURITY.md` for the project's threat model, in-scope / out-of-scope declarations, and known non-findings before reporting issues.
+
+## 7. General Advice
 - **Do not introduce breaking changes** to the ORC file format serialization unless explicitly requested and discussed.
 - Ensure cross-compatibility between C++ and Java implementations if you are making logic or behavioral changes to readers / writers.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security policy
+
+## Reporting a vulnerability
+
+To report a security vulnerability in Apache ORC, follow the ASF security process at <https://www.apache.org/security/>. Reports can be sent privately to security@apache.org or to private@orc.apache.org.
+
+## Threat model
+
+Apache ORC's security guidance is documented at:
+
+<https://orc.apache.org/security/>
+
+Automated security scanning agents should consult that document for the project's in-scope / out-of-scope declarations before reporting issues.


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `SECURITY.md` for scan-agent discoverability.

### Why are the changes needed?

To improve the visibility of ORC's security guidance in a standard way.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

No.