### PR TITLE
ORC-2187: Set protobuf message size limit in C++ reader

### DIFF
--- a/c++/src/Reader.cc
+++ b/c++/src/Reader.cc
@@ -531,13 +531,13 @@ namespace orc {
 
         if (pbStream.kind() == proto::Stream_Kind_ROW_INDEX) {
           proto::RowIndex rowIndex;
-          if (!rowIndex.ParseFromZeroCopyStream(inStream.get())) {
+          if (!parseProtobufFromStream(&rowIndex, inStream.get())) {
             throw ParseError("Failed to parse the row index");
           }
           rowIndexes_[colId] = rowIndex;
         } else if (!skipBloomFilters_) {  // Stream_Kind_BLOOM_FILTER_UTF8
           proto::BloomFilterIndex pbBFIndex;
-          if (!pbBFIndex.ParseFromZeroCopyStream(inStream.get())) {
+          if (!parseProtobufFromStream(&pbBFIndex, inStream.get())) {
             throw ParseError("Failed to parse bloom filter index");
           }
           BloomFilterIndex bfIndex;
@@ -618,7 +618,7 @@ namespace orc {
                                   *contents.pool, contents.readerMetrics);
 
     proto::StripeFooter result;
-    if (!result.ParseFromZeroCopyStream(pbStream.get())) {
+    if (!parseProtobufFromStream(&result, pbStream.get())) {
       throw ParseError(std::string("bad StripeFooter from ") + pbStream->getName());
     }
     // Verify StripeFooter in case it's corrupt
@@ -814,7 +814,7 @@ namespace orc {
                                contents_->blockSize, *(contents_->pool), contents_->readerMetrics);
 
         proto::RowIndex rowIndex;
-        if (!rowIndex.ParseFromZeroCopyStream(pbStream.get())) {
+        if (!parseProtobufFromStream(&rowIndex, pbStream.get())) {
           throw ParseError("Failed to parse RowIndex from stripe footer");
         }
         int num_entries = rowIndex.entry_size();
@@ -912,7 +912,7 @@ namespace orc {
                                                     metadataSize, *contents_->pool),
           contents_->blockSize, *contents_->pool, contents_->readerMetrics);
       contents_->metadata.reset(new proto::Metadata());
-      if (!contents_->metadata->ParseFromZeroCopyStream(pbStream.get())) {
+      if (!parseProtobufFromStream(contents_->metadata.get(), pbStream.get())) {
         throw ParseError("Failed to parse the metadata");
       }
     }
@@ -1612,7 +1612,7 @@ namespace orc {
         getCompressionBlockSize(ps), memoryPool, readerMetrics);
 
     auto footer = std::make_unique<proto::Footer>();
-    if (!footer->ParseFromZeroCopyStream(pbStream.get())) {
+    if (!parseProtobufFromStream(footer.get(), pbStream.get())) {
       throw ParseError("Failed to parse the footer from " + stream->getName());
     }
 
@@ -1712,7 +1712,7 @@ namespace orc {
                                contents_->blockSize, *(contents_->pool), contents_->readerMetrics);
 
         proto::BloomFilterIndex pbBFIndex;
-        if (!pbBFIndex.ParseFromZeroCopyStream(pbStream.get())) {
+        if (!parseProtobufFromStream(&pbBFIndex, pbStream.get())) {
           throw ParseError("Failed to parse BloomFilterIndex");
         }
 
@@ -1769,7 +1769,7 @@ namespace orc {
                                contents_->blockSize, *(contents_->pool), contents_->readerMetrics);
 
         proto::RowIndex pbRowIndex;
-        if (!pbRowIndex.ParseFromZeroCopyStream(pbStream.get())) {
+        if (!parseProtobufFromStream(&pbRowIndex, pbStream.get())) {
           std::stringstream errMsgBuffer;
           errMsgBuffer << "Failed to parse RowIndex at column " << column << " in stripe "
                        << stripeIndex;

--- a/c++/src/StripeStream.cc
+++ b/c++/src/StripeStream.cc
@@ -157,7 +157,7 @@ namespace orc {
                                                     footerLength_, memory_),
           blockSize_, memory_, metrics_);
       stripeFooter_ = std::make_unique<proto::StripeFooter>();
-      if (!stripeFooter_->ParseFromZeroCopyStream(pbStream.get())) {
+      if (!parseProtobufFromStream(stripeFooter_.get(), pbStream.get())) {
         throw ParseError("Failed to parse the stripe footer");
       }
     }

--- a/c++/src/wrap/coded-stream-wrapper.h
+++ b/c++/src/wrap/coded-stream-wrapper.h
@@ -37,4 +37,21 @@ DIAGNOSTIC_IGNORE("-Wconversion")
 
 DIAGNOSTIC_POP
 
+namespace orc {
+  // Matches the Java reader's InStream.PROTOBUF_MESSAGE_MAX_LIMIT (1 GB) so both
+  // implementations reject oversized messages identically.
+  constexpr int PROTOBUF_MESSAGE_MAX_LIMIT = 1024 << 20;
+
+  // Parse a protobuf message from a ZeroCopyInputStream while enforcing the
+  // total byte limit above. Use this instead of Message::ParseFromZeroCopyStream
+  // for any message read from file contents.
+  template <typename Message>
+  inline bool parseProtobufFromStream(Message* message,
+                                      google::protobuf::io::ZeroCopyInputStream* input) {
+    google::protobuf::io::CodedInputStream codedStream(input);
+    codedStream.SetTotalBytesLimit(PROTOBUF_MESSAGE_MAX_LIMIT);
+    return message->ParseFromCodedStream(&codedStream);
+  }
+}  // namespace orc
+
 #endif


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR caps the size of protobuf messages parsed from ORC file contents in the C++ reader, matching the Java reader.

### Why are the changes needed?

The Java reader already caps protobuf message size at 1 GB, but the C++ reader parsed with no limit.

https://github.com/apache/orc/blob/7cc86ec686b4edcdb3c4d641ae362f101d4c8015/java/core/src/java/org/apache/orc/impl/InStream.java#L45

https://github.com/apache/orc/blob/7cc86ec686b4edcdb3c4d641ae362f101d4c8015/java/core/src/java/org/apache/orc/impl/InStream.java#L922

`SetTotalBytesLimit` has the same mechanism with `InStream.setSizeLimit`.

### How was this patch tested?

Pass the existing C++ tests (`orc-test`).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5