### PR TITLE
ORC-2195: Upgrade `lz4-java` to 1.11.1

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -176,7 +176,7 @@
       <dependency>
         <groupId>at.yawk.lz4</groupId>
         <artifactId>lz4-java</artifactId>
-        <version>1.11.0</version>
+        <version>1.11.1</version>
       </dependency>
       <dependency>
         <groupId>com.github.luben</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade `at.yawk.lz4:lz4-java` to 1.11.1.

### Why are the changes needed?

To bring the latest bug fixes from the following release.

- https://github.com/yawkat/lz4-java/releases/tag/v1.11.1 (2026-07-06)
  - [Native XXHash implementations can crash the JVM when passed invalid byte array ranges](https://github.com/yawkat/lz4-java/security/advisories/GHSA-xx22-p4ch-683r)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5