### PR TITLE
ORC-2193: Parse encrypted FileStatistics via createCodedInputStream

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
+++ b/java/core/src/java/org/apache/orc/impl/ReaderImpl.java
@@ -412,7 +412,8 @@ public class ReaderImpl implements Reader {
                                            .withEncryption(algorithm, key, iv);
       InStream in = InStream.create("encrypted file stats", buffer,
           0, bytes.length, options);
-      OrcProto.FileStatistics decrypted = OrcProto.FileStatistics.parseFrom(in);
+      OrcProto.FileStatistics decrypted =
+          OrcProto.FileStatistics.parseFrom(InStream.createCodedInputStream(in));
       ColumnStatistics[] result = new ColumnStatistics[decrypted.getColumnCount()];
       TypeDescription root = encryption.getRoot();
       for(int i= 0; i < result.length; ++i){


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR makes the encrypted `FileStatistics` parsing path in the Java reader consistent with all other protobuf parse paths by wrapping it with `InStream.createCodedInputStream(...)`.

### Why are the changes needed?

Every other protobuf parse path in the reader (footer, metadata, stripe footer, row index, bloom filter, columnar stripe stats) goes through `createCodedInputStream`, which applies `setSizeLimit(1 GB)`. This was the only exception, so this aligns it for consistency. It is not a security fix: the input is an already-bounded in-memory sub-message from the footer.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5