### PR TITLE
ORC-2208: Update Python documentation with PyArrow 25.0.0, Pandas 3.0.3, and Dask 2026.7.1

### DIFF
--- a/site/_docs/dask.md
+++ b/site/_docs/dask.md
@@ -9,7 +9,7 @@ permalink: /docs/dask.html
 [Dask](https://dask.org) also supports Apache ORC.
 
 ```
-pip3 install "dask[dataframe]==2025.5.1"
+pip3 install "dask[dataframe]==2026.7.1"
 pip3 install pandas
 ```
 

--- a/site/_docs/pandas.md
+++ b/site/_docs/pandas.md
@@ -10,7 +10,7 @@ permalink: /docs/pandas.html
 Since Pandas relies on [pyarrow](https://pypi.org/project/pyarrow/) for ORC support, it is required.
 
 ```
-pip3 install pandas==2.3.3
+pip3 install pandas==3.0.3
 pip3 install pyarrow
 ```
 
@@ -25,10 +25,10 @@ In [3]: df.to_orc("test.orc")
 
 In [4]: pd.read_orc("test.orc")
 Out[4]:
-   col1  col2
-0     1     a
-1     2     b
-2     3  None
+   col1 col2
+0     1    a
+1     2    b
+2     3  NaN
 
 In [5]: pd.read_orc("test.orc", columns=["col1"])
 Out[5]:

--- a/site/_docs/pyarrow.md
+++ b/site/_docs/pyarrow.md
@@ -9,7 +9,7 @@ permalink: /docs/pyarrow.html
 [Apache Arrow](https://arrow.apache.org) project's [PyArrow](https://pypi.org/project/pyarrow/) is the recommended package.
 
 ```
-pip3 install pyarrow==20.0.0
+pip3 install pyarrow==25.0.0
 pip3 install pandas
 ```
 
@@ -24,10 +24,10 @@ In [3]: orc.write_table(pa.table({"col1": [1, 2, 3], "col2": ["a", "b", None]}),
 
 In [4]: orc.read_table("test.orc").to_pandas()
 Out[4]:
-   col1  col2
-0     1     a
-1     2     b
-2     3  None
+   col1 col2
+0     1    a
+1     2    b
+2     3  NaN
 
 In [5]: orc.read_table("test.orc", columns=["col1"]).to_pandas()
 Out[5]:


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to update Python documentation with PyArrow 25.0.0, Pandas 3.0.3, and Dask 2026.7.1.

In addition, the expected outputs of the PyArrow and Pandas examples are updated because
Pandas 3.x displays missing string values as `NaN` instead of `None`.

### Why are the changes needed?

To provide an up-to-date Python documentation.

### How was this patch tested?

Manually tested with `Python 3.14.6`.

```
$ pip3 install pyarrow==25.0.0
$ pip3 install pandas==3.0.3
$ pip3 install "dask[dataframe]==2026.7.1"
```

All examples in `pyarrow.md`, `pandas.md`, and `dask.md` were executed and the outputs were verified.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5