### PR TITLE
ORC-2177: Fix array conversion with empty first batch

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
+++ b/java/core/src/java/org/apache/orc/impl/ConvertTreeReaderFactory.java
@@ -301,11 +301,13 @@ public class ConvertTreeReaderFactory extends TreeReaderFactory {
       resultColVector.reset();
       if (fromColVector.isRepeating) {
         resultColVector.isRepeating = true;
-        if (fromColVector.noNulls || !fromColVector.isNull[0]) {
-          setConvertVectorElement(0);
-        } else {
-          resultColVector.noNulls = false;
-          resultColVector.isNull[0] = true;
+        if (batchSize > 0) {
+          if (fromColVector.noNulls || !fromColVector.isNull[0]) {
+            setConvertVectorElement(0);
+          } else {
+            resultColVector.noNulls = false;
+            resultColVector.isNull[0] = true;
+          }
         }
       } else if (fromColVector.noNulls) {
         for (int i = 0; i < batchSize; i++) {

--- a/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
+++ b/java/core/src/test/org/apache/orc/impl/TestConvertTreeReaderFactory.java
@@ -746,4 +746,38 @@ public class TestConvertTreeReaderFactory implements TestConf {
     readDecimalInNullStripe("decimal(18,2)", DecimalColumnVector.class,
             new String[]{"null", "1024", "1"});
   }
+
+  @Test
+  public void testIntArrayToStringArrayFirstBatchAllEmpty() throws Exception {
+    TypeDescription fileSchema = TypeDescription.fromString("struct<col1:array<int>>");
+    TypeDescription readerSchema = TypeDescription.fromString("struct<col1:array<string>>");
+
+    try (Writer w = OrcFile.createWriter(testFilePath,
+        OrcFile.writerOptions(conf).setSchema(fileSchema))) {
+      VectorizedRowBatch b = fileSchema.createRowBatch(3);
+      ListColumnVector lc = (ListColumnVector) b.cols[0];
+      for (int i = 0; i < 3; i++) {
+        lc.offsets[i] = 0;
+        lc.lengths[i] = 0;
+      }
+      lc.childCount = 0;
+      b.size = 3;
+      w.addRowBatch(b);
+    }
+
+    try (Reader reader = OrcFile.createReader(testFilePath, OrcFile.readerOptions(conf));
+         RecordReader rows = reader.rows(reader.options().schema(readerSchema))) {
+      VectorizedRowBatch rb = readerSchema.createRowBatch(3);
+      assertTrue(rows.nextBatch(rb));
+      ListColumnVector r = (ListColumnVector) rb.cols[0];
+      // Cast verifies schema evolution took effect (would be LongColumnVector without evolution)
+      BytesColumnVector child = (BytesColumnVector) r.child;
+      assertEquals(0, r.childCount);
+      for (int i = 0; i < 3; i++) {
+        assertEquals(0, r.lengths[i], "row " + i + " should be empty array");
+      }
+    } finally {
+      fs.delete(testFilePath, false);
+    }
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add a `batchSize > 0` guard in `ConvertTreeReader.convertVector()` before accessing index 0. 

### Why are the changes needed?
When reading an ORC file with schema evolution converting `array<int>` to `array<string>`, an `ArrayIndexOutOfBoundsException` is thrown if the first batch processed by the element reader has `childCount=0` (i.e., all rows in the batch contain empty arrays).

```java
java.lang.ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0
	at org.apache.orc.impl.ConvertTreeReaderFactory$StringGroupFromAnyIntegerTreeReader.setConvertVectorElement(ConvertTreeReaderFactory.java:1094)
	at org.apache.orc.impl.ConvertTreeReaderFactory$ConvertTreeReader.convertVector(ConvertTreeReaderFactory.java:305)
	at org.apache.orc.impl.ConvertTreeReaderFactory$StringGroupFromAnyIntegerTreeReader.nextVector(ConvertTreeReaderFactory.java:1115)
	at org.apache.orc.impl.TreeReaderFactory$ListTreeReader.nextVector(TreeReaderFactory.java:2892)
	at org.apache.orc.impl.reader.tree.StructBatchReader.readBatchColumn(StructBatchReader.java:66)
	at org.apache.orc.impl.reader.tree.StructBatchReader.nextBatchForLevel(StructBatchReader.java:101)
	at org.apache.orc.impl.reader.tree.StructBatchReader.nextBatch(StructBatchReader.java:78)
	at org.apache.orc.impl.RecordReaderImpl.nextBatch(RecordReaderImpl.java:1444)
```

### How was this patch tested?
Added `testIntArrayToStringArrayFirstBatchAllEmpty` in `TestConvertTreeReaderFactory`

### Was this patch authored or co-authored using generative AI tooling?
Generated-by: Claude
