### PR TITLE
ORC-2209: Upgrade `site` Docker image to Ubuntu 26.04

### DIFF
--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -17,7 +17,7 @@
 # ORC site builder
 #
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 LABEL org.opencontainers.image.authors="Apache ORC project <dev@orc.apache.org>"
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.ref.name="Apache ORC site builder"


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade the base image of `site/Dockerfile` from `ubuntu:24.04` to `ubuntu:26.04`.

### Why are the changes needed?

Ubuntu 26.04 LTS is the latest LTS release. This allows the ORC site builder image to use the newer toolchain and receive the latest security updates.

### How was this patch tested?

Build the site Docker image manually.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5