### PR TITLE
ORC-2210: Upgrade Spark to 4.2.0 and align Jackson, Avro, and Netty dependencies

### DIFF
--- a/java/bench/pom.xml
+++ b/java/bench/pom.xml
@@ -38,7 +38,7 @@
   </modules>
 
   <properties>
-    <avro.version>1.12.0</avro.version>
+    <avro.version>1.12.1</avro.version>
     <hive.version>4.1.0</hive.version>
     <jmh.version>1.37</jmh.version>
     <junit.version>6.0.2</junit.version>
@@ -46,7 +46,7 @@
     <parquet.version>1.17.1</parquet.version>
     <scala.binary.version>2.13</scala.binary.version>
     <scala.version>2.13.18</scala.version>
-    <spark.version>4.2.0-preview2</spark.version>
+    <spark.version>4.2.0</spark.version>
   </properties>
 
   <dependencyManagement>
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.2.10.Final</version>
+        <version>4.2.13.Final</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>

--- a/java/bench/spark/pom.xml
+++ b/java/bench/spark/pom.xml
@@ -37,7 +37,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Spark Jackson version may not be same as ORC -->
-    <spark.jackson.version>2.21.4</spark.jackson.version>
+    <spark.jackson.version>2.21.2</spark.jackson.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Spark to 4.2.0 in `java/bench` module and align the Spark-related transitive dependencies.

- `spark.version`: 4.2.0-preview2 -> 4.2.0
- `spark.jackson.version`: 2.21.4 -> 2.21.2 (**Note that this is a downgrade to match**)
- `avro.version`: 1.12.0 -> 1.12.1
- `netty-all`: 4.2.10.Final -> 4.2.13.Final

### Why are the changes needed?

Apache Spark 4.2.0 is the official GA release which supersedes 4.2.0-preview2.
- https://repo1.maven.org/maven2/org/apache/spark/spark-sql_2.13/4.2.0/

The Jackson, Avro, and Netty versions are aligned with Spark 4.2.0's dependencies.

### How was this patch tested?

Pass the CIs.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5

Closes #2693