### PR TITLE
ORC-624: [C++] Avoid unaligned trailer loads in LZO decompressor

### DIFF
--- a/c++/src/LzoDecompressor.cc
+++ b/c++/src/LzoDecompressor.cc
@@ -32,6 +32,11 @@ namespace orc {
   static const int32_t SIZE_OF_INT = 4;
   static const int32_t SIZE_OF_LONG = 8;
 
+  static uint32_t readLittleEndianShort(const char* input) {
+    return static_cast<uint32_t>(static_cast<uint8_t>(input[0])) |
+           (static_cast<uint32_t>(static_cast<uint8_t>(input[1])) << 8U);
+  }
+
   static std::string toHex(uint64_t val) {
     std::ostringstream out;
     out << "0x" << std::hex << val;
@@ -198,7 +203,7 @@ namespace orc {
           if (input + SIZE_OF_SHORT > inputLimit) {
             throw MalformedInputException(input - inputAddress);
           }
-          uint32_t trailer = *reinterpret_cast<const uint16_t*>(input) & 0xFFFF;
+          uint32_t trailer = readLittleEndianShort(input);
           input += SIZE_OF_SHORT;
 
           // copy offset :: 16 bits :: valid range [32767..49151]
@@ -237,7 +242,7 @@ namespace orc {
           if (input + SIZE_OF_SHORT > inputLimit) {
             throw MalformedInputException(input - inputAddress);
           }
-          int32_t trailer = *reinterpret_cast<const int16_t*>(input) & 0xFFFF;
+          int32_t trailer = static_cast<int32_t>(readLittleEndianShort(input));
           input += SIZE_OF_SHORT;
 
           // copy offset :: 14 bits :: valid range [0..16383]

--- a/c++/test/TestDecompression.cc
+++ b/c++/test/TestDecompression.cc
@@ -425,6 +425,43 @@ namespace orc {
     ASSERT_TRUE(!result->Next(&ptr, &length));
   }
 
+  TEST_F(TestDecompression, testLzoLongDistanceMatch) {
+    constexpr size_t literalLength = 16385;
+    std::vector<unsigned char> buffer(3);
+
+    // Emit enough literals for a 0x10 command to reference data 16 KiB back.
+    buffer.push_back(0);
+    buffer.insert(buffer.end(), 64, 0);
+    buffer.push_back(47);
+    buffer.insert(buffer.end(), literalLength, 'a');
+
+    // Copy four bytes from 16 KiB back, then stop.
+    buffer.push_back(0x12);
+    buffer.push_back(0);
+    buffer.push_back(0);
+    buffer.push_back(0x11);
+    buffer.push_back(0);
+    buffer.push_back(0);
+
+    const size_t compressedSize = buffer.size() - 3;
+    buffer[0] = static_cast<unsigned char>(compressedSize << 1);
+    buffer[1] = static_cast<unsigned char>(compressedSize >> 7);
+    buffer[2] = static_cast<unsigned char>(compressedSize >> 15);
+
+    std::unique_ptr<SeekableInputStream> result =
+        createDecompressor(CompressionKind_LZO,
+                           std::make_unique<SeekableArrayInputStream>(buffer.data(), buffer.size()),
+                           128 * 1024, *getDefaultPool(), getDefaultReaderMetrics());
+    const void* ptr;
+    int length;
+    ASSERT_TRUE(result->Next(&ptr, &length));
+    ASSERT_EQ(literalLength + 4, static_cast<size_t>(length));
+    for (size_t i = 0; i < static_cast<size_t>(length); ++i) {
+      ASSERT_EQ('a', static_cast<const char*>(ptr)[i]);
+    }
+    ASSERT_FALSE(result->Next(&ptr, &length));
+  }
+
   TEST_F(TestDecompression, testLzoOverflow) {
     const unsigned char bad_lzo_data[] = {// Header: compressedSize = 12, original = false
                                           0x18, 0x00, 0x00,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR replaces two potentially unaligned 16-bit trailer loads with an alignment-safe little-endian reader.

It also adds a long-distance match test covering the previously untested `0x10` LZO command path. This is a focused replacement for the LZO portion of #496, which was closed without merging.

### Why are the changes needed?

The LZO input pointer advances byte by byte and is not guaranteed to be 2-byte aligned. Dereferencing it as `uint16_t*` or `int16_t*` is undefined behavior and is reported by UBSan.

### How was this patch tested?

```bash
cmake --build build --target orc-test -j8
cd build/c++/test
./orc-test --gtest_filter='TestDecompression.testLzoLong:TestDecompression.testLzoLongDistanceMatch:TestDecompression.testLzoOverflow:TestDecompression.testLzoTruncatedStopCommand'
```

All four tests passed. The existing long test covers the `0x20` command path, and the new test covers the `0x10` path.

### Was this patch authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)