### PR TITLE
ORC-2182: Pin docker setup actions to approved commit hashes to recover CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -78,11 +78,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
       with:
         platforms: linux/riscv64
     - name: Set up Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
     - name: Build Docker image
       run: |
         cd docker/${{ matrix.os }}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR pins two `docker/*` GitHub Actions in `.github/workflows/build_and_test.yml` to commit hashes approved by the ASF (`apache/infrastructure-actions/approved_patterns.yml`):

| Action | Before | After |
| --- | --- | --- |
| `docker/setup-qemu-action` | `@v3` | `@c7c53464625b32c7a7e944ae62b3e17d2b600130` (v3.7.0) |
| `docker/setup-buildx-action` | `@v3` | `@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5` (v4.1.0) |

Note that the approved patterns list has no `v3.x` hash for `docker/setup-buildx-action`, so it is bumped from `v3` to the latest approved `v4.1.0`.

### Why are the changes needed?

The ASF infrastructure policy requires third-party GitHub Actions to be pinned to approved commit hashes instead of mutable version tags, to prevent supply-chain attacks from tag reassignment.

Currently, the CI is broken like the following.
- https://github.com/apache/orc/actions/runs/28527900078

<img width="612" height="213" alt="Screenshot 2026-07-01 at 08 35 48" src="https://github.com/user-attachments/assets/50e31ed2-b282-461e-be50-ee84db79360b" />


### How was this patch tested?

Pass the GitHub Actions.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8