### PR TITLE
ORC-2211: Use `javadoc.io` links in Maven Javadoc configuration

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -679,20 +679,10 @@
           <doclint>none</doclint>
           <links>
             <link>https://hadoop.apache.org/docs/r${hadoop.version}/api</link>
-            <link>https://orc.apache.org/api/orc-core</link>
-            <link>https://orc.apache.org/api/orc-mapreduce</link>
-            <link>https://orc.apache.org/api/orc-tools</link>
+            <link>https://javadoc.io/doc/org.apache.orc/orc-core/latest</link>
+            <link>https://javadoc.io/doc/org.apache.orc/orc-mapreduce/latest</link>
+            <link>https://javadoc.io/doc/org.apache.orc/orc-tools/latest</link>
           </links>
-          <offlineLinks>
-            <offlineLink>
-              <url>https://orc.apache.org/api/orc-core</url>
-              <location>${javadoc.location}/api/orc-core</location>
-            </offlineLink>
-            <offlineLink>
-              <url>https://orc.apache.org/api/orc-mapreduce</url>
-              <location>${javadoc.location}/api/orc-mapreduce</location>
-            </offlineLink>
-          </offlineLinks>
           <reportOutputDirectory>${javadoc.location}/api</reportOutputDirectory>
           <notimestamp>true</notimestamp>
         </configuration>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to use `javadoc.io` links in the Maven Javadoc plugin configuration instead of the removed `orc.apache.org/api` links, and to remove the obsolete `<offlineLinks>` block.

### Why are the changes needed?

Since the website stopped hosting Javadoc under `orc.apache.org/api` (ORC-2207), the `Javadoc generation` CI job fails on all PRs.

- https://github.com/apache/orc/actions/runs/29601757265/job/87955299789

```
[ERROR] error: Error fetching URL: https://orc.apache.org/api/orc-core/ (java.io.FileNotFoundException: https://orc.apache.org/api/orc-core/package-list)
```

### How was this patch tested?

Manually ran the same commands as the `Javadoc generation` CI job and verified `BUILD SUCCESS`.

```
cd java
./mvnw install -DskipTests
./mvnw javadoc:javadoc
```

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: Claude Fable 5