### PR TITLE
ORC-2204: Use `amazonlinux:2023` instead of a dated snapshot tag

### DIFF
--- a/docker/amazonlinux23/Dockerfile
+++ b/docker/amazonlinux23/Dockerfile
@@ -17,7 +17,7 @@
 # ORC compile for Amazon Linux 2023
 #
 
-FROM amazonlinux:2023.10.20260202.2
+FROM amazonlinux:2023
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache ORC on Amazon Linux 2023"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use the rolling `amazonlinux:2023` tag instead of a dated snapshot tag in the `amazonlinux23` docker image.

### Why are the changes needed?

This is consistent with the other docker images which use rolling tags, e.g., `oraclelinux:9`, `ubuntu:24.04`, and `ubi10`.

### How was this patch tested?

Manual review.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5