### PR TITLE
ORC-2181: Add `ubuntu-26.04(-arm)?` to GitHub Actions `build` job

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -86,6 +86,12 @@ jobs:
           - os: ubuntu-24.04-arm
             java: 17
             cxx: clang++
+          - os: ubuntu-26.04
+            java: 25
+            cxx: clang++
+          - os: ubuntu-26.04-arm
+            java: 25
+            cxx: clang++
           - os: ubuntu-latest
             java: 25
           - os: macos-14


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to add `ubuntu-26.04` and `ubuntu-26.04-arm` to the GitHub Action `build` job with Java 25.

### Why are the changes needed?

To improve the test coverage by running the build and test on the latest Ubuntu 26.04 (both x86_64 and arm64) with the latest Java version.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8