### PR TITLE
ORC-2198: Validate stream offset+length against stripe data boundary in StripePlanner

### DIFF
--- a/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
+++ b/java/core/src/java/org/apache/orc/impl/reader/StripePlanner.java
@@ -21,6 +21,7 @@ package org.apache.orc.impl.reader;
 import com.google.protobuf.CodedInputStream;
 import org.apache.orc.DataReader;
 import org.apache.orc.EncryptionAlgorithm;
+import org.apache.orc.FileFormatException;
 import org.apache.orc.OrcFile;
 import org.apache.orc.OrcProto;
 import org.apache.orc.StripeInformation;
@@ -147,7 +148,8 @@ public class StripePlanner {
     dataStreams.clear();
     indexStreams.clear();
     buildEncodings(footer, columnInclude);
-    findStreams(stripe.getOffset(), footer, columnInclude);
+    long dataEnd = stripe.getOffset() + stripe.getIndexLength() + stripe.getDataLength();
+    findStreams(stripe.getOffset(), dataEnd, footer, columnInclude);
     // figure out whether each column has null values in this stripe
     Arrays.fill(hasNull, false);
     for(StreamInformation stream: dataStreams) {
@@ -268,6 +270,7 @@ public class StripePlanner {
   /**
    * For each stream, decide whether to include it in the list of streams.
    * @param offset the position in the file for this stream
+   * @param dataEnd the end of the stripe's index and data region
    * @param columnInclude which columns are being read
    * @param stream the stream to consider
    * @param area only the area will be included
@@ -275,10 +278,11 @@ public class StripePlanner {
    * @return the offset for the next stream
    */
   private long handleStream(long offset,
+                            long dataEnd,
                             boolean[] columnInclude,
                             OrcProto.Stream stream,
                             StreamName.Area area,
-                            ReaderEncryptionVariant variant) {
+                            ReaderEncryptionVariant variant) throws IOException {
     int column = stream.getColumn();
     if (stream.hasKind()) {
       OrcProto.Stream.Kind kind = stream.getKind();
@@ -317,7 +321,13 @@ public class StripePlanner {
         }
       }
     }
-    return stream.getLength();
+    long length = stream.getLength();
+    if (length < 0 || offset + length < offset || offset + length > dataEnd) {
+      throw new FileFormatException("Malformed ORC file. Stream for column " + column
+          + " kind " + stream.getKind() + " exceeds stripe bounds: streamOffset=" + offset
+          + ", streamLength=" + length + ", stripeDataEnd=" + dataEnd);
+    }
+    return length;
   }
 
   /**
@@ -325,10 +335,12 @@ public class StripePlanner {
    * CurrentOffset total order must be consistent with write
    * {@link PhysicalFsWriter#finalizeStripe}
    * @param streamStart the starting offset of streams in the file
+   * @param dataEnd the end of the stripe's index and data region
    * @param footer the footer for the stripe
    * @param columnInclude which columns are being read
    */
   private void findStreams(long streamStart,
+                           long dataEnd,
                            OrcProto.StripeFooter footer,
                            boolean[] columnInclude) throws IOException {
     long currentOffset = streamStart;
@@ -342,19 +354,21 @@ public class StripePlanner {
     // Storage layout of index and data, So we need to find the streams in this order
     //
     // find index streams, encrypted first and then unencrypted
-    currentOffset = findStreamsByArea(currentOffset, footer, StreamName.Area.INDEX, columnInclude);
+    currentOffset = findStreamsByArea(currentOffset, dataEnd, footer, StreamName.Area.INDEX,
+        columnInclude);
 
     // find data streams, encrypted first and then unencrypted
-    findStreamsByArea(currentOffset, footer, StreamName.Area.DATA, columnInclude);
+    findStreamsByArea(currentOffset, dataEnd, footer, StreamName.Area.DATA, columnInclude);
   }
 
   private long findStreamsByArea(long currentOffset,
+                                long dataEnd,
                                 OrcProto.StripeFooter footer,
                                 StreamName.Area area,
-                                boolean[] columnInclude) {
+                                boolean[] columnInclude) throws IOException {
     // find unencrypted streams
     for(OrcProto.Stream stream: footer.getStreamsList()) {
-      currentOffset += handleStream(currentOffset, columnInclude, stream, area, null);
+      currentOffset += handleStream(currentOffset, dataEnd, columnInclude, stream, area, null);
     }
 
     // find encrypted streams
@@ -363,7 +377,8 @@ public class StripePlanner {
       OrcProto.StripeEncryptionVariant stripeVariant =
           footer.getEncryption(variantId);
       for(OrcProto.Stream stream: stripeVariant.getStreamsList()) {
-        currentOffset += handleStream(currentOffset, columnInclude, stream, area, variant);
+        currentOffset += handleStream(currentOffset, dataEnd, columnInclude, stream, area,
+            variant);
       }
     }
     return currentOffset;

--- a/java/core/src/test/org/apache/orc/impl/reader/TestStripePlanner.java
+++ b/java/core/src/test/org/apache/orc/impl/reader/TestStripePlanner.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.orc.impl.reader;
+
+import org.apache.orc.DataReader;
+import org.apache.orc.FileFormatException;
+import org.apache.orc.OrcFile;
+import org.apache.orc.OrcProto;
+import org.apache.orc.StripeInformation;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.InStream;
+import org.apache.orc.impl.MockDataReader;
+import org.apache.orc.impl.MockStripe;
+import org.apache.orc.impl.ReaderImpl;
+import org.apache.orc.impl.StreamName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.ByteBuffer;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TestStripePlanner {
+
+  private static ByteBuffer createDataStream(int bytes) {
+    ByteBuffer buffer = ByteBuffer.allocate(bytes);
+    buffer.position(0);
+    buffer.limit(bytes);
+    return buffer;
+  }
+
+  /**
+   * A stream whose declared length pushes its offset past the stripe's
+   * index+data region must be rejected, matching the C++ reader's
+   * StripeStreamsImpl::getStream boundary check.
+   */
+  @Test
+  public void testStreamLengthExceedsStripeBoundary() throws Exception {
+    TypeDescription schema = TypeDescription.fromString("struct<x:int>");
+    // stripe data region is [offset, offset + indexLength + dataLength) = [3, 103)
+    OrcProto.StripeInformation protoStripe = OrcProto.StripeInformation.newBuilder()
+        .setOffset(3)
+        .setIndexLength(0)
+        .setDataLength(100)
+        .setNumberOfRows(1000)
+        .build();
+    StripeInformation stripe =
+        new ReaderImpl.StripeInformationImpl(protoStripe, 0, -1, null);
+    // a single DATA stream whose length (1000) far exceeds the 100-byte data region
+    OrcProto.StripeFooter footer = OrcProto.StripeFooter.newBuilder()
+        .addStreams(OrcProto.Stream.newBuilder()
+            .setColumn(1)
+            .setKind(OrcProto.Stream.Kind.DATA)
+            .setLength(1000)
+            .build())
+        .addColumns(OrcProto.ColumnEncoding.newBuilder()
+            .setKind(OrcProto.ColumnEncoding.Kind.DIRECT).build())
+        .addColumns(OrcProto.ColumnEncoding.newBuilder()
+            .setKind(OrcProto.ColumnEncoding.Kind.DIRECT).build())
+        .build();
+    DataReader dataReader = mock(DataReader.class);
+    when(dataReader.readStripeFooter(any())).thenReturn(footer);
+
+    StripePlanner planner = new StripePlanner(schema, new ReaderEncryption(),
+        dataReader, OrcFile.WriterVersion.ORC_14, false, Integer.MAX_VALUE);
+    FileFormatException e = assertThrows(FileFormatException.class,
+        () -> planner.parseStripe(stripe, new boolean[]{true, true}));
+    assertTrue(e.getMessage().contains("Malformed ORC file"), e.getMessage());
+  }
+
+  /**
+   * A well-formed stripe, whose stream lengths sum exactly to the index+data
+   * region, still plans correctly.
+   */
+  @Test
+  public void testWellFormedStripePlans() throws Exception {
+    TypeDescription schema = TypeDescription.fromString("struct<x:int>");
+    MockDataReader dataReader = new MockDataReader(schema)
+        .addStream(1, OrcProto.Stream.Kind.PRESENT, createDataStream(1000))
+        .addStream(1, OrcProto.Stream.Kind.DATA, createDataStream(9000))
+        .addEncoding(OrcProto.ColumnEncoding.Kind.DIRECT)
+        .addStripeFooter(1000, null);
+    MockStripe stripe = dataReader.getStripe(0);
+
+    StripePlanner planner = new StripePlanner(schema, new ReaderEncryption(),
+        dataReader, OrcFile.WriterVersion.ORC_14, false, Integer.MAX_VALUE);
+    planner.parseStripe(stripe, new boolean[]{true, true});
+    planner.readData(null, null, false,
+        org.apache.orc.impl.reader.tree.TypeReader.ReadPhase.ALL);
+    assertNotNull(planner.getStream(new StreamName(1, OrcProto.Stream.Kind.DATA)));
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to validate each stream's `offset + length` against the stripe data boundary in the Java `StripePlanner`, throwing `FileFormatException` when a stream overflows or exceeds the stripe's index+data region.

### Why are the changes needed?

This closes a C++/Java reader parity gap. The C++ reader already rejects such streams in `StripeStreamsImpl::getStream` by computing `dataEnd = stripeOffset + indexLength + dataLength`, while the Java `StripePlanner.handleStream` accumulated `currentOffset += stream.getLength()` with no bound check. Since `stream.getLength()` is an untrusted protobuf `uint64`, a crafted stripe footer could drive reads outside the stripe region.

### How was this patch tested?

Pass the CIs with the newly added test case.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5