### PR TITLE
ORC-2203: Remove unused variables in docker/run-all.sh

### DIFF
--- a/docker/run-all.sh
+++ b/docker/run-all.sh
@@ -16,12 +16,8 @@
 # limitations under the License.
 
 GITHUB_USER=$1
-URL=https://github.com/$GITHUB_USER/orc.git
 BRANCH=$2
 
-CLONE="git clone $URL -b $BRANCH"
-MAKEDIR="mkdir orc/build && cd orc/build"
-VOLUME="--volume m2cache:/root/.m2/repository"
 mkdir -p logs
 
 function failure {


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to remove unused variable assignments (`URL`, `CLONE`, `MAKEDIR`, `VOLUME`) from `docker/run-all.sh`.

### Why are the changes needed?

These variables are leftovers from before the per-OS build logic was extracted into `docker/run-one.sh`, which defines and uses its own `CLONE`/`MAKEDIR`/`VOLUME`. In `run-all.sh`, they are never referenced; the build loop invokes `./run-one.sh $1 $2 $build` with the positional arguments directly. `URL` is also removed because it was only referenced by the unused `CLONE`. The `GITHUB_USER=$1` and `BRANCH=$2` assignments are kept as documentation of the expected arguments.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5