### PR TITLE
ORC-2183: Use `Visual Studio 18 2026` generator in Windows CIs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -150,7 +150,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake .. -G "Visual Studio 17 2022" \
+        cmake .. -G "Visual Studio 18 2026" \
           -DCMAKE_BUILD_TYPE=RELEASE \
           -DBUILD_LIBHDFSPP=OFF \
           -DBUILD_TOOLS=OFF \


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `Visual Studio 18 2026` generator in Windows CIs.

### Why are the changes needed?

Currently, old release branches are broken like the following.

- https://github.com/apache/orc/tree/branch-2.3
  - https://github.com/apache/orc/actions/runs/28533751383/job/84594800835

<img width="531" height="378" alt="Screenshot 2026-07-04 at 21 44 22" src="https://github.com/user-attachments/assets/ebcdf919-704f-4c9c-bf4d-436c1621883d" />

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5