### PR TITLE
ORC-2202: Use `debian:13` instead of `13.1` in `docker/debian13/Dockerfile`

### DIFF
--- a/docker/debian13/Dockerfile
+++ b/docker/debian13/Dockerfile
@@ -17,7 +17,7 @@
 # ORC compile for Debian 13
 #
 
-FROM debian:13.1
+FROM debian:13
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache ORC on Debian 13"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `debian:13` instead of `debian:13.1` in `docker/debian13/Dockerfile`.

### Why are the changes needed?

Debian 13 has moved past the `13.1` point release, so the pinned tag no longer tracks the latest point releases. Using the `debian:13` tag keeps the image up to date automatically and is consistent with the other OS Dockerfiles (`ubuntu:24.04`, `oraclelinux:9`, `oraclelinux:10`), as well as the previous Debian Dockerfiles which used floating codename tags (`debian:bullseye`, `debian:bookworm`).

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5