### PR TITLE
ORC-2179: Add RISC-V Docker image and GitHub Actions support

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -63,6 +63,38 @@ jobs:
         cd docker
         ./run-one.sh local main ${{ matrix.os }}
 
+  riscv64:
+    name: "RISC-V ${{ matrix.os }}"
+    needs: [license-check]
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      max-parallel: 20
+      matrix:
+        os:
+          - riscv64-ubuntu24
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: linux/riscv64
+    - name: Set up Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Build Docker image
+      run: |
+        cd docker/${{ matrix.os }}
+        docker buildx build --platform linux/riscv64 --load \
+          --cache-from type=gha,scope=riscv64-ubuntu24 \
+          --cache-to type=gha,mode=max,scope=riscv64-ubuntu24 \
+          -t orc-riscv64 .
+    - name: Build ORC with RVV
+      run: |
+        docker run --platform linux/riscv64 --rm -v $(pwd):/root/orc orc-riscv64 /bin/bash -c \
+          "mkdir -p build && cd build && cmake -DBUILD_JAVA=OFF -DBUILD_ENABLE_RVV=ON -DCMAKE_BUILD_TYPE=Release ../orc && make -j\$(nproc) package"
+
   build:
     name: "Java ${{ matrix.java }} and ${{ matrix.cxx }} on ${{ matrix.os }}"
     needs: [license-check]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -91,8 +91,10 @@ jobs:
           --cache-to type=gha,mode=max,scope=riscv64-ubuntu26 \
           -t orc-riscv64 .
     - name: Build ORC with RVV
+      env:
+        QEMU_CPU: rv64,v=on,vlen=128,vext_spec=v1.0
       run: |
-        docker run --platform linux/riscv64 --rm -v $(pwd):/root/orc orc-riscv64 /bin/bash -c \
+        docker run --platform linux/riscv64 --rm -e QEMU_CPU -v $(pwd):/root/orc orc-riscv64 /bin/bash -c \
           "mkdir -p build && cd build && cmake -DBUILD_JAVA=OFF -DBUILD_ENABLE_RVV=ON -DCMAKE_BUILD_TYPE=Release ../orc && make -j\$(nproc) package"
 
   build:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,7 +73,7 @@ jobs:
       max-parallel: 20
       matrix:
         os:
-          - riscv64-ubuntu24
+          - riscv64-ubuntu26
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -87,8 +87,8 @@ jobs:
       run: |
         cd docker/${{ matrix.os }}
         docker buildx build --platform linux/riscv64 --load \
-          --cache-from type=gha,scope=riscv64-ubuntu24 \
-          --cache-to type=gha,mode=max,scope=riscv64-ubuntu24 \
+          --cache-from type=gha,scope=riscv64-ubuntu26 \
+          --cache-to type=gha,mode=max,scope=riscv64-ubuntu26 \
           -t orc-riscv64 .
     - name: Build ORC with RVV
       run: |

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -6,3 +6,4 @@ oraclelinux9
 oraclelinux10
 amazonlinux23
 ubi10
+riscv64-ubuntu24

--- a/docker/os-list.txt
+++ b/docker/os-list.txt
@@ -6,4 +6,4 @@ oraclelinux9
 oraclelinux10
 amazonlinux23
 ubi10
-riscv64-ubuntu24
+riscv64-ubuntu26

--- a/docker/riscv64-ubuntu24/Dockerfile
+++ b/docker/riscv64-ubuntu24/Dockerfile
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ORC compile for RISC-V Ubuntu 24
+#
+
+FROM --platform=linux/riscv64 ubuntu:24.04
+LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.ref.name="Apache ORC on RISC-V Ubuntu 24"
+LABEL org.opencontainers.image.version=""
+ARG jdk=21
+ARG cc=gcc
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      ca-certificates \
+      cmake \
+      git \
+      libsasl2-dev \
+      libssl-dev \
+      make \
+      curl \
+      maven \
+      openjdk-${jdk}-jdk-headless \
+      tzdata \
+      $( [ "${cc}" = "gcc" ] && echo "gcc g++" || echo "clang" ) && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    if [ "${cc}" != "gcc" ] ; then \
+      update-alternatives --set cc /usr/bin/clang && \
+      update-alternatives --set c++ /usr/bin/clang++; \
+    fi
+RUN update-alternatives --set java \
+      $(update-alternatives --list java | grep "java-${jdk}-openjdk") && \
+    update-alternatives --set javac \
+      $(update-alternatives --list javac | grep "java-${jdk}-openjdk")
+
+ENV CC=cc
+ENV CXX=c++
+
+RUN ln -fs /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && \
+    mkdir -p /usr/share/zoneinfo/US && \
+    ln -fs /usr/share/zoneinfo/America/Los_Angeles /usr/share/zoneinfo/US/Pacific
+
+WORKDIR /root
+VOLUME /root/.m2/repository
+
+CMD ["/bin/bash", "-c", "if [ ! -d orc ]; then echo \"No volume provided, building from apache main.\"; echo \"Pass '-v\`pwd\`:/root/orc' to docker run to build local source.\"; git clone https://github.com/apache/orc.git -b main; fi && mkdir build && cd build && cmake ../orc && make package test-out"]

--- a/docker/riscv64-ubuntu26/Dockerfile
+++ b/docker/riscv64-ubuntu26/Dockerfile
@@ -14,13 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# ORC compile for RISC-V Ubuntu 24
+# ORC compile for RISC-V Ubuntu 26
 #
 
-FROM --platform=linux/riscv64 ubuntu:24.04
+FROM --platform=linux/riscv64 ubuntu:26.04
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
-LABEL org.opencontainers.image.ref.name="Apache ORC on RISC-V Ubuntu 24"
+LABEL org.opencontainers.image.ref.name="Apache ORC on RISC-V Ubuntu 26"
 LABEL org.opencontainers.image.version=""
 ARG jdk=21
 ARG cc=gcc


### PR DESCRIPTION
### What this PR does

Adds a RISC-V (riscv64) Docker image for Ubuntu 24.04 and wires it into GitHub Actions so we can continuously build ORC on RISC-V.

### Changes

- `docker/riscv64-ubuntu24/Dockerfile`: new image based on the existing Ubuntu 24.04 Dockerfile. Supports both `cc=gcc` (default) and `cc=clang` build args.
- `docker/os-list.txt`: registered the new image.
- `.github/workflows/build_and_test.yml`: added a `riscv64` job running under QEMU on `ubuntu-latest`.

### Notes

- The job currently only builds ORC. RVV-specific tests will be added in follow-up PRs after the RVV decoder implementation is in.
- I followed the same pattern as the existing `aarch64` / `ubuntu24` Docker images to keep things consistent.
- Local verification was done with `docker buildx` on a host with QEMU user-static registered.

### ScreenShot
<img width="970" height="340" alt="1" src="https://github.com/user-attachments/assets/4cee0ece-a594-4fbe-8cf7-4b6e2b8f7219" />
<img width="875" height="255" alt="2" src="https://github.com/user-attachments/assets/6ece8345-a613-4bfe-8cd2-1ee9e92a32c7" />
