### PR TITLE
ORC-2207: Use `javadoc.io` links in `site` docs

### DIFF
--- a/site/_docs/core-java.md
+++ b/site/_docs/core-java.md
@@ -212,9 +212,9 @@ public class MapColumnVector extends ColumnVector {
 
 ### Simple Example
 To write an ORC file, you need to define the schema and use the
-[OrcFile](/api/orc-core/index.html?org/apache/orc/OrcFile.html)
+[OrcFile](https://javadoc.io/doc/org.apache.orc/orc-core/latest/org/apache/orc/OrcFile.html)
 class to create a
-[Writer](/api/orc-core/index.html?org/apache/orc/Writer.html)
+[Writer](https://javadoc.io/doc/org.apache.orc/orc-core/latest/org/apache/orc/Writer.html)
 with the desired filename. This example sets the required schema
 parameter, but there are many other options to control the ORC writer.
 
@@ -319,9 +319,9 @@ writer.close();
 ## Reading ORC Files
 
 To read ORC files, use the
-[OrcFile](/api/orc-core/index.html?org/apache/orc/OrcFile.html)
+[OrcFile](https://javadoc.io/doc/org.apache.orc/orc-core/latest/org/apache/orc/OrcFile.html)
 class to create a
-[Reader](/api/orc-core/index.html?org/apache/orc/Reader.html)
+[Reader](https://javadoc.io/doc/org.apache.orc/orc-core/latest/org/apache/orc/Reader.html)
 that contains the metadata about the file. There are a few options to
 the ORC reader, but far fewer than the writer and none of them are
 required. The reader has methods for getting the number of rows,
@@ -333,7 +333,7 @@ Reader reader = OrcFile.createReader(new Path("my-file.orc"),
 ~~~
 
 To get the data, create a
-[RecordReader](/api/orc-core/index.html?org/apache/orc/RecordReader.html)
+[RecordReader](https://javadoc.io/doc/org.apache.orc/orc-core/latest/org/apache/orc/RecordReader.html)
 object. By default, the RecordReader reads all rows and all columns,
 but there are options to control the data that is read.
 

--- a/site/_docs/mapred.md
+++ b/site/_docs/mapred.md
@@ -30,7 +30,7 @@ Add ORC and your desired version of Hadoop to your `pom.xml`:
 
 Set the minimal properties in your JobConf:
 
-* **mapreduce.job.inputformat.class** = [org.apache.orc.mapred.OrcInputFormat](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcInputFormat.html)
+* **mapreduce.job.inputformat.class** = [org.apache.orc.mapred.OrcInputFormat](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcInputFormat.html)
 * **mapreduce.input.fileinputformat.inputdir** = your input directory
 
 ORC files contain a series of values of the same type and that type
@@ -44,7 +44,7 @@ the key and a value based on the table below expanded recursively.
 
 | ORC Type | Writable Type |
 | -------- | ------------- |
-| array | [org.apache.orc.mapred.OrcList](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcStruct.html) |
+| array | [org.apache.orc.mapred.OrcList](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcStruct.html) |
 | binary | org.apache.hadoop.io.BytesWritable |
 | bigint | org.apache.hadoop.io.LongWritable |
 | boolean | org.apache.hadoop.io.BooleanWritable |
@@ -54,13 +54,13 @@ the key and a value based on the table below expanded recursively.
 | double | org.apache.hadoop.io.DoubleWritable |
 | float | org.apache.hadoop.io.FloatWritable |
 | int | org.apache.hadoop.io.IntWritable |
-| map | [org.apache.orc.mapred.OrcMap](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcMap.html) |
+| map | [org.apache.orc.mapred.OrcMap](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcMap.html) |
 | smallint | org.apache.hadoop.io.ShortWritable |
 | string | org.apache.hadoop.io.Text |
-| struct | [org.apache.orc.mapred.OrcStruct](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcStruct.html) |
-| timestamp | [org.apache.orc.mapred.OrcTimestamp](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcTimestamp.html) |
+| struct | [org.apache.orc.mapred.OrcStruct](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcStruct.html) |
+| timestamp | [org.apache.orc.mapred.OrcTimestamp](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcTimestamp.html) |
 | tinyint | org.apache.hadoop.io.ByteWritable |
-| uniontype | [org.apache.orc.mapred.OrcUnion](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcUnion.html) |
+| uniontype | [org.apache.orc.mapred.OrcUnion](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcUnion.html) |
 | varchar | org.apache.hadoop.io.Text |
 
 Let's assume that your input directory contains ORC files with the
@@ -90,7 +90,7 @@ public class MyMapper
 
 To write ORC files from your MapReduce job, you'll need to set
 
-* **mapreduce.job.outputformat.class** = [org.apache.orc.mapred.OrcOutputFormat](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcOutputFormat.html)
+* **mapreduce.job.outputformat.class** = [org.apache.orc.mapred.OrcOutputFormat](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcOutputFormat.html)
 * **mapreduce.output.fileoutputformat.outputdir** = your output directory
 * **orc.mapred.output.schema** = the schema to write to the ORC file
 
@@ -140,9 +140,9 @@ MapReduce shuffle. The complex ORC types, since they are generic
 types, need to have their full type information provided to create the
 object. To enable MapReduce to properly instantiate the OrcStruct and
 other ORC types, we need to wrap it in either an
-[OrcKey](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcKey.html)
+[OrcKey](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcKey.html)
 for the shuffle key or
-[OrcValue](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcValue.html)
+[OrcValue](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcValue.html)
 for the shuffle value.
 
 To send two OrcStructs through the shuffle, define the following properties

--- a/site/_docs/mapreduce.md
+++ b/site/_docs/mapreduce.md
@@ -30,7 +30,7 @@ Add ORC and your desired version of Hadoop to your `pom.xml`:
 
 Set the minimal properties in your JobConf:
 
-* **mapreduce.job.inputformat.class** = [org.apache.orc.mapreduce.OrcInputFormat](/api/orc-mapreduce/index.html?org/apache/orc/mapreduce/OrcInputFormat.html)
+* **mapreduce.job.inputformat.class** = [org.apache.orc.mapreduce.OrcInputFormat](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapreduce/OrcInputFormat.html)
 * **mapreduce.input.fileinputformat.inputdir** = your input directory
 
 ORC files contain a series of values of the same type and that type
@@ -44,7 +44,7 @@ the key and a value based on the table below expanded recursively.
 
 | ORC Type | Writable Type |
 | -------- | ------------- |
-| array | [org.apache.orc.mapred.OrcList](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcStruct.html) |
+| array | [org.apache.orc.mapred.OrcList](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcStruct.html) |
 | binary | org.apache.hadoop.io.BytesWritable |
 | bigint | org.apache.hadoop.io.LongWritable |
 | boolean | org.apache.hadoop.io.BooleanWritable |
@@ -54,13 +54,13 @@ the key and a value based on the table below expanded recursively.
 | double | org.apache.hadoop.io.DoubleWritable |
 | float | org.apache.hadoop.io.FloatWritable |
 | int | org.apache.hadoop.io.IntWritable |
-| map | [org.apache.orc.mapred.OrcMap](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcMap.html) |
+| map | [org.apache.orc.mapred.OrcMap](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcMap.html) |
 | smallint | org.apache.hadoop.io.ShortWritable |
 | string | org.apache.hadoop.io.Text |
-| struct | [org.apache.orc.mapred.OrcStruct](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcStruct.html) |
-| timestamp | [org.apache.orc.mapred.OrcTimestamp](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcTimestamp.html) |
+| struct | [org.apache.orc.mapred.OrcStruct](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcStruct.html) |
+| timestamp | [org.apache.orc.mapred.OrcTimestamp](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcTimestamp.html) |
 | tinyint | org.apache.hadoop.io.ByteWritable |
-| uniontype | [org.apache.orc.mapred.OrcUnion](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcUnion.html) |
+| uniontype | [org.apache.orc.mapred.OrcUnion](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcUnion.html) |
 | varchar | org.apache.hadoop.io.Text |
 
 Let's assume that your input directory contains ORC files with the
@@ -86,7 +86,7 @@ public static class MyMapper
 
 To write ORC files from your MapReduce job, you'll need to set
 
-* **mapreduce.job.outputformat.class** = [org.apache.orc.mapreduce.OrcOutputFormat](/api/orc-mapreduce/index.html?org/apache/orc/mapreduce/OrcOutputFormat.html)
+* **mapreduce.job.outputformat.class** = [org.apache.orc.mapreduce.OrcOutputFormat](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapreduce/OrcOutputFormat.html)
 * **mapreduce.output.fileoutputformat.outputdir** = your output directory
 * **orc.mapred.output.schema** = the schema to write to the ORC file
 
@@ -132,9 +132,9 @@ MapReduce shuffle. The complex ORC types, since they are generic
 types, need to have their full type information provided to create the
 object. To enable MapReduce to properly instantiate the OrcStruct and
 other ORC types, we need to wrap it in either an
-[OrcKey](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcKey.html)
+[OrcKey](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcKey.html)
 for the shuffle key or
-[OrcValue](/api/orc-mapreduce/index.html?org/apache/orc/mapred/OrcValue.html)
+[OrcValue](https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest/org/apache/orc/mapred/OrcValue.html)
 for the shuffle value.
 
 To send two OrcStructs through the shuffle, define the following properties


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces the relative javadoc links under `site/` with absolute `javadoc.io` URLs, e.g.

- Before: `/api/orc-core/index.html?org/apache/orc/OrcFile.html`
- After: `https://javadoc.io/doc/org.apache.orc/orc-core/latest/org/apache/orc/OrcFile.html`

All 22 links in `site/_docs/core-java.md`, `site/_docs/mapred.md`, and `site/_docs/mapreduce.md` are converted.

### Why are the changes needed?

The relative `/api/` links depend on javadoc being published alongside the website. Linking to `javadoc.io` points at the published artifact javadoc directly.

### How was this patch tested?

Manual verification; documentation-only change. `grep -rn "/api/" site/` returns no matches.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8