### PR TITLE
ORC-2191: Reject overflowing PostScript tail lengths in ReaderImpl

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -854,13 +854,38 @@ public class ReaderImpl implements Reader {
           CompressionKind.valueOf(ps.getCompression().name());
       fileTailBuilder.setPostscriptLength(psLen).setPostscript(ps);
 
-      int footerSize = (int) ps.getFooterLength();
-      int metadataSize = (int) ps.getMetadataLength();
-      int stripeStatSize = (int) ps.getStripeStatisticsLength();
+      long footerLength = ps.getFooterLength();
+      long metadataLength = ps.getMetadataLength();
+      long stripeStatLength = ps.getStripeStatisticsLength();
+
+      // Reject malformed tail lengths before narrowing to int, symmetric with the
+      // C++ overflow-safe checks added in ORC-2167. A crafted PostScript length near
+      // UINT64_MAX (read as a negative long) or above 2GB would otherwise truncate or
+      // overflow into a bogus seek offset or ByteBuffer allocation size.
+      if (footerLength < 0 || footerLength > Integer.MAX_VALUE ||
+          metadataLength < 0 || metadataLength > Integer.MAX_VALUE ||
+          stripeStatLength < 0 || stripeStatLength > Integer.MAX_VALUE) {
+        throw new FileFormatException("Malformed ORC file " + path
+            + ". Invalid tail length. fileLength=" + size
+            + ", postscriptLength=" + psLen + ", footerLength=" + footerLength
+            + ", metadataLength=" + metadataLength
+            + ", stripeStatisticsLength=" + stripeStatLength);
+      }
+
+      int footerSize = (int) footerLength;
+      int metadataSize = (int) metadataLength;
+      int stripeStatSize = (int) stripeStatLength;
 
       //check if extra bytes need to be read
-      int tailSize = 1 + psLen + footerSize + metadataSize + stripeStatSize;
-      int extra = Math.max(0, tailSize - readSize);
+      long tailSize = 1L + psLen + footerSize + metadataSize + stripeStatSize;
+      if (tailSize > size || tailSize > Integer.MAX_VALUE) {
+        throw new FileFormatException("Malformed ORC file " + path
+            + ". Invalid tail size " + tailSize + " for file of length " + size
+            + " (postscriptLength=" + psLen + ", footerLength=" + footerSize
+            + ", metadataLength=" + metadataSize
+            + ", stripeStatisticsLength=" + stripeStatSize + ")");
+      }
+      int extra = Math.max(0, (int) tailSize - readSize);
       if (extra > 0) {
         //more bytes need to be read, seek back to the right place and read extra bytes
         BufferChunk orig = buffer;

--- a/java/core/src/test/org/apache/orc/impl/TestReaderImpl.java
+++ b/java/core/src/test/org/apache/orc/impl/TestReaderImpl.java
@@ -173,6 +173,64 @@ public class TestReaderImpl implements TestConf {
   }
 
   @Test
+  public void testMalformedTailLengthOverflow() throws Exception {
+    Path tmpDir = new Path(System.getProperty("test.tmp.dir",
+        "target/test/tmp"));
+    FileSystem fs = tmpDir.getFileSystem(conf);
+    // Each triple sets one of footer/metadata/stripeStatistics length to a value
+    // that would overflow or truncate when narrowed to int: 2^31 (negative int),
+    // 2^32 (truncates to 0), and -1L (UINT64_MAX as read from protobuf uint64).
+    long[][] cases = new long[][]{
+        {1L << 31, 0, 0},
+        {1L << 32, 0, 0},
+        {-1L, 0, 0},
+        {0, 1L << 31, 0},
+        {0, -1L, 0},
+        {0, 0, 1L << 31},
+        {0, 0, -1L},
+    };
+    for (long[] c : cases) {
+      byte[] fileBytes = composeMalformedTailFile(c[0], c[1], c[2]);
+      Path tmpPath = new Path(tmpDir,
+          "malformed-tail-" + c[0] + "-" + c[1] + "-" + c[2] + ".orc");
+      try (FSDataOutputStream out = fs.create(tmpPath, true)) {
+        out.write(fileBytes);
+      }
+      try {
+        FileFormatException e = assertThrows(FileFormatException.class, () ->
+            OrcFile.createReader(tmpPath, OrcFile.readerOptions(conf)).close());
+        assertTrue(e.getMessage().contains("Malformed ORC file"),
+            "Unexpected message: " + e.getMessage());
+        assertTrue(e.getMessage().contains("tail"),
+            "Unexpected message: " + e.getMessage());
+      } finally {
+        fs.delete(tmpPath, false);
+      }
+    }
+  }
+
+  private static byte[] composeMalformedTailFile(long footerLength,
+      long metadataLength, long stripeStatLength) {
+    // Valid compressionBlockSize so the failure is triggered by the tail-length
+    // check rather than the compression-block-size check.
+    byte[] psBytes = OrcProto.PostScript.newBuilder()
+        .setFooterLength(footerLength)
+        .setCompression(OrcProto.CompressionKind.NONE)
+        .setCompressionBlockSize(1 << 16)
+        .addVersion(0).addVersion(12)
+        .setMetadataLength(metadataLength)
+        .setStripeStatisticsLength(stripeStatLength)
+        .setWriterVersion(OrcFile.CURRENT_WRITER.getId())
+        .setMagic(OrcFile.MAGIC)
+        .build().toByteArray();
+    ByteBuffer buf = ByteBuffer.allocate(3 + psBytes.length + 1);
+    buf.put(OrcFile.MAGIC.getBytes(StandardCharsets.UTF_8));
+    buf.put(psBytes);
+    buf.put((byte) psBytes.length);
+    return buf.array();
+  }
+
+  @Test
   public void testOptionSafety() throws IOException {
     Reader.Options options = new Reader.Options();
     String expected = options.toString();


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR validates the PostScript tail lengths in `ReaderImpl.extractFileTail` before they are cast
from `long` to `int`, throwing `FileFormatException` when `footerLength`, `metadataLength`,
`stripeStatisticsLength`, or their sum is negative or exceeds the file length / `Integer.MAX_VALUE`.
It is the Java counterpart of the C++ overflow checks in ORC-2167.

### Why are the changes needed?

These fields are protobuf `uint64` read as Java `long`. A malformed value near `UINT64_MAX` or above
2GB would truncate/overflow on the `int` cast into a bogus offset or allocation size instead of a
clear error. Per the ORC threat model this is a fail-fast robustness fix, not a CVE.

### How was this patch tested?

Added `TestReaderImpl.testMalformedTailLengthOverflow`, which crafts files with tail lengths of
`2^31`, `2^32`, and `UINT64_MAX` and asserts `OrcFile.createReader` throws `FileFormatException`.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5