### PR TITLE
ORC-2201: Update `docker/README.md` to match the current docker test environment

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -3,10 +3,10 @@
 ## Supported OSes
 
 * Debian 13
-* Fedora 37
 * Ubuntu 24 and 26
 * Oracle Linux 9 and 10
 * Amazon Linux 2023
+* UBI 10
 
 ## Pre-built Images
 
@@ -33,12 +33,16 @@ The scripts are:
 * `run-one.sh` *owner* *branch* *os* - test the owner's branch on one OS
 * `reinit.sh` - rebuild all of the base images without the image cache
 
-`run-all.sh`, `run-one.sh` and `reinit.sh` tests both on jdk17 and 21 across OSes
+Each OS image uses a single JDK version: JDK 17 (oraclelinux9, amazonlinux23),
+JDK 21 (debian13, ubuntu24, oraclelinux10) and JDK 25 (ubuntu26, ubi10).
 
 A base image for each OS is built using:
 
     cd docker/$os
-    FOR jdk21: docker build -t "orc-$os-jdk21" --build-arg jdk=21 .
+    docker build -t "apache/orc-dev:$os" .
+
+For debian13, ubuntu24 and ubuntu26, the JDK version can be changed via
+`--build-arg jdk=N`.
 
 ## Clean up
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update `docker/README.md` to match the current contents of the `docker/` directory.

1. Update the supported OS list to match `docker/os-list.txt`: remove `Fedora 37` (removed in ORC-1915) and add `UBI 10` (added in ORC-2121).
2. Replace the stale statement that the scripts test both JDK 17 and 21 across OSes. Each OS image now uses a single JDK version: JDK 17 (`oraclelinux9`, `amazonlinux23`), JDK 21 (`debian13`, `ubuntu24`, `oraclelinux10`), and JDK 25 (`ubuntu26`, `ubi10`).
3. Fix the base image build example to match the actual tagging used by `reinit.sh` (`apache/orc-dev:$os`), and note that `debian13`/`ubuntu24`/`ubuntu26` accept a `--build-arg jdk=N` to change the JDK version.

### Why are the changes needed?

The README is out of sync with the actual docker test environment and misleads contributors who run the docker-based tests.

### How was this patch tested?

Manually verified against `docker/os-list.txt`, `docker/reinit.sh`, and each `docker/*/Dockerfile`. Also checked with `markdownlint docker/README.md` (no warnings).

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5