### PR TITLE
ORC-2190: [C++] Reject compressed chunk length exceeding block size in C++ reader

### DIFF
--- a/c++/src/Compression.cc
+++ b/c++/src/Compression.cc
@@ -419,6 +419,9 @@ namespace orc {
     MemoryPool& pool;
     std::unique_ptr<SeekableInputStream> input;
 
+    // the configured compression block size, used to validate chunk lengths
+    size_t blockSize;
+
     // uncompressed output
     DataBuffer<char> outputDataBuffer;
 
@@ -460,6 +463,7 @@ namespace orc {
                                            ReaderMetrics* metrics)
       : pool(pool),
         input(std::move(inStream)),
+        blockSize(bufferSize),
         outputDataBuffer(pool, bufferSize),
         state(DECOMPRESS_HEADER),
         outputBufferStart(nullptr),
@@ -518,6 +522,12 @@ namespace orc {
         state = DECOMPRESS_START;
       }
       remainingLength = header >> 1;
+      if (state == DECOMPRESS_START && remainingLength > blockSize) {
+        std::ostringstream ss;
+        ss << "Buffer size too small. size = " << blockSize << " needed = " << remainingLength
+           << " in " << getName();
+        throw ParseError(ss.str());
+      }
     } else {
       remainingLength = 0;
     }

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -574,6 +574,19 @@ namespace orc {
     EXPECT_EQ(16, static_cast<const char*>(ptr)[2]);
   }
 
+  TEST(Zlib, testChunkLengthExceedsBlockSize) {
+    // Craft a compressed chunk header whose chunkLength (100) exceeds the
+    // configured block size (5). header = chunkLength << 1 = 200 = 0xC8.
+    const unsigned char buffer[] = {0xc8, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5};
+    std::unique_ptr<SeekableInputStream> result = createDecompressor(
+        CompressionKind_ZLIB,
+        std::make_unique<SeekableArrayInputStream>(buffer, ARRAY_SIZE(buffer), 5), 5,
+        *getDefaultPool(), getDefaultReaderMetrics());
+    const void* ptr;
+    int length;
+    EXPECT_THROW(result->Next(&ptr, &length), ParseError);
+  }
+
   TEST(Zlib, testInflate) {
     const unsigned char buffer[] = {0xe, 0x0, 0x0, 0x63, 0x60, 0x64, 0x62, 0xc0, 0x8d, 0x0};
     std::unique_ptr<SeekableInputStream> result =


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the ORC C++ reader reject a compressed chunk whose length exceeds the configured
compression block size, matching the Java reader.

https://github.com/apache/orc/blob/5d3cf1318b58416719e89169ae9d56f758311f7e/java/core/src/java/org/apache/orc/impl/InStream.java#L504-L507

### Why are the changes needed?

The Java reader already performs this check in `InStream.CompressedStream.readHeader`, but the C++
reader was missing it. This is a defense-in-depth hardening (not a CVE): the chunk length is already
bounded to ~8MB by the 3-byte header, but the spec-mandated first check was absent on the C++ side.
Well-formed files are unaffected.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5